### PR TITLE
Another way to define route properties?

### DIFF
--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -67,12 +67,20 @@ function dismissModal(params = {}) {
   return platformSpecific.dismissModal(params);
 }
 
+function startTabBasedApp(params) {
+  return platformSpecific.startTabBasedApp(params);
+}
+
+function startSingleScreenApp(params) {
+  return platformSpecific.startSingleScreenApp(params);
+}
+
 export default {
   registerScreen,
   getRegisteredScreen,
   registerComponent,
   showModal,
   dismissModal,
-  startTabBasedApp: platformSpecific.startTabBasedApp,
-  startSingleScreenApp: platformSpecific.startSingleScreenApp
+  startTabBasedApp,
+  startSingleScreenApp
 }

--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -3,6 +3,12 @@ import platformSpecific from './platformSpecific';
 import Screen from './Screen';
 
 const registeredScreens = {};
+const _routeResolver = null;
+
+function resolveRoute(params) {
+  if (!_routeResolver) return params;
+  return _routeResolver(params);
+}
 
 function registerScreen(screenID, generator) {
   registeredScreens[screenID] = generator;
@@ -68,14 +74,17 @@ function dismissModal(params = {}) {
 }
 
 function startTabBasedApp(params) {
+  if (params.routeResolver) _routeResolver = params.routeResolver;
   return platformSpecific.startTabBasedApp(params);
 }
 
 function startSingleScreenApp(params) {
+  if (params.routeResolver) _routeResolver = params.routeResolver;
   return platformSpecific.startSingleScreenApp(params);
 }
 
 export default {
+  resolveRoute,
   registerScreen,
   getRegisteredScreen,
   registerComponent,

--- a/src/Screen.js
+++ b/src/Screen.js
@@ -12,31 +12,31 @@ class Navigator {
     this.navigatorEventSubscription = null;
   }
   push(params = {}) {
-    return platformSpecific.navigatorPush(this, params);
+    return platformSpecific.navigatorPush(this, Navigation.resolveRoute(params));
   }
   pop(params = {}) {
-    return platformSpecific.navigatorPop(this, params);
+    return platformSpecific.navigatorPop(this, Navigation.resolveRoute(params));
   }
   popToRoot(params = {}) {
-    return platformSpecific.navigatorPopToRoot(this, params);
+    return platformSpecific.navigatorPopToRoot(this, Navigation.resolveRoute(params));
   }
   resetTo(params = {}) {
-    return platformSpecific.navigatorResetTo(this, params);
+    return platformSpecific.navigatorResetTo(this, Navigation.resolveRoute(params));
   }
   showModal(params = {}) {
-    return Navigation.showModal(params);
+    return Navigation.showModal(Navigation.resolveRoute(params));
   }
   dismissModal(params = {}) {
-    return Navigation.dismissModal(params);
+    return Navigation.dismissModal(Navigation.resolveRoute(params));
   }
   setButtons(params = {}) {
-    return platformSpecific.navigatorSetButtons(this, this.navigatorEventID, params);
+    return platformSpecific.navigatorSetButtons(this, this.navigatorEventID, Navigation.resolveRoute(params));
   }
   setTitle(params = {}) {
-    return platformSpecific.navigatorSetTitle(this, params);
+    return platformSpecific.navigatorSetTitle(this, Navigation.resolveRoute(params));
   }
   toggleDrawer(params = {}) {
-    return platformSpecific.navigatorToggleDrawer(this, params);
+    return platformSpecific.navigatorToggleDrawer(this, Navigation.resolveRoute(params));
   }
   setOnNavigatorEvent(callback) {
     this.navigatorEventHandler = callback;


### PR DESCRIPTION
Opening mostly to start a discussion:

First of all thanks so much for this and react-native-controllers! I tried pretty much all navigator permutations out there, and this is the only one that gets the job done without issues. Big +999 for the idea of delegating navigation/navbar to obj-c, I am also unsure why there's so much effort into trying to reproduce all of this in JS.

Now, the one thing I miss from `Navigator` is the ability to lazily configure a route.

For instance, here to set the screen title you pretty much have to do while pushing/opening a modal with it – whereas with `Navigator` you have the opportunity to set that up both from `renderScene` or from the `navigationBar`.

In this pull I'm adding an optional callback passed before the screen params are resolved, so you can define your titles elsewhere, like:

```js
// routes defined somewhere:
Routes = {
  login: {
    title: 'Please Login'
  }
}

// navigation setup
Navigation.startSingleScreenApp({
  screen: {
    screen: 'main',
  },
  routeResolver: (original) => {
    let route = Routes[original.screen];
    return React.addons.update(route, { $merge: original });
  }
});
```

I suspect this could be helpful to others migrating from `Navigator`.

BUT, going a bit further, I do love how we can define navigator styles from within the component via a static property! Would be awesome to be able to define the screen title right there, along with the actual component, its buttons and navigator style.

So in summary, two proposals:

- Take optional callback to add a layer of indirection between the route params and what's passed on to the screen (this pull)
- Take more generic screen options via a static property. Not just `navigatorStyle`, but pretty much everything you can pass to `push` and others. They would just like the navigator style: serve as default, but can still be overrided by route params.

Hope this makes sense, if so I can obviously open a pull for the 2nd above too.