### PR TITLE
Pass the style parameter to DrawerControllerIOS

### DIFF
--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -55,6 +55,7 @@ function startTabBasedApp(params) {
                                disableOpenGesture={params.drawer.disableOpenGesture}
                                type={params.drawer.type ? params.drawer.type : 'MMDrawer'}
                                animationType={params.drawer.animationType ? params.drawer.animationType : 'slide'}
+                               style={params.drawer.style}
           >
             {this.renderBody()}
           </DrawerControllerIOS>
@@ -141,6 +142,7 @@ function startSingleScreenApp(params) {
                                disableOpenGesture={params.drawer.disableOpenGesture}
                                type={params.drawer.type ? params.drawer.type : 'MMDrawer'}
                                animationType={params.drawer.animationType ? params.drawer.animationType : 'slide'}
+                               style={params.drawer.style}
           >
             {this.renderBody()}
           </DrawerControllerIOS>


### PR DESCRIPTION
Now the style parameter is used inside RCCDrawerController but it's not passed through startTabBasedApp/startSingleScreenApp. Passing the style parameter allows to disable sidebar shadow trough style.drawerShadow.