### PR TITLE
Fixed path of RN local Maven repo

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -43,7 +43,7 @@ repositories {
     jcenter()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        url "$rootDir/../../example-redux/node_modules/react-native/android"
+        url "rootDir/../node_modules/react-native/android"
     }
 }
 


### PR DESCRIPTION
Summary:
The old path only work for 'example-redux'