### PR TITLE
fixed blank nav bar titles on Android when title font size not set.

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/TitleBar.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/TitleBar.java
@@ -151,12 +151,11 @@ public class TitleBar extends Toolbar {
     }
 
     protected void setTitleTextFontSize(StyleParams params) {
-        if (params.titleBarTitleFontSize == -1) {
-            return;
-        }
-        View titleView = getTitleView();
-        if (titleView instanceof TextView) {
-            ((TextView) titleView).setTextSize(((float) params.titleBarTitleFontSize));
+        if (params.titleBarTitleFontSize > 0) {
+            View titleView = getTitleView();
+            if (titleView instanceof TextView) {
+                ((TextView) titleView).setTextSize(((float) params.titleBarTitleFontSize));
+            }
         }
     }
 


### PR DESCRIPTION
When using appStyle and not setting the navBarTitleFontSize prop, it was defaulting to 0 and was therefore passing the return and setting a 0 font size title.

Closes #1515.