### PR TITLE
iOS TabBar : Image gets center if there is no title

### DIFF
--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -94,6 +94,12 @@
     viewController.tabBarItem = [[UITabBarItem alloc] initWithTitle:title image:iconImage tag:0];
     viewController.tabBarItem.accessibilityIdentifier = tabItemLayout[@"props"][@"testID"];
     viewController.tabBarItem.selectedImage = iconImageSelected;
+    //if there is no title, then the image will be centered
+    if(!title){
+      int offset = 7;
+      UIEdgeInsets imageInset = UIEdgeInsetsMake(offset, 0, -offset, 0);
+      viewController.tabBarItem.imageInsets = imageInset;
+    }
     
     if (buttonColor)
     {


### PR DESCRIPTION
If there is no label, then the icon will be vertically centered

```jsx
Navigation.startTabBasedApp({
      tabs: [
        {
          screen: 'InTeach.CoursesScreen',
          icon: icons['graduation'],
          //label: 'My Label',
          selectedIcon: icons['graduation'],
          title: language('navCourses'),
          navigatorStyle: {
            navBarHidden: true,
            tabBarButtonColor: 'rgba(255,255,255,0.5)',
            tabBarBackgroundColor: colors.mainColor,
            tabBarSelectedButtonColor: colors.white,
            statusBarTextColorScheme: 'light'
          }
        }
```

I need to do the same on Android,if someone has an idea on how to do it... ;) 