### PR TITLE
Control the opacity of a translucent nav bar

### DIFF
--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -437,6 +437,13 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   BOOL navBarTranslucentBool = navBarTranslucent ? [navBarTranslucent boolValue] : NO;
   if (navBarTranslucentBool || navBarBlurBool) {
     viewController.navigationController.navigationBar.translucent = YES;
+
+    // Set background opacity from the background color
+    // Ref: http://stackoverflow.com/questions/28875932/ios-navigation-bar-loses-transparency-when-i-set-bartintcolor
+    CGFloat alpha;
+    [viewController.navigationController.navigationBar.barTintColor getRed:NULL green:NULL blue:NULL alpha:&alpha];
+    [(UIView*)[viewController.navigationController.navigationBar.subviews objectAtIndex:0] setAlpha:alpha];
+
   } else {
     viewController.navigationController.navigationBar.translucent = NO;
   }


### PR DESCRIPTION
The navigator style `navBarTranslucent: true` does not enable the navbar to be partially transparent - you end up with the NavBar being tinted with the background color but it is completely opaque.

This change (iOS only) separately sets the alpha of the navbar by extracting out the alpha color component from `navBarBackgroundColor`.

I raised this as an issue in [#898](https://github.com/wix/react-native-navigation/issues/898)