### PR TITLE
Fixed BottomTabs height being calculated twice

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
@@ -103,7 +103,7 @@ public class BottomTabs extends AHBottomNavigation {
     private void createVisibilityAnimator() {
         visibilityAnimator = new VisibilityAnimator(BottomTabs.this,
                 VisibilityAnimator.HideDirection.Down,
-                (int) ViewUtils.convertDpToPixel(Constants.BOTTOM_TABS_HEIGHT));
+                Constants.BOTTOM_TABS_HEIGHT);
     }
 
     private void setStyle() {


### PR DESCRIPTION
BottomTabs height is currently being calculated twice in Android making the hide animation not work in all cases