### PR TITLE
Update sharedElementTransition.ios.js

### DIFF
--- a/src/views/sharedElementTransition.ios.js
+++ b/src/views/sharedElementTransition.ios.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {Component, PropTypes} from 'react';
 import {
   View
 } from 'react-native';


### PR DESCRIPTION
Fix missing import of PropTypes throwing an error on iOS