### PR TITLE
Fixes to Modal and top buttons

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/Modal.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/Modal.java
@@ -10,11 +10,31 @@ import com.reactnativenavigation.layouts.Layout;
 import com.reactnativenavigation.layouts.ScreenStackContainer;
 import com.reactnativenavigation.layouts.SingleScreenLayout;
 import com.reactnativenavigation.params.ScreenParams;
+import com.reactnativenavigation.params.TitleBarButtonParams;
+import com.reactnativenavigation.params.TitleBarLeftButtonParams;
+
+import java.util.List;
 
 public class Modal extends Dialog implements DialogInterface.OnDismissListener, ScreenStackContainer {
 
     private final AppCompatActivity activity;
     private final OnModalDismissedListener onModalDismissedListener;
+
+    public void setTopBarVisible(String screenInstanceId, boolean hidden, boolean animated) {
+        layout.setTopBarVisible(screenInstanceId, hidden, animated);
+    }
+
+    public void setTitleBarTitle(String screenInstanceId, String title) {
+        layout.setTitleBarTitle(screenInstanceId, title);
+    }
+
+    public void setTitleBarRightButtons(String screenInstanceId, String navigatorEventId, List<TitleBarButtonParams> titleBarButtons) {
+        layout.setTitleBarRightButtons(screenInstanceId, navigatorEventId, titleBarButtons);
+    }
+
+    public void setTitleBarLeftButton(String screenInstanceId, String navigatorEventId, TitleBarLeftButtonParams titleBarLeftButton) {
+        layout.setTitleBarLeftButton(screenInstanceId, navigatorEventId, titleBarLeftButton);
+    }
 
     public interface OnModalDismissedListener {
         void onModalDismissed(Modal modal);

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/ModalController.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/ModalController.java
@@ -4,7 +4,10 @@ import android.support.v7.app.AppCompatActivity;
 
 import com.reactnativenavigation.layouts.ScreenStackContainer;
 import com.reactnativenavigation.params.ScreenParams;
+import com.reactnativenavigation.params.TitleBarButtonParams;
+import com.reactnativenavigation.params.TitleBarLeftButtonParams;
 
+import java.util.List;
 import java.util.Stack;
 
 public class ModalController implements ScreenStackContainer, Modal.OnModalDismissedListener {
@@ -70,4 +73,27 @@ public class ModalController implements ScreenStackContainer, Modal.OnModalDismi
         stack.remove(modal);
     }
 
+    public void setTopBarVisible(String screenInstanceId, boolean hidden, boolean animated) {
+        for (Modal modal : stack) {
+            modal.setTopBarVisible(screenInstanceId, hidden, animated);
+        }
+    }
+
+    public void setTitleBarTitle(String screenInstanceId, String title) {
+        for (Modal modal : stack) {
+            modal.setTitleBarTitle(screenInstanceId, title);
+        }
+    }
+
+    public void setTitleBarRightButtons(String screenInstanceId, String navigatorEventId, List<TitleBarButtonParams> titleBarButtons) {
+        for (Modal modal : stack) {
+            modal.setTitleBarRightButtons(screenInstanceId, navigatorEventId, titleBarButtons);
+        }
+    }
+
+    public void setTitleBarLeftButton(String screenInstanceId, String navigatorEventId, TitleBarLeftButtonParams titleBarLeftButton) {
+        for (Modal modal : stack) {
+            modal.setTitleBarLeftButton(screenInstanceId, navigatorEventId, titleBarLeftButton);
+        }
+    }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -119,31 +119,47 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     }
 
     void pop(ScreenParams params) {
-        layout.pop(params);
+        if (modalController.isShowing()) {
+            modalController.pop(params);
+        } else {
+            layout.pop(params);
+        }
     }
 
     void popToRoot(ScreenParams params) {
-        layout.popToRoot(params);
+        if (modalController.isShowing()) {
+            modalController.popToRoot(params);
+        } else {
+            layout.popToRoot(params);
+        }
     }
 
     void newStack(ScreenParams params) {
-        layout.newStack(params);
+        if (modalController.isShowing()) {
+            modalController.newStack(params);
+        } else {
+            layout.newStack(params);
+        }
     }
 
     void setTopBarVisible(String screenInstanceId, boolean hidden, boolean animated) {
         layout.setTopBarVisible(screenInstanceId, hidden, animated);
+        modalController.setTopBarVisible(screenInstanceId, hidden, animated);
     }
 
     void setTitleBarTitle(String screenInstanceId, String title) {
         layout.setTitleBarTitle(screenInstanceId, title);
+        modalController.setTitleBarTitle(screenInstanceId, title);
     }
 
     public void setTitleBarButtons(String screenInstanceId, String navigatorEventId, List<TitleBarButtonParams> titleBarButtons) {
         layout.setTitleBarRightButtons(screenInstanceId, navigatorEventId, titleBarButtons);
+        modalController.setTitleBarRightButtons(screenInstanceId, navigatorEventId, titleBarButtons);
     }
 
     public void setTitleBarLeftButton(String screenInstanceId, String navigatorEventId, TitleBarLeftButtonParams titleBarLeftButton) {
         layout.setTitleBarLeftButton(screenInstanceId, navigatorEventId, titleBarLeftButton);
+        modalController.setTitleBarLeftButton(screenInstanceId, navigatorEventId, titleBarLeftButton);
     }
 
     void showModal(ScreenParams screenParams) {

--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/TitleBarButtonParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/TitleBarButtonParamsParser.java
@@ -27,7 +27,7 @@ public class TitleBarButtonParamsParser extends Parser {
         }
         result.color = new StyleParams.Color(ColorParser.parse(bundle.getString("color")));
         result.showAsAction = parseShowAsAction(bundle.getString("showAsAction"));
-        result.enabled = bundle.getBoolean("enabled", true);
+        result.enabled = !bundle.getBoolean("disabled", false);
         result.eventId = bundle.getString("id");
         return result;
     }

--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/TitleBarButtonParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/TitleBarButtonParamsParser.java
@@ -27,7 +27,7 @@ public class TitleBarButtonParamsParser extends Parser {
         }
         result.color = new StyleParams.Color(ColorParser.parse(bundle.getString("color")));
         result.showAsAction = parseShowAsAction(bundle.getString("showAsAction"));
-        result.enabled = !bundle.getBoolean("disabled", false);
+        result.enabled = bundle.getBoolean("enabled", true);
         result.eventId = bundle.getString("id");
         return result;
     }

--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -266,6 +266,7 @@ function addNavigatorButtons(screen) {
   const rightButtons = getRightButtons(screen);
   if (rightButtons) {
     rightButtons.forEach(function(button) {
+      button.enabled = !button.disabled;
       if (button.icon) {
         const icon = resolveAssetSource(button.icon);
         if (icon) {


### PR DESCRIPTION
All stack actions routed through NavigationActivity are also forwarded to ModalController

TitleBarButtonParams field 'enabled' is read from 'disabled' to match iOS and existing API. (sorry)