### PR TITLE
Update android-specific-use-cases.md to Specify correct Lifecyclecallbacks

### DIFF
--- a/docs/android-specific-use-cases.md
+++ b/docs/android-specific-use-cases.md
@@ -54,7 +54,7 @@ public class MainApplication extends NavigationApplication {
 public class MyApplication extends NavigationApplication {
     @Override
     public void onCreate() {
-        registerActivityLifecycleCallbacks(new LifecycleCallbacks() {
+        registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacks() {
             @Override
             public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
                 activity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);


### PR DESCRIPTION
Taking the code from the docs for setting the softInputMode as is, it fails to build because the LifecycleCallbacks is an invalid symbol and is actually called ActivityLifecycleCallbacks.