### PR TITLE
Revert "Use UIStoryboard methods for presenting a splash screen on iOS"

### DIFF
--- a/ios/RCCManager.m
+++ b/ios/RCCManager.m
@@ -134,18 +134,28 @@
 -(void)showSplashScreen
 {
   CGRect screenBounds = [UIScreen mainScreen].bounds;
-  UIViewController *splashViewController = nil;
-
+  UIView *splashView = nil;
+  
   NSString* launchStoryBoard = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UILaunchStoryboardName"];
   if (launchStoryBoard != nil)
   {//load the splash from the storyboard that's defined in the info.plist as the LaunchScreen
-    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:launchStoryBoard bundle:[NSBundle mainBundle]];
-    splashViewController = [storyboard instantiateInitialViewController];
+    @try
+    {
+      splashView = [[NSBundle mainBundle] loadNibNamed:launchStoryBoard owner:self options:nil][0];
+      if (splashView != nil)
+      {
+        splashView.frame = CGRectMake(0, 0, screenBounds.size.width, screenBounds.size.height);
+      }
+    }
+    @catch(NSException *e)
+    {
+      splashView = nil;
+    }
   }
   else
   {//load the splash from the DEfault image or from LaunchImage in the xcassets
     CGFloat screenHeight = screenBounds.size.height;
-
+    
     NSString* imageName = @"Default";
     if (screenHeight == 568)
       imageName = [imageName stringByAppendingString:@"-568h"];
@@ -153,13 +163,13 @@
       imageName = [imageName stringByAppendingString:@"-667h"];
     else if (screenHeight == 736)
       imageName = [imageName stringByAppendingString:@"-736h"];
-
+    
     //xcassets LaunchImage files
     UIImage *image = [UIImage imageNamed:imageName];
     if (image == nil)
     {
       imageName = @"LaunchImage";
-
+      
       if (screenHeight == 480)
         imageName = [imageName stringByAppendingString:@"-700"];
       if (screenHeight == 568)
@@ -168,21 +178,23 @@
         imageName = [imageName stringByAppendingString:@"-800-667h"];
       else if (screenHeight == 736)
         imageName = [imageName stringByAppendingString:@"-800-Portrait-736h"];
-
+      
       image = [UIImage imageNamed:imageName];
     }
-
+    
     if (image != nil)
     {
-      UIImageView *imageView = [[UIImageView alloc] initWithImage:image];
-      splashViewController = [[UIViewController alloc] init];
-      splashViewController.view = imageView;
+      splashView = [[UIImageView alloc] initWithImage:image];
     }
   }
-
-  if (splashViewController != nil) {
+  
+  if (splashView != nil)
+  {
+    UIViewController *splashVC = [[UIViewController alloc] init];
+    splashVC.view = splashView;
+    
     id<UIApplicationDelegate> appDelegate = [UIApplication sharedApplication].delegate;
-    appDelegate.window.rootViewController = splashViewController;
+    appDelegate.window.rootViewController = splashVC;
     [appDelegate.window makeKeyAndVisible];
   }
 }


### PR DESCRIPTION
Reverts wix/react-native-navigation#1453,
This is a good feature, but it breaks all current projects. Please fix and add support for loading splash screens with support for `.xib`s