### PR TITLE
pass type and animationType to DrawerControllerIOS in startSingleScreenApp

### DIFF
--- a/src/platformSpecific.ios.js
+++ b/src/platformSpecific.ios.js
@@ -100,7 +100,10 @@ function startSingleScreenApp(params) {
             passPropsLeft={{navigatorID: navigatorID}}
             componentRight={params.drawer.right ? params.drawer.right.screen : undefined}
             passPropsRight={{navigatorID: navigatorID}}
-            disableOpenGesture={params.drawer.disableOpenGesture}>
+            disableOpenGesture={params.drawer.disableOpenGesture}
+            type={params.drawer.type ? params.drawer.type : undefined}
+            animationType={params.drawer.animationType ? params.drawer.animationType : undefined}
+            >
             {this.renderBody()}
           </DrawerControllerIOS>
         );


### PR DESCRIPTION
Currently getting this warning: `Set to default type=MMdrawer animationType=slide`

Setting the props made no difference when running in single screen app mode as the props weren't passed to the DrawerControllerIOS component