### PR TITLE
propose cleaner, more familiar usage patterns

### DIFF
--- a/example/src/app.js
+++ b/example/src/app.js
@@ -1,29 +1,31 @@
 import { Navigation } from 'react-native-navigation';
 
-import './screens/FirstTabScreen';
-import './screens/SecondTabScreen';
-import './screens/ThirdTabScreen';
-import './screens/SideMenu';
+//import and call the default function from each module
+//The default function of a module should register all the pushable screens
+import register1 from './module_1';
+import register2 from './module_2';
+register1();
+register2();
 
 Navigation.startTabBasedApp({
   tabs: [
     {
       label: 'One',
-      screen: 'example.FirstTabScreen',
+      screen: 'module_1.FirstTabScreen',
       icon: require('../img/one.png'),
       selectedIcon: require('../img/one_selected.png'),
       title: 'Screen One'
     },
     {
       label: 'Two',
-      screen: 'example.SecondTabScreen',
+      screen: 'module_2.SecondTabScreen',
       icon: require('../img/two.png'),
       selectedIcon: require('../img/two_selected.png'),
       title: 'Screen Two'
     },
     {
       label: 'Three',
-      screen: 'example.ThirdTabScreen',
+      screen: 'module_2.ThirdTabScreen',
       icon: require('../img/three.png'),
       selectedIcon: require('../img/three_selected.png'),
       title: 'Screen Three',
@@ -37,7 +39,7 @@ Navigation.startTabBasedApp({
   ],
   drawer: {
     left: {
-      screen: 'example.SideMenu'
+      screen: 'module_1.SideMenu'
     }
   }
 });

--- a/example/src/module_1/FirstTabScreen.js
+++ b/example/src/module_1/FirstTabScreen.js
@@ -3,26 +3,47 @@ import React, {
   View,
   ScrollView,
   TouchableOpacity,
-  StyleSheet
+  StyleSheet,
+  AlertIOS
 } from 'react-native';
 
 // important imports, the magic is here
 import { Navigation, Screen } from 'react-native-navigation';
 
-// need to import every screen we push
-import './PushedScreen';
-import './StyledScreen';
-
 // instead of React.Component, we extend Screen (imported above)
-class ModalScreen extends Screen {
+export default class FirstTabScreen extends Screen {
   static navigatorButtons = {
     leftButtons: [{
-      title: 'Close',
-      id: 'close'
-    }]
+      icon: require('../../img/navicon_menu.png'),
+      id: 'menu'
+    }],
+    rightButtons: [
+      {
+        title: 'Edit',
+        id: 'edit'
+      },
+      {
+        icon: require('../../img/navicon_add.png'),
+        id: 'add'
+      }
+    ]
   };
   constructor(props) {
     super(props);
+  }
+  onNavigatorEvent(event) {
+    if (event.id == 'menu') {
+      this.navigator.toggleDrawer({
+        side: 'left',
+        animated: true
+      });
+    }
+    if (event.id == 'edit') {
+      AlertIOS.alert('NavBar', 'Edit button pressed');
+    }
+    if (event.id == 'add') {
+      AlertIOS.alert('NavBar', 'Add button pressed');
+    }
   }
   render() {
     return (
@@ -36,32 +57,30 @@ class ModalScreen extends Screen {
           <Text style={styles.button}>Push Styled Screen</Text>
         </TouchableOpacity>
 
-        <TouchableOpacity onPress={ this.onClosePress.bind(this) }>
-          <Text style={styles.button}>Close Modal</Text>
+        <TouchableOpacity onPress={ this.onModalPress.bind(this) }>
+          <Text style={styles.button}>Show Modal Screen</Text>
         </TouchableOpacity>
 
       </View>
     );
   }
-  onNavigatorEvent(event) {
-    if (event.id == 'close') {
-      this.navigator.dismissModal();
-    }
-  }
   onPushPress() {
     this.navigator.push({
       title: "More",
-      screen: "example.PushedScreen"
+      screen: "module_2.PushedScreen"
     });
   }
   onPushStyledPress() {
     this.navigator.push({
-      title: "More",
-      screen: "example.StyledScreen"
+      title: "Styled",
+      screen: "module_1.StyledScreen"
     });
   }
-  onClosePress() {
-    this.navigator.dismissModal();
+  onModalPress() {
+    this.navigator.showModal({
+      title: "Modal",
+      screen: "module_1.ModalScreen"
+    });
   }
 }
 
@@ -74,6 +93,3 @@ const styles = StyleSheet.create({
     color: 'blue'
   }
 });
-
-// every screen must be registered with a unique name
-Navigation.registerScreen('example.ModalScreen', () => ModalScreen);

--- a/example/src/module_1/ModalScreen.js
+++ b/example/src/module_1/ModalScreen.js
@@ -7,14 +7,16 @@ import React, {
 } from 'react-native';
 
 // important imports, the magic is here
-import { Navigation, Screen } from 'react-native-navigation';
-
-// need to import every screen we push
-import './PushedScreen';
-import './StyledScreen';
+import { Screen } from 'react-native-navigation';
 
 // instead of React.Component, we extend Screen (imported above)
-class PushedScreen extends Screen {
+export default class ModalScreen extends Screen {
+  static navigatorButtons = {
+    leftButtons: [{
+      title: 'Close',
+      id: 'close'
+    }]
+  };
   constructor(props) {
     super(props);
   }
@@ -30,34 +32,32 @@ class PushedScreen extends Screen {
           <Text style={styles.button}>Push Styled Screen</Text>
         </TouchableOpacity>
 
-        <TouchableOpacity onPress={ this.onPopPress.bind(this) }>
-          <Text style={styles.button}>Pop Screen</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity onPress={ this.onPopToRootPress.bind(this) }>
-          <Text style={styles.button}>Pop To Root</Text>
+        <TouchableOpacity onPress={ this.onClosePress.bind(this) }>
+          <Text style={styles.button}>Close Modal</Text>
         </TouchableOpacity>
 
       </View>
     );
   }
+  onNavigatorEvent(event) {
+    if (event.id == 'close') {
+      this.navigator.dismissModal();
+    }
+  }
   onPushPress() {
     this.navigator.push({
       title: "More",
-      screen: "example.PushedScreen"
+      screen: "module_2.PushedScreen"
     });
   }
   onPushStyledPress() {
     this.navigator.push({
       title: "More",
-      screen: "example.StyledScreen"
+      screen: "module_1.StyledScreen"
     });
   }
-  onPopPress() {
-    this.navigator.pop();
-  }
-  onPopToRootPress() {
-    this.navigator.popToRoot();
+  onClosePress() {
+    this.navigator.dismissModal();
   }
 }
 
@@ -70,6 +70,3 @@ const styles = StyleSheet.create({
     color: 'blue'
   }
 });
-
-// every screen must be registered with a unique name
-Navigation.registerScreen('example.PushedScreen', () => PushedScreen);

--- a/example/src/module_1/SideMenu.js
+++ b/example/src/module_1/SideMenu.js
@@ -7,23 +7,14 @@ import React, {
   AlertIOS
 } from 'react-native';
 
-// important imports, the magic is here
-import { Navigation, Screen } from 'react-native-navigation';
-
-// instead of React.Component, we extend Screen (imported above)
-class SideMenu extends Screen {
-  constructor(props) {
-    super(props);
-  }
-  render() {
+// Note that it's not necessary to extend Navigation.Screen for all pushed screens
+// It's only necessary if you want to access the navigator from inside the screen
+export default function() {
     return (
       <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
-
         <Text>Side Menu</Text>
-
       </View>
     );
-  }
 }
 
 const styles = StyleSheet.create({
@@ -35,6 +26,3 @@ const styles = StyleSheet.create({
     color: 'blue'
   }
 });
-
-// every screen must be registered with a unique name
-Navigation.registerScreen('example.SideMenu', () => SideMenu);

--- a/example/src/module_1/StyledScreen.js
+++ b/example/src/module_1/StyledScreen.js
@@ -9,14 +9,10 @@ import React, {
 } from 'react-native';
 
 // important imports, the magic is here
-import { Navigation, Screen } from 'react-native-navigation';
-
-// need to import every screen we push
-import './PushedScreen';
-import './StyledScreen';
+import { Screen } from 'react-native-navigation';
 
 // instead of React.Component, we extend Screen (imported above)
-class StyledScreen extends Screen {
+export default class StyledScreen extends Screen {
   static navigatorStyle = {
     drawUnderNavBar: true,
     drawUnderTabBar: true,
@@ -65,13 +61,13 @@ class StyledScreen extends Screen {
   onPushPress() {
     this.navigator.push({
       title: "More",
-      screen: "example.PushedScreen"
+      screen: "module_2.PushedScreen"
     });
   }
   onPushStyledPress() {
     this.navigator.push({
       title: "More",
-      screen: "example.StyledScreen"
+      screen: "module_1.StyledScreen"
     });
   }
   onPopPress() {
@@ -88,6 +84,3 @@ const styles = StyleSheet.create({
     color: 'blue'
   }
 });
-
-// every screen must be registered with a unique name
-Navigation.registerScreen('example.StyledScreen', () => StyledScreen);

--- a/example/src/module_1/index.js
+++ b/example/src/module_1/index.js
@@ -1,0 +1,14 @@
+// need to import and register every screen we want to be pushable
+import StyledScreen from './StyledScreen';
+import ModalScreen from './ModalScreen';
+import FirstTabScreen from './FirstTabScreen';
+import SideMenu from './SideMenu';
+
+//the names must be unique across the entire application. Scope them to the module/package to avoid conflicts
+export default function() {
+  Navigation.registerScreen('module_1.ModalScreen', () => ModalScreen);
+  Navigation.registerScreen('module_1.StyledScreen', () => StyledScreen);
+  Navigation.registerScreen('module_1.FirstTabScreen', () => FirstTabScreen);
+  Navigation.registerScreen('module_1.SideMenu', () => SideMenu);
+
+}

--- a/example/src/module_2/PushedScreen.js
+++ b/example/src/module_2/PushedScreen.js
@@ -7,15 +7,10 @@ import React, {
 } from 'react-native';
 
 // important imports, the magic is here
-import { Navigation, Screen } from 'react-native-navigation';
-
-// need to import every screen we push
-import './PushedScreen';
-import './StyledScreen';
-import './ModalScreen';
+import { Screen } from 'react-native-navigation';
 
 // instead of React.Component, we extend Screen (imported above)
-class ThirdTabScreen extends Screen {
+export default class PushedScreen extends Screen {
   constructor(props) {
     super(props);
   }
@@ -31,8 +26,12 @@ class ThirdTabScreen extends Screen {
           <Text style={styles.button}>Push Styled Screen</Text>
         </TouchableOpacity>
 
-        <TouchableOpacity onPress={ this.onModalPress.bind(this) }>
-          <Text style={styles.button}>Show Modal Screen</Text>
+        <TouchableOpacity onPress={ this.onPopPress.bind(this) }>
+          <Text style={styles.button}>Pop Screen</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity onPress={ this.onPopToRootPress.bind(this) }>
+          <Text style={styles.button}>Pop To Root</Text>
         </TouchableOpacity>
 
       </View>
@@ -41,20 +40,20 @@ class ThirdTabScreen extends Screen {
   onPushPress() {
     this.navigator.push({
       title: "More",
-      screen: "example.PushedScreen"
+      screen: "module_2.PushedScreen"
     });
   }
   onPushStyledPress() {
     this.navigator.push({
-      title: "Styled",
-      screen: "example.StyledScreen"
+      title: "More",
+      screen: "module_1.StyledScreen"
     });
   }
-  onModalPress() {
-    this.navigator.showModal({
-      title: "Modal",
-      screen: "example.ModalScreen"
-    });
+  onPopPress() {
+    this.navigator.pop();
+  }
+  onPopToRootPress() {
+    this.navigator.popToRoot();
   }
 }
 
@@ -67,6 +66,3 @@ const styles = StyleSheet.create({
     color: 'blue'
   }
 });
-
-// every screen must be registered with a unique name
-Navigation.registerScreen('example.ThirdTabScreen', () => ThirdTabScreen);

--- a/example/src/module_2/SecondTabScreen.js
+++ b/example/src/module_2/SecondTabScreen.js
@@ -8,10 +8,10 @@ import React, {
 } from 'react-native';
 
 // important imports, the magic is here
-import { Navigation, Screen } from 'react-native-navigation';
+import { Screen } from 'react-native-navigation';
 
 // instead of React.Component, we extend Screen (imported above)
-class SecondTabScreen extends Screen {
+export default class SecondTabScreen extends Screen {
   constructor(props) {
     super(props);
     this.buttonsCounter = 0;
@@ -86,6 +86,3 @@ const styles = StyleSheet.create({
     color: 'blue'
   }
 });
-
-// every screen must be registered with a unique name
-Navigation.registerScreen('example.SecondTabScreen', () => SecondTabScreen);

--- a/example/src/module_2/ThirdTabScreen.js
+++ b/example/src/module_2/ThirdTabScreen.js
@@ -3,52 +3,16 @@ import React, {
   View,
   ScrollView,
   TouchableOpacity,
-  StyleSheet,
-  AlertIOS
+  StyleSheet
 } from 'react-native';
 
 // important imports, the magic is here
-import { Navigation, Screen } from 'react-native-navigation';
-
-// need to import every screen we push
-import './PushedScreen';
-import './StyledScreen';
-import './ModalScreen';
+import { Screen } from 'react-native-navigation';
 
 // instead of React.Component, we extend Screen (imported above)
-class FirstTabScreen extends Screen {
-  static navigatorButtons = {
-    leftButtons: [{
-      icon: require('../../img/navicon_menu.png'),
-      id: 'menu'
-    }],
-    rightButtons: [
-      {
-        title: 'Edit',
-        id: 'edit'
-      },
-      {
-        icon: require('../../img/navicon_add.png'),
-        id: 'add'
-      }
-    ]
-  };
+export default class ThirdTabScreen extends Screen {
   constructor(props) {
     super(props);
-  }
-  onNavigatorEvent(event) {
-    if (event.id == 'menu') {
-      this.navigator.toggleDrawer({
-        side: 'left',
-        animated: true
-      });
-    }
-    if (event.id == 'edit') {
-      AlertIOS.alert('NavBar', 'Edit button pressed');
-    }
-    if (event.id == 'add') {
-      AlertIOS.alert('NavBar', 'Add button pressed');
-    }
   }
   render() {
     return (
@@ -72,19 +36,19 @@ class FirstTabScreen extends Screen {
   onPushPress() {
     this.navigator.push({
       title: "More",
-      screen: "example.PushedScreen"
+      screen: "module_2.PushedScreen"
     });
   }
   onPushStyledPress() {
     this.navigator.push({
       title: "Styled",
-      screen: "example.StyledScreen"
+      screen: "module_1.StyledScreen"
     });
   }
   onModalPress() {
     this.navigator.showModal({
       title: "Modal",
-      screen: "example.ModalScreen"
+      screen: "module_1.ModalScreen"
     });
   }
 }
@@ -98,6 +62,3 @@ const styles = StyleSheet.create({
     color: 'blue'
   }
 });
-
-// every screen must be registered with a unique name
-Navigation.registerScreen('example.FirstTabScreen', () => FirstTabScreen);

--- a/example/src/module_2/index.js
+++ b/example/src/module_2/index.js
@@ -1,0 +1,14 @@
+// need to import and register every screen we want to be pushable
+import PushedScreen from './PushedScreen';
+import SecondTabScreen from './SecondTabScreen';
+import ThirdTabScreen from './ThirdTabScreen';
+
+
+export default function () {
+  //the names must be unique across the entire application. Scope them to the module/package to avoid conflicts
+  Navigation.registerScreen('module_2.PushedScreen', () => PushedScreen);
+  Navigation.registerScreen('module_2.ThirdTabScreen', () => ThirdTabScreen);
+  Navigation.registerScreen('module_2.SecondTabScreen', () => SecondTabScreen);
+
+}
+


### PR DESCRIPTION
This PR modifies the example app to encourage/propose a usage pattern that is more familiar to React Native developers, feels less invasive, and better highlights some of the power of this solution by showing how it can be used to create a clean separation of concerns between multiple modules in the same application. 

- The app is initialized with a navigator that knows what tabs/drawers to create, and imports modules that provide a single function that registers their screens. These modules might even be npm modules, developed in different repositories and by entirely separate teams. The modules' only responsibility to the navigator is that they namespace their screen names to ensure uniqueness and that they export a function that registers all their pushable screens. 
- A screen's implementation should look like a regular React Native `Component`. A developer working on a project using react-native-navigation should feel at home immediately and adoption shouldn't feel like a lot of change. The README doesn't seem very scary, but looking at the example made me kind of wrinkle my nose a bit. :) 
    - It's unnecessary to import everything that is being pushed all the time. (It's also not possible, because some of the pushed screens are in different modules. You know the screen's name and that's it.)
    - You still need to extend `Screen` instead of `Component`. I'm considering ways around this, but I'm not sure it's a good idea so we'll come back to this. If we come up with a way to use this solution declaratively we'll probably be able to get rid of the `Screen` business along with all uses of `this.navigator`. 
- It wasn't immediately obvious to me that you only need to extend `Screen` if you want to reference the navigator inside the screen. You can push any component if it's registered, regardless of type. I'm not sure how often people have screens that don't do any navigation, but I suppose it could happen. I think clarifying this reduces the amount of mysterious magic going on. 

I might be missing something in the implementation that makes my proposal back recommendation. If this isn't feasible or if you think it's not a good idea, let me know.