### PR TITLE
Android modal dismissal should check stack for orientation of next modal

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/Modal.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/Modal.java
@@ -32,6 +32,10 @@ public class Modal extends Dialog implements DialogInterface.OnDismissListener, 
     private final ScreenParams screenParams;
     private Layout layout;
     private boolean isDestroyed;
+    
+    public ScreenParams getScreenParams() {
+        return screenParams;
+    }
 
     public void setTopBarVisible(String screenInstanceId, boolean hidden, boolean animated) {
         layout.setTopBarVisible(screenInstanceId, hidden, animated);
@@ -190,7 +194,6 @@ public class Modal extends Dialog implements DialogInterface.OnDismissListener, 
             return;
         }
         destroy();
-        setOrientation(AppStyle.appStyle.orientation);
         onModalDismissedListener.onModalDismissed(this);
     }
 

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/ModalController.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/ModalController.java
@@ -8,6 +8,7 @@ import com.facebook.react.bridge.Callback;
 import com.reactnativenavigation.events.EventBus;
 import com.reactnativenavigation.events.ModalDismissedEvent;
 import com.reactnativenavigation.layouts.ScreenStackContainer;
+import com.reactnativenavigation.params.AppStyle;
 import com.reactnativenavigation.params.ContextualMenuParams;
 import com.reactnativenavigation.params.FabParams;
 import com.reactnativenavigation.params.ScreenParams;
@@ -45,6 +46,12 @@ class ModalController implements ScreenStackContainer, Modal.OnModalDismissedLis
         if (isShowing()) {
             stack.pop().dismiss();
         }
+        if (stack.empty()) {
+            activity.setRequestedOrientation(AppStyle.appStyle.orientation.orientationCode);
+        } else {
+            Modal newTopModal = stack.peek();
+            activity.setRequestedOrientation(newTopModal.getScreenParams().styleParams.orientation.orientationCode);
+        }
     }
 
     void dismissAllModals() {
@@ -52,6 +59,7 @@ class ModalController implements ScreenStackContainer, Modal.OnModalDismissedLis
             modal.dismiss();
         }
         stack.clear();
+        activity.setRequestedOrientation(AppStyle.appStyle.orientation.orientationCode);
     }
 
     boolean isShowing() {


### PR DESCRIPTION
Fix for issue #1229 

I'm not an Android guy, so excuse my ignorance. 
This fix worked for me. Should be a good starting point at least. 