### PR TITLE
Fix react-native imports to prevent warnings in RN 0.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "author": "Tal Kol <talkol@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": ">=0.19.0"
+    "react-native": ">=0.19.0",
+    "react": ">=0.14.8"
   },
   "dependencies": {
     "react-native-controllers": "^1.3.5"

--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -1,4 +1,5 @@
-import React, { AppRegistry } from 'react-native';
+import React from 'react';
+import { AppRegistry } from 'react-native';
 import platformSpecific from './platformSpecific';
 import Screen from './Screen';
 

--- a/src/Screen.js
+++ b/src/Screen.js
@@ -1,5 +1,5 @@
+import { Component } from 'react';
 import {
-  Component,
   NativeAppEventEmitter,
   DeviceEventEmitter,
   Platform

--- a/src/platformSpecific.android.js
+++ b/src/platformSpecific.android.js
@@ -1,14 +1,10 @@
-import React, {
-  AppRegistry,
-  Component
-} from 'react-native';
+import React, { Component } from 'react';
+import { AppRegistry } from 'react-native';
 
 import Navigation from './Navigation';
 import utils from './utils';
 
-import {
-  RctActivity
-} from 'react-native-navigation';
+import { RctActivity } from 'react-native-navigation';
 
 var resolveAssetSource = require('resolveAssetSource');
 
@@ -32,7 +28,7 @@ function startTabBasedApp(params) {
   }
 
   params.tabs.forEach(function (tab, idx) {
-    addNavigatorParams(tab, null, idx)
+    addNavigatorParams(tab, null, idx);
     addNavigatorButtons(tab);
     addNavigationStyleParams(tab);
   });
@@ -41,7 +37,7 @@ function startTabBasedApp(params) {
 }
 
 function navigatorPush(navigator, params) {
-  addNavigatorParams(params, navigator)
+  addNavigatorParams(params, navigator);
   addNavigatorButtons(params);
   addNavigationStyleParams(params);
   RctActivity.navigatorPush(params);


### PR DESCRIPTION
[React Native 0.25](https://github.com/facebook/react-native/releases/tag/v0.25.1) deprecates requiring React API from `react-native` package. This PR includes fixes.