### PR TITLE
Add a way to dynamically enable/disable a side menu for Android

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/bridge/NavigationReactModule.java
+++ b/android/app/src/main/java/com/reactnativenavigation/bridge/NavigationReactModule.java
@@ -152,6 +152,11 @@ public class NavigationReactModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void setSideMenuEnabled(boolean enabled, String side) {
+        NavigationCommandsHandler.setSideMenuEnabled(enabled, Side.fromString(side));
+    }
+
+    @ReactMethod
     public void toggleTopBarVisible(final ReadableMap params) {
     }
 

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -314,6 +314,10 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
         layout.setSideMenuVisible(animated, visible, side);
     }
 
+    public void setSideMenuEnabled(boolean enabled, Side side) {
+        layout.setSideMenuEnabled(enabled, side);
+    }
+
     public void selectTopTabByTabIndex(String screenInstanceId, int index) {
         layout.selectTopTabByTabIndex(screenInstanceId, index);
         modalController.selectTopTabByTabIndex(screenInstanceId, index);

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationCommandsHandler.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationCommandsHandler.java
@@ -317,6 +317,20 @@ public class NavigationCommandsHandler {
         });
     }
 
+    public static void setSideMenuEnabled(final boolean enabled, final Side side) {
+        final NavigationActivity currentActivity = NavigationActivity.currentActivity;
+        if (currentActivity == null) {
+            return;
+        }
+
+        NavigationApplication.instance.runOnMainThread(new Runnable() {
+            @Override
+            public void run() {
+                currentActivity.setSideMenuEnabled(enabled, side);
+            }
+        });
+    }
+
     public static void selectTopTabByTabIndex(final String screenInstanceId, final int index) {
         final NavigationActivity currentActivity = NavigationActivity.currentActivity;
         if (currentActivity == null) {

--- a/android/app/src/main/java/com/reactnativenavigation/layouts/BottomTabsLayout.java
+++ b/android/app/src/main/java/com/reactnativenavigation/layouts/BottomTabsLayout.java
@@ -3,6 +3,7 @@ package com.reactnativenavigation.layouts;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.RelativeLayout;
@@ -228,6 +229,13 @@ public class BottomTabsLayout extends BaseLayout implements AHBottomNavigation.O
     public void setSideMenuVisible(boolean animated, boolean visible, Side side) {
         if (sideMenu != null) {
             sideMenu.setVisible(visible, animated, side);
+        }
+    }
+
+    @Override
+    public void setSideMenuEnabled(boolean enabled, Side side) {
+        if (sideMenu != null) {
+            sideMenu.setDrawerLockMode(enabled ? DrawerLayout.LOCK_MODE_UNLOCKED : DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
         }
     }
 

--- a/android/app/src/main/java/com/reactnativenavigation/layouts/Layout.java
+++ b/android/app/src/main/java/com/reactnativenavigation/layouts/Layout.java
@@ -37,6 +37,8 @@ public interface Layout extends ScreenStackContainer {
 
     void setSideMenuVisible(boolean animated, boolean visible, Side side);
 
+    void setSideMenuEnabled(boolean enabled, Side side);
+
     void showSnackbar(SnackbarParams params);
 
     void showSlidingOverlay(SlidingOverlayParams params);

--- a/android/app/src/main/java/com/reactnativenavigation/layouts/SingleScreenLayout.java
+++ b/android/app/src/main/java/com/reactnativenavigation/layouts/SingleScreenLayout.java
@@ -220,6 +220,13 @@ public class SingleScreenLayout extends BaseLayout {
     }
 
     @Override
+    public void setSideMenuEnabled(boolean enabled, Side side) {
+        if (sideMenu != null) {
+            sideMenu.setEnabled(enabled, side);
+        }
+    }
+
+    @Override
     public void showSnackbar(SnackbarParams params) {
         final String navigatorEventId = stack.peek().getNavigatorEventId();
         snackbarAndFabContainer.showSnackbar(navigatorEventId, params);

--- a/android/app/src/main/java/com/reactnativenavigation/views/SideMenu.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/SideMenu.java
@@ -61,6 +61,14 @@ public class SideMenu extends DrawerLayout {
         }
     }
 
+    public void setEnabled(boolean enabled, Side side) {
+        if (enabled) {
+            setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED, side.gravity);
+        } else {
+            setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED, side.gravity);
+        }
+    }
+
     public void openDrawer(Side side) {
         openDrawer(side.gravity);
     }

--- a/docs/screen-api.md
+++ b/docs/screen-api.md
@@ -173,6 +173,17 @@ this.props.navigator.toggleDrawer({
 });
 ```
 
+## setDrawerEnabled(params = {}) (Android only)
+
+Enables or disables the side menu drawer assuming you have one in your app. Both drawers are enabled by default.
+
+```js
+this.props.navigator.setDrawerEnabled({
+  side: 'left', // the side of the drawer since you can have two, 'left' / 'right'
+  enabled: false // should the drawer be enabled or disabled (locked closed)
+});
+```
+
 ## toggleTabs(params = {})
 
 Toggle whether the tabs are displayed or not (only in tab-based apps).

--- a/src/Screen.js
+++ b/src/Screen.js
@@ -96,6 +96,10 @@ class Navigator {
     return platformSpecific.navigatorToggleDrawer(this, params);
   }
 
+  setDrawerEnabled(params = {}) {
+    return platformSpecific.navigatorSetDrawerEnabled(this, params);
+  }
+
   toggleTabs(params = {}) {
     return platformSpecific.navigatorToggleTabs(this, params);
   }

--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -388,6 +388,10 @@ function navigatorToggleDrawer(navigator, params) {
   }
 }
 
+function navigatorSetDrawerEnabled(navigator, params) {
+  newPlatformSpecific.setSideMenuEnabled(params.enabled, params.side);
+}
+
 function navigatorToggleNavBar(navigator, params) {
   const screenInstanceID = navigator.screenInstanceID;
   const visible = params.to === 'shown' || params.to === 'show';
@@ -693,6 +697,7 @@ export default {
   navigatorSwitchToTab,
   navigatorSwitchToTopTab,
   navigatorToggleDrawer,
+  navigatorSetDrawerEnabled,
   navigatorToggleTabs,
   navigatorToggleNavBar,
   showSnackbar,

--- a/src/platformSpecific.android.js
+++ b/src/platformSpecific.android.js
@@ -121,6 +121,10 @@ function setSideMenuVisible(animated, visible, side) {
   NativeReactModule.setSideMenuVisible(animated, visible, side);
 }
 
+function setSideMenuEnabled(enabled, side) {
+  NativeReactModule.setSideMenuEnabled(enabled, side);
+}
+
 function selectTopTabByTabIndex(screenInstanceId, index) {
   NativeReactModule.selectTopTabByTabIndex(screenInstanceId, index);
 }
@@ -195,6 +199,7 @@ module.exports = {
   dismissInAppNotification,
   toggleSideMenuVisible,
   setSideMenuVisible,
+  setSideMenuEnabled,
   selectBottomTabByNavigatorId,
   selectBottomTabByTabIndex,
   setBottomTabBadgeByNavigatorId,


### PR DESCRIPTION
Fixes #326 for Android only - I looked at the props approach but I needed a bit more control than I could get with that.

Sidenote: I'll need to do similar for iOS, but that looks a bit tricker given the multiple different drawer implementations (and the first implementation I looked at didn't have a clean way to disable without removing the view completely).