### PR TITLE
Update custom RctManager to use old bridge

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/core/RctManager.java
+++ b/android/app/src/main/java/com/reactnativenavigation/core/RctManager.java
@@ -59,6 +59,7 @@ public class RctManager {
      */
     public ReactInstanceManager createReactInstanceManager(BaseReactActivity reactActivity) {
         ReactInstanceManager.Builder builder = ReactInstanceManager.builder()
+                .setUseOldBridge(true)
                 .setApplication((Application) reactActivity.getApplicationContext())
                 .setJSMainModuleName(reactActivity.getJSMainModuleName())
                 .setUseDeveloperSupport(reactActivity.getUseDeveloperSupport())


### PR DESCRIPTION
This error was reported in Android (API 23), React Native 0.30.
https://github.com/facebook/react-native/issues/8701