### PR TITLE
[iOS] Allow lightbox tap to dismiss without background color

### DIFF
--- a/ios/RCCLightBox.m
+++ b/ios/RCCLightBox.m
@@ -51,13 +51,13 @@ const NSInteger kLightBoxTag = 0x101010;
                     self.overlayColorView.backgroundColor = backgroundColor;
                     self.overlayColorView.alpha = 0;
                     [self addSubview:self.overlayColorView];
-
-                    if (style[@"tapBackgroundToDismiss"] != nil && [RCTConvert BOOL:style[@"tapBackgroundToDismiss"]])
-                    {
-                        UITapGestureRecognizer *singleTap=[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissAnimated)];
-                        [self.overlayColorView addGestureRecognizer:singleTap];
-                    }
                 }
+            }
+
+            if (style[@"tapBackgroundToDismiss"] != nil && [RCTConvert BOOL:style[@"tapBackgroundToDismiss"]])
+            {
+                UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissAnimated)];
+                [self addGestureRecognizer:singleTap];
             }
         }
         

--- a/ios/RCCLightBox.m
+++ b/ios/RCCLightBox.m
@@ -8,7 +8,7 @@
 
 const NSInteger kLightBoxTag = 0x101010;
 
-@interface RCCLightBoxView : UIView
+@interface RCCLightBoxView : UIView<UIGestureRecognizerDelegate>
 @property (nonatomic, strong) RCTRootView *reactView;
 @property (nonatomic, strong) UIVisualEffectView *visualEffectView;
 @property (nonatomic, strong) UIView *overlayColorView;
@@ -57,6 +57,7 @@ const NSInteger kLightBoxTag = 0x101010;
             if (style[@"tapBackgroundToDismiss"] != nil && [RCTConvert BOOL:style[@"tapBackgroundToDismiss"]])
             {
                 UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissAnimated)];
+                singleTap.delegate = self;
                 [self addGestureRecognizer:singleTap];
             }
         }
@@ -74,6 +75,12 @@ const NSInteger kLightBoxTag = 0x101010;
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onRNReload) name:RCTJavaScriptWillStartLoadingNotification object:nil];
     }
     return self;
+}
+
+
+-(BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
+{
+    return ![touch.view isDescendantOfView:self.reactView];
 }
 
 -(void)layoutSubviews


### PR DESCRIPTION
This allows for tapping the background without setting a color here, meaning this feature can be enabled with one less view in the view hierarchy. Additionally, this allows for taps on any background view, visual effect view, color tint view, etc, but not on the content.
