### PR TITLE
Custom UIBarButtonItem View in NavigationBar

### DIFF
--- a/example/src/components/CustomNavButton.js
+++ b/example/src/components/CustomNavButton.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Text, TouchableOpacity } from 'react-native';
+
+export default class CustomNavButton extends React.Component {
+    render() {
+        return (
+            <TouchableOpacity onPress={this.props.onPress}>
+                <Text>CustomButton</Text>
+            </TouchableOpacity>
+        );
+    }
+}

--- a/example/src/screens/Actions.js
+++ b/example/src/screens/Actions.js
@@ -20,6 +20,9 @@ class Actions extends React.Component {
             console.log('guyca', 'contextualMenuDismissed');
             this._contextualMenu = false;
         }
+        if (event.id === 'customButton') {
+            alert('custom button');
+        }
     }
 
     setTitle = () => {
@@ -106,6 +109,16 @@ class Actions extends React.Component {
         this._rightButton = title;
     };
 
+    setCustomButton = () => {
+        this._rightButton = '';
+        this.props.navigator.setButtons({
+            rightButtons: [{
+                customView: 'example.NavBar.CustomButton',
+                id: 'customButton'
+            }]
+        })
+    };
+
     toggleFAB = () => {
         if (this._fab) {
             this.props.navigator.setButtons({
@@ -150,6 +163,7 @@ class Actions extends React.Component {
                 <Row title={'Show Snackbar'} onPress={this.showSnackbar} platform={'android'}/>
                 <Row title={'Toggle Contextual Menu'} onPress={this.toggleContextualMenu} platform={'android'}/>
                 <Row title={'Set Right Buttons'} onPress={this.setButtons}/>
+                <Row title={'Set Custom Right Button'} onPress={this.setCustomButton}/>
                 <Row title={'Toggle FAB'} onPress={this.toggleFAB} platform={'android'}/>
             </ScrollView>
         );

--- a/example/src/screens/index.js
+++ b/example/src/screens/index.js
@@ -34,6 +34,8 @@ import TopTabs from './types/TopTabs';
 import TabOne from './types/tabs/TabOne';
 import TabTwo from './types/tabs/TabTwo';
 
+import CustomButton from "../components/CustomNavButton";
+
 import CollapsingHeader from './transitions/CollapsingHeader';
 import SharedElementTransitions from './transitions/SharedElementTransitions';
 
@@ -59,6 +61,8 @@ export default function () {
     Navigation.registerComponent('example.Types.TopTabs', () => TopTabs);
     Navigation.registerComponent('example.Types.TopTabs.TabOne', () => TabOne);
     Navigation.registerComponent('example.Types.TopTabs.TabTwo', () => TabTwo);
+
+    Navigation.registerComponent('example.NavBar.CustomButton', () => CustomButton);
 
     Navigation.registerComponent('example.Transitions.CollapsingHeader', () => CollapsingHeader);
     Navigation.registerComponent('example.Transitions.SharedElementTransitions', () => SharedElementTransitions);

--- a/ios/RCCCustomButtonView.h
+++ b/ios/RCCCustomButtonView.h
@@ -1,0 +1,16 @@
+//
+// Created by Hank Brekke on 5/19/17.
+// Copyright (c) 2017 hnryjms. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+
+@interface RCCCustomButtonView : UIView
+
+@property (nonatomic, strong) NSString *callbackId;
+@property (nonatomic, strong) NSString *buttonId;
+
+- (instancetype)initWithFrame:(CGRect)frame subView:(UIView*)subView;
+
+@end

--- a/ios/RCCCustomButtonView.m
+++ b/ios/RCCCustomButtonView.m
@@ -1,0 +1,32 @@
+//
+// Created by Hank Brekke on 5/19/17.
+// Copyright (c) 2017 hnryjms. All rights reserved.
+//
+
+#import "RCCCustomButtonView.h"
+
+@interface RCCCustomButtonView ()
+
+@property (nonatomic, strong) UIView *subView;
+
+@end
+
+
+@implementation RCCCustomButtonView
+
+- (instancetype)initWithFrame:(CGRect)frame subView:(UIView*)subView {
+    self = [super initWithFrame:frame];
+
+    if (self) {
+        self.backgroundColor = [UIColor clearColor];
+        self.subView = subView;
+
+        subView.frame = self.bounds;
+        subView.autoresizingMask = (UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth);
+        [self addSubview:subView];
+    }
+
+    return self;
+}
+
+@end

--- a/ios/RCCManagerModule.m
+++ b/ios/RCCManagerModule.m
@@ -6,6 +6,7 @@
 #import "RCCDrawerController.h"
 #import "RCCLightBox.h"
 #import <React/RCTConvert.h>
+#import <React/RCTEventDispatcher.h>
 #import "RCCTabBarController.h"
 #import "RCCTheSideBarManagerViewController.h"
 #import "RCCNotification.h"
@@ -270,6 +271,17 @@ RCT_EXPORT_METHOD(
     RCCNavigationController* controller = [[RCCManager sharedInstance] getControllerWithId:controllerId componentType:@"NavigationControllerIOS"];
     if (!controller || ![controller isKindOfClass:[RCCNavigationController class]]) return;
     return [controller performAction:performAction actionParams:actionParams bridge:[[RCCManager sharedInstance] getBridge]];
+}
+
+RCT_EXPORT_METHOD(
+                  NavigationBarCustomButtonPressWithCallbackId:(NSString *)callbackId buttonId:(NSString *)buttonId)
+{
+    if (!callbackId) return;
+    [[[RCCManager sharedInstance] getBridge].eventDispatcher sendAppEventWithName:callbackId body:@
+    {
+            @"type": @"NavBarButtonPress",
+            @"id": buttonId ? buttonId : [NSNull null]
+    }];
 }
 
 RCT_EXPORT_METHOD(

--- a/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		261108801E6C495400BF5D98 /* UIViewController+Rotation.m in Sources */ = {isa = PBXBuildFile; fileRef = 2611087F1E6C495400BF5D98 /* UIViewController+Rotation.m */; };
 		26714EAC1EB0E9D3009F4D52 /* RCCCustomTitleView.m in Sources */ = {isa = PBXBuildFile; fileRef = 26714EAB1EB0E9D3009F4D52 /* RCCCustomTitleView.m */; };
 		26AFF3F51D7EEE2400CBA211 /* RCCTitleViewHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 26AFF3F41D7EEE2400CBA211 /* RCCTitleViewHelper.m */; };
+		5C518FCB1B3879B7DDDF7327 /* RCCCustomButtonView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C5188CC2F6D6A5339638783 /* RCCCustomButtonView.m */; };
 		CC84A19E1C1A0C4E00B3A6A2 /* RCCManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CC84A1941C1A0C4E00B3A6A2 /* RCCManager.m */; };
 		CC84A19F1C1A0C4E00B3A6A2 /* RCCManagerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = CC84A1961C1A0C4E00B3A6A2 /* RCCManagerModule.m */; };
 		CC84A1A01C1A0C4E00B3A6A2 /* RCCNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = CC84A1981C1A0C4E00B3A6A2 /* RCCNavigationController.m */; };
@@ -58,6 +59,8 @@
 		26714EAB1EB0E9D3009F4D52 /* RCCCustomTitleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCCCustomTitleView.m; sourceTree = "<group>"; };
 		26AFF3F31D7EEE2400CBA211 /* RCCTitleViewHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCCTitleViewHelper.h; path = Helpers/RCCTitleViewHelper.h; sourceTree = "<group>"; };
 		26AFF3F41D7EEE2400CBA211 /* RCCTitleViewHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCCTitleViewHelper.m; path = Helpers/RCCTitleViewHelper.m; sourceTree = "<group>"; };
+		5C51885E590AEBEAF2273A13 /* RCCCustomButtonView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCCCustomButtonView.h; sourceTree = "<group>"; };
+		5C5188CC2F6D6A5339638783 /* RCCCustomButtonView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCCCustomButtonView.m; sourceTree = "<group>"; };
 		CC84A1931C1A0C4E00B3A6A2 /* RCCManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCCManager.h; sourceTree = "<group>"; };
 		CC84A1941C1A0C4E00B3A6A2 /* RCCManager.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = RCCManager.m; sourceTree = "<group>"; tabWidth = 2; };
 		CC84A1951C1A0C4E00B3A6A2 /* RCCManagerModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCCManagerModule.h; sourceTree = "<group>"; };
@@ -222,6 +225,8 @@
 				D83514F41D29719A00D53758 /* RCCNotification.h */,
 				D83514F51D29719A00D53758 /* RCCNotification.m */,
 				D8AFADBE1BEE6F3F00A4592D /* Products */,
+				5C5188CC2F6D6A5339638783 /* RCCCustomButtonView.m */,
+				5C51885E590AEBEAF2273A13 /* RCCCustomButtonView.h */,
 			);
 			sourceTree = "<group>";
 		};
@@ -329,6 +334,7 @@
 				D85082E41CBCF54200FDB961 /* SidebarAnimation.m in Sources */,
 				D8E11C571CBD1F670018B644 /* RCCDrawerController.m in Sources */,
 				260804DB1CE0D9D20094DBA1 /* RCCToolBar.m in Sources */,
+				5C518FCB1B3879B7DDDF7327 /* RCCCustomButtonView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-navigation",
-  "version": "1.1.0",
+  "version": "1.1.76",
   "description": "React Native Navigation - truly native navigation for iOS and Android",
   "license": "MIT",
   "nativePackage": true,

--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -48,7 +48,7 @@ function _registerComponentNoRedux(screenID, generator) {
 
       render() {
         return (
-          <InternalComponent testID={screenID} navigator={this.navigator} {...this.state.internalProps} />
+          <InternalComponent testID={screenID} onPress={this.button ? this.button.onPress.bind(this.button) : null} navigator={this.navigator} {...this.state.internalProps} />
         );
       }
     };
@@ -80,7 +80,7 @@ function _registerComponentRedux(screenID, generator, store, Provider, options) 
       render() {
         return (
           <Provider store={store} {...options}>
-            <InternalComponent testID={screenID} navigator={this.navigator} {...this.state.internalProps} />
+            <InternalComponent testID={screenID} onPress={this.button ? this.button.onPress.bind(this.button) : null} navigator={this.navigator} {...this.state.internalProps} />
           </Provider>
         );
       }

--- a/src/Screen.js
+++ b/src/Screen.js
@@ -163,6 +163,16 @@ class Navigator {
   }
 }
 
+class Button {
+  constructor(callbackID, buttonID) {
+    this.callbackID = callbackID;
+    this.buttonID = buttonID;
+  }
+  onPress() {
+    return platformSpecific.navigatorCustomButtonPress(this.callbackID, this.buttonID);
+  }
+}
+
 export default class Screen extends Component {
   static navigatorStyle = {};
   static navigatorButtons = {};
@@ -171,6 +181,9 @@ export default class Screen extends Component {
     super(props);
     if (props.navigatorID) {
       this.navigator = new Navigator(props.navigatorID, props.navigatorEventID, props.screenInstanceID);
+    }
+    if (props.buttonID) {
+      this.button = new Button(props.callbackID, props.buttonID)
     }
   }
 

--- a/src/deprecated/controllers/index.js
+++ b/src/deprecated/controllers/index.js
@@ -210,6 +210,9 @@ var Controllers = {
         RCCManager.NavigationControllerIOS(id, "setButtons", {buttons: buttons, side: "right", animated: animated});
         return unsubscribe;
       },
+      customButtonPress: function(callbackID, buttonID) {
+        RCCManager.NavigationBarCustomButtonPressWithCallbackId(callbackID, buttonID)
+      },
       setHidden: function(params = {}) {
         RCCManager.NavigationControllerIOS(id, "setHidden", params);
       }

--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -321,6 +321,10 @@ function navigatorSetButtons(navigator, navigatorEventID, _params) {
   newPlatformSpecific.setScreenButtons(navigator.screenInstanceID, navigatorEventID, params.rightButtons, leftButton, fab);
 }
 
+function navigatorCustomButtonPress() {
+  // iOS only
+}
+
 function shouldRemoveLeftButton(params) {
   return params.leftButtons && params.leftButtons.length === 0;
 }
@@ -685,6 +689,7 @@ export default {
   dismissLightBox,
   dismissInAppNotification,
   navigatorSetButtons,
+  navigatorCustomButtonPress,
   navigatorSetTabBadge,
   navigatorSetTabButton,
   navigatorSetTitle,

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -431,6 +431,10 @@ function navigatorSetButtons(navigator, navigatorEventID, params) {
   }
 }
 
+function navigatorCustomButtonPress(callbackID, buttonID) {
+  Controllers.NavigationControllerIOS().customButtonPress(callbackID, buttonID);
+}
+
 function showModal(params) {
   if (!params.screen) {
     console.error('showModal(params): params.screen is required');
@@ -622,6 +626,7 @@ export default {
   showInAppNotification,
   dismissInAppNotification,
   navigatorSetButtons,
+  navigatorCustomButtonPress,
   navigatorSetTitle,
   navigatorSetSubtitle,
   navigatorSetStyle,


### PR DESCRIPTION
See #606 #524 

Allowing custom views in UIBarButtonItems will allow much functionality with text/image combinations, badges with symbols and other React-based functionality embedded inside a single button of the navigation bar.

I built an alternative to `class Navigator()` for retaining button information in order to pass an `onPress` prop down to the internal component of a screen when it is being rendered, which allows buttons in the nav bar to propagate outward, and then down to their respective `navigator` view rendering the page. I'm open to some suggestions on how to improve this.

Thanks to @artald and @gran33 for the earlier commits (95e0958eeee4251464fe1ec49421e9e68dd49014  and 1320de5d3e2e33471938620bb29e4889dd0d6626) I referenced when building this.

### Remaining Tasks

- [ ] Add documentation on new properties
- [ ] TBD: Split `<Screen` and `<NavButtonScreen` compnoents https://github.com/wix/react-native-navigation/pull/1274#discussion_r125650407
- [ ] Merge `master` and resolve conflicts