### PR TITLE
Update example AppDelegate to pass launchOptions to the bridge

### DIFF
--- a/example/ios/example/AppDelegate.m
+++ b/example/ios/example/AppDelegate.m
@@ -29,7 +29,7 @@
   // **********************************************
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   self.window.backgroundColor = [UIColor whiteColor];
-  [[RCCManager sharedInstance] initBridgeWithBundleURL:jsCodeLocation];
+  [[RCCManager sharedInstance] initBridgeWithBundleURL:jsCodeLocation launchOptions:launchOptions];
 
   /*
   // original RN bootstrap - remove this part


### PR DESCRIPTION
I ran into an issue trying to get push notifications to work on iOS when the user taps on a notification to launch the app from a "cold" state using react-native-navigation with react-native-notifications.  Without passing launchOptions to the bridge it is not possible to detect the push notification that launched the app.  The example AppDelegate.m and associated docs don't mention this scenario so this should help other users since I don't see a downside to passing launchOptions by default.

This fixes https://github.com/wix/react-native-notifications/issues/35