### PR TITLE
Add compatibility with react-native link

### DIFF
--- a/docs/installation-android.md
+++ b/docs/installation-android.md
@@ -57,18 +57,20 @@
 			return BuildConfig.DEBUG;
 		}
 
+		protected List<ReactPackage> getPackages() {
+			// Add additional packages you require here
+			return Arrays.<ReactPackage>asList(
+				// eg. new VectorIconsPackage()
+			);
+		}
+
 		@Override
 		public List<ReactPackage> createAdditionalReactPackages() {
-
-		// Add additional packages you require here
-		return Arrays.<ReactPackage>asList(
-			// eg. new VectorIconsPackage()
-		);
-
+			return this.getPackages();
+		}
 		// No need to add RnnPackage and MainReactPackage
 		// Simply return null if you do not have additional packages:
 		// return null;
-		}
 	}
 	```
 


### PR DESCRIPTION
Since `react-native link` adds the new packages to `getPackages()` I added the method and return whatever it has from the `createAdditionalReactPackages()`

```java
  protected List<ReactPackage> getPackages() {
    return Arrays.<ReactPackage>asList(
          // eg. new SvgPackage(),
    );
  }

  @Override
  public List<ReactPackage> createAdditionalReactPackages() {
      return this.getPackages();
  }
```