### PR TITLE
Replace React.PropTypes with prop-types

### DIFF
--- a/example/src/components/Row.js
+++ b/example/src/components/Row.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { StyleSheet, View, Text, TouchableHighlight, Platform } from 'react-native';
 
 function Row({ title, onPress, platform, testID }) {

--- a/old-example-redux/src/screens/BottomTabsSideMenu.js
+++ b/old-example-redux/src/screens/BottomTabsSideMenu.js
@@ -1,4 +1,4 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
 import {
   Text,
   View,

--- a/old-example-redux/src/screens/FirstTabScreen.js
+++ b/old-example-redux/src/screens/FirstTabScreen.js
@@ -1,4 +1,4 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
 import {
   Text,
   View,

--- a/old-example-redux/src/screens/ListScreen.js
+++ b/old-example-redux/src/screens/ListScreen.js
@@ -1,4 +1,4 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
 import {
   Text,
   View,

--- a/old-example-redux/src/screens/LoginScreen.js
+++ b/old-example-redux/src/screens/LoginScreen.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {
   Text,
   View,

--- a/old-example-redux/src/screens/PushedScreen.js
+++ b/old-example-redux/src/screens/PushedScreen.js
@@ -1,4 +1,4 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
 import {
   Text,
   View,

--- a/old-example-redux/src/screens/SecondTabScreen.js
+++ b/old-example-redux/src/screens/SecondTabScreen.js
@@ -1,4 +1,4 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
 import {
   Text,
   Image,

--- a/old-example-redux/src/screens/SideMenu.js
+++ b/old-example-redux/src/screens/SideMenu.js
@@ -1,4 +1,4 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
 import {
   Text,
   View,

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "jest": "18.x.x",
     "jest-cli": "18.x.x",
     "jest-react-native": "18.x.x",
+    "prop-types": "^15.5.10",
     "react": "16.0.0-alpha.6",
     "react-native": "0.43.0",
     "react-test-renderer": "15.4.2",

--- a/src/views/sharedElementTransition.ios.js
+++ b/src/views/sharedElementTransition.ios.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {
   View
 } from 'react-native';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2986,7 +2986,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -3488,6 +3488,13 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
 
 prr@~0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Small update in using `"prop-types"` instead of `React.PropTypes` since it's using React 16.0.0-alpha.6.

For the old examples, I only removed `PropTypes`. It looks like its not actually being used on the files, but let me know if you want `prop-types` to be added anyway and I can do so. 

(Sorry if I missed any contribution guidelines! Can't seem to find any information on it...)