### PR TITLE
Bug: Right drawer on Android doesn't work #297

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/layouts/SingleScreenLayout.java
+++ b/android/app/src/main/java/com/reactnativenavigation/layouts/SingleScreenLayout.java
@@ -47,7 +47,7 @@ public class SingleScreenLayout extends RelativeLayout implements Layout {
     }
 
     private void createLayout() {
-        if (leftSideMenuParams == null) {
+        if (leftSideMenuParams == null && rightSideMenuParams == null) {
             createStack(getScreenStackParent());
         } else {
             sideMenu = createSideMenu();


### PR DESCRIPTION
If the left drawer is not defined in startSingleScreenApp config then the right drawer doesn't work