### PR TITLE
[docs] Fix projectDir for android/settings.gradle

### DIFF
--- a/docs/installation-android.md
+++ b/docs/installation-android.md
@@ -12,7 +12,7 @@
 
 	```groovy
 	include ':react-native-navigation'
-	project(':react-native-navigation').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-navigation/android/app/')
+	project(':react-native-navigation').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-navigation/lib/android/app/')
 	```
 
 3. Update project dependencies in `android/app/build.gradle`.


### PR DESCRIPTION
The react-native-navigation package's source files are installed under node_modules/lib folder and give an error while building with the currently suggested docs for adding projectDir in android/settings.gradle