### PR TITLE
Add screen events for side menus on Android

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/SideMenu.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/SideMenu.java
@@ -4,9 +4,11 @@ import android.content.Context;
 import android.support.annotation.Nullable;
 import android.support.v4.widget.DrawerLayout;
 import android.view.Gravity;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.RelativeLayout;
 
+import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.params.SideMenuParams;
 import com.reactnativenavigation.screens.Screen;
 import com.reactnativenavigation.utils.ViewUtils;
@@ -29,6 +31,7 @@ public class SideMenu extends DrawerLayout {
     private ContentView leftSideMenuView;
     private ContentView rightSideMenuView;
     private RelativeLayout contentContainer;
+    private SimpleDrawerListener sideMenuListener;
 
     public RelativeLayout getContentContainer() {
         return contentContainer;
@@ -43,6 +46,7 @@ public class SideMenu extends DrawerLayout {
         if (sideMenuView == null) {
             return;
         }
+        removeDrawerListener(sideMenuListener);
         sideMenuView.unmountReactView();
         removeView(sideMenuView);
     }
@@ -84,6 +88,7 @@ public class SideMenu extends DrawerLayout {
         rightSideMenuView = createSideMenu(rightMenuParams);
         setStyle(leftMenuParams);
         setStyle(rightMenuParams);
+        setScreenEventListener();
     }
 
     private void createContentContainer() {
@@ -114,6 +119,23 @@ public class SideMenu extends DrawerLayout {
                 sideMenuView.setLayoutParams(lp);
             }
         });
+    }
+
+    public void setScreenEventListener() {
+        sideMenuListener = new SimpleDrawerListener() {
+            @Override
+            public void onDrawerOpened(View drawerView) {
+                NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("willAppear", ((ContentView)drawerView).getNavigatorEventId());
+                NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("didAppear", ((ContentView)drawerView).getNavigatorEventId());
+            }
+
+            @Override
+            public void onDrawerClosed(View drawerView) {
+                NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("willDisappear", ((ContentView)drawerView).getNavigatorEventId());
+                NavigationApplication.instance.getEventEmitter().sendScreenChangedEvent("didDisappear", ((ContentView)drawerView).getNavigatorEventId());
+            }
+        };
+        addDrawerListener(sideMenuListener);
     }
 
     private void setStyle(SideMenuParams params) {


### PR DESCRIPTION
The existing screen events don't appear to encompass the left and right side menus. This change adds those events in.