### PR TITLE
rightButtons not getting passed through to native code

### DIFF
--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -366,9 +366,6 @@ function addNavigatorParams(screen, navigator = null, idx = '') {
 }
 
 function addNavigatorButtons(screen, sideMenuParams) {
-  const Screen = Navigation.getRegisteredScreen(screen.screen);
-  screen.navigatorButtons = _.cloneDeep(Screen.navigatorButtons);
-
   // Get image uri from image id
   const rightButtons = getRightButtons(screen);
   if (rightButtons) {
@@ -485,9 +482,17 @@ function getLeftButtonDeprecated(screen) {
 function getRightButtons(screen) {
   if (screen.navigatorButtons && screen.navigatorButtons.rightButtons) {
     return screen.navigatorButtons.rightButtons;
+  } else if (screen.rightButtons) {
+    return screen.rightButtons
   }
 
-  return screen.rightButtons;
+  const Screen = Navigation.getRegisteredScreen(screen.screen);
+
+  if (Screen.navigatorButtons && !_.isEmpty(Screen.navigatorButtons)) {
+    return _.cloneDeep(Screen.navigatorButtons);
+  }
+
+  return null;
 }
 
 function addNavigationStyleParams(screen) {


### PR DESCRIPTION
Fixed an issue where rightButtons defined on the screen parameters were overwritten by parameters defined on the Screen component itself.