### PR TITLE
Clear intent extras in onPause

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/IntentDataHandler.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/IntentDataHandler.java
@@ -1,6 +1,7 @@
 package com.reactnativenavigation.controllers;
 
 import android.content.Intent;
+import android.os.Bundle;
 import android.support.annotation.Nullable;
 
 import com.reactnativenavigation.NavigationApplication;
@@ -36,6 +37,8 @@ class IntentDataHandler {
     static void onPause(@Nullable Intent intent) {
         if (intent != null) {
             intent.setData(null);
+            intent.getExtras().clear();
+            intent.replaceExtras(Bundle.EMPTY);
         }
         clear();
     }


### PR DESCRIPTION
this prevents linking module from handling intents each time app is returned to foreground