### PR TITLE
Add tabBarBlur for native blur mask

### DIFF
--- a/docs/styling-the-tab-bar.md
+++ b/docs/styling-the-tab-bar.md
@@ -25,6 +25,7 @@ Navigation.startTabBasedApp({
   tabBarSelectedLabelColor: 'red', // iOS only. change the color of the selected tab text
   forceTitlesDisplay: true // Android only. If true - Show all bottom tab labels. If false - only the selected tab's label is visible.
   tabBarHideShadow: true // iOS only. Remove default tab bar top shadow (hairline)
+  tabBarBlur: true, // iOS only. Can also be the string 'dark' for dark style blur.
 }
 ```
 

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -120,6 +120,17 @@
     {
       self.tabBar.clipsToBounds = [tabBarHideShadow boolValue] ? YES : NO;
     }
+    
+    NSString *tabBarBlur = tabsStyle[@"tabBarBlur"];
+    if (tabBarBlur) {
+      [[UITabBar appearance] setBackgroundImage:[UIImage new]];
+      UIToolbar* blurredView = [[UIToolbar alloc] initWithFrame:self.tabBar.bounds];
+      BOOL isDefault = [tabBarBlur boolValue];
+      if (!isDefault && [tabBarBlur isEqualToString:@"dark"]) {
+        [blurredView setBarStyle:UIBarStyleBlack];
+      }
+      [self.tabBar insertSubview:blurredView atIndex:0];
+    }
   }
   
   NSMutableArray *viewControllers = [NSMutableArray array];


### PR DESCRIPTION
Added tabBarBlur to `tabsStyle` for better iOS native look and feel.

Uses `UIBarStyle`(https://developer.apple.com/documentation/uikit/uibarstyle?language=objc) for setting the type of blur style.

Value can be `true || false || 'dark'`