### PR TITLE
Currently visible screen

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/bridge/NavigationReactModule.java
+++ b/android/app/src/main/java/com/reactnativenavigation/bridge/NavigationReactModule.java
@@ -263,4 +263,9 @@ public class NavigationReactModule extends ReactContextBaseJavaModule {
     public void isAppLaunched(Promise promise) {
         NavigationCommandsHandler.isAppLaunched(promise);
     }
+
+    @ReactMethod
+    public void getCurrentlyVisibleScreenId(Promise promise) {
+        NavigationCommandsHandler.getCurrentlyVisibleScreenId(promise);
+    }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/Modal.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/Modal.java
@@ -95,6 +95,10 @@ public class Modal extends Dialog implements DialogInterface.OnDismissListener, 
         layout.selectTopTabByTabIndex(screenInstanceId, index);
     }
 
+    String getCurrentlyVisibleScreenId() {
+        return layout.getCurrentlyVisibleScreenId();
+    }
+
     interface OnModalDismissedListener {
         void onModalDismissed(Modal modal);
     }

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/ModalController.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/ModalController.java
@@ -183,4 +183,8 @@ class ModalController implements ScreenStackContainer, Modal.OnModalDismissedLis
             modal.selectTopTabByScreen(screenInstanceId);
         }
     }
+
+    String getCurrentlyVisibleScreenId() {
+        return stack.peek().getCurrentlyVisibleScreenId();
+    }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -391,8 +391,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     public void showContextualMenu(String screenInstanceId, ContextualMenuParams params, Callback onButtonClicked) {
         if (modalController.isShowing()) {
             modalController.showContextualMenu(screenInstanceId, params, onButtonClicked);
-        } else
-        {
+        } else {
             layout.showContextualMenu(screenInstanceId, params, onButtonClicked);
         }
     }
@@ -447,5 +446,9 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
         if (mPermissionListener != null && mPermissionListener.onRequestPermissionsResult(requestCode, permissions, grantResults)) {
             mPermissionListener = null;
         }
+    }
+
+    public String getCurrentlyVisibleScreenId() {
+        return modalController.isShowing() ? modalController.getCurrentlyVisibleScreenId() : layout.getCurrentlyVisibleScreenId();
     }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationCommandsHandler.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationCommandsHandler.java
@@ -3,8 +3,10 @@ package com.reactnativenavigation.controllers;
 import android.content.Intent;
 import android.os.Bundle;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.WritableMap;
 import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.params.ActivityParams;
 import com.reactnativenavigation.params.ContextualMenuParams;
@@ -539,5 +541,21 @@ public class NavigationCommandsHandler {
     public static void isAppLaunched(Promise promise) {
         final boolean isAppLaunched = SplashActivity.isResumed || NavigationActivity.currentActivity != null;
         promise.resolve(isAppLaunched);
+    }
+
+    public static void getCurrentlyVisibleScreenId(final Promise promise) {
+        final NavigationActivity currentActivity = NavigationActivity.currentActivity;
+        if (currentActivity == null) {
+            promise.resolve("");
+            return;
+        }
+        NavigationApplication.instance.runOnMainThread(new Runnable() {
+            @Override
+            public void run() {
+                WritableMap map = Arguments.createMap();
+                map.putString("screenId", currentActivity.getCurrentlyVisibleScreenId());
+                promise.resolve(map);
+            }
+        });
     }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/layouts/BottomTabsLayout.java
+++ b/android/app/src/main/java/com/reactnativenavigation/layouts/BottomTabsLayout.java
@@ -211,6 +211,11 @@ public class BottomTabsLayout extends BaseLayout implements AHBottomNavigation.O
     }
 
     @Override
+    public String getCurrentlyVisibleScreenId() {
+        return getCurrentScreen().getScreenInstanceId();
+    }
+
+    @Override
     public void selectTopTabByTabIndex(String screenInstanceId, int index) {
         for (int i = 0; i < bottomTabs.getItemsCount(); i++) {
             screenStacks[i].selectTopTabByTabIndex(screenInstanceId, index);

--- a/android/app/src/main/java/com/reactnativenavigation/layouts/Layout.java
+++ b/android/app/src/main/java/com/reactnativenavigation/layouts/Layout.java
@@ -66,4 +66,6 @@ public interface Layout extends ScreenStackContainer {
     void selectTopTabByScreen(String screenInstanceId);
 
     void updateScreenStyle(String screenInstanceId, Bundle styleParams);
+
+    String getCurrentlyVisibleScreenId();
 }

--- a/android/app/src/main/java/com/reactnativenavigation/layouts/SingleScreenLayout.java
+++ b/android/app/src/main/java/com/reactnativenavigation/layouts/SingleScreenLayout.java
@@ -274,6 +274,11 @@ public class SingleScreenLayout extends BaseLayout {
     }
 
     @Override
+    public String getCurrentlyVisibleScreenId() {
+        return stack.peek().getScreenInstanceId();
+    }
+
+    @Override
     public void showSlidingOverlay(final SlidingOverlayParams params) {
         slidingOverlaysQueue.add(new SlidingOverlay(this, params));
     }

--- a/ios/RCCManager.h
+++ b/ios/RCCManager.h
@@ -15,6 +15,7 @@
 -(void)registerController:(UIViewController*)controller componentId:(NSString*)componentId componentType:(NSString*)componentType;
 -(id)getControllerWithId:(NSString*)componentId componentType:(NSString*)componentType;
 -(void)unregisterController:(UIViewController*)vc;
+-(NSString*) getIdForController:(UIViewController*)vc;
 
 -(void)clearModuleRegistry;
 

--- a/ios/RCCManager.m
+++ b/ios/RCCManager.m
@@ -1,4 +1,5 @@
 #import "RCCManager.h"
+#import "RCCViewController.h"
 #import <React/RCTBridge.h>
 #import <React/RCTRedBox.h>
 #import <Foundation/Foundation.h>
@@ -114,6 +115,32 @@
   }
 
   return component;
+}
+
+-(NSString*) getIdForController:(UIViewController*)vc
+{
+  if([vc isKindOfClass:[RCCViewController class]])
+  {
+    NSString *controllerId = ((RCCViewController*)vc).controllerId;
+    if(controllerId != nil)
+    {
+      return controllerId;
+    }
+  }
+  
+  for (NSString *key in [self.modulesRegistry allKeys])
+  {
+    NSMutableDictionary *componentsDic = self.modulesRegistry[key];
+    for (NSString *componentID in [componentsDic allKeys])
+    {
+      UIViewController *tmpVc = componentsDic[componentID];
+      if (tmpVc == vc)
+      {
+        return componentID;
+      }
+    }
+  }
+  return nil;
 }
 
 -(void)initBridgeWithBundleURL:(NSURL *)bundleURL

--- a/ios/RCCManagerModule.m
+++ b/ios/RCCManagerModule.m
@@ -342,6 +342,35 @@ RCT_EXPORT_METHOD(
                                                                     completion:^(){ resolve(nil); }];
 }
 
+- (UIViewController *) getVisibleViewControllerFor:(UIViewController *)vc
+{
+    if ([vc isKindOfClass:[UINavigationController class]])
+    {
+        return [self getVisibleViewControllerFor:[((UINavigationController*)vc) visibleViewController]];
+    }
+    else if ([vc isKindOfClass:[UITabBarController class]])
+    {
+        return [self getVisibleViewControllerFor:[((UITabBarController*)vc) selectedViewController]];
+    }
+    else if (vc.presentedViewController)
+    {
+        return [self getVisibleViewControllerFor:vc.presentedViewController];
+    }
+    else
+    {
+        return vc;
+    }
+}
+
+RCT_EXPORT_METHOD(getCurrentlyVisibleScreenId:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    UIViewController *rootVC = [UIApplication sharedApplication].delegate.window.rootViewController;
+    UIViewController *visibleVC = [self getVisibleViewControllerFor:rootVC];
+    NSString *controllerId = [[RCCManager sharedIntance] getIdForController:visibleVC];
+    id result = (controllerId != nil) ? @{@"screenId": controllerId} : nil;
+    resolve(result);
+}
+
 -(BOOL)viewControllerIsModal:(UIViewController*)viewController
 {
     BOOL viewControllerIsModal = (viewController.presentingViewController.presentedViewController == viewController)

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -34,6 +34,7 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   
   RCCViewController *viewController = [[RCCViewController alloc] initWithComponent:component passProps:passProps navigatorStyle:navigatorStyle globalProps:globalProps bridge:bridge];
   if (!viewController) return nil;
+  viewController.controllerId = props[@"id"];
   
   NSArray *leftButtons = props[@"leftButtons"];
   if (leftButtons)
@@ -104,6 +105,7 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
     }
     
     RCCViewController *viewController = [[RCCViewController alloc] initWithComponent:component passProps:passProps navigatorStyle:navigatorStyle globalProps:nil bridge:bridge];
+    viewController.controllerId = passProps[@"screenInstanceID"];
     
     [self processTitleView:viewController
                      props:actionParams
@@ -210,6 +212,7 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
     NSDictionary *navigatorStyle = actionParams[@"style"];
     
     RCCViewController *viewController = [[RCCViewController alloc] initWithComponent:component passProps:passProps navigatorStyle:navigatorStyle globalProps:nil bridge:bridge];
+    viewController.controllerId = passProps[@"screenInstanceID"];
     
     [self processTitleView:viewController
                      props:actionParams

--- a/ios/RCCViewController.h
+++ b/ios/RCCViewController.h
@@ -7,6 +7,7 @@ extern NSString* const RCCViewControllerCancelReactTouchesNotification;
 
 @property (nonatomic) NSMutableDictionary *navigatorStyle;
 @property (nonatomic) BOOL navBarHidden;
+@property (nonatomic, strong) NSString *controllerId;
 
 + (UIViewController*)controllerWithLayout:(NSDictionary *)layout globalProps:(NSDictionary *)globalProps bridge:(RCTBridge *)bridge;
 

--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -94,6 +94,11 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   if (controller && componentId)
   {
     [[RCCManager sharedInstance] registerController:controller componentId:componentId componentType:type];
+    
+    if([controller isKindOfClass:[RCCViewController class]])
+    {
+      ((RCCViewController*)controller).controllerId = componentId;
+    }
   }
   
   // set background image at root level

--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -166,8 +166,13 @@ async function isAppLaunched() {
   return await platformSpecific.isAppLaunched();
 }
 
+function getCurrentlyVisibleScreenId() {
+  return platformSpecific.getCurrentlyVisibleScreenId();
+}
+
 export default {
   getRegisteredScreen,
+  getCurrentlyVisibleScreenId,
   registerComponent,
   showModal: showModal,
   dismissModal: dismissModal,

--- a/src/Screen.js
+++ b/src/Screen.js
@@ -165,6 +165,14 @@ class Navigator {
       Navigation.clearEventHandler(this.navigatorEventID);
     }
   }
+
+  async screenIsCurrentlyVisible() {
+    const res = await Navigation.getCurrentlyVisibleScreenId();
+    if (!res) {
+      return false;
+    }
+    return res.screenId === this.screenInstanceID;
+  }
 }
 
 export default class Screen extends Component {

--- a/src/deprecated/controllers/index.js
+++ b/src/deprecated/controllers/index.js
@@ -313,6 +313,12 @@ var Controllers = {
     }
   },
 
+  ScreenUtils: {
+    getCurrentlyVisibleScreenId: async function() {
+      return await RCCManager.getCurrentlyVisibleScreenId();
+    }
+  },
+
   NavigationToolBarIOS: OriginalReactNative.requireNativeComponent('RCCToolBar', null),
 
   Constants: Constants

--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -683,7 +683,7 @@ async function isAppLaunched() {
 }
 
 async function getCurrentlyVisibleScreenId() {
-  //Currently only implemented for iOS
+  return await newPlatformSpecific.getCurrentlyVisibleScreenId();
 }
 
 export default {

--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -682,6 +682,10 @@ async function isAppLaunched() {
   return await newPlatformSpecific.isAppLaunched();
 }
 
+async function getCurrentlyVisibleScreenId() {
+  //Currently only implemented for iOS
+}
+
 export default {
   startTabBasedApp,
   startSingleScreenApp,
@@ -712,5 +716,6 @@ export default {
   dismissSnackbar,
   showContextualMenu,
   dismissContextualMenu,
-  isAppLaunched
+  isAppLaunched,
+  getCurrentlyVisibleScreenId
 };

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -1,6 +1,6 @@
 /*eslint-disable*/
 import Navigation from './../Navigation';
-import Controllers, {Modal, Notification} from './controllers';
+import Controllers, {Modal, Notification, ScreenUtils} from './controllers';
 const React = Controllers.hijackReact();
 const {
   ControllerRegistry,
@@ -616,6 +616,10 @@ function dismissContextualMenu() {
   // Android only
 }
 
+async function getCurrentlyVisibleScreenId() {
+  return await ScreenUtils.getCurrentlyVisibleScreenId();
+}
+
 export default {
   startTabBasedApp,
   startSingleScreenApp,
@@ -643,5 +647,6 @@ export default {
   navigatorSwitchToTab,
   navigatorToggleNavBar,
   showContextualMenu,
-  dismissContextualMenu
+  dismissContextualMenu,
+  getCurrentlyVisibleScreenId
 };

--- a/src/platformSpecific.android.js
+++ b/src/platformSpecific.android.js
@@ -181,6 +181,10 @@ async function isAppLaunched() {
   return await NativeReactModule.isAppLaunched();
 }
 
+async function getCurrentlyVisibleScreenId() {
+  return await NativeReactModule.getCurrentlyVisibleScreenId();
+}
+
 module.exports = {
   startApp,
   push,
@@ -215,5 +219,6 @@ module.exports = {
   showContextualMenu,
   dismissContextualMenu,
   setScreenStyle,
-  isAppLaunched
+  isAppLaunched,
+  getCurrentlyVisibleScreenId
 };


### PR DESCRIPTION
This PR adds api to get the currently visible screen.

Usage:

1. From a screen, using navigator instance: 
    `const isVisible = await this.props.navigator.isCurrentlyVisibleScreen()`

2. Globally, using `Navigation` object:
     `const visibleScreenInstanceId = await Navigation. getCurrentlyVisibleScreenId()`