### PR TITLE
[iOS] KYDrawerController support

### DIFF
--- a/ios/RCCDrawerController/KYDrawerController/KYDrawerController.h
+++ b/ios/RCCDrawerController/KYDrawerController/KYDrawerController.h
@@ -1,0 +1,64 @@
+//
+//  KYDrawerController.h
+//  KYDrawerController
+//
+//  Created by Yifei Zhou on 1/8/16.
+//  Copyright © 2016 Yifei Zhou. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class KYDrawerController;
+
+typedef NS_ENUM(NSUInteger, KYDrawerControllerDrawerState) { KYDrawerControllerDrawerStateOpened, KYDrawerControllerDrawerStateClosed };
+
+typedef NS_ENUM(NSUInteger, KYDrawerControllerDrawerDirection) { KYDrawerControllerDrawerDirectionLeft, KYDrawerControllerDrawerDirectionRight };
+
+@protocol KYDrawerControllerDelegate <NSObject>
+
+@optional
+- (void)drawerController:(KYDrawerController *)drawerController stateDidChange:(KYDrawerControllerDrawerState)drawerState;
+
+@end
+
+@interface KYDrawerController : UIViewController
+
+@property (copy, nonatomic, nullable) IBInspectable NSString *mainSegueIdentifier;
+
+@property (copy, nonatomic, nullable) IBInspectable NSString *drawerSegueIdentifier;
+
+@property (assign, nonatomic) IBInspectable CGFloat containerViewMaxAlpha;
+
+@property (assign, nonatomic) IBInspectable NSTimeInterval drawerAnimationDuration;
+
+@property (strong, nonatomic) UIViewController *mainViewController;
+
+@property (strong, nonatomic) UIViewController *drawerViewController;
+
+@property (readonly, nonatomic) UIViewController *displayingViewController;
+
+@property (weak, nonatomic, nullable) id<KYDrawerControllerDelegate> delegate;
+
+@property (assign, nonatomic) KYDrawerControllerDrawerState drawerState;
+
+@property (assign, nonatomic) KYDrawerControllerDrawerDirection drawerDirection;
+
+@property (assign, nonatomic) CGFloat drawerWidth;
+
+@property (assign, nonatomic, getter=isScreenEdgePanGestreEnabled) BOOL screenEdgePanGestreEnabled;
+
+@property (strong, nonatomic) UITapGestureRecognizer *containerViewTapGesture;
+
+@property (readonly, nonatomic) UIScreenEdgePanGestureRecognizer *screenEdgePanGesture;
+
+@property (readonly, nonatomic) UIPanGestureRecognizer *panGesture;
+
+- (instancetype)initWithDrawerDirection:(KYDrawerControllerDrawerDirection)drawerDirection drawerWidth:(CGFloat)drawerWidth;
+
+- (void)setDrawerState:(KYDrawerControllerDrawerState)drawerState animated:(BOOL)animated;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/RCCDrawerController/KYDrawerController/KYDrawerController.m
+++ b/ios/RCCDrawerController/KYDrawerController/KYDrawerController.m
@@ -1,0 +1,456 @@
+//
+//  KYDrawerController.m
+//  KYDrawerController
+//
+//  Created by Yifei Zhou on 1/8/16.
+//  Copyright © 2016 Yifei Zhou. All rights reserved.
+//
+
+#import "KYDrawerController.h"
+
+static CGFloat const kContainerViewMaxAlpha = 0.2;
+static NSTimeInterval const kDrawerAnimationDuration = 0.25;
+
+@interface KYDrawerController () <UIGestureRecognizerDelegate>
+
+@property (strong, nonatomic) NSLayoutConstraint *drawerConstraint;
+
+@property (strong, nonatomic) NSLayoutConstraint *drawerWidthConstraint;
+
+@property (assign, nonatomic) CGPoint panStartLocation;
+
+@property (assign, nonatomic) CGFloat panDelta;
+
+@property (strong, nonatomic) UIView *containerView;
+
+/// Returns `true` if `beginAppearanceTransition()` has been called with `true` as the first parameter, and `false`
+/// if the first parameter is `false`. Returns `nil` if appearance transition is not in progress.
+@property (strong, nonatomic) NSNumber *isAppearing;
+
+@property (readwrite, strong, nonatomic) UIScreenEdgePanGestureRecognizer *screenEdgePanGesture;
+
+@property (readwrite, strong, nonatomic) UIPanGestureRecognizer *panGesture;
+
+@end
+
+@implementation KYDrawerController
+
+@synthesize screenEdgePanGesture = _screenEdgePanGesture;
+@synthesize panGesture = _panGesture;
+@synthesize containerViewTapGesture = _containerViewTapGesture;
+
+- (void)awakeFromNib
+{
+    [super awakeFromNib];
+    [self _commonInit];
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        [self _commonInit];
+    }
+    return self;
+}
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+    if (self) {
+        [self _commonInit];
+    }
+    return self;
+}
+
+- (instancetype)initWithDrawerDirection:(KYDrawerControllerDrawerDirection)drawerDirection drawerWidth:(CGFloat)drawerWidth
+{
+    self = [super init];
+    if (self) {
+        [self _commonInit];
+        self.drawerDirection = drawerDirection;
+        self.drawerWidth = drawerWidth;
+    }
+    return self;
+}
+
+- (void)_commonInit
+{
+    _containerViewMaxAlpha = kContainerViewMaxAlpha;
+    _drawerAnimationDuration = kDrawerAnimationDuration;
+    
+    _drawerWidth = 280.0f;
+    _screenEdgePanGestreEnabled = YES;
+    _drawerDirection = KYDrawerControllerDrawerDirectionLeft;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+
+    NSDictionary *viewDictionary = @{ @"_containerView" : self.containerView };
+
+    [self.view addGestureRecognizer:self.screenEdgePanGesture];
+    [self.view addGestureRecognizer:self.panGesture];
+    [self.view addSubview:self.containerView];
+    [self.view
+        addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-0-[_containerView]-0-|" options:kNilOptions metrics:nil views:viewDictionary]];
+    [self.view
+        addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-0-[_containerView]-0-|" options:kNilOptions metrics:nil views:viewDictionary]];
+
+    self.containerView.hidden = YES;
+    
+    if (self.mainSegueIdentifier) {
+        [self performSegueWithIdentifier:self.mainSegueIdentifier sender:self];
+    }
+    
+    if (self.drawerSegueIdentifier) {
+        [self performSegueWithIdentifier:self.drawerSegueIdentifier sender:self];
+    }
+}
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    [self.displayingViewController beginAppearanceTransition:YES animated:animated];
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    [self.displayingViewController endAppearanceTransition];
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+    [super viewWillDisappear:animated];
+    [self.displayingViewController beginAppearanceTransition:NO animated:animated];
+}
+
+- (void)viewDidDisappear:(BOOL)animated
+{
+    [super viewDidDisappear:animated];
+    [self.displayingViewController endAppearanceTransition];
+}
+
+- (BOOL)shouldAutomaticallyForwardAppearanceMethods
+{
+    return NO;
+}
+
+- (void)setDrawerState:(KYDrawerControllerDrawerState)drawerState animated:(BOOL)animated
+{
+    self.containerView.hidden = NO;
+
+    NSTimeInterval duration = animated ? self.drawerAnimationDuration : 0;
+    
+    BOOL isAppearing = drawerState == KYDrawerControllerDrawerStateOpened;
+    if (!_isAppearing || [_isAppearing boolValue] != isAppearing) {
+        _isAppearing = @(isAppearing);
+        [self.drawerViewController beginAppearanceTransition:isAppearing animated:animated];
+        [self.mainViewController beginAppearanceTransition:!isAppearing animated:animated];
+    }
+
+    [UIView animateWithDuration:duration
+        delay:0
+        options:UIViewAnimationOptionCurveEaseOut
+        animations:^{
+          if (drawerState == KYDrawerControllerDrawerStateClosed) {
+              self.drawerConstraint.constant = 0;
+              self.containerView.backgroundColor = [UIColor colorWithWhite:0 alpha:0];
+          }
+          else if (drawerState == KYDrawerControllerDrawerStateOpened) {
+              CGFloat constant;
+              if (self.drawerDirection == KYDrawerControllerDrawerDirectionLeft) {
+                  constant = self.drawerWidth;
+              }
+              else {
+                  constant = -self.drawerWidth;
+              }
+              self.drawerConstraint.constant = constant;
+              self.containerView.backgroundColor = [UIColor colorWithWhite:0 alpha:self.containerViewMaxAlpha];
+          }
+          [self.containerView layoutIfNeeded];
+        }
+        completion:^(BOOL finished) {
+          if (drawerState == KYDrawerControllerDrawerStateClosed) {
+              self.containerView.hidden = YES;
+          }
+          [self.drawerViewController endAppearanceTransition];
+          [self.mainViewController endAppearanceTransition];
+          self.isAppearing = nil;
+          if ([self.delegate respondsToSelector:@selector(drawerController:stateDidChange:)]) {
+              [self.delegate drawerController:self stateDidChange:drawerState];
+          }
+        }];
+}
+
+#pragma mark - Actions
+
+- (IBAction)didTapContainerView:(id)sender
+{
+    [self setDrawerState:KYDrawerControllerDrawerStateClosed animated:YES];
+}
+
+- (IBAction)handlePanGesture:(id)sender
+{
+    self.containerView.hidden = NO;
+
+    if (![sender isKindOfClass:[UIGestureRecognizer class]]) {
+        return;
+    }
+
+    UIGestureRecognizer *gesture = sender;
+    if (gesture.state == UIGestureRecognizerStateBegan) {
+        self.panStartLocation = [gesture locationInView:self.view];
+    }
+
+    CGFloat delta = [gesture locationInView:self.view].x - self.panStartLocation.x;
+    CGFloat constant;
+    CGFloat backGroundAlpha;
+    KYDrawerControllerDrawerState drawerState = KYDrawerControllerDrawerStateOpened;
+
+    if (self.drawerDirection == KYDrawerControllerDrawerDirectionLeft) {
+        drawerState = self.panDelta <= 0 ? KYDrawerControllerDrawerStateClosed : KYDrawerControllerDrawerStateOpened;
+        constant = fmin(self.drawerConstraint.constant + delta, self.drawerWidth);
+        backGroundAlpha = fmin(self.containerViewMaxAlpha, self.containerViewMaxAlpha * fabs(constant) / self.drawerWidth);
+    }
+    else {
+        drawerState = self.panDelta >= 0 ? KYDrawerControllerDrawerStateClosed : KYDrawerControllerDrawerStateOpened;
+        constant = fmax(self.drawerConstraint.constant + delta, -self.drawerWidth);
+        backGroundAlpha = fmin(self.containerViewMaxAlpha, self.containerViewMaxAlpha * fabs(constant) / self.drawerWidth);
+    }
+
+    self.drawerConstraint.constant = constant;
+    self.containerView.backgroundColor = [UIColor colorWithWhite:0 alpha:backGroundAlpha];
+
+    if (gesture.state == UIGestureRecognizerStateChanged) {
+        BOOL isAppearing = drawerState != KYDrawerControllerDrawerStateOpened;
+        if (_isAppearing == nil) {
+            _isAppearing = @(isAppearing);
+            [self.drawerViewController beginAppearanceTransition:isAppearing animated:YES];
+            [self.mainViewController beginAppearanceTransition:!isAppearing animated:YES];
+        }
+        
+        self.panStartLocation = [gesture locationInView:self.view];
+        self.panDelta = delta;
+    }
+    else if (gesture.state == UIGestureRecognizerStateEnded || gesture.state == UIGestureRecognizerStateCancelled) {
+        [self setDrawerState:drawerState animated:YES];
+    }
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
+{
+    if (gestureRecognizer == self.panGesture) {
+        return self.drawerState == KYDrawerControllerDrawerStateOpened;
+    }
+    else if (gestureRecognizer == self.screenEdgePanGesture) {
+        return self.screenEdgePanGestreEnabled ? (self.drawerState == KYDrawerControllerDrawerStateClosed) : NO;
+    }
+    else {
+        return touch.view == gestureRecognizer.view;
+    }
+}
+
+#pragma mark - Getters & Setters
+
+- (UIViewController *)displayingViewController
+{
+    switch (self.drawerState) {
+        case KYDrawerControllerDrawerStateClosed:
+            return self.mainViewController;
+        case KYDrawerControllerDrawerStateOpened:
+            return self.drawerViewController;
+        default:
+            return nil;
+    }
+}
+
+- (void)setMainViewController:(UIViewController *)mainViewController
+{
+    UIViewController *oldController = _mainViewController;
+
+    {
+        [oldController willMoveToParentViewController:nil];
+        [oldController.view removeFromSuperview];
+        [oldController removeFromParentViewController];
+    }
+
+    _mainViewController = mainViewController;
+
+    if (!_mainViewController) {
+        return;
+    }
+
+    [self addChildViewController:_mainViewController];
+
+    _mainViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view insertSubview:_mainViewController.view atIndex:0];
+
+    NSDictionary *viewDictionary = @{ @"mainView" : _mainViewController.view };
+
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-0-[mainView]-0-|" options:kNilOptions metrics:nil views:viewDictionary]];
+
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-0-[mainView]-0-|" options:kNilOptions metrics:nil views:viewDictionary]];
+
+    [_mainViewController didMoveToParentViewController:self];
+}
+
+- (void)setDrawerDirection:(KYDrawerControllerDrawerDirection)drawerDirection
+{
+    _drawerDirection = drawerDirection;
+
+    if (_drawerDirection == KYDrawerControllerDrawerDirectionLeft) {
+        self.screenEdgePanGesture.edges = UIRectEdgeLeft;
+    }
+    else if (_drawerDirection == KYDrawerControllerDrawerDirectionRight) {
+        self.screenEdgePanGesture.edges = UIRectEdgeRight;
+    }
+
+    self.drawerViewController = _drawerViewController;
+}
+
+- (void)setDrawerViewController:(UIViewController *)drawerViewController
+{
+    UIViewController *oldController = _drawerViewController;
+
+    {
+        [oldController willMoveToParentViewController:nil];
+        [oldController.view removeFromSuperview];
+        [oldController removeFromParentViewController];
+    }
+
+    _drawerViewController = drawerViewController;
+
+    if (!_drawerViewController) {
+        return;
+    }
+
+    [self addChildViewController:_drawerViewController];
+    
+    _drawerViewController.view.layer.shadowColor = [UIColor blackColor].CGColor;
+    _drawerViewController.view.layer.shadowOpacity = 0.4f;
+    _drawerViewController.view.layer.shadowRadius = 5.0f;
+    _drawerViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.containerView addSubview:_drawerViewController.view];
+
+    NSLayoutAttribute itemAttribute;
+    NSLayoutAttribute toItemAttribute;
+
+    if (self.drawerDirection == KYDrawerControllerDrawerDirectionLeft) {
+        itemAttribute = NSLayoutAttributeRight;
+        toItemAttribute = NSLayoutAttributeLeft;
+    }
+    else {
+        itemAttribute = NSLayoutAttributeLeft;
+        toItemAttribute = NSLayoutAttributeRight;
+    }
+   
+    NSDictionary *viewDictionary = @{ @"drawerView" : _drawerViewController.view };
+
+    self.drawerWidthConstraint = [NSLayoutConstraint constraintWithItem:_drawerViewController.view
+                                                              attribute:NSLayoutAttributeWidth
+                                                              relatedBy:NSLayoutRelationEqual
+                                                                 toItem:nil
+                                                              attribute:NSLayoutAttributeWidth
+                                                             multiplier:1
+                                                               constant:self.drawerWidth];
+
+    [_drawerViewController.view addConstraint:self.drawerWidthConstraint];
+
+    self.drawerConstraint = [NSLayoutConstraint constraintWithItem:_drawerViewController.view
+                                                         attribute:itemAttribute
+                                                         relatedBy:NSLayoutRelationEqual
+                                                            toItem:self.containerView
+                                                         attribute:toItemAttribute
+                                                        multiplier:1
+                                                          constant:0];
+
+    [self.containerView addConstraint:_drawerConstraint];
+    [self.containerView
+        addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-0-[drawerView]-0-|" options:kNilOptions metrics:nil views:viewDictionary]];
+    [self.containerView updateConstraints];
+
+    [_drawerViewController updateViewConstraints];
+    [_drawerViewController didMoveToParentViewController:self];
+}
+
+- (KYDrawerControllerDrawerState)drawerState
+{
+    return self.containerView.hidden ? KYDrawerControllerDrawerStateClosed : KYDrawerControllerDrawerStateOpened;
+}
+
+- (void)setDrawerState:(KYDrawerControllerDrawerState)drawerState
+{
+    [self setDrawerState:drawerState animated:NO];
+}
+
+- (void)setDrawerWidth:(CGFloat)drawerWidth
+{
+    _drawerWidth = drawerWidth;
+    self.drawerWidthConstraint.constant = drawerWidth;
+}
+
+#pragma mark - Lazy initializer
+
+- (UIView *)containerView
+{
+    if (!_containerView) {
+        UIView *view = [[UIView alloc] initWithFrame:self.view.frame];
+
+        view.translatesAutoresizingMaskIntoConstraints = NO;
+        view.backgroundColor = [UIColor clearColor];
+        [view addGestureRecognizer:self.containerViewTapGesture];
+
+        _containerView = view;
+    }
+    return _containerView;
+}
+
+- (UITapGestureRecognizer *)containerViewTapGesture
+{
+    if (!_containerViewTapGesture) {
+        UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didTapContainerView:)];
+        tapGesture.delegate = self;
+        _containerViewTapGesture = tapGesture;
+    }
+    return _containerViewTapGesture;
+}
+
+- (void)setContainerViewTapGesture:(UITapGestureRecognizer *)containerViewTapGesture
+{
+    _containerViewTapGesture != nil ? ([self.containerView removeGestureRecognizer:_containerViewTapGesture]) : nil;
+    _containerViewTapGesture = containerViewTapGesture;
+    [self.containerView addGestureRecognizer:_containerViewTapGesture];
+}
+
+- (UIScreenEdgePanGestureRecognizer *)screenEdgePanGesture
+{
+    if (!_screenEdgePanGesture) {
+        UIScreenEdgePanGestureRecognizer *gesture = [[UIScreenEdgePanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePanGesture:)];
+        if (self.drawerDirection == KYDrawerControllerDrawerDirectionLeft) {
+            gesture.edges = UIRectEdgeLeft;
+        }
+        else if (self.drawerDirection == KYDrawerControllerDrawerDirectionRight) {
+            gesture.edges = UIRectEdgeRight;
+        }
+        gesture.delegate = self;
+
+        _screenEdgePanGesture = gesture;
+    }
+    return _screenEdgePanGesture;
+}
+
+- (UIPanGestureRecognizer *)panGesture
+{
+    if (!_panGesture) {
+        UIPanGestureRecognizer *gesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePanGesture:)];
+        gesture.delegate = self;
+
+        _panGesture = gesture;
+    }
+    return _panGesture;
+}
+
+@end

--- a/ios/RCCDrawerController/RCCKYDrawerController.h
+++ b/ios/RCCDrawerController/RCCKYDrawerController.h
@@ -1,0 +1,14 @@
+//
+//  RCCKYDrawerController.h
+//  ReactNativeNavigation
+//
+//  Created by Egor Khmelev on 30/06/2017.
+//  Copyright © 2017 artal. All rights reserved.
+//
+
+#import "KYDrawerController.h"
+#import "RCCDrawerProtocol.h"
+
+@interface RCCKYDrawerController : KYDrawerController <RCCDrawerDelegate>
+
+@end

--- a/ios/RCCDrawerController/RCCKYDrawerController.m
+++ b/ios/RCCDrawerController/RCCKYDrawerController.m
@@ -1,0 +1,117 @@
+//
+//  RCCKYDrawerController.m
+//  ReactNativeNavigation
+//
+//  Created by Egor Khmelev on 30/06/2017.
+//  Copyright © 2017 artal. All rights reserved.
+//
+
+#import "RCCKYDrawerController.h"
+#import "RCCViewController.h"
+#import <React/RCTConvert.h>
+
+@interface RCCKYDrawerController ()
+
+@end
+
+@implementation RCCKYDrawerController
+
+@synthesize overlayButton = _overlayButton, drawerStyle = _drawerStyle;
+
+- (instancetype)initWithProps:(NSDictionary *)props children:(NSArray *)children globalProps:(NSDictionary*)globalProps bridge:(RCTBridge *)bridge {
+    if ([children count] < 1) return nil;
+    
+    UIViewController *centerVC = [RCCViewController controllerWithLayout:children[0] globalProps:props bridge:bridge];
+    UIViewController *leftVC = nil;
+    UIViewController *rightVC = nil;
+    
+    // left
+    NSString *componentLeft = props[@"componentLeft"];
+    if (componentLeft)  {
+        leftVC = [[RCCViewController alloc] initWithComponent:componentLeft passProps:props[@"passPropsLeft"] navigatorStyle:nil globalProps:props bridge:bridge];
+    }
+    
+    // right
+    NSString *componentRight = props[@"componentRight"];
+    if (componentRight) {
+        rightVC = [[RCCViewController alloc] initWithComponent:componentRight passProps:props[@"passPropsRight"] navigatorStyle:nil globalProps:props bridge:bridge];
+    }
+    
+    self = [super init];
+    if (!self) return nil;
+    
+    self.mainViewController = centerVC;
+    
+    if (rightVC) {
+        self.drawerDirection = KYDrawerControllerDrawerDirectionRight;
+        self.drawerViewController = rightVC;
+    } else {
+        self.drawerViewController = leftVC;
+    }
+    
+    self.drawerStyle = props[@"style"];
+    [self setStyleWithProps:self.drawerStyle];
+    
+    return self;
+    
+}
+
+- (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge {
+    // open
+    if ([performAction isEqualToString:@"open"])
+    {
+        if (self.drawerState != KYDrawerControllerDrawerStateOpened) {
+            [self setDrawerState:KYDrawerControllerDrawerStateOpened animated:YES];
+        }
+        return;
+    }
+    
+    // close
+    if ([performAction isEqualToString:@"close"])
+    {
+        if (self.drawerState != KYDrawerControllerDrawerStateClosed) {
+            [self setDrawerState:KYDrawerControllerDrawerStateClosed animated:YES];
+        }
+        return;
+    }
+    
+    // toggle
+    if ([performAction isEqualToString:@"toggle"])
+    {
+        if (self.drawerState == KYDrawerControllerDrawerStateOpened) {
+            [self setDrawerState:KYDrawerControllerDrawerStateClosed animated:YES];
+        } else {
+            [self setDrawerState: KYDrawerControllerDrawerStateOpened animated:YES];
+        }
+        return;
+    }
+
+    // setStyle
+    if ([performAction isEqualToString:@"setStyle"])
+    {
+        [self setStyleWithProps:actionParams];
+        return;
+    }
+    
+}
+
+- (void)setStyleWithProps:(NSDictionary *)styleProps {
+    if (styleProps[@"drawerWidth"]) {
+        self.drawerWidth = (CGFloat) [RCTConvert float:styleProps[@"drawerWidth"]];
+    }
+    
+    if (styleProps[@"drawerAnimationDuration"]) {
+        self.drawerAnimationDuration = (NSTimeInterval) ([RCTConvert float:styleProps[@"drawerAnimationDuration"]] / 1000.f);
+    }
+    
+    if (styleProps[@"containerViewMaxAlpha"]) {
+        self.containerViewMaxAlpha = (CGFloat) [RCTConvert float:styleProps[@"containerViewMaxAlpha"]];
+    }
+
+    if (styleProps[@"screenEdgePanGestreEnabled"]) {
+        self.screenEdgePanGestreEnabled = [RCTConvert BOOL:styleProps[@"screenEdgePanGestreEnabled"]];
+    }
+}
+
+
+@end

--- a/ios/RCCManagerModule.m
+++ b/ios/RCCManagerModule.m
@@ -8,6 +8,7 @@
 #import <React/RCTConvert.h>
 #import "RCCTabBarController.h"
 #import "RCCTheSideBarManagerViewController.h"
+#import "RCCKYDrawerController.h"
 #import "RCCNotification.h"
 
 #define kSlideDownAnimationDuration 0.35
@@ -278,7 +279,7 @@ RCT_EXPORT_METHOD(
     if (!controllerId || !performAction) return;
     
     id<RCCDrawerDelegate> controller = [[RCCManager sharedIntance] getControllerWithId:controllerId componentType:@"DrawerControllerIOS"];
-    if (!controller || (![controller isKindOfClass:[RCCDrawerController class]] && ![controller isKindOfClass:[RCCTheSideBarManagerViewController class]])) return;
+    if (!controller || (![controller isKindOfClass:[RCCDrawerController class]] && ![controller isKindOfClass:[RCCTheSideBarManagerViewController class]] && ![controller isKindOfClass:[RCCKYDrawerController class]])) return;
     return [controller performAction:performAction actionParams:actionParams bridge:[[RCCManager sharedIntance] getBridge]];
     
 }

--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -11,7 +11,7 @@
 #import "RCTHelpers.h"
 #import "RCCTitleViewHelper.h"
 #import "RCCCustomTitleView.h"
-
+#import "RCCKYDrawerController.h"
 
 NSString* const RCCViewControllerCancelReactTouchesNotification = @"RCCViewControllerCancelReactTouchesNotification";
 
@@ -81,10 +81,10 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
     NSString *drawerType = props[@"type"];
     
     if ([drawerType isEqualToString:@"TheSideBar"]) {
-      
       controller = [[RCCTheSideBarManagerViewController alloc] initWithProps:props children:children globalProps:globalProps bridge:bridge];
-    }
-    else {
+    } else if ([drawerType isEqualToString:@"KYDrawerController"]) {
+      controller = [[RCCKYDrawerController alloc] initWithProps:props children:children globalProps:globalProps bridge:bridge];
+    } else {
       controller = [[RCCDrawerController alloc] initWithProps:props children:children globalProps:globalProps bridge:bridge];
     }
   }

--- a/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		252B529C1F07C77800ECBA11 /* RCCKYDrawerController.m in Sources */ = {isa = PBXBuildFile; fileRef = 252B529B1F07C77800ECBA11 /* RCCKYDrawerController.m */; };
+		252B52A01F07C79900ECBA11 /* KYDrawerController.m in Sources */ = {isa = PBXBuildFile; fileRef = 252B529F1F07C79900ECBA11 /* KYDrawerController.m */; };
 		260804DB1CE0D9D20094DBA1 /* RCCToolBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 260804DA1CE0D9D20094DBA1 /* RCCToolBar.m */; };
 		261108801E6C495400BF5D98 /* UIViewController+Rotation.m in Sources */ = {isa = PBXBuildFile; fileRef = 2611087F1E6C495400BF5D98 /* UIViewController+Rotation.m */; };
 		26714EAC1EB0E9D3009F4D52 /* RCCCustomTitleView.m in Sources */ = {isa = PBXBuildFile; fileRef = 26714EAB1EB0E9D3009F4D52 /* RCCCustomTitleView.m */; };
@@ -50,6 +52,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		252B529A1F07C77800ECBA11 /* RCCKYDrawerController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCCKYDrawerController.h; sourceTree = "<group>"; };
+		252B529B1F07C77800ECBA11 /* RCCKYDrawerController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCCKYDrawerController.m; sourceTree = "<group>"; };
+		252B529E1F07C79900ECBA11 /* KYDrawerController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KYDrawerController.h; sourceTree = "<group>"; };
+		252B529F1F07C79900ECBA11 /* KYDrawerController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KYDrawerController.m; sourceTree = "<group>"; };
 		260804D91CE0D9D20094DBA1 /* RCCToolBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCCToolBar.h; sourceTree = "<group>"; };
 		260804DA1CE0D9D20094DBA1 /* RCCToolBar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCCToolBar.m; sourceTree = "<group>"; };
 		2611087E1E6C495400BF5D98 /* UIViewController+Rotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIViewController+Rotation.h"; path = "../UIViewController+Rotation.h"; sourceTree = "<group>"; };
@@ -123,6 +129,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		252B529D1F07C79900ECBA11 /* KYDrawerController */ = {
+			isa = PBXGroup;
+			children = (
+				252B529E1F07C79900ECBA11 /* KYDrawerController.h */,
+				252B529F1F07C79900ECBA11 /* KYDrawerController.m */,
+			);
+			path = KYDrawerController;
+			sourceTree = "<group>";
+		};
 		260804D51CE0D7090094DBA1 /* RCCToolBar */ = {
 			isa = PBXGroup;
 			children = (
@@ -135,10 +150,13 @@
 		D85082BB1CBCF42400FDB961 /* RCCDrawerController */ = {
 			isa = PBXGroup;
 			children = (
+				252B529D1F07C79900ECBA11 /* KYDrawerController */,
 				D85082BC1CBCF42400FDB961 /* MMDrawerController */,
 				D85082CF1CBCF54200FDB961 /* TheSidebarController */,
 				D85082CB1CBCF54200FDB961 /* RCCDrawerHelper.m */,
 				D85082CC1CBCF54200FDB961 /* RCCDrawerProtocol.h */,
+				252B529A1F07C77800ECBA11 /* RCCKYDrawerController.h */,
+				252B529B1F07C77800ECBA11 /* RCCKYDrawerController.m */,
 				D85082CD1CBCF54200FDB961 /* RCCTheSideBarManagerViewController.h */,
 				D85082CE1CBCF54200FDB961 /* RCCTheSideBarManagerViewController.m */,
 				D85082C81CBCF42400FDB961 /* RCCDrawerController.h */,
@@ -304,12 +322,14 @@
 				D85082EA1CBCF54200FDB961 /* TheSidebarController.m in Sources */,
 				CC84A1A01C1A0C4E00B3A6A2 /* RCCNavigationController.m in Sources */,
 				D83514F61D29719A00D53758 /* RCCNotification.m in Sources */,
+				252B529C1F07C77800ECBA11 /* RCCKYDrawerController.m in Sources */,
 				CC84A19F1C1A0C4E00B3A6A2 /* RCCManagerModule.m in Sources */,
 				26AFF3F51D7EEE2400CBA211 /* RCCTitleViewHelper.m in Sources */,
 				D8D779981D04B7180050CFEA /* RCTHelpers.m in Sources */,
 				D85082E81CBCF54200FDB961 /* SidebarLuvocracyAnimation.m in Sources */,
 				D85082E31CBCF54200FDB961 /* SidebarAirbnbAnimation.m in Sources */,
 				D84813191C8C5EB700051BAF /* RCCLightBox.m in Sources */,
+				252B52A01F07C79900ECBA11 /* KYDrawerController.m in Sources */,
 				CC84A19E1C1A0C4E00B3A6A2 /* RCCManager.m in Sources */,
 				26714EAC1EB0E9D3009F4D52 /* RCCCustomTitleView.m in Sources */,
 				D85082E21CBCF54200FDB961 /* RCCTheSideBarManagerViewController.m in Sources */,

--- a/src/Screen.js
+++ b/src/Screen.js
@@ -100,6 +100,10 @@ class Navigator {
     return platformSpecific.navigatorSetDrawerEnabled(this, params);
   }
 
+  setDrawerStyle(params = {}) {
+    return platformSpecific.navigatorSetDrawerStyle(this, params);
+  }
+
   toggleTabs(params = {}) {
     return platformSpecific.navigatorToggleTabs(this, params);
   }

--- a/src/deprecated/controllers/index.js
+++ b/src/deprecated/controllers/index.js
@@ -74,6 +74,9 @@ function _validateDrawerProps(layout) {
         }
       })
     }
+    else if (drawerProps.type === "KYDrawerController") {
+      shouldSetToDefault = false;
+    }
 
     if (shouldSetToDefault) {
       console.warn("Set to default type=MMDrawer animationType=slide");

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -367,6 +367,11 @@ function navigatorToggleDrawer(navigator, params) {
   }
 }
 
+function navigatorSetDrawerStyle(navigator, params) {
+  const controllerID = navigator.navigatorID.split('_')[0];
+  Controllers.DrawerControllerIOS(controllerID + '_drawer').setStyle(params);
+}
+
 function navigatorToggleTabs(navigator, params) {
   const controllerID = navigator.navigatorID.split('_')[0];
   Controllers.TabBarControllerIOS(controllerID + '_tabs').setHidden({
@@ -632,6 +637,7 @@ export default {
   dismissInAppNotification,
   navigatorSetButtons,
   navigatorSetDrawerEnabled,
+  navigatorSetDrawerStyle,
   navigatorSetTitle,
   navigatorSetSubtitle,
   navigatorSetStyle,


### PR DESCRIPTION
This PR adds support of `KYDrawerController` to current drawer implementation. This library is similar to default Android implementation (I need the exact iOS layout in my project). The only trade-off is that it supports left or right drawer pane but not both and this behaviour controlled by direction. If developer defines the right one it will switch to opposite direction, thats it. 

Also this PR adds missing `Navigator.setDrawerStyle`.