### PR TITLE
Set BottomTab colours only if needed

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
@@ -43,10 +43,14 @@ public class BottomTabs extends AHBottomNavigation {
             setBackgroundColor(params.bottomTabsColor);
         }
         if (params.bottomTabsButtonColor.hasColor()) {
-            setInactiveColor(params.bottomTabsButtonColor.getColor());
+            if (getInactiveColor() != params.bottomTabsButtonColor.getColor()) {
+                setInactiveColor(params.bottomTabsButtonColor.getColor());
+            }
         }
         if (params.selectedBottomTabsButtonColor.hasColor()) {
-            setAccentColor(params.selectedBottomTabsButtonColor.getColor());
+            if (getAccentColor() != params.selectedBottomTabsButtonColor.getColor()) {
+                setAccentColor(params.selectedBottomTabsButtonColor.getColor());
+            }
         }
 
         setVisibility(params.bottomTabsHidden, true);
@@ -90,8 +94,10 @@ public class BottomTabs extends AHBottomNavigation {
 
     private void setBackgroundColor(StyleParams.Color bottomTabsColor) {
         if (bottomTabsColor.hasColor()) {
-            setDefaultBackgroundColor(bottomTabsColor.getColor());
-        } else {
+            if (bottomTabsColor.getColor() != getDefaultBackgroundColor()) {
+                setDefaultBackgroundColor(bottomTabsColor.getColor());
+            }
+        } else if (Color.WHITE != getDefaultBackgroundColor()){
             setDefaultBackgroundColor(Color.WHITE);
         }
     }


### PR DESCRIPTION
Fixes #1411
Each time a color attribute is set in AHBottomNavigation, all items in
the BottomTabs are recreated. If a badge is set, it is animated each
time items are recreated. This behaviour can even be seen in the gifs
in the repo https://github.com/aurelhubert/ahbottomnavigation