### PR TITLE
Support headlessJs

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/bridge/EventEmitter.java
+++ b/android/app/src/main/java/com/reactnativenavigation/bridge/EventEmitter.java
@@ -52,4 +52,11 @@ public class EventEmitter {
         }
         reactGateway.getReactEventEmitter().sendEvent(eventId, Arguments.createMap());
     }
+
+    public void sendAppLaunchedEvent() {
+        if (!NavigationApplication.instance.isReactContextInitialized()) {
+            return;
+        }
+        reactGateway.getReactEventEmitter().sendEvent("RNN.appLaunched", Arguments.createMap());
+    }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/bridge/NavigationReactModule.java
+++ b/android/app/src/main/java/com/reactnativenavigation/bridge/NavigationReactModule.java
@@ -258,4 +258,9 @@ public class NavigationReactModule extends ReactContextBaseJavaModule {
     public void getOrientation(Promise promise) {
         NavigationCommandsHandler.getOrientation(promise);
     }
+
+    @ReactMethod
+    public void isAppLaunched(Promise promise) {
+        NavigationCommandsHandler.isAppLaunched(promise);
+    }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationCommandsHandler.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationCommandsHandler.java
@@ -535,4 +535,9 @@ public class NavigationCommandsHandler {
         }
         promise.resolve(OrientationHelper.getOrientation(currentActivity));
     }
+
+    public static void isAppLaunched(Promise promise) {
+        final boolean isAppLaunched = SplashActivity.isResumed || NavigationActivity.currentActivity != null;
+        promise.resolve(isAppLaunched);
+    }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
@@ -11,6 +11,7 @@ import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.react.ReactDevPermission;
 
 public abstract class SplashActivity extends AppCompatActivity {
+    public static boolean isResumed = false;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -22,8 +23,11 @@ public abstract class SplashActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        isResumed = true;
 
         if (NavigationApplication.instance.getReactGateway().hasStartedCreatingContext()) {
+            NavigationApplication.instance.getEventEmitter().sendAppLaunchedEvent();
+            overridePendingTransition(0, 0);
             finish();
             return;
         }
@@ -40,6 +44,12 @@ public abstract class SplashActivity extends AppCompatActivity {
 
         // TODO I'm starting to think this entire flow is incorrect and should be done in Application
         NavigationApplication.instance.startReactContextOnceInBackgroundAndExecuteJS();
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        isResumed = false;
     }
 
     private void setSplashLayout() {

--- a/src/NativeEventsReceiver.js
+++ b/src/NativeEventsReceiver.js
@@ -1,0 +1,14 @@
+import {
+  NativeAppEventEmitter,
+  DeviceEventEmitter,
+  Platform
+} from 'react-native';
+export default class NativeEventsReceiver {
+  constructor() {
+    this.emitter = Platform.OS === 'android' ? DeviceEventEmitter : NativeAppEventEmitter;
+  }
+
+  appLaunched(callback) {
+    this.emitter.addListener('RNN.appLaunched', callback);
+  }
+}

--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -162,6 +162,10 @@ function handleDeepLink(params = {}) {
   }
 }
 
+async function isAppLaunched() {
+  return await platformSpecific.isAppLaunched();
+}
+
 export default {
   getRegisteredScreen,
   registerComponent,
@@ -177,5 +181,6 @@ export default {
   startSingleScreenApp: startSingleScreenApp,
   setEventHandler: setEventHandler,
   clearEventHandler: clearEventHandler,
-  handleDeepLink: handleDeepLink
+  handleDeepLink: handleDeepLink,
+  isAppLaunched: isAppLaunched
 };

--- a/src/deprecated/indexDeprecated.android.js
+++ b/src/deprecated/indexDeprecated.android.js
@@ -1,8 +1,9 @@
 import Navigation from './../Navigation';
 import SharedElementTransition from './../views/sharedElementTransition';
+import NativeEventsReceiver from './../NativeEventsReceiver';
 
 module.exports = {
   Navigation,
-  SharedElementTransition
+  SharedElementTransition,
+  NativeEventsReceiver
 };
-

--- a/src/deprecated/indexDeprecated.ios.js
+++ b/src/deprecated/indexDeprecated.ios.js
@@ -1,9 +1,11 @@
 import Navigation from './../Navigation';
 import {NavigationToolBarIOS} from './controllers';
 import SharedElementTransition from '../views/sharedElementTransition';
+import NativeEventsReceiver from './../NativeEventsReceiver';
 
 module.exports = {
   Navigation,
   NavigationToolBarIOS,
-  SharedElementTransition
+  SharedElementTransition,
+  NativeEventsReceiver
 };

--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -675,6 +675,10 @@ function dismissContextualMenu() {
   newPlatformSpecific.dismissContextualMenu();
 }
 
+async function isAppLaunched() {
+  return await newPlatformSpecific.isAppLaunched();
+}
+
 export default {
   startTabBasedApp,
   startSingleScreenApp,
@@ -704,5 +708,6 @@ export default {
   showSnackbar,
   dismissSnackbar,
   showContextualMenu,
-  dismissContextualMenu
+  dismissContextualMenu,
+  isAppLaunched
 };

--- a/src/platformSpecific.android.js
+++ b/src/platformSpecific.android.js
@@ -177,6 +177,10 @@ function setScreenStyle(screenInstanceId, style) {
   NativeReactModule.setScreenStyle(screenInstanceId, style);
 }
 
+async function isAppLaunched() {
+  return await NativeReactModule.isAppLaunched();
+}
+
 module.exports = {
   startApp,
   push,
@@ -210,5 +214,6 @@ module.exports = {
   dismissSnackbar,
   showContextualMenu,
   dismissContextualMenu,
-  setScreenStyle
+  setScreenStyle,
+  isAppLaunched
 };


### PR DESCRIPTION
Currently startApp is called from global context which results in the
app being launched when headlessJs tasks run in the background.
In order to support this use case, while not breaking existing users,
this commit adds two mechanisms which should help users detrmine if
the native Activity is running and startApp can be called safely.

1. RNN.appLaunched event is emitted is SplashActivity starts and react
   context has already been created. This is the use case of openeing
   the app while headless js task was started or has just finished and
   react context is in a "pasued" state.

2. Navigation.isAppLaunched() convenience method has been added.
   It returns a promise which when resolved, indicates if the app
   is launched and we should show the ui or not.

Usage

```js
import {Navigation, NativeEventsReceiver} from 'react-native-navigation';

Promise.resolve(Navigation.isAppLaunched())
  .then(appLaunched => {
    if (appLaunched) {
      startApp();
    } else {
      new NativeEventsReceiver().appLaunched(startApp);
    }
  });

function startApp() {
  Navigation.startTabBasedApp({ ... });
}
```

closes #1320 