### PR TITLE
[Android] Fix for RN33 onActivityResult interface change

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactGateway.java
+++ b/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactGateway.java
@@ -74,7 +74,8 @@ public class NavigationReactGateway implements ReactGateway {
     }
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        getReactInstanceManager().onActivityResult(requestCode, resultCode, data);
+        Activity currentActivity = getReactInstanceManager().getCurrentReactContext().getCurrentActivity();
+        getReactInstanceManager().onActivityResult(currentActivity, requestCode, resultCode, data);
     }
 
     public ReactNativeHost getReactNativeHost() {


### PR DESCRIPTION
Retrieve current activity from reactInstanceManager in order to listen to onActivityResult interface change in RN33 or above. This also ensure result is passed back to React instance so other modules are able to get onActivityResult called.
