### PR TITLE
Make screen background image stretch when using screenBackgroundImage…

### DIFF
--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -245,7 +245,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   if (screenBackgroundImageName) {
     
     UIImage *image = [UIImage imageNamed: screenBackgroundImageName];
-    [viewController.view setBackgroundColor: [UIColor colorWithPatternImage: image]];
+    viewController.view.layer.contents = (__bridge id _Nullable)(image.CGImage);
   }
   
   NSString *navBarBackgroundColor = self.navigatorStyle[@"navBarBackgroundColor"];


### PR DESCRIPTION
There was a problem with the size of the background image:

<img width="383" alt="pr" src="https://cloud.githubusercontent.com/assets/7172563/24921582/988b589a-1eeb-11e7-988a-4160903fec48.png">

> see https://github.com/wix/react-native-navigation/pull/861#issuecomment-293282628

This PR make the background image stretch so you won't have this "repeat" effect.

