### PR TITLE
Change subtitle color property name to navBarSubtitleColor

### DIFF
--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -134,7 +134,7 @@ function convertStyleParams(originalStyleObject) {
     titleBarHidden: originalStyleObject.navBarHidden,
     titleBarHideOnScroll: originalStyleObject.navBarHideOnScroll,
     titleBarTitleColor: processColor(originalStyleObject.navBarTextColor),
-    titleBarSubtitleColor: processColor(originalStyleObject.navBarTextSubtitleColor),
+    titleBarSubtitleColor: processColor(originalStyleObject.navBarSubtitleColor),
     titleBarButtonColor: processColor(originalStyleObject.navBarButtonColor),
     titleBarDisabledButtonColor: processColor(originalStyleObject.titleBarDisabledButtonColor),
     backButtonHidden: originalStyleObject.backButtonHidden,


### PR DESCRIPTION
This commit changes the subtitle color property name on **Android** from `navBarTextSubtitleColor` to `navBarSubtitleColor`