### PR TITLE
[WIP] Add overlay module

### DIFF
--- a/ios/RCCNavigationController.h
+++ b/ios/RCCNavigationController.h
@@ -1,7 +1,10 @@
 #import <UIKit/UIKit.h>
 #import <React/RCTBridge.h>
+#import <React/RCTRootView.h>
 
 @interface RCCNavigationController : UINavigationController <UINavigationControllerDelegate>
+
+@property (nonatomic, strong) RCTRootView *reactView;
 
 - (instancetype)initWithProps:(NSDictionary *)props children:(NSArray *)children globalProps:(NSDictionary*)globalProps bridge:(RCTBridge *)bridge;
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge;

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -47,6 +47,7 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
     [self setButtons:rightButtons viewController:viewController side:@"right" animated:NO];
   }
   
+  
   self = [super initWithRootViewController:viewController];
   if (!self) return nil;
   self.delegate = self;
@@ -60,16 +61,15 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
 
   [self setRotation:props];
   
+  // Add our custom overlay view
+  NSString *overlayModule = props[@"overlayModuleName"];
+  if (overlayModule)
+  {
+    RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:overlayModule initialProperties:@{}];
+    [[self view] addSubview:rootView];
+  }
+  
   return self;
-}
-
-- (void)viewDidLoad {
-  [super viewDidLoad];
-  
-  RCTBridge *bridge = [[RCCManager sharedInstance] getBridge];
-  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"QuoteBar" initialProperties:@{}];
-  [[self view] addSubview:rootView];
-  
 }
 
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -67,6 +67,7 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   {
     
     self.reactView = [[RCTRootView alloc] initWithBridge:bridge moduleName:overlayModule initialProperties:passProps];
+    [self.reactView setPassThroughTouches:YES];
     self.reactView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
     self.reactView.backgroundColor = [UIColor clearColor];
     self.reactView.sizeFlexibility = RCTRootViewSizeFlexibilityWidthAndHeight;

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -63,6 +63,14 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   return self;
 }
 
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  
+  RCTBridge *bridge = [[RCCManager sharedInstance] getBridge];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"QuoteBar" initialProperties:@{}];
+  [[self view] addSubview:rootView];
+  
+}
 
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge
 {

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -79,10 +79,11 @@ function startTabBasedApp(params) {
                     subtitle={tab.subtitle}
                     titleImage={tab.titleImage}
                     component={tab.screen}
+                    overlayModuleName={tab.overlayModuleName}
                     passProps={{
                     navigatorID: tab.navigationParams.navigatorID,
                     screenInstanceID: tab.navigationParams.screenInstanceID,
-                    navigatorEventID: tab.navigationParams.navigatorEventID
+                    navigatorEventID: tab.navigationParams.navigatorEventID,
                   }}
                     style={tab.navigationParams.navigatorStyle}
                     leftButtons={tab.navigationParams.navigatorButtons.leftButtons}
@@ -161,6 +162,7 @@ function startSingleScreenApp(params) {
           subtitle={params.subtitle}
           titleImage={screen.titleImage}
           component={screen.screen}
+          overlayModuleName={screen.overlayModuleName}
           passProps={{
             navigatorID: navigatorID,
             screenInstanceID: screenInstanceID,
@@ -247,7 +249,8 @@ function navigatorPush(navigator, params) {
     backButtonTitle: params.backButtonTitle,
     backButtonHidden: params.backButtonHidden,
     leftButtons: navigatorButtons.leftButtons,
-    rightButtons: navigatorButtons.rightButtons
+    rightButtons: navigatorButtons.rightButtons,
+    overlayModuleName: params.overlayModuleName
   });
 }
 
@@ -301,7 +304,8 @@ function navigatorResetTo(navigator, params) {
     passProps: passProps,
     style: navigatorStyle,
     leftButtons: navigatorButtons.leftButtons,
-    rightButtons: navigatorButtons.rightButtons
+    rightButtons: navigatorButtons.rightButtons,
+    overlayModuleName: params.overlayModuleName
   });
 }
 
@@ -475,6 +479,7 @@ function showModal(params) {
           subtitle={params.subtitle}
           titleImage={params.titleImage}
           component={params.screen}
+          overlayModuleName={params.overlayModuleName}
           passProps={passProps}
           style={navigatorStyle}
           leftButtons={navigatorButtons.leftButtons}

--- a/src/views/sharedElementTransition.ios.js
+++ b/src/views/sharedElementTransition.ios.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {
   View
 } from 'react-native';

--- a/src/views/sharedElementTransition.ios.js
+++ b/src/views/sharedElementTransition.ios.js
@@ -1,5 +1,4 @@
-import React, {Component} from 'react';
-import PropTypes from 'prop-types';
+import React, {Component, PropTypes} from 'react';
 import {
   View
 } from 'react-native';


### PR DESCRIPTION
This PR adds an overlay module property to the navigation controller that allows a view to be included above all views on the `RCCNavigationController`. To include the view a user must register a module with the `AppRegistry` and pass it through as the `overlayModuleName` property when launching a single screen app.

It stems from the issue outlined in #1280.

This is not yet complete and aims for the following:

- [x] Overlay view on Navigation Controller - iOS
- [ ] Overlay view on Navigation Controller - Android
- [ ] Overlay view on Tab Controller - iOS
- [ ] Overlay view on Tab Controller - Android

Any comments or suggestions for improvement are very welcome. 