### PR TITLE
Fixed props failing to pass to tabs after startTabBasedApp... iOS

### DIFF
--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -600,9 +600,7 @@ function savePassProps(params) {
 
   if (params.tabs) {
     _.forEach(params.tabs, (tab) => {
-      if (!tab.passProps) {
-        tab.passProps = params.passProps;
-      }
+      tab.passProps = params.passProps;
       savePassProps(tab);
     });
   }


### PR DESCRIPTION
Fixed props failing to pass to tabs after startTabBasedApp has been called more than once.

Closes Issue #1419