### PR TITLE
Add support for hiding the Toolbar on Android

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/activities/BottomTabActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/activities/BottomTabActivity.java
@@ -64,10 +64,9 @@ public class BottomTabActivity extends BaseReactActivity implements AHBottomNavi
 
     private void setupToolbar(ArrayList<Screen> screens) {
         Screen initialScreen = screens.get(0);
-        setNavigationStyle(initialScreen);
         mToolbar.setScreens(screens);
-        mToolbar.setTitle(initialScreen.title);
-        setSupportActionBar(mToolbar);
+        mToolbar.updateToolbar(initialScreen);
+        setNavigationStyle(initialScreen);
     }
 
     @Override
@@ -104,6 +103,7 @@ public class BottomTabActivity extends BaseReactActivity implements AHBottomNavi
     @Override
     public void push(Screen screen) {
         super.push(screen);
+        setNavigationStyle(screen);
         mScreenStacks.get(mCurrentStackPosition).push(screen);
     }
 
@@ -111,7 +111,7 @@ public class BottomTabActivity extends BaseReactActivity implements AHBottomNavi
     public Screen pop(String navigatorId) {
         super.pop(navigatorId);
         Screen screen = mScreenStacks.get(mCurrentStackPosition).pop();
-        setNavigationStyle(screen);
+        setNavigationStyle(getCurrentScreen());
         return screen;
     }
 

--- a/android/app/src/main/java/com/reactnativenavigation/activities/SingleScreenActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/activities/SingleScreenActivity.java
@@ -36,9 +36,8 @@ public class SingleScreenActivity extends BaseReactActivity {
     }
 
     protected void setupToolbar(Screen screen) {
+        mToolbar.updateToolbar(screen);
         setNavigationStyle(screen);
-        mToolbar.setTitle(screen.title);
-        setSupportActionBar(mToolbar);
     }
     
     @Override
@@ -52,7 +51,7 @@ public class SingleScreenActivity extends BaseReactActivity {
     public Screen pop(String navigatorId) {
         super.pop(navigatorId);
         Screen screen = mScreenStack.pop();
-        setNavigationStyle(screen);
+        setNavigationStyle(getCurrentScreen());
         return screen;
     }
 

--- a/android/app/src/main/java/com/reactnativenavigation/activities/TabActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/activities/TabActivity.java
@@ -39,11 +39,9 @@ public class TabActivity extends BaseReactActivity {
 
     private void setupToolbar(ArrayList<Screen> screens) {
         Screen initialScreen = screens.get(0);
-        setNavigationStyle(initialScreen);
         mToolbar.setScreens(screens);
-        mToolbar.setTitle(initialScreen.title);
-        mToolbar.setupToolbarButtonsAsync(initialScreen);
-        setSupportActionBar(mToolbar);
+        mToolbar.updateToolbar(initialScreen);
+        setNavigationStyle(initialScreen);
     }
 
     @Override
@@ -70,6 +68,7 @@ public class TabActivity extends BaseReactActivity {
     @Override
     public void push(Screen screen) {
         super.push(screen);
+        setNavigationStyle(screen);
         mAdapter.push(screen);
     }
 
@@ -77,7 +76,7 @@ public class TabActivity extends BaseReactActivity {
     public Screen pop(String navigatorId) {
         super.pop(navigatorId);
         Screen screen = mAdapter.pop(navigatorId);
-        setNavigationStyle(screen);
+        setNavigationStyle(getCurrentScreen());
         return screen;
     }
 

--- a/android/app/src/main/java/com/reactnativenavigation/core/objects/JsonObject.java
+++ b/android/app/src/main/java/com/reactnativenavigation/core/objects/JsonObject.java
@@ -28,4 +28,8 @@ public class JsonObject {
     protected Integer getColor(ReadableMap map, String key) {
         return map.hasKey(key) ? Color.parseColor(map.getString(key)) : null;
     }
+    
+    protected Boolean getBoolean(ReadableMap map, String key) {
+        return map.hasKey(key) ? map.getBoolean(key) : null;
+    }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/core/objects/Screen.java
+++ b/android/app/src/main/java/com/reactnativenavigation/core/objects/Screen.java
@@ -34,6 +34,7 @@ public class Screen extends JsonObject implements Serializable {
     private static final String KEY_TOOL_BAR_STYLE = "navigatorStyle";
     private static final String KEY_STATUS_BAR_COLOR = "statusBarColor";
     private static final String KEY_TOOL_BAR_COLOR = "toolBarColor";
+    private static final String KEY_TOOL_BAR_HIDDEN = "navBarHidden";
     private static final String KEY_NAVIGATION_BAR_COLOR = "navigationBarColor";
     private static final String KEY_BUTTONS_TINT_COLOR = "buttonsTint";
     private static final String KEY_TITLE_COLOR = "titleColor";
@@ -54,6 +55,7 @@ public class Screen extends JsonObject implements Serializable {
 
     // Navigation styling
     @Nullable @ColorInt public Integer toolBarColor;
+    @Nullable public Boolean toolBarHidden;
     @Nullable @ColorInt public Integer statusBarColor;
     @Nullable @ColorInt public Integer navigationBarColor;
     @Nullable @ColorInt public Integer buttonsTintColor;
@@ -105,6 +107,7 @@ public class Screen extends JsonObject implements Serializable {
         ReadableMap style = getMap(screen, KEY_TOOL_BAR_STYLE);
         if (style != null) {
             toolBarColor = getColor(style, KEY_TOOL_BAR_COLOR);
+            toolBarHidden = getBoolean(style, KEY_TOOL_BAR_HIDDEN);
             statusBarColor = getColor(style, KEY_STATUS_BAR_COLOR);
             navigationBarColor = getColor(style, KEY_NAVIGATION_BAR_COLOR);
             buttonsTintColor = getColor(style, KEY_BUTTONS_TINT_COLOR);

--- a/android/app/src/main/java/com/reactnativenavigation/modal/RnnModal.java
+++ b/android/app/src/main/java/com/reactnativenavigation/modal/RnnModal.java
@@ -29,6 +29,7 @@ public class RnnModal extends Dialog implements DialogInterface.OnDismissListene
     private ScreenStack mScreenStack;
     private View mContentView;
     private Screen mScreen;
+    private RnnToolBar mToolBar;
 
     public RnnModal(BaseReactActivity context, Screen screen) {
         super(context, R.style.Modal);
@@ -41,13 +42,10 @@ public class RnnModal extends Dialog implements DialogInterface.OnDismissListene
     private void init(final Context context) {
         requestWindowFeature(Window.FEATURE_NO_TITLE);
         mContentView = LayoutInflater.from(context).inflate(R.layout.modal_layout, null, false);
-        RnnToolBar toolBar = (RnnToolBar) mContentView.findViewById(R.id.toolbar);
+        mToolBar = (RnnToolBar) mContentView.findViewById(R.id.toolbar);
         mScreenStack = (ScreenStack) mContentView.findViewById(R.id.screenStack);
-
         setContentView(mContentView);
-        toolBar.setStyle(mScreen);
-        toolBar.setTitle(mScreen.title);
-        toolBar.setupToolbarButtonsAsync(mScreen);
+        mToolBar.updateToolbar(mScreen);
         mScreenStack.push(mScreen, new RctView.OnDisplayedListener() {
             @Override
             public void onDisplayed() {
@@ -67,10 +65,17 @@ public class RnnModal extends Dialog implements DialogInterface.OnDismissListene
 
     public void push(Screen screen) {
         mScreenStack.push(screen);
+        mToolBar.updateToolbar(mScreen);
     }
 
     public Screen pop() {
-        return mScreenStack.pop();
+        if (mScreenStack.getStackSize() > 1) {
+            return mScreenStack.pop();
+        } else {
+            ModalController.getInstance().remove();
+            super.onBackPressed();
+            return null;
+        }
     }
 
     @Override

--- a/android/app/src/main/java/com/reactnativenavigation/views/RnnToolBar.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/RnnToolBar.java
@@ -5,9 +5,11 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
+import android.support.annotation.UiThread;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.res.ResourcesCompat;
 import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.AttributeSet;
 import android.view.Menu;
@@ -70,6 +72,12 @@ public class RnnToolBar extends Toolbar {
         } else {
             resetTitleTextColor();
         }
+        
+        if (screen.toolBarHidden != null && screen.toolBarHidden) {
+            hideToolbar();
+        } else {
+            showToolbar();
+        }
     }
 
     private void resetBackground() {
@@ -92,6 +100,20 @@ public class RnnToolBar extends Toolbar {
     public void setupToolbarButtonsAsync(Screen oldScreen, Screen newScreen) {
         if (mSetupToolbarTask == null) {
             mSetupToolbarTask = new SetupToolbarButtonsTask(this, oldScreen, newScreen).execute();
+        }
+    }
+
+    private void showToolbar() {
+        ActionBar actionBar = ContextProvider.getActivityContext().getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.show();
+        }
+    }
+
+    private void hideToolbar() {
+        ActionBar actionBar = ContextProvider.getActivityContext().getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.hide();
         }
     }
 
@@ -124,6 +146,18 @@ public class RnnToolBar extends Toolbar {
     @SuppressWarnings({"ConstantConditions"})
     public void hideBackButton() {
         ContextProvider.getActivityContext().getSupportActionBar().setDisplayHomeAsUpEnabled(false);
+    }
+
+    @UiThread
+    public void updateToolbar(Screen screen) {
+        setSupportActionBar();
+        setTitle(screen.title);
+        setStyle(screen);
+        setupToolbarButtonsAsync(screen);
+    }
+
+    private void setSupportActionBar() {
+        ((AppCompatActivity) getContext()).setSupportActionBar(this);
     }
 
     private static class SetupToolbarButtonsTask extends AsyncTask<Void, Void, Map<String, Drawable>> {


### PR DESCRIPTION
This PR will ideally also make it a lot easier to support multiple Toolbar styles within a single app.

Most of the edge cases I could find were around multiple modals, but worth checking tab/single screen activity push/pop shows/hides the Toolbar correctly as well.

Haven't touched native Android code before, so really open to feedback and suggestions.