### PR TITLE
SharedElementTransition iOS fixes

### DIFF
--- a/src/views/sharedElementTransition.ios.js
+++ b/src/views/sharedElementTransition.ios.js
@@ -1,11 +1,14 @@
 import React, {Component} from 'react';
 import {
-  requireNativeComponent,
   View
 } from 'react-native';
 
 export default class SharedElementTransition extends Component {
   render() {
-    return <View />;
+    return (
+      <View {...this.props}>
+        {this.props.children}
+      </View>
+    );
   }
 }


### PR DESCRIPTION
Render children and pass props to children