### PR TITLE
Add error when trying to load a component which was badly registered

### DIFF
--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -24,6 +24,10 @@ function registerComponent(screenID, generator, store = undefined, Provider = un
 function _registerComponentNoRedux(screenID, generator) {
   const generatorWrapper = function() {
     const InternalComponent = generator();
+    if (!InternalComponent) {
+      console.error(`Navigation: ${screenID} registration result is 'undefined'`);
+    }
+    
     return class extends Screen {
       static navigatorStyle = InternalComponent.navigatorStyle || {};
       static navigatorButtons = InternalComponent.navigatorButtons || {};


### PR DESCRIPTION
I struggeled quite a while debugging #485 "Cannot read property 'navigatorStyle' of undefined"  which originates from incorrectly registering the component. In order to save time for other users I suggest this small change to give a more verbose error when this happens.

