### PR TITLE
Generate controllerID before using it in tabs.map

### DIFF
--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -17,6 +17,7 @@ function startTabBasedApp(params) {
     return;
   }
 
+  const controllerID = _.uniqueId('controllerID');
   params.tabs.map(function(tab, index) {
     const navigatorID = controllerID + '_nav' + index;
     const screenInstanceID = _.uniqueId('screenInstanceID');
@@ -38,7 +39,6 @@ function startTabBasedApp(params) {
     };
   });
 
-  const controllerID = _.uniqueId('controllerID');
   const Controller = Controllers.createClass({
     render: function() {
       if (!params.drawer || (!params.drawer.left && !params.drawer.right)) {


### PR DESCRIPTION
Fixes https://github.com/wix/react-native-navigation/issues/284

`controllerID` was generated when used in `params.tabs.map(function(tab, index) {...`. Moving it before the `.map` fixes the issue as each screen has correct name reference for controllerID.