### PR TITLE
[Android] Fix starting menu icon color

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/RnnToolBar.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/RnnToolBar.java
@@ -56,6 +56,7 @@ public class RnnToolBar extends Toolbar {
     private DrawerLayout mDrawerLayout;
     private ActionBarDrawerToggle mDrawerToggle;
     private ArrayList<View> mMenuItems;
+    private int mButtonColor;
 
     public RnnToolBar(Context context) {
         super(context);
@@ -82,6 +83,8 @@ public class RnnToolBar extends Toolbar {
     }
 
     public void setStyle(Screen screen) {
+        mButtonColor = (screen.navBarButtonColor != null) ? screen.navBarButtonColor : Color.BLACK;
+
         if (screen.toolBarColor != null) {
             setBackgroundColor(screen.toolBarColor);
         } else {
@@ -244,7 +247,7 @@ public class RnnToolBar extends Toolbar {
             if (screen != null && screen.navBarButtonColor != null) {
                 navArrow.setColor(screen.navBarButtonColor);
             } else {
-                navArrow.setColor(Color.BLACK);
+                navArrow.setColor(mButtonColor);
             }
             navIcon = navArrow;
         }


### PR DESCRIPTION
The navBarButtonColor was only being applied to screens after the first.  The fix ensures the color is applied to the starting screen as well.