### PR TITLE
[iOS] Added option to remove default tab bar shadow (hairline)

### DIFF
--- a/docs/styling-the-tab-bar.md
+++ b/docs/styling-the-tab-bar.md
@@ -20,6 +20,7 @@ Navigation.startTabBasedApp({
   tabBarBackgroundColor: '#551A8B' // change the background color of the tab bar
   tabBarTranslucent: false // change the translucent of the tab bar to false
   tabBarTextFontFamily: 'Avenir-Medium' //change the tab font family
+  tabBarHideShadow: true // iOS only. Remove default tab bar top shadow (hairline)
   forceTitlesDisplay: true // Android only. If true - Show all bottom tab labels. If false - only the selected tab's label is visible.
 }
 ```

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -103,6 +103,12 @@
     {
       self.tabBar.translucent = [tabBarTranslucent boolValue] ? YES : NO;
     }
+
+    NSString *tabBarHideShadow = tabsStyle[@"tabBarHideShadow"];
+    if (tabBarHideShadow)
+    {
+      self.tabBar.clipsToBounds = [tabBarHideShadow boolValue] ? YES : NO;
+    }
   }
   
   NSMutableArray *viewControllers = [NSMutableArray array];


### PR DESCRIPTION
tabBarHideShadow: bool // iOS only. Control default tab bar top shadow (hairline)