### PR TITLE
Android modal lifecycle events hardware/soft back button handled (#1238)

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/Modal.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/Modal.java
@@ -76,6 +76,10 @@ public class Modal extends Dialog implements DialogInterface.OnDismissListener, 
         layout.hideSlidingOverlay();
     }
 
+    Layout getLayout() {
+        return layout;
+    }
+
     @Override
     public boolean onTitleBarBackButtonClick() {
         if (!layout.onBackPressed()) {
@@ -178,8 +182,8 @@ public class Modal extends Dialog implements DialogInterface.OnDismissListener, 
     public void dismiss() {
         if (!isDestroyed) {
             NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("willDisappear", layout.getCurrentScreen().getNavigatorEventId());
-            NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("didDisappear", layout.getCurrentScreen().getNavigatorEventId());
         }
+        onDismiss(this);
         super.dismiss();
     }
 
@@ -188,8 +192,8 @@ public class Modal extends Dialog implements DialogInterface.OnDismissListener, 
         if (isDestroyed) {
             return;
         }
-        destroy();
         onModalDismissedListener.onModalDismissed(this);
+        destroy();
     }
 
     void onModalDismissed() {

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -236,24 +236,39 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     }
 
     void showModal(ScreenParams screenParams) {
-        Screen previousScreen = layout.getCurrentScreen();
-        NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("willDisappear", previousScreen.getNavigatorEventId());
-        NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("didDisappear", previousScreen.getNavigatorEventId());
-        modalController.showModal(screenParams);
+        Screen currentScreen;
+        if (modalController.getStackSize() > 0) {
+            currentScreen = modalController.getTopModal().getLayout().getCurrentScreen();
+        } else {
+            currentScreen = layout.getCurrentScreen();
+        }
+
+        NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("willDisappear", currentScreen.getNavigatorEventId());
+        NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("didDisappear", currentScreen.getNavigatorEventId());
+
+        modalController.showModal(screenParams, new Modal.OnModalDismissedListener() {
+            @Override
+            public void onModalDismissed(Modal modal) {
+                Screen previousScreen;
+                if (modalController.getStackSize() > 0) {
+                    previousScreen = modalController.getTopModal().getLayout().getCurrentScreen();
+                } else {
+                    previousScreen = layout.getCurrentScreen();
+                }
+
+                NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("willAppear", previousScreen.getNavigatorEventId());
+                NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("didAppear", previousScreen.getNavigatorEventId());
+                NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("didDisappear", modal.getLayout().getCurrentScreen().getNavigatorEventId());
+            }
+        });
     }
 
     void dismissTopModal() {
         modalController.dismissTopModal();
-        Screen previousScreen = layout.getCurrentScreen();
-        NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("willAppear", previousScreen.getNavigatorEventId());
-        NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("didAppear", previousScreen.getNavigatorEventId());
     }
 
     void dismissAllModals() {
         modalController.dismissAllModals();
-        Screen previousScreen = layout.getCurrentScreen();
-        NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("willAppear", previousScreen.getNavigatorEventId());
-        NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("didAppear", previousScreen.getNavigatorEventId());
     }
 
     public void showLightBox(LightBoxParams params) {


### PR DESCRIPTION
Called lifecycle events for Modal Hardware/Soft back button.
Called modal DidDisappear event after previous Screen DidAppear event

Closes #1238