### PR TITLE
Support for using a custom UIBarButtonItemStyle for iOS navigation bar buttons

### DIFF
--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -228,15 +228,21 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
     UIImage *iconImage = nil;
     id icon = button[@"icon"];
     if (icon) iconImage = [RCTConvert UIImage:icon];
+    UIBarButtonItemStyle style = UIBarButtonItemStylePlain;
+    NSString *customStyle = button[@"style"];
+    if (customStyle && [customStyle isEqualToString:@"done"])
+    {
+      style = UIBarButtonItemStyleDone;
+    }
     
     UIBarButtonItem *barButtonItem;
     if (iconImage)
     {
-      barButtonItem = [[UIBarButtonItem alloc] initWithImage:iconImage style:UIBarButtonItemStylePlain target:self action:@selector(onButtonPress:)];
+      barButtonItem = [[UIBarButtonItem alloc] initWithImage:iconImage style:style target:self action:@selector(onButtonPress:)];
     }
     else if (title)
     {
-      barButtonItem = [[UIBarButtonItem alloc] initWithTitle:title style:UIBarButtonItemStylePlain target:self action:@selector(onButtonPress:)];
+      barButtonItem = [[UIBarButtonItem alloc] initWithTitle:title style:style target:self action:@selector(onButtonPress:)];
     }
     else continue;
     objc_setAssociatedObject(barButtonItem, &CALLBACK_ASSOCIATED_KEY, button[@"onPress"], OBJC_ASSOCIATION_RETAIN_NONATOMIC);


### PR DESCRIPTION
This adds support for a new key: style. When the style key’s value is "done", UIBarButtonItemStyleDone will be used.

To accommodate existing apps and to stick to iOS standards, UIBarButtonItemStylePlain remains the default.

If this PR is approved I will create another PR for changes to the wiki.