### PR TITLE
Export `Navigator` class for public use

### DIFF
--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import {AppRegistry} from 'react-native';
 import platformSpecific from './deprecated/platformSpecificDeprecated';
-import Screen from './Screen';
+import { Screen } from './Screen';
 
 import PropRegistry from './PropRegistry';
 

--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import {AppRegistry} from 'react-native';
 import platformSpecific from './deprecated/platformSpecificDeprecated';
-import { Screen } from './Screen';
+import {Screen} from './Screen';
 
 import PropRegistry from './PropRegistry';
 

--- a/src/Screen.js
+++ b/src/Screen.js
@@ -175,7 +175,7 @@ class Navigator {
   }
 }
 
-export default class Screen extends Component {
+class Screen extends Component {
   static navigatorStyle = {};
   static navigatorButtons = {};
 
@@ -193,3 +193,5 @@ export default class Screen extends Component {
     }
   }
 }
+
+export { Screen, Navigator };

--- a/src/Screen.js
+++ b/src/Screen.js
@@ -194,4 +194,7 @@ class Screen extends Component {
   }
 }
 
-export { Screen, Navigator };
+export {
+  Screen,
+  Navigator
+};

--- a/src/deprecated/indexDeprecated.android.js
+++ b/src/deprecated/indexDeprecated.android.js
@@ -2,6 +2,7 @@ import Navigation from './../Navigation';
 import SharedElementTransition from './../views/sharedElementTransition';
 import NativeEventsReceiver from './../NativeEventsReceiver';
 import ScreenVisibilityListener from './../ScreenVisibilityListener';
+import { Navigator } from './../Screen';
 
 module.exports = {
   Navigation,

--- a/src/deprecated/indexDeprecated.android.js
+++ b/src/deprecated/indexDeprecated.android.js
@@ -8,5 +8,6 @@ module.exports = {
   Navigation,
   SharedElementTransition,
   NativeEventsReceiver,
-  ScreenVisibilityListener
+  ScreenVisibilityListener,
+  Navigator
 };

--- a/src/deprecated/indexDeprecated.android.js
+++ b/src/deprecated/indexDeprecated.android.js
@@ -2,7 +2,7 @@ import Navigation from './../Navigation';
 import SharedElementTransition from './../views/sharedElementTransition';
 import NativeEventsReceiver from './../NativeEventsReceiver';
 import ScreenVisibilityListener from './../ScreenVisibilityListener';
-import { Navigator } from './../Screen';
+import {Navigator} from './../Screen';
 
 module.exports = {
   Navigation,

--- a/src/deprecated/indexDeprecated.ios.js
+++ b/src/deprecated/indexDeprecated.ios.js
@@ -3,11 +3,13 @@ import {NavigationToolBarIOS} from './controllers';
 import SharedElementTransition from '../views/sharedElementTransition';
 import NativeEventsReceiver from './../NativeEventsReceiver';
 import ScreenVisibilityListener from './../ScreenVisibilityListener';
+import { Navigator } from './../Screen';
 
 module.exports = {
   Navigation,
   NavigationToolBarIOS,
   SharedElementTransition,
   NativeEventsReceiver,
-  ScreenVisibilityListener
+  ScreenVisibilityListener,
+  Navigator
 };

--- a/src/deprecated/indexDeprecated.ios.js
+++ b/src/deprecated/indexDeprecated.ios.js
@@ -3,7 +3,7 @@ import {NavigationToolBarIOS} from './controllers';
 import SharedElementTransition from '../views/sharedElementTransition';
 import NativeEventsReceiver from './../NativeEventsReceiver';
 import ScreenVisibilityListener from './../ScreenVisibilityListener';
-import { Navigator } from './../Screen';
+import {Navigator} from './../Screen';
 
 module.exports = {
   Navigation,


### PR DESCRIPTION
When using ESLint rule `react/prop-types`, an error is show when using `this.props.navigator` if `navigator` is not specified in the components propTypes.

Changing this library to export the `Navigator` class allows users to use it in propTypes, i.e:

```JavaScript
import PropTypes from 'prop-types';
import { Navigator } from 'react-native-navigation';

...

Component.propTypes = {
    navigator: PropTypes.instanceOf(Navigator),
};
```

Whereas before you had 2 options, either:
1. Use `PropTypes.object`, which is another ESLint error (`react/forbid-prop-types`),

or

2. create your own `PropTypes.shape()`, but that feels convoluted and error-prone.

Hope this all makes sense.