### PR TITLE
Passing callbacks to modal/pushed views

### DIFF
--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -5,6 +5,8 @@ import Screen from './Screen';
 
 const registeredScreens = {};
 
+const registeredCallbacks = {};
+
 function registerScreen(screenID, generator) {
   registeredScreens[screenID] = generator;
   AppRegistry.registerComponent(screenID, generator);
@@ -63,6 +65,14 @@ function getRegisteredScreen(screenID) {
   return generator();
 }
 
+function registerCallback(screenInstanceID, callback) {
+  registeredCallbacks[screenInstanceID] = callback;
+}
+
+function getRegisteredCallback(screenInstanceID) {
+  return registeredCallbacks[screenInstanceID];
+}
+
 function showModal(params = {}) {
   return platformSpecific.showModal(params);
 }
@@ -95,6 +105,8 @@ export default {
   registerScreen,
   getRegisteredScreen,
   registerComponent,
+  registerCallback,
+  getRegisteredCallback,
   showModal,
   dismissModal,
   dismissAllModals,

--- a/src/Screen.js
+++ b/src/Screen.js
@@ -9,8 +9,6 @@ import Navigation from './Navigation';
 
 const _allNavigatorEventHandlers = {};
 
-const _callbackRegistry = {};
-
 class Navigator {
   constructor(navigatorID, navigatorEventID, getScreenInstanceID) {
     this.navigatorID = navigatorID;
@@ -21,9 +19,6 @@ class Navigator {
   }
 
   push(params = {}) {
-    params.registerCallbackID = function(screenInstanceID) {
-      _callbackRegistry[screenInstanceID] = params.callback;
-    };
     return platformSpecific.navigatorPush(this, params);
   }
 
@@ -40,9 +35,6 @@ class Navigator {
   }
 
   showModal(params = {}) {
-    params.registerCallbackID = function(screenInstanceID) {
-      _callbackRegistry[screenInstanceID] = params.callback;
-    };
     return Navigation.showModal(params);
   }
 
@@ -140,7 +132,7 @@ class Navigator {
   }
 
   callback(...values) {
-    _callbackRegistry[this.getScreenInstanceID()](...values);
+    Navigation.getRegisteredCallback(this.getScreenInstanceID())(...values);
   }
 }
 

--- a/src/Screen.js
+++ b/src/Screen.js
@@ -12,14 +12,18 @@ const _allNavigatorEventHandlers = {};
 const _callbackRegistry = {};
 
 class Navigator {
-  constructor(navigatorID, navigatorEventID) {
+  constructor(navigatorID, navigatorEventID, getScreenInstanceID) {
     this.navigatorID = navigatorID;
     this.navigatorEventID = navigatorEventID;
     this.navigatorEventHandler = null;
     this.navigatorEventSubscription = null;
+    this.getScreenInstanceID = getScreenInstanceID;
   }
 
   push(params = {}) {
+    params.registerCallbackID = function(screenInstanceID) {
+      _callbackRegistry[screenInstanceID] = params.callback;
+    };
     return platformSpecific.navigatorPush(this, params);
   }
 
@@ -36,8 +40,8 @@ class Navigator {
   }
 
   showModal(params = {}) {
-    params.registerCallbackID = function(navigatorID) {
-      _callbackRegistry[navigatorID] = params.callback;
+    params.registerCallbackID = function(screenInstanceID) {
+      _callbackRegistry[screenInstanceID] = params.callback;
     };
     return Navigation.showModal(params);
   }
@@ -136,7 +140,7 @@ class Navigator {
   }
 
   callback(...values) {
-    _callbackRegistry[this.navigatorID](...values);
+    _callbackRegistry[this.getScreenInstanceID()](...values);
   }
 }
 
@@ -147,7 +151,7 @@ export default class Screen extends Component {
   constructor(props) {
     super(props);
     if (props.navigatorID) {
-      this.navigator = new Navigator(props.navigatorID, props.navigatorEventID);
+      this.navigator = new Navigator(props.navigatorID, props.navigatorEventID, () => this.props.screenInstanceID);
     }
   }
 

--- a/src/Screen.js
+++ b/src/Screen.js
@@ -10,12 +10,12 @@ import Navigation from './Navigation';
 const _allNavigatorEventHandlers = {};
 
 class Navigator {
-  constructor(navigatorID, navigatorEventID, getScreenInstanceID) {
+  constructor(navigatorID, navigatorEventID, screenInstanceID) {
     this.navigatorID = navigatorID;
     this.navigatorEventID = navigatorEventID;
+    this.screenInstanceID = screenInstanceID;
     this.navigatorEventHandler = null;
     this.navigatorEventSubscription = null;
-    this.getScreenInstanceID = getScreenInstanceID;
   }
 
   push(params = {}) {
@@ -132,7 +132,7 @@ class Navigator {
   }
 
   callback(...values) {
-    Navigation.getRegisteredCallback(this.getScreenInstanceID())(...values);
+    Navigation.getRegisteredCallback(this.screenInstanceID)(...values);
   }
 }
 
@@ -143,7 +143,7 @@ export default class Screen extends Component {
   constructor(props) {
     super(props);
     if (props.navigatorID) {
-      this.navigator = new Navigator(props.navigatorID, props.navigatorEventID, () => this.props.screenInstanceID);
+      this.navigator = new Navigator(props.navigatorID, props.navigatorEventID, props.screenInstanceID);
     }
   }
 

--- a/src/Screen.js
+++ b/src/Screen.js
@@ -9,6 +9,8 @@ import Navigation from './Navigation';
 
 const _allNavigatorEventHandlers = {};
 
+const _callbackRegistry = {};
+
 class Navigator {
   constructor(navigatorID, navigatorEventID) {
     this.navigatorID = navigatorID;
@@ -34,6 +36,9 @@ class Navigator {
   }
 
   showModal(params = {}) {
+    params.registerCallbackID = function(navigatorID) {
+      _callbackRegistry[navigatorID] = params.callback;
+    };
     return Navigation.showModal(params);
   }
 
@@ -128,6 +133,10 @@ class Navigator {
       this.navigatorEventSubscription.remove();
       delete _allNavigatorEventHandlers[this.navigatorEventID];
     }
+  }
+
+  callback(...values) {
+    _callbackRegistry[this.navigatorID](...values);
   }
 }
 

--- a/src/Screen.js
+++ b/src/Screen.js
@@ -132,7 +132,10 @@ class Navigator {
   }
 
   callback(...values) {
-    Navigation.getRegisteredCallback(this.screenInstanceID)(...values);
+    const callback = Navigation.getRegisteredCallback(this.screenInstanceID);
+    if (callback) {
+      return callback(...values);
+    }
   }
 }
 

--- a/src/platformSpecific.android.js
+++ b/src/platformSpecific.android.js
@@ -153,7 +153,7 @@ function addNavigatorParams(screen, navigator = null, idx = '') {
   screen.navigatorID = navigator ? navigator.navigatorID : utils.getRandomId() + '_nav' + idx;
   screen.screenInstanceID = utils.getRandomId();
   screen.navigatorEventID = screen.screenInstanceID + '_events';
-  screen.registerCallbackID && screen.registerCallbackID(screen.screenInstanceID);
+  Navigation.registerCallback(screen.screenInstanceID, screen.callback);
 }
 
 function addNavigatorButtons(screen) {

--- a/src/platformSpecific.android.js
+++ b/src/platformSpecific.android.js
@@ -153,6 +153,7 @@ function addNavigatorParams(screen, navigator = null, idx = '') {
   screen.navigatorID = navigator ? navigator.navigatorID : utils.getRandomId() + '_nav' + idx;
   screen.screenInstanceID = utils.getRandomId();
   screen.navigatorEventID = screen.screenInstanceID + '_events';
+  screen.registerCallbackID && screen.registerCallbackID(screen.navigatorID);
 }
 
 function addNavigatorButtons(screen) {

--- a/src/platformSpecific.android.js
+++ b/src/platformSpecific.android.js
@@ -153,7 +153,7 @@ function addNavigatorParams(screen, navigator = null, idx = '') {
   screen.navigatorID = navigator ? navigator.navigatorID : utils.getRandomId() + '_nav' + idx;
   screen.screenInstanceID = utils.getRandomId();
   screen.navigatorEventID = screen.screenInstanceID + '_events';
-  screen.registerCallbackID && screen.registerCallbackID(screen.navigatorID);
+  screen.registerCallbackID && screen.registerCallbackID(screen.screenInstanceID);
 }
 
 function addNavigatorButtons(screen) {

--- a/src/platformSpecific.ios.js
+++ b/src/platformSpecific.ios.js
@@ -176,6 +176,7 @@ function navigatorPush(navigator, params) {
     return;
   }
   const screenInstanceID = utils.getRandomId();
+  params.registerCallbackID(screenInstanceID);
   const {
     navigatorStyle,
     navigatorButtons,
@@ -341,8 +342,8 @@ function showModal(params) {
   const Controller = Controllers.createClass({
     render: function() {
       const navigatorID = controllerID + '_nav';
-      params.registerCallbackID(navigatorID);
       const screenInstanceID = utils.getRandomId();
+      params.registerCallbackID(screenInstanceID);
       const {
         navigatorStyle,
         navigatorButtons,

--- a/src/platformSpecific.ios.js
+++ b/src/platformSpecific.ios.js
@@ -341,6 +341,7 @@ function showModal(params) {
   const Controller = Controllers.createClass({
     render: function() {
       const navigatorID = controllerID + '_nav';
+      params.registerCallbackID(navigatorID);
       const screenInstanceID = utils.getRandomId();
       const {
         navigatorStyle,

--- a/src/platformSpecific.ios.js
+++ b/src/platformSpecific.ios.js
@@ -176,7 +176,7 @@ function navigatorPush(navigator, params) {
     return;
   }
   const screenInstanceID = utils.getRandomId();
-  params.registerCallbackID(screenInstanceID);
+  Navigation.registerCallback(screenInstanceID, params.callback);
   const {
     navigatorStyle,
     navigatorButtons,
@@ -343,7 +343,7 @@ function showModal(params) {
     render: function() {
       const navigatorID = controllerID + '_nav';
       const screenInstanceID = utils.getRandomId();
-      params.registerCallbackID(screenInstanceID);
+      Navigation.registerCallback(screenInstanceID, params.callback);
       const {
         navigatorStyle,
         navigatorButtons,


### PR DESCRIPTION
Addresses: https://github.com/wix/react-native-controllers/issues/13 (sort of, since it's in a different repo), https://github.com/wix/react-native-navigation/issues/10, https://github.com/wix/react-native-navigation/issues/100

This is a simple & functioning prototype for passing callbacks to modal views for both iOS and Android. I was inspired by option 3 in https://github.com/wix/react-native-controllers/issues/13.

The callback is passed in as a parameter to `showModal`:

```js
this.props.navigator.showModal({
  screen: 'example.CameraView',
  callback: (imagePath) => this.setState({ imagePath })
})
```

And the modal view simply calls:

```js
this.props.navigator.callback(value)
```

This model only supports one callback per view, but IMO that's fine because you can differentiate events using params.

It's a very small change and avoids any bridging/platform-specific implementations by putting the callback function in a global registry when `showModal`/`push` are called and associating it with the new screen's ID. `navigator.callback(...)` then calls the function from the registry using the current screen's ID.

Thoughts?
