### PR TITLE
Fixed bottom tab bar animation setting the wrong value

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/animation/VisibilityAnimator.java
+++ b/android/app/src/main/java/com/reactnativenavigation/animation/VisibilityAnimator.java
@@ -46,7 +46,6 @@ public class VisibilityAnimator {
             animator.start();
         } else {
             view.setTranslationY(SHOW_END_VALUE);
-            view.setY(SHOW_END_VALUE);
             view.setVisibility(View.VISIBLE);
         }
     }
@@ -57,7 +56,6 @@ public class VisibilityAnimator {
             animator.start();
         } else {
             view.setTranslationY(hiddenEndValue);
-            view.setY(hiddenEndValue);
             view.setVisibility(View.GONE);
         }
     }


### PR DESCRIPTION
Closes issue #1357 

setY should not be set on a view inside a RelativeLayout, this was setting the tab bar to the Y position of 0