### PR TITLE
Add statusBarColor to navigator props docs

### DIFF
--- a/docs/styling-the-navigator.md
+++ b/docs/styling-the-navigator.md
@@ -38,6 +38,7 @@ export default class StyledScreen extends Component {
   statusBarBlur: false, // blur the area under the status bar, works best with navBarHidden:true
   navBarBlur: false, // blur the entire nav bar, works best with drawUnderNavBar:true
   tabBarHidden: false, // make the screen content hide the tab bar (remembered across pushes)
+  statusBarColor: '#000000', // change the color of the status bar. Android only
   statusBarHideWithNavBar: false // hide the status bar if the nav bar is also hidden, useful for navBarHidden:true
   statusBarHidden: false, // make the status bar hidden regardless of nav bar state
   statusBarTextColorScheme: 'dark', // text color of status bar, 'dark' / 'light' (remembered across pushes)


### PR DESCRIPTION
Reading the docs I couldn't see a way to simply change the color of the status bar on Android. Only via https://github.com/wix/react-native-navigation/issues/571#issuecomment-267255350 I saw there was a prop to do this.

(Assuming this is Android only since iOS only allows for light or dark).