### PR TITLE
fixing typo causing subtitle text color cant be changed... + fixing props on showInAppNotification..

### DIFF
--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -127,7 +127,7 @@ function convertStyleParams(originalStyleObject) {
     titleBarHidden: originalStyleObject.navBarHidden,
     titleBarHideOnScroll: originalStyleObject.navBarHideOnScroll,
     titleBarTitleColor: processColor(originalStyleObject.navBarTextColor),
-    titleBarSubtitleColor: processColor(originalStyleObject.navBarTextSubtitleColor),
+    titleBarSubtitleColor: processColor(originalStyleObject.navBarSubtitleTextColor),
     titleBarButtonColor: processColor(originalStyleObject.navBarButtonColor),
     titleBarDisabledButtonColor: processColor(originalStyleObject.titleBarDisabledButtonColor),
     backButtonHidden: originalStyleObject.backButtonHidden,

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -515,6 +515,8 @@ function showInAppNotification(params) {
     navigatorEventID,
     navigatorID
   };
+  
+  savePassProps(params);
 
   Notification.show({
     component: params.screen,


### PR DESCRIPTION
i cant change subtitle text color...

see here https://github.com/wix/react-native-navigation/blob/master/ios/Helpers/RCCTitleViewHelper.m#L152

it should be `navBarSubtitleTextColor`,, not `navBarTextSubtitleColor`...