### PR TITLE
Custom left button on android

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/TitleBar.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/TitleBar.java
@@ -161,6 +161,9 @@ public class TitleBar extends Toolbar {
 
     private void updateLeftButton(TitleBarLeftButtonParams leftButtonParams) {
         leftButton.setIconState(leftButtonParams);
+        if (leftButtonParams.icon != null) {
+            setNavigationIcon(leftButtonParams.icon);
+        }
     }
 
     private boolean shouldSetLeftButton(TitleBarLeftButtonParams leftButtonParams) {


### PR DESCRIPTION
It fix the problem about setButtons function that doesn't set a custom icon on Android. However, if the ID is not none of the default 4 ids doesn't work. It solves the issue that I created #1179