### PR TITLE
Add tabBarHidden property to docs

### DIFF
--- a/docs/styling-the-tab-bar.md
+++ b/docs/styling-the-tab-bar.md
@@ -15,6 +15,7 @@ Navigation.startTabBasedApp({
 
 ```js
 {
+  tabBarHidden: false, // make the tab bar hidden
   tabBarButtonColor: '#ffff00', // change the color of the tab icons and text (also unselected)
   tabBarSelectedButtonColor: '#ff9900', // change the color of the selected tab icon and text (only selected)
   tabBarBackgroundColor: '#551A8B' // change the background color of the tab bar


### PR DESCRIPTION
I found it in this issue https://github.com/wix/react-native-navigation/issues/129#issuecomment-249433746 and it wasn't on the [official documentation](http://wix.github.io/react-native-navigation/#/styling-the-tab-bar)