### PR TITLE
softInputMode activity param (Android only)

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -3,7 +3,9 @@ package com.reactnativenavigation.controllers;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.KeyEvent;
+import android.view.WindowManager;
 
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
@@ -53,6 +55,8 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
         }
 
         activityParams = NavigationCommandsHandler.parseActivityParams(getIntent());
+
+        getWindow().setSoftInputMode(activityParams.softInputMode);
 
         disableActivityShowAnimationIfNeeded();
         createLayout();

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -3,9 +3,7 @@ package com.reactnativenavigation.controllers;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
 import android.view.KeyEvent;
-import android.view.WindowManager;
 
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;

--- a/android/app/src/main/java/com/reactnativenavigation/params/ActivityParams.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/ActivityParams.java
@@ -1,6 +1,5 @@
 package com.reactnativenavigation.params;
 
-import android.view.WindowManager;
 import java.util.List;
 
 public class ActivityParams {

--- a/android/app/src/main/java/com/reactnativenavigation/params/ActivityParams.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/ActivityParams.java
@@ -1,5 +1,6 @@
 package com.reactnativenavigation.params;
 
+import android.view.WindowManager;
 import java.util.List;
 
 public class ActivityParams {
@@ -12,4 +13,5 @@ public class ActivityParams {
     public List<ScreenParams> tabParams;
     public SideMenuParams sideMenuParams;
     public boolean animateShow;
+    public int softInputMode;
 }

--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/ActivityParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/ActivityParamsParser.java
@@ -1,6 +1,7 @@
 package com.reactnativenavigation.params.parsers;
 
 import android.os.Bundle;
+import android.util.Log;
 
 import com.reactnativenavigation.params.ActivityParams;
 import com.reactnativenavigation.params.AppStyle;
@@ -26,6 +27,10 @@ public class ActivityParamsParser extends Parser {
         }
 
         result.animateShow = params.getBoolean("animateShow", true);
+
+        if (hasKey(params, "softInputMode")) {
+            result.softInputMode = Integer.parseInt(params.getString("softInputMode"));
+        }
 
         return result;
     }

--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/ActivityParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/ActivityParamsParser.java
@@ -1,7 +1,6 @@
 package com.reactnativenavigation.params.parsers;
 
 import android.os.Bundle;
-import android.util.Log;
 
 import com.reactnativenavigation.params.ActivityParams;
 import com.reactnativenavigation.params.AppStyle;


### PR DESCRIPTION
To allow TextInputs in ListViews that would be obscured by the keyboard (i.e. at the bottom of the screen) to move so that they are visible, it is necessary to set `softInputmode` to `adjustPan`.  
If this is not set, the keyboard appears and then disappears immediately. 
See e.g. https://github.com/facebook/react-native/issues/8180

This PR allows the `softInputMode` to be set from JS via `startApp`. It expects a numerical string, e.g.
```
softInputMode: '32' 
```
(I tried sending as an Int but I got a ClassCastException as it seems to be transmitted as a Double?)

It would be more user friendly to also be able to send a string representation like you would in the manifest e.g. 
```
softInputMode: 'adjustPan'
```
This could be achieved with a map representing the values listed at https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#softInputMode. I'm happy to implement this but wanted to get feedback first. 