### PR TITLE
Fixed lightbox status bar color override on Android

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/LightBox.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/LightBox.java
@@ -8,13 +8,14 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Color;
+import android.os.Build;
 import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.view.WindowManager;
 import android.widget.RelativeLayout;
-
 import com.reactnativenavigation.R;
 import com.reactnativenavigation.params.LightBoxParams;
 import com.reactnativenavigation.screens.Screen;

--- a/android/app/src/main/java/com/reactnativenavigation/views/LightBox.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/LightBox.java
@@ -36,6 +36,10 @@ public class LightBox extends Dialog implements DialogInterface.OnDismissListene
         requestWindowFeature(Window.FEATURE_NO_TITLE);
         createContent(activity, params);
         getWindow().setWindowAnimations(android.R.style.Animation);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+        }
     }
 
     private void createContent(final Context context, LightBoxParams params) {

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -7,6 +7,7 @@
 
     <style name="LightBox" parent="@android:style/Theme.Translucent.NoTitleBar">
         <item name="android:windowAnimationStyle">@style/modalAnimations</item>
+        <item name="android:statusBarColor" tools:targetApi="lollipop">@android:color/transparent</item>
     </style>
 
     <style name="modalAnimations">


### PR DESCRIPTION
This PR fixes the black status bar on Android causing differences between iOS and Android for draw space