### PR TITLE
Allow a custom backButtonImage

### DIFF
--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -86,7 +86,15 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
     [self processTitleView:viewController
                      props:actionParams
                      style:navigatorStyle];
-    
+
+    NSString *backButtonImage = actionParams[@"backButtonImage"];
+    if (backButtonImage)
+    {
+      UIImage *backImg = [RCTConvert UIImage:backButtonImage];
+      self.topViewController.navigationController.navigationBar.backIndicatorImage = backImg;
+      self.topViewController.navigationController.navigationBar.backIndicatorTransitionMaskImage = backImg;
+    }
+
     NSString *backButtonTitle = actionParams[@"backButtonTitle"];
     if (backButtonTitle)
     {

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -238,6 +238,7 @@ function navigatorPush(navigator, params) {
     style: navigatorStyle,
     backButtonTitle: params.backButtonTitle,
     backButtonHidden: params.backButtonHidden,
+    backButtonImage: params.backButtonImage,
     leftButtons: navigatorButtons.leftButtons,
     rightButtons: navigatorButtons.rightButtons
   });


### PR DESCRIPTION
Allow the use of a custom image as the back button.

Example: (Left - Original iOS, Right - Custom)

![screen shot 2016-11-18 at 21 08 28](https://cloud.githubusercontent.com/assets/1582690/20446774/43f90018-add3-11e6-99b8-5d8f69942fab.png)

_FYI:_ The following produced 2 back buttons (like in the image):

```objc
NSString *backButtonImage = actionParams[@"backButtonImage"];
UIImage *backImg = [RCTConvert UIImage:backButtonImage];
UIBarButtonItem *backItem = [[UIBarButtonItem alloc] initWithImage:backImg
                                                             style:UIBarButtonItemStylePlain
                                                             target:nil
                                                             action:nil];
self.topViewController.navigationItem.backBarButtonItem = backItem;
```

---

The following works as you would expect and replaces the existing back button.

```objc
UINavigationBar *navbar = self.topViewController.navigationController.navigationBar;
navbar.backIndicatorImage = backImg;
navbar.backIndicatorTransitionMaskImage = backImg;
```

![screen shot 2016-11-18 at 21 13 21](https://cloud.githubusercontent.com/assets/1582690/20446914/de7b1176-add3-11e6-8f0c-1cb1c78ae280.png)

---

The custom font was done with pull #307.

Icon was done with react-native-vector-icons:

```
// 'back' is a custom icon from https://icomoon.io
Icon.getImageSource('back', 22, '#FFF').then((iconImage) => {
    this.props.navigator.push({
        screen: 'com.screen',
        title: 'FANCY TITLE',
        passProps: { propOne: "1" },
        backButtonTitle: '',
        backButtonImage: iconImage,
    });
});
```