### PR TITLE
[iOS] Fix disabledBackGesture.

### DIFF
--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -24,7 +24,6 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 @property (nonatomic) BOOL _statusBarHideWithNavBar;
 @property (nonatomic) BOOL _statusBarHidden;
 @property (nonatomic) BOOL _statusBarTextColorSchemeLight;
-@property (nonatomic) BOOL _disableBackGesture;
 @property (nonatomic, strong) NSDictionary *originalNavBarImages;
 @property (nonatomic, strong) UIImageView *navBarHairlineImageView;
 @end
@@ -658,7 +657,9 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 
 #pragma mark - UIGestureRecognizerDelegate
 -(BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
-  return self._disableBackGesture ? self._disableBackGesture : YES;
+  NSNumber *disabledBackGesture = self.navigatorStyle[@"disabledBackGesture"];
+  BOOL disabledBackGestureBool = disabledBackGesture ? [disabledBackGesture boolValue] : NO;
+  return !disabledBackGestureBool;
 }
 
 

--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -26,7 +26,6 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 @property (nonatomic) BOOL _statusBarTextColorSchemeLight;
 @property (nonatomic, strong) NSDictionary *originalNavBarImages;
 @property (nonatomic, strong) UIImageView *navBarHairlineImageView;
-@property (nonatomic, weak) id <UIGestureRecognizerDelegate> originalInteractivePopGestureDelegate;
 @end
 
 @implementation RCCViewController
@@ -485,21 +484,6 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
     self.navBarHairlineImageView.hidden = NO;
   }
   
- //Bug fix: in case there is a interactivePopGestureRecognizer, it prevents react-native from getting touch events on the left screen area that the gesture handles
- //overriding the delegate of the gesture prevents this from happening while keeping the gesture intact (another option was to disable it completely by demand)
- self.originalInteractivePopGestureDelegate = nil;
- if(self.navigationController.viewControllers.count > 1){
-   if (self.navigationController != nil && self.navigationController.interactivePopGestureRecognizer != nil)
-   {
-     id <UIGestureRecognizerDelegate> interactivePopGestureRecognizer = self.navigationController.interactivePopGestureRecognizer.delegate;
-     if (interactivePopGestureRecognizer != nil)
-     {
-       self.originalInteractivePopGestureDelegate = interactivePopGestureRecognizer;
-       self.navigationController.interactivePopGestureRecognizer.delegate = self;
-     }
-   }
- }
-  
   NSString *navBarCustomView = self.navigatorStyle[@"navBarCustomView"];
   if (navBarCustomView && ![self.navigationItem.titleView isKindOfClass:[RCCCustomTitleView class]]) {
     if ([self.view isKindOfClass:[RCTRootView class]]) {
@@ -540,12 +524,6 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 
 -(void)setStyleOnDisappear {
   self.navBarHairlineImageView.hidden = NO;
-  
-  if (self.navigationController != nil && self.navigationController.interactivePopGestureRecognizer != nil && self.originalInteractivePopGestureDelegate != nil)
-  {
-    self.navigationController.interactivePopGestureRecognizer.delegate = self.originalInteractivePopGestureDelegate;
-    self.originalInteractivePopGestureDelegate = nil;
-  }
 }
 
 // only styles that can't be set on willAppear should be set here


### PR DESCRIPTION
This `return self._disableBackGesture ? self._disableBackGesture : YES;` check is incorrect, it's the same as `true ? true : true;`.
Also `_disableBackGesture` was never set. We should just `return !disabledBackGestureBool` (bool value of the prop).