### PR TITLE
> Added the dontCreateSideMenuNavButton side menu param.

### DIFF
--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -387,7 +387,7 @@ function addNavigatorButtons(screen, sideMenuParams) {
   }
 
   let leftButton = getLeftButton(screen);
-  if (sideMenuParams && !leftButton) {
+  if (sideMenuParams && !sideMenuParams.dontCreateSideMenuNavButton && !leftButton) {
     leftButton = createSideMenuButton();
   }
   if (leftButton) {


### PR DESCRIPTION
This solves https://github.com/wix/react-native-navigation/issues/621.

The user can now create a singleScreen like so:

```javascript
Navigation.startSingleScreenApp({
    screen: {
      screen: ScheneKeys.WELCOME,
      title: 'Welcome',
    },
    drawer: {
      left: {
        screen: ScheneKeys.SIDE_MENU,
      },
      dontCreateSideMenuNavButton: true,
    },
  });
```

and skip the automatic creation of the hamburger nav button (on Android).
