### PR TITLE
Fix collapse issue after list bounce back

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/collapsingToolbar/CollapseCalculator.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/collapsingToolbar/CollapseCalculator.java
@@ -9,7 +9,6 @@ import android.widget.ScrollView;
 
 import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.views.collapsingToolbar.behaviours.CollapseBehaviour;
-import com.reactnativenavigation.views.collapsingToolbar.behaviours.CollapseTitleBarBehaviour;
 import com.reactnativenavigation.views.collapsingToolbar.behaviours.TitleBarHideOnScrollBehaviour;
 
 public class CollapseCalculator {
@@ -123,8 +122,9 @@ public class CollapseCalculator {
         }
         checkCollapseLimits();
         return (isNotCollapsedOrExpended() ||
-               (canCollapse && isExpendedAndScrollingUp(direction)) ||
-               (canExpend && isCollapsedAndScrollingDown(direction)));
+               (canCollapse && isExpendedAndScrollingUp(direction) && collapseBehaviour.canCollapse(scrollView.getScrollY(), scaledTouchSlop)) ||
+               (canExpend && isCollapsedAndScrollingDown(direction) && collapseBehaviour.canExpend(scrollView.getScrollY(), scaledTouchSlop))
+        );
     }
 
     private boolean isScrolling() {
@@ -157,14 +157,12 @@ public class CollapseCalculator {
 
     private boolean calculateCanCollapse(float currentTopBarTranslation, float finalExpendedTranslation, float finalCollapsedTranslation) {
         return currentTopBarTranslation > finalCollapsedTranslation &&
-               currentTopBarTranslation <= finalExpendedTranslation &&
-               (scrollView.getScrollY() <= scaledTouchSlop || (collapseBehaviour instanceof TitleBarHideOnScrollBehaviour || collapseBehaviour instanceof CollapseTitleBarBehaviour));
+               currentTopBarTranslation <= finalExpendedTranslation;
     }
 
     private boolean calculateCanExpend(float currentTopBarTranslation, float finalExpendedTranslation, float finalCollapsedTranslation) {
         return currentTopBarTranslation >= finalCollapsedTranslation &&
-               currentTopBarTranslation < finalExpendedTranslation &&
-               (scrollView.getScrollY() <= scaledTouchSlop || (collapseBehaviour instanceof TitleBarHideOnScrollBehaviour || collapseBehaviour instanceof CollapseTitleBarBehaviour));
+               currentTopBarTranslation < finalExpendedTranslation;
     }
 
     private boolean isCollapsedAndScrollingDown(Direction direction) {

--- a/android/app/src/main/java/com/reactnativenavigation/views/collapsingToolbar/behaviours/CollapseBehaviour.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/collapsingToolbar/behaviours/CollapseBehaviour.java
@@ -4,4 +4,8 @@ public interface CollapseBehaviour {
     boolean shouldCollapseOnFling();
 
     boolean shouldCollapseOnTouchUp();
+
+    boolean canCollapse(int scrollY, int scaledTouchSlop);
+
+    boolean canExpend(int scrollY, int scaledTouchSlop);
 }

--- a/android/app/src/main/java/com/reactnativenavigation/views/collapsingToolbar/behaviours/CollapseTitleBarBehaviour.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/collapsingToolbar/behaviours/CollapseTitleBarBehaviour.java
@@ -10,4 +10,14 @@ public class CollapseTitleBarBehaviour implements CollapseBehaviour {
     public boolean shouldCollapseOnTouchUp() {
         return true;
     }
+
+    @Override
+    public boolean canCollapse(int scrollY, int scaledTouchSlop) {
+        return true;
+    }
+
+    @Override
+    public boolean canExpend(int scrollY, int scaledTouchSlop) {
+        return true;
+    }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/views/collapsingToolbar/behaviours/CollapseTopBarBehaviour.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/collapsingToolbar/behaviours/CollapseTopBarBehaviour.java
@@ -10,4 +10,14 @@ public class CollapseTopBarBehaviour implements CollapseBehaviour {
     public boolean shouldCollapseOnTouchUp() {
         return false;
     }
+
+    @Override
+    public boolean canCollapse(int scrollY, int scaledTouchSlop) {
+        return scrollY <= scaledTouchSlop;
+    }
+
+    @Override
+    public boolean canExpend(int scrollY, int scaledTouchSlop) {
+        return scrollY <= scaledTouchSlop;
+    }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/views/collapsingToolbar/behaviours/TitleBarHideOnScrollBehaviour.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/collapsingToolbar/behaviours/TitleBarHideOnScrollBehaviour.java
@@ -10,4 +10,14 @@ public class TitleBarHideOnScrollBehaviour implements CollapseBehaviour {
     public boolean shouldCollapseOnTouchUp() {
         return true;
     }
+
+    @Override
+    public boolean canCollapse(int scrollY, int scaledTouchSlop) {
+        return true;
+    }
+
+    @Override
+    public boolean canExpend(int scrollY, int scaledTouchSlop) {
+        return true;
+    }
 }


### PR DESCRIPTION
When a view with collapsing header was fully expended, scrolling down
and quickly releasing the finger would couse the list to "bounce back".
Since the view can collapse only if its scrollY amount is less then the
scaled touch slop - the view didn't collapse and instead, scroll was
enabled.