### PR TITLE
Allow the user to use his own navigatorButtons when calling showModal, push etc..

### DIFF
--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -349,6 +349,7 @@ function showModal(params) {
   addTitleBarBackButtonIfNeeded(params);
   addNavigationStyleParams(params);
 
+
   /*
    * adapt to new API
    */
@@ -383,7 +384,9 @@ function addNavigatorParams(screen, navigator = null, idx = '') {
 
 function addNavigatorButtons(screen, sideMenuParams) {
   const Screen = Navigation.getRegisteredScreen(screen.screen);
-  screen.navigatorButtons = _.cloneDeep(Screen.navigatorButtons);
+  if (screen.navigatorButtons == null) {
+    screen.navigatorButtons = _.cloneDeep(Screen.navigatorButtons);
+  }
 
   // Get image uri from image id
   const rightButtons = getRightButtons(screen);


### PR DESCRIPTION
Android: If the user has specified navigatorButtons on the showModal params use those instead of the default navigatorButtons of the registered screen.

If I don't add that if, the existing code erases the navigatorButtons I pass on my params object.