### PR TITLE
[iOS] Add custom bar button item class

### DIFF
--- a/ios/RCCCustomBarButtonItem.h
+++ b/ios/RCCCustomBarButtonItem.h
@@ -1,0 +1,12 @@
+#import <UIKit/UIKit.h>
+
+@class RCTRootView;
+@class RCTBridge;
+
+@interface RCCCustomBarButtonItem : UIBarButtonItem
+
+@property (nonnull, nonatomic, strong, readonly) RCTRootView *reactView;
+
+- (__nonnull instancetype)initWithComponentName:(NSString *__nonnull)component passProps:(NSDictionary *__nullable)passProps bridge:(RCTBridge *__nonnull)bridge;
+
+@end

--- a/ios/RCCCustomBarButtonItem.m
+++ b/ios/RCCCustomBarButtonItem.m
@@ -1,0 +1,30 @@
+#import <React/RCTRootView.h>
+#import <React/RCTRootViewDelegate.h>
+#import "RCCCustomBarButtonItem.h"
+
+@interface RCCCustomBarButtonItem () <RCTRootViewDelegate>
+
+@property (nonnull, nonatomic, strong, readwrite) RCTRootView *reactView;
+
+@end
+
+@implementation RCCCustomBarButtonItem
+
+- (instancetype)initWithComponentName:(NSString *__nonnull)component passProps:(NSDictionary *)passProps bridge:(RCTBridge *__nonnull)bridge {
+    RCTRootView *reactView = [[RCTRootView alloc] initWithBridge:bridge moduleName:component initialProperties:passProps];
+    self = [super initWithCustomView:reactView];
+    if (self) {
+        reactView.sizeFlexibility = RCTRootViewSizeFlexibilityWidthAndHeight;
+        reactView.delegate = self;
+        reactView.backgroundColor = [UIColor clearColor];
+    }
+    return self;
+}
+
+- (void)rootViewDidChangeIntrinsicSize:(RCTRootView *)rootView {
+    CGSize size = rootView.intrinsicSize;
+    rootView.frame = CGRectMake(0, 0, size.width, size.height);
+    self.width = size.width;
+}
+
+@end

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -3,8 +3,10 @@
 #import "RCCManager.h"
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTConvert.h>
+#import <React/RCTRootView.h>
 #import <objc/runtime.h>
 #import "RCCTitleViewHelper.h"
+#import "RCCCustomBarButtonItem.h"
 #import "UIViewController+Rotation.h"
 #import "RCTHelpers.h"
 
@@ -331,7 +333,8 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
     UIImage *iconImage = nil;
     id icon = button[@"icon"];
     if (icon) iconImage = [RCTConvert UIImage:icon];
-    
+    NSString *__nullable component = button[@"component"];
+
     UIBarButtonItem *barButtonItem;
     if (iconImage)
     {
@@ -345,6 +348,10 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
       if (buttonTextAttributes.allKeys.count > 0) {
         [barButtonItem setTitleTextAttributes:buttonTextAttributes forState:UIControlStateNormal];
       }
+    }
+    else if (component) {
+      RCTBridge *bridge = [[RCCManager sharedInstance] getBridge];
+      barButtonItem = [[RCCCustomBarButtonItem alloc] initWithComponentName:component passProps:button[@"passProps"] bridge:bridge];
     }
     else continue;
     objc_setAssociatedObject(barButtonItem, &CALLBACK_ASSOCIATED_KEY, button[@"onPress"], OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		261108801E6C495400BF5D98 /* UIViewController+Rotation.m in Sources */ = {isa = PBXBuildFile; fileRef = 2611087F1E6C495400BF5D98 /* UIViewController+Rotation.m */; };
 		26714EAC1EB0E9D3009F4D52 /* RCCCustomTitleView.m in Sources */ = {isa = PBXBuildFile; fileRef = 26714EAB1EB0E9D3009F4D52 /* RCCCustomTitleView.m */; };
 		26AFF3F51D7EEE2400CBA211 /* RCCTitleViewHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 26AFF3F41D7EEE2400CBA211 /* RCCTitleViewHelper.m */; };
+		2DCD499A1F33AAC30035123A /* RCCCustomBarButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DCD49981F33AAC30035123A /* RCCCustomBarButtonItem.m */; };
 		CC84A19E1C1A0C4E00B3A6A2 /* RCCManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CC84A1941C1A0C4E00B3A6A2 /* RCCManager.m */; };
 		CC84A19F1C1A0C4E00B3A6A2 /* RCCManagerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = CC84A1961C1A0C4E00B3A6A2 /* RCCManagerModule.m */; };
 		CC84A1A01C1A0C4E00B3A6A2 /* RCCNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = CC84A1981C1A0C4E00B3A6A2 /* RCCNavigationController.m */; };
@@ -58,6 +59,8 @@
 		26714EAB1EB0E9D3009F4D52 /* RCCCustomTitleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCCCustomTitleView.m; sourceTree = "<group>"; };
 		26AFF3F31D7EEE2400CBA211 /* RCCTitleViewHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCCTitleViewHelper.h; path = Helpers/RCCTitleViewHelper.h; sourceTree = "<group>"; };
 		26AFF3F41D7EEE2400CBA211 /* RCCTitleViewHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCCTitleViewHelper.m; path = Helpers/RCCTitleViewHelper.m; sourceTree = "<group>"; };
+2DCD49981F33AAC30035123A /* RCCCustomBarButtonItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCCCustomBarButtonItem.m; path = RCCCustomBarButtonItem.m; sourceTree = "<group>"; };
+		2DCD49991F33AAC30035123A /* RCCCustomBarButtonItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCCCustomBarButtonItem.h; path = RCCCustomBarButtonItem.h; sourceTree = "<group>"; };
 		CC84A1931C1A0C4E00B3A6A2 /* RCCManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCCManager.h; sourceTree = "<group>"; };
 		CC84A1941C1A0C4E00B3A6A2 /* RCCManager.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = RCCManager.m; sourceTree = "<group>"; tabWidth = 2; };
 		CC84A1951C1A0C4E00B3A6A2 /* RCCManagerModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCCManagerModule.h; sourceTree = "<group>"; };
@@ -204,6 +207,8 @@
 				D85082BB1CBCF42400FDB961 /* RCCDrawerController */,
 				CC84A1931C1A0C4E00B3A6A2 /* RCCManager.h */,
 				CC84A1941C1A0C4E00B3A6A2 /* RCCManager.m */,
+				2DCD49991F33AAC30035123A /* RCCCustomBarButtonItem.h */,
+				2DCD49981F33AAC30035123A /* RCCCustomBarButtonItem.m */,
 				26714EAA1EB0E9D3009F4D52 /* RCCCustomTitleView.h */,
 				26714EAB1EB0E9D3009F4D52 /* RCCCustomTitleView.m */,
 				26AFF3F31D7EEE2400CBA211 /* RCCTitleViewHelper.h */,
@@ -303,6 +308,7 @@
 			files = (
 				D85082EA1CBCF54200FDB961 /* TheSidebarController.m in Sources */,
 				CC84A1A01C1A0C4E00B3A6A2 /* RCCNavigationController.m in Sources */,
+				2DCD499A1F33AAC30035123A /* RCCCustomBarButtonItem.m in Sources */,
 				D83514F61D29719A00D53758 /* RCCNotification.m in Sources */,
 				CC84A19F1C1A0C4E00B3A6A2 /* RCCManagerModule.m in Sources */,
 				26AFF3F51D7EEE2400CBA211 /* RCCTitleViewHelper.m in Sources */,


### PR DESCRIPTION
This allows for custom React Native views to be rendered as a bar button item in the navigation bar.

![simulator screen shot - iphone 7 - 2017-08-04 at 16 07 42](https://user-images.githubusercontent.com/1051453/28985572-25f4b326-7931-11e7-8190-1d93f089b4e8.png)

This can be used by registering the component, just like any screen, and then by specifying the `component` for the navigation item, either left or right, like so:

```js
const styles = StyleSheet.create({
  button: {
    overflow: 'hidden',
    width: 34,
    height: 34,
    borderRadius: 34 / 2,
    justifyContent: 'center',
    alignItems: 'center',
  },
});

// Our custom component we want as a button in the nav bar
const CustomButton = ({ text }) =>
  <TouchableOpacity
    style={[styles.button, { backgroundColor: 'tomato' }]}
    onPress={() => console.log('pressed me!')}
  >
    <View style={styles.button}>
      <Text style={{ color: 'white' }}>
        {text}
      </Text>
    </View>
  </TouchableOpacity>;

// Register the component
Navigation.registerComponent('CustomButton', () => CustomButton);

Navigation.startSingleScreenApp({
  screen: {
    screen: 'react-native-navigation-bootstrap',
    title: 'Navigation Bootstrap',
    navigatorButtons: {
      leftButtons: [
        {
          id: 'custom',
          component: 'CustomButton', // This line loads our component as a nav bar button item
          passProps: {
            text: 'Hi!',
          },
        },
      ],
    },
  },
});
```

I chose this approach such that we could leverage existing UIKit APIs, as well as continuing to use React Native's primitive iOS views (that is, an `RCTRootView`), just like the view controllers do. This means that we don't need special logic to hook in for handling touches and what not since React Native will handle that for us anyway.

Replaces #1274