### PR TITLE
Fix mistake in platformSpecificDeprecated.ios

### DIFF
--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -553,7 +553,7 @@ function savePassProps(params) {
   }
 
   if (params.screen && params.screen.passProps) {
-    PropRegistry.save(params.screen.navigationParams.screenInstanceID, params.screen.passProps);
+    PropRegistry.save(params.navigationParams.screenInstanceID, params.screen.passProps);
   }
 
   if (_.get(params, 'screen.topTabs')) {


### PR DESCRIPTION
There was issue: 

![image](https://cloud.githubusercontent.com/assets/7809008/25206403/1419ea4e-2568-11e7-9e41-bbed0ac8b7c9.png)

Seems like a mistake. Fixes by this PR.