### PR TITLE
Remove createJSModules @override marker - RN 0.47 compatibility

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/bridge/NavigationReactPackage.java
+++ b/android/app/src/main/java/com/reactnativenavigation/bridge/NavigationReactPackage.java
@@ -20,7 +20,7 @@ public class NavigationReactPackage implements ReactPackage {
         );
     }
 
-    @Override
+    // Depreciated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. This is backwards compatible according to my tests.