### PR TITLE
Added support for passing client prop to Provider wrapper component

### DIFF
--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -10,9 +10,9 @@ function registerScreen(screenID, generator) {
   AppRegistry.registerComponent(screenID, generator);
 }
 
-function registerComponent(screenID, generator, store = undefined, Provider = undefined) {
+function registerComponent(screenID, generator, store = undefined, Provider = undefined, client= undefined) {
   if (store && Provider) {
-    return _registerComponentRedux(screenID, generator, store, Provider);
+    return _registerComponentRedux(screenID, generator, store, Provider, client);
   } else {
     return _registerComponentNoRedux(screenID, generator);
   }
@@ -35,7 +35,7 @@ function _registerComponentNoRedux(screenID, generator) {
   return generatorWrapper;
 }
 
-function _registerComponentRedux(screenID, generator, store, Provider) {
+function _registerComponentRedux(screenID, generator, store, Provider, client) {
   const generatorWrapper = function() {
     const InternalComponent = generator();
     return class extends Screen {
@@ -43,7 +43,7 @@ function _registerComponentRedux(screenID, generator, store, Provider) {
       static navigatorButtons = InternalComponent.navigatorButtons || {};
       render() {
         return (
-          <Provider store={store}>
+          <Provider store={store} client={client}>
             <InternalComponent navigator={this.navigator} {...this.props} />
           </Provider>
         );

--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -10,7 +10,7 @@ function registerScreen(screenID, generator) {
   AppRegistry.registerComponent(screenID, generator);
 }
 
-function registerComponent(screenID, generator, store = undefined, Provider = undefined, client= undefined) {
+function registerComponent(screenID, generator, store = undefined, Provider = undefined, client = undefined) {
   if (store && Provider) {
     return _registerComponentRedux(screenID, generator, store, Provider, client);
   } else {


### PR DESCRIPTION
Passing a client prop to the <Provider /> allows use of libraries such as Apollo Client, which depend on access to the root element.

More information: http://docs.apollostack.com/apollo-client/react.html

For example, the Apollo Client library has an enhanced ApolloProvider component to allow access to its client in the react tree. It depends on a client prop. This PR allows use as below:

app.js:
```
/* ...create redux store, etc  */

import ApolloClient from 'apollo-client';
import { ApolloProvider } from 'react-apollo';
import { registerScreens } from './screens'; // react-native-navigation

const client = new ApolloClient();

registerScreens(store, ApolloProvider, client);
```

registerScreens.js:
```
/* ... import screens ... */

export function registerScreens(store, Provider, client) {
  Navigation.registerComponent('cz.ScreenWithApolloDependencies', () => ScreenWithApolloDependencies, store, Provider, client);
}
```

Another viable alternative would a more generic way of passing props to the `<Provider />` component. This could be as simple as taking a 4th `providerProps` argument where I've put '`client`', which would  then be spread on to `<Provider />`.