### PR TITLE
[iOS] Added ability to set static(root) background image

### DIFF
--- a/docs/styling-the-navigator.md
+++ b/docs/styling-the-navigator.md
@@ -62,7 +62,8 @@ this.props.navigator.setStyle({
   
   disabledBackGesture: false, // default: false. Disable the back gesture (swipe gesture) in order to pop the top screen. 
   screenBackgroundImageName: '<name of image in Images.xcassets>', // Optional. default screen background image.
-  
+  rootBackgroundImageName: '<name of image in Images.xcassets>', // Static while you transition between screens. Works best with screenBackgroundColor: 'transparent'
+
   navBarButtonFontSize: 20, // Change font size nav bar buttons (eg. the back button) (remembered across pushes)
   navBarButtonFontWeight: '500', // Change font weight nav bar buttons (eg. the back button) (remembered across pushes)
 

--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -95,6 +95,14 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
     [[RCCManager sharedInstance] registerController:controller componentId:componentId componentType:type];
   }
   
+  // set background image at root level
+  NSString *rootBackgroundImageName = props[@"style"][@"rootBackgroundImageName"];
+  if (rootBackgroundImageName) {
+    UIImage *image = [UIImage imageNamed: rootBackgroundImageName];
+    UIImageView *imageView = [[UIImageView alloc] initWithImage:image];
+    [controller.view insertSubview:imageView atIndex:0];
+  }
+  
   return controller;
 }
 


### PR DESCRIPTION
```
rootBackgroundImageName: '<name of image in Images.xcassets>',
```
Same as `screenBackgroundImageName` but it's static while you transition between screens.
You have to set `screenBackgroundColor: 'transparent',` and also transparent color for your root View.