### PR TITLE
Adding a custom button to the tab bar

### DIFF
--- a/ios/RCCEventEmitter.h
+++ b/ios/RCCEventEmitter.h
@@ -1,11 +1,3 @@
-//
-//  RCCEventEmitter.h
-//  ReactNativeNavigation
-//
-//  Created by Daniel Maly on 22/12/2016.
-//  Copyright © 2016 artal. All rights reserved.
-//
-
 #import "RCTEventEmitter.h"
 
 #ifndef RCCEventEmitter_h

--- a/ios/RCCEventEmitter.h
+++ b/ios/RCCEventEmitter.h
@@ -1,0 +1,21 @@
+//
+//  RCCEventEmitter.h
+//  ReactNativeNavigation
+//
+//  Created by Daniel Maly on 22/12/2016.
+//  Copyright © 2016 artal. All rights reserved.
+//
+
+#import "RCTEventEmitter.h"
+
+#ifndef RCCEventEmitter_h
+#define RCCEventEmitter_h
+
+@interface RCCEventEmitter : RCTEventEmitter
+
++ (void)tabBarMiddleButtonClicked:(id) sender;
+
+@end
+
+
+#endif /* RCCEventEmitter_h */

--- a/ios/RCCEventEmitter.m
+++ b/ios/RCCEventEmitter.m
@@ -1,0 +1,59 @@
+//
+//  RCCEventEmitter.m
+//  ReactNativeNavigation
+//
+//  Created by Daniel Maly on 22/12/2016.
+//  Copyright © 2016 artal. All rights reserved.
+//
+
+#import <RCTEventEmitter.h>
+
+
+@interface RCCEventEmitter: RCTEventEmitter <RCTBridgeModule,UIAlertViewDelegate>
+@end
+
+@implementation RCCEventEmitter
+
+RCT_EXPORT_MODULE();
+
+- (NSArray<NSString*> *)supportedEvents {
+    return @[@"TabBarMiddleButtonClicked"];
+}
+
+
+- (void)startObserving {
+    for (NSString *event in [self supportedEvents]) {
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(handleNotification:)
+                                                     name:event
+                                                   object:nil];
+    }
+}
+
+- (void)stopObserving {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+# pragma mark Public
+
++ (void)tabBarMiddleButtonClicked:(id) sender {
+    [self postNotificationName:@"TabBarMiddleButtonClicked" withPayload:nil];
+}
+
+
+# pragma mark Private
+
++ (void)postNotificationName:(NSString *)name withPayload:(NSObject *)object {
+    NSDictionary<NSString *, id> *payload = object ? @{@"payload": object} : @{};
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:name
+                                                        object:self
+                                                      userInfo:payload];
+}
+
+- (void)handleNotification:(NSNotification *)notification {
+    [self sendEventWithName:notification.name body:notification.userInfo];
+}
+
+
+@end

--- a/ios/RCCEventEmitter.m
+++ b/ios/RCCEventEmitter.m
@@ -1,11 +1,3 @@
-//
-//  RCCEventEmitter.m
-//  ReactNativeNavigation
-//
-//  Created by Daniel Maly on 22/12/2016.
-//  Copyright © 2016 artal. All rights reserved.
-//
-
 #import <RCTEventEmitter.h>
 
 

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -4,10 +4,6 @@
 #import "RCCManager.h"
 #import "RCCEventEmitter.h"
 
-@interface RCCTabBarController()
-@property (nonatomic, strong) RCCEventEmitter* eventEmitter;
-@end
-
 @implementation RCCTabBarController
 
 
@@ -32,9 +28,6 @@
 {
   self = [super init];
   if (!self) return nil;
-
-  self.eventEmitter = [[RCCEventEmitter alloc] init];
-  [self.eventEmitter setBridge:bridge];
   
   self.tabBar.translucent = YES; // default
 

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -2,8 +2,15 @@
 #import "RCCViewController.h"
 #import "RCTConvert.h"
 #import "RCCManager.h"
+#import "RCCEventEmitter.h"
+
+@interface RCCTabBarController()
+@property (nonatomic, strong) RCCEventEmitter* eventEmitter;
+@end
 
 @implementation RCCTabBarController
+
+
 
 - (UIImage *)image:(UIImage*)image withColor:(UIColor *)color1
 {
@@ -26,12 +33,15 @@
   self = [super init];
   if (!self) return nil;
 
+  self.eventEmitter = [[RCCEventEmitter alloc] init];
+  [self.eventEmitter setBridge:bridge];
+  
   self.tabBar.translucent = YES; // default
 
   UIColor *buttonColor = nil;
   UIColor *selectedButtonColor = nil;
   NSDictionary *tabsStyle = props[@"style"];
-
+  
   NSDictionary *middleButtonProps = nil;
   bool displayMiddleButton = false;
 
@@ -73,7 +83,7 @@
       displayMiddleButton = children.count % 2 == 1;
       continue;
     }
-
+    
     // make sure the layout is valid
     if (![tabItemLayout[@"type"] isEqualToString:@"TabBarControllerIOS.Item"]) continue;
     if (!tabItemLayout[@"props"]) continue;
@@ -159,12 +169,12 @@
       iconImageSelected = [RCTConvert UIImage:selectedIcon];
       [middleView setImage:iconImageSelected forState:UIControlStateHighlighted];
     }
+    
+    [middleView addTarget:self action:@selector(middleButtonClicked:) forControlEvents:UIControlEventTouchUpInside];
 
-    [middleView setBackgroundColor:[UIColor redColor]];
     [self.view addSubview:middleView];
 
   }
-
 
   // replace the tabs
   self.viewControllers = viewControllers;
@@ -260,6 +270,10 @@
     {
       completion();
     }
+}
+
+-(void)middleButtonClicked:(id)sender {
+  [RCCEventEmitter tabBarMiddleButtonClicked:sender];
 }
 
 @end

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -31,9 +31,9 @@
   UIColor *buttonColor = nil;
   UIColor *selectedButtonColor = nil;
   NSDictionary *tabsStyle = props[@"style"];
-  NSDictionary *middleButtonProps = props[@"middleButton"];
 
-  bool displayMiddleButton = middleButtonProps && children.count % 2 == 0;
+  NSDictionary *middleButtonProps = nil;
+  bool displayMiddleButton = false;
 
   if (tabsStyle)
   {
@@ -67,6 +67,13 @@
   // go over all the tab bar items
   for (NSDictionary *tabItemLayout in children)
   {
+    // check for middle button
+    if([tabItemLayout[@"type"] isEqualToString:@"TabBarControllerIOS.MiddleButton"]) {
+      middleButtonProps = tabItemLayout[@"props"];
+      displayMiddleButton = children.count % 2 == 1;
+      continue;
+    }
+
     // make sure the layout is valid
     if (![tabItemLayout[@"type"] isEqualToString:@"TabBarControllerIOS.Item"]) continue;
     if (!tabItemLayout[@"props"]) continue;

--- a/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		260804DB1CE0D9D20094DBA1 /* RCCToolBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 260804DA1CE0D9D20094DBA1 /* RCCToolBar.m */; };
 		26AFF3F51D7EEE2400CBA211 /* RCCTitleViewHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 26AFF3F41D7EEE2400CBA211 /* RCCTitleViewHelper.m */; };
+		82E9912A1E0BC65B009AD3A0 /* RCCEventEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 82E991291E0BC65B009AD3A0 /* RCCEventEmitter.m */; };
 		CC84A19E1C1A0C4E00B3A6A2 /* RCCManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CC84A1941C1A0C4E00B3A6A2 /* RCCManager.m */; };
 		CC84A19F1C1A0C4E00B3A6A2 /* RCCManagerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = CC84A1961C1A0C4E00B3A6A2 /* RCCManagerModule.m */; };
 		CC84A1A01C1A0C4E00B3A6A2 /* RCCNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = CC84A1981C1A0C4E00B3A6A2 /* RCCNavigationController.m */; };
@@ -52,6 +53,8 @@
 		260804DA1CE0D9D20094DBA1 /* RCCToolBar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCCToolBar.m; sourceTree = "<group>"; };
 		26AFF3F31D7EEE2400CBA211 /* RCCTitleViewHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCCTitleViewHelper.h; sourceTree = "<group>"; };
 		26AFF3F41D7EEE2400CBA211 /* RCCTitleViewHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCCTitleViewHelper.m; sourceTree = "<group>"; };
+		82E991291E0BC65B009AD3A0 /* RCCEventEmitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCCEventEmitter.m; sourceTree = "<group>"; };
+		82E9912B1E0C0F15009AD3A0 /* RCCEventEmitter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCCEventEmitter.h; sourceTree = "<group>"; };
 		CC84A1931C1A0C4E00B3A6A2 /* RCCManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCCManager.h; sourceTree = "<group>"; };
 		CC84A1941C1A0C4E00B3A6A2 /* RCCManager.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = RCCManager.m; sourceTree = "<group>"; tabWidth = 2; };
 		CC84A1951C1A0C4E00B3A6A2 /* RCCManagerModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCCManagerModule.h; sourceTree = "<group>"; };
@@ -194,6 +197,8 @@
 		D8AFADB41BEE6F3F00A4592D = {
 			isa = PBXGroup;
 			children = (
+				82E9912B1E0C0F15009AD3A0 /* RCCEventEmitter.h */,
+				82E991291E0BC65B009AD3A0 /* RCCEventEmitter.m */,
 				D8D779951D04B7180050CFEA /* Helpers */,
 				260804D51CE0D7090094DBA1 /* RCCToolBar */,
 				D85082BB1CBCF42400FDB961 /* RCCDrawerController */,
@@ -291,6 +296,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				82E9912A1E0BC65B009AD3A0 /* RCCEventEmitter.m in Sources */,
 				D85082EA1CBCF54200FDB961 /* TheSidebarController.m in Sources */,
 				CC84A1A01C1A0C4E00B3A6A2 /* RCCNavigationController.m in Sources */,
 				D83514F61D29719A00D53758 /* RCCNotification.m in Sources */,

--- a/src/deprecated/controllers/index.js
+++ b/src/deprecated/controllers/index.js
@@ -109,7 +109,11 @@ var Controllers = {
       },
 
       ControllerRegistry: Controllers.ControllerRegistry,
-      TabBarControllerIOS: {name: 'TabBarControllerIOS', Item: {name: 'TabBarControllerIOS.Item'}},
+      TabBarControllerIOS: {
+        name: 'TabBarControllerIOS',
+        Item: {name: 'TabBarControllerIOS.Item'},
+        MiddleButton: {name: 'TabBarControllerIOS.MiddleButton'}
+      },
       NavigationControllerIOS: {name: 'NavigationControllerIOS'},
       ViewControllerIOS: {name: 'ViewControllerIOS'},
       DrawerControllerIOS: {name: 'DrawerControllerIOS'},
@@ -307,4 +311,3 @@ var Controllers = {
 };
 
 module.exports = Controllers;
-

--- a/src/deprecated/controllers/index.js
+++ b/src/deprecated/controllers/index.js
@@ -2,6 +2,7 @@
 var OriginalReactNative = require('react-native');
 var RCCManager = OriginalReactNative.NativeModules.RCCManager;
 var NativeAppEventEmitter = OriginalReactNative.NativeAppEventEmitter;
+var RCCEventEmitter = new OriginalReactNative.NativeEventEmitter(OriginalReactNative.NativeModules.RCCEventEmitter);
 var utils = require('./utils');
 var Constants = require('./Constants');
 var resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSource');
@@ -307,7 +308,10 @@ var Controllers = {
 
   NavigationToolBarIOS: OriginalReactNative.requireNativeComponent('RCCToolBar', null),
 
+  RCCEventEmitter: RCCEventEmitter,
+
   Constants: Constants
 };
 
 module.exports = Controllers;
+

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -62,6 +62,14 @@ function startTabBasedApp(params) {
         );
       }
     },
+    renderMiddleButton: function(middleButtonProps) {
+      if(middleButtonProps) {
+        return <TabBarControllerIOS.MiddleButton {...middleButtonProps} />
+      }
+      else {
+        return null
+      }
+    },
     renderBody: function() {
       return (
         <TabBarControllerIOS
@@ -69,6 +77,7 @@ function startTabBasedApp(params) {
           style={params.tabsStyle}
           middleButton={params.middleButton}
         >
+          {this.renderMiddleButton(params.middleButton)}
           {
             params.tabs.map(function(tab, index) {
               return (

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -40,6 +40,13 @@ function startTabBasedApp(params) {
     };
   });
 
+  if(params.middleButton) {
+    Controllers.RCCEventEmitter.removeAllListeners('TabBarMiddleButtonClicked')
+    Controllers.RCCEventEmitter.addListener('TabBarMiddleButtonClicked', () => {
+      params.middleButton.onclicked();
+    });
+  }
+
   const Controller = Controllers.createClass({
     render: function() {
       if (!params.drawer || (!params.drawer.left && !params.drawer.right)) {
@@ -67,7 +74,7 @@ function startTabBasedApp(params) {
         return <TabBarControllerIOS.MiddleButton {...middleButtonProps} />
       }
       else {
-        return null
+        return null;
       }
     },
     renderBody: function() {

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -65,7 +65,9 @@ function startTabBasedApp(params) {
       return (
         <TabBarControllerIOS
           id={controllerID + '_tabs'}
-          style={params.tabsStyle}>
+          style={params.tabsStyle}
+          middleButton={params.middleButton}
+        >
           {
             params.tabs.map(function(tab, index) {
               return (


### PR DESCRIPTION
I have added the option to have a custom middle button on the iOS tab bar which sends an event to JS when it gets clicked. Here is what it looks like:

<img width="375" alt="screenshot 2016-12-22 16 47 48" src="https://cloud.githubusercontent.com/assets/1443921/21431143/7314abc4-c866-11e6-91ad-8e87265926f1.png">

You can define it in `startTabBasedApp` like this:

```
Navigation.startTabBasedApp({
	tabs,
	title: 'My Application',
	animationType: 'slide-down',
	middleButton: {
		height: 65,
		width: 150,
		icon: require('resources/img/icon_add.png'),
		onclicked: () => {console.log('Middle tab bar button clicked')}
	}
})
```

The button will only appear if there are 2 or 4 other tabs defined. The TabBarViewController creates a dummy ViewController under the middle tab and it is the responsibility of the calling code to make sure the button is big enough to obscure the tab completely.

I also added an EventEmitter module that doesn't use the now deprecated `bridge.eventDispatcher`.