### PR TITLE
Compatibility with RN 0.43 and lower

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/react/JsDevReloadListenerReplacer.java
+++ b/android/app/src/main/java/com/reactnativenavigation/react/JsDevReloadListenerReplacer.java
@@ -2,7 +2,6 @@ package com.reactnativenavigation.react;
 
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.JavaJSExecutor;
-import com.facebook.react.devsupport.DevSupportManager;
 import com.facebook.react.devsupport.ReactInstanceDevCommandsHandler;
 import com.reactnativenavigation.utils.ReflectionUtils;
 
@@ -27,8 +26,7 @@ public class JsDevReloadListenerReplacer {
     }
 
     private void replaceInDevSupportManager(DevCommandsHandlerProxy proxy) {
-        DevSupportManager devSupportManager = (DevSupportManager)
-                ReflectionUtils.getDeclaredField(reactInstanceManager, "mDevSupportManager");
+        Object devSupportManager = ReflectionUtils.getDeclaredField(reactInstanceManager, "mDevSupportManager");
         ReflectionUtils.setField(devSupportManager, "mReactInstanceCommandsHandler", proxy);
     }
 

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "lodash": "4.x.x"
   },
   "devDependencies": {
-    "react-native": "0.41.2",
-    "react": "15.4.2",
+    "react-native": "0.43.0",
+    "react": "16.0.0-alpha.6",
     "babel-cli": "6.x.x",
     "babel-core": "6.x.x",
     "babel-polyfill": "6.x.x",


### PR DESCRIPTION
The method uses generic object, so don't is necessary casting.
Tested on RN 0.42 and 0.43