### PR TITLE
start activity with fade animation when animationType: 'fade' is passed

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
+++ b/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
@@ -1,8 +1,11 @@
 package com.reactnativenavigation;
 
 import android.app.Application;
+import android.content.Intent;
+import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.Nullable;
+import android.support.v4.app.ActivityOptionsCompat;
 
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
@@ -32,6 +35,20 @@ public abstract class NavigationApplication extends Application implements React
         reactGateway = new NavigationReactGateway();
         eventEmitter = new EventEmitter(reactGateway);
         activityCallbacks = new ActivityCallbacks();
+    }
+
+    @Override
+    public void startActivity(Intent intent) {
+        String animationType = intent.getStringExtra("animationType");
+        if (animationType != null && animationType.equals("fade")) {
+            Bundle bundle = ActivityOptionsCompat.makeCustomAnimation(getApplicationContext(),
+                    android.R.anim.fade_in,
+                    android.R.anim.fade_out
+            ).toBundle();
+            super.startActivity(intent, bundle);
+        } else {
+            super.startActivity(intent);
+        }
     }
 
     public void startReactContextOnceInBackgroundAndExecuteJS() {

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationCommandsHandler.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationCommandsHandler.java
@@ -41,6 +41,7 @@ public class NavigationCommandsHandler {
         IntentDataHandler.onStartApp(intent);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.putExtra(ACTIVITY_PARAMS_BUNDLE, params);
+        intent.putExtra("animationType", params.getString("animationType"));
         NavigationApplication.instance.startActivity(intent);
     }
 


### PR DESCRIPTION
 [Android] make fade animation transition when passed `animationType: 'fade'` and called startSingleScreenApp or startTabBasedApp.
fixes #870 