### PR TITLE
Import View from react-native

### DIFF
--- a/src/views/sharedElementTransition.ios.js
+++ b/src/views/sharedElementTransition.ios.js
@@ -1,6 +1,7 @@
-import React, {Component, View} from 'react';
+import React, {Component} from 'react';
 import {
-  requireNativeComponent
+  requireNativeComponent,
+  View
 } from 'react-native';
 
 export default class SharedElementTransition extends Component {


### PR DESCRIPTION
I encountered [this error](https://github.com/facebook/react-native/issues/8436) and identified the cause as an import in `src/views/sharedElementTransition.ios.js`.

My understanding is that the React Native API changed at some point – `View` should be imported from `react-native` and not from `react`.

I'm using React Native 0.43.1 and React 16.0.0-alpha.6, but it looks like the React Native API change  was made around v0.25.