### PR TITLE
Fixed compilation error when used with react-native 0.47

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/bridge/NavigationReactPackage.java
+++ b/android/app/src/main/java/com/reactnativenavigation/bridge/NavigationReactPackage.java
@@ -21,11 +21,6 @@ public class NavigationReactPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList(
                 new SharedElementTransitionManager()


### PR DESCRIPTION
In react-native 0.47 thre was removed unused method `createJSModules()` in `ReactPackage class`. That caused compilation error due to overriding nonexisting method. Removing overrde from `NavigationReactPackage` fixes that error and is still compatibile with previous react-native verisons.