### PR TITLE
[iOS] Overlay view

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/layouts/LayoutFactory.java
+++ b/android/app/src/main/java/com/reactnativenavigation/layouts/LayoutFactory.java
@@ -17,7 +17,7 @@ public class LayoutFactory {
     }
 
     private static Layout createSingleScreenLayout(AppCompatActivity activity, ActivityParams params) {
-        return new SingleScreenLayout(activity, params.leftSideMenuParams, params.rightSideMenuParams, params.screenParams);
+        return new SingleScreenLayout(activity, params);
     }
 
     private static Layout createBottomTabsScreenLayout(AppCompatActivity activity, ActivityParams params) {

--- a/android/app/src/main/java/com/reactnativenavigation/layouts/SingleScreenLayout.java
+++ b/android/app/src/main/java/com/reactnativenavigation/layouts/SingleScreenLayout.java
@@ -11,6 +11,7 @@ import com.facebook.react.bridge.Promise;
 import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.events.EventBus;
 import com.reactnativenavigation.events.ScreenChangedEvent;
+import com.reactnativenavigation.params.ActivityParams;
 import com.reactnativenavigation.params.ContextualMenuParams;
 import com.reactnativenavigation.params.FabParams;
 import com.reactnativenavigation.params.LightBoxParams;
@@ -23,6 +24,8 @@ import com.reactnativenavigation.params.TitleBarLeftButtonParams;
 import com.reactnativenavigation.screens.NavigationType;
 import com.reactnativenavigation.screens.Screen;
 import com.reactnativenavigation.screens.ScreenStack;
+import com.reactnativenavigation.utils.ViewUtils;
+import com.reactnativenavigation.views.ContentOverlayView;
 import com.reactnativenavigation.views.LeftButtonOnClickListener;
 import com.reactnativenavigation.views.LightBox;
 import com.reactnativenavigation.views.SideMenu;
@@ -38,8 +41,11 @@ import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 public class SingleScreenLayout extends BaseLayout {
 
     protected final ScreenParams screenParams;
+    protected final ScreenParams overlayParams;
     private final SideMenuParams leftSideMenuParams;
     private final SideMenuParams rightSideMenuParams;
+    private RelativeLayout container;
+    private ContentOverlayView overlayView;
     protected ScreenStack stack;
     private SnackbarAndFabContainer snackbarAndFabContainer;
     protected LeftButtonOnClickListener leftButtonOnClickListener;
@@ -49,8 +55,18 @@ public class SingleScreenLayout extends BaseLayout {
 
     public SingleScreenLayout(AppCompatActivity activity, SideMenuParams leftSideMenuParams,
                               SideMenuParams rightSideMenuParams, ScreenParams screenParams) {
+        this(activity, leftSideMenuParams, rightSideMenuParams, screenParams, null);
+    }
+
+    public SingleScreenLayout(AppCompatActivity activity, ActivityParams params) {
+        this(activity, params.leftSideMenuParams, params.rightSideMenuParams, params.screenParams, params.overlayParams);
+    }
+
+    public SingleScreenLayout(AppCompatActivity activity, SideMenuParams leftSideMenuParams,
+                              SideMenuParams rightSideMenuParams, ScreenParams screenParams, ScreenParams overlayParams) {
         super(activity);
         this.screenParams = screenParams;
+        this.overlayParams = overlayParams;
         this.leftSideMenuParams = leftSideMenuParams;
         this.rightSideMenuParams = rightSideMenuParams;
         createLayout();
@@ -82,7 +98,19 @@ public class SingleScreenLayout extends BaseLayout {
         if (stack != null) {
             stack.destroy();
         }
-        stack = new ScreenStack(getActivity(), parent, screenParams.getNavigatorId(), this);
+
+        container = new RelativeLayout(getContext());
+        container.setId(ViewUtils.generateViewId());
+        LayoutParams containerLayoutParams = new LayoutParams(MATCH_PARENT, MATCH_PARENT);
+        parent.addView(container, containerLayoutParams);
+
+        if (overlayParams != null) {
+            overlayView = new ContentOverlayView(getActivity(), overlayParams.screenId, overlayParams.navigationParams);
+            LayoutParams overlayViewLayoutParams = new LayoutParams(MATCH_PARENT, MATCH_PARENT);
+            parent.addView(overlayView, overlayViewLayoutParams);
+        }
+
+        stack = new ScreenStack(getActivity(), container, screenParams.getNavigatorId(), this);
         LayoutParams lp = new LayoutParams(MATCH_PARENT, MATCH_PARENT);
         pushInitialScreen(lp);
     }
@@ -132,6 +160,15 @@ public class SingleScreenLayout extends BaseLayout {
     public void destroy() {
         stack.destroy();
         snackbarAndFabContainer.destroy();
+
+        RelativeLayout parentLayout = getScreenStackParent();
+
+        if (overlayView != null) {
+            overlayView.unmountReactView();
+            parentLayout.removeView(overlayView);
+        }
+        parentLayout.removeView(container);
+
         if (sideMenu != null) {
             sideMenu.destroy();
         }

--- a/android/app/src/main/java/com/reactnativenavigation/params/ActivityParams.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/ActivityParams.java
@@ -9,6 +9,7 @@ public class ActivityParams {
 
     public Type type;
     public ScreenParams screenParams;
+    public ScreenParams overlayParams;
     public List<ScreenParams> tabParams;
     public SideMenuParams leftSideMenuParams;
     public SideMenuParams rightSideMenuParams;

--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/ActivityParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/ActivityParamsParser.java
@@ -29,6 +29,10 @@ public class ActivityParamsParser extends Parser {
             result.rightSideMenuParams = sideMenus[SideMenu.Side.Right.ordinal()];
         }
 
+        if (hasKey(params, "overlay")) {
+            result.overlayParams = ScreenParamsParser.parse(params.getBundle("overlay"));
+        }
+
         result.animateShow = params.getBoolean("animateShow", true);
 
         return result;

--- a/android/app/src/main/java/com/reactnativenavigation/screens/ScreenStack.java
+++ b/android/app/src/main/java/com/reactnativenavigation/screens/ScreenStack.java
@@ -178,7 +178,7 @@ public class ScreenStack {
     }
 
     private void addScreenBeforeSnackbarAndFabLayout(Screen screen, LayoutParams layoutParams) {
-        parent.addView(screen, parent.getChildCount() - 1, layoutParams);
+        parent.addView(screen, parent.getChildCount(), layoutParams);
     }
 
     public void pop(boolean animated, double jsPopTimestamp) {

--- a/android/app/src/main/java/com/reactnativenavigation/views/ContentOverlayView.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/ContentOverlayView.java
@@ -1,0 +1,26 @@
+package com.reactnativenavigation.views;
+
+import android.content.Context;
+import android.view.MotionEvent;
+
+import com.facebook.react.uimanager.TouchTargetHelper;
+import com.reactnativenavigation.params.NavigationParams;
+
+/**
+ * Created by khmelev on 28/10/2017.
+ */
+
+public class ContentOverlayView extends ContentView {
+
+    public ContentOverlayView(Context context, String screenId, NavigationParams navigationParams) {
+        super(context, screenId, navigationParams);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent ev) {
+        super.onTouchEvent(ev);
+
+        int tag = TouchTargetHelper.findTargetTagForTouch(ev.getX(), ev.getY(), this);
+        return tag != this.getId();
+    }
+}

--- a/docs/top-level-api.md
+++ b/docs/top-level-api.md
@@ -83,6 +83,10 @@ Navigation.startTabBasedApp({
                                         // for TheSideBar: 'airbnb', 'facebook', 'luvocracy','wunder-list'
     disableOpenGesture: false // optional, can the drawer be opened with a swipe instead of button
   },
+  overlay: { // optional, add this if you want an overlay view over your tabs (iOS only)
+    screen: 'example.OverlayScreen', // unique ID registered with Navigation.registerScreen
+    passProps: {} // simple serializable object that will pass as props to all top screens (optional)
+  },  
   passProps: {}, // simple serializable object that will pass as props to all top screens (optional)
   animationType: 'slide-down' // optional, add transition animation to root change: 'none', 'slide-down', 'fade'
 });
@@ -122,6 +126,10 @@ Navigation.startSingleScreenApp({
                                         // for TheSideBar: 'airbnb', 'facebook', 'luvocracy','wunder-list'
     disableOpenGesture: false // optional, can the drawer, both right and left, be opened with a swipe instead of button
   },
+  overlay: { // optional, add this if you want an overlay view over your navigation controller (iOS only)
+    screen: 'example.OverlayScreen', // unique ID registered with Navigation.registerScreen
+    passProps: {} // simple serializable object that will pass as props to all top screens (optional)
+  },  
   passProps: {}, // simple serializable object that will pass as props to all top screens (optional)
   animationType: 'slide-down' // optional, add transition animation to root change: 'none', 'slide-down', 'fade'
 });
@@ -195,6 +203,25 @@ Trigger a deep link within the app. See [deep links](https://wix.github.io/react
     link: 'link/in/any/format',
     payload: '' // (optional) Extra payload with deep link
   });
+```
+
+## showOverlay(params = {})
+
+Show new overlay or replace currently visible overlay (iOS only)
+
+```js
+Navigation.showOverlay({
+  screen: 'example.OverlayScreen', // unique ID registered with Navigation.registerScreen
+  passProps: {} // simple serializable object that will pass as props to all top screens (optional)
+});
+```
+
+## removeOverlay()
+
+Remove currently visible overlay (iOS only)
+
+```js
+Navigation.removeOverlay();
 ```
 
 ## registerScreen(screenID, generator)

--- a/ios/RCCManagerModule.m
+++ b/ios/RCCManagerModule.m
@@ -386,6 +386,24 @@ RCT_EXPORT_METHOD(getCurrentlyVisibleScreenId:(RCTPromiseResolveBlock)resolve re
     resolve(result);
 }
 
+RCT_EXPORT_METHOD(
+                  showOverlay:(NSDictionary*)params)
+{
+    UIViewController *rootVC = [UIApplication sharedApplication].delegate.window.rootViewController;
+    if ([rootVC respondsToSelector:@selector(showOverlay:)]) {
+        [rootVC performSelector:@selector(showOverlay:) withObject:params];
+    }
+}
+
+RCT_EXPORT_METHOD(
+                  removeOverlay)
+{
+    UIViewController *rootVC = [UIApplication sharedApplication].delegate.window.rootViewController;
+    if ([rootVC respondsToSelector:@selector(removeOverlay)]) {
+        [rootVC performSelector:@selector(removeOverlay)];
+    }
+}
+
 -(BOOL)viewControllerIsModal:(UIViewController*)viewController
 {
     BOOL viewControllerIsModal = (viewController.presentingViewController.presentedViewController == viewController)

--- a/ios/RCCNavigationController.h
+++ b/ios/RCCNavigationController.h
@@ -5,5 +5,7 @@
 
 - (instancetype)initWithProps:(NSDictionary *)props children:(NSArray *)children globalProps:(NSDictionary*)globalProps bridge:(RCTBridge *)bridge;
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge;
+- (void)showOverlay:(NSDictionary *)params;
+- (void)removeOverlay;
 
 @end

--- a/ios/RCCNavigationController.h
+++ b/ios/RCCNavigationController.h
@@ -1,10 +1,7 @@
 #import <UIKit/UIKit.h>
 #import <React/RCTBridge.h>
-#import <React/RCTRootView.h>
 
 @interface RCCNavigationController : UINavigationController <UINavigationControllerDelegate>
-
-@property (strong, nonatomic) RCTRootView *overlayView;
 
 - (instancetype)initWithProps:(NSDictionary *)props children:(NSArray *)children globalProps:(NSDictionary*)globalProps bridge:(RCTBridge *)bridge;
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge;

--- a/ios/RCCNavigationController.h
+++ b/ios/RCCNavigationController.h
@@ -1,7 +1,10 @@
 #import <UIKit/UIKit.h>
 #import <React/RCTBridge.h>
+#import <React/RCTRootView.h>
 
 @interface RCCNavigationController : UINavigationController <UINavigationControllerDelegate>
+
+@property (strong, nonatomic) RCTRootView *overlayView;
 
 - (instancetype)initWithProps:(NSDictionary *)props children:(NSArray *)children globalProps:(NSDictionary*)globalProps bridge:(RCTBridge *)bridge;
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge;

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -15,6 +15,12 @@
 #import "RCTHelpers.h"
 #import "RCTConvert+UIBarButtonSystemItem.h"
 
+@interface RCCNavigationController()
+
+@property (strong, nonatomic) RCTRootView *overlayView;
+
+@end
+
 @implementation RCCNavigationController
 {
   BOOL _transitioning;

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -90,6 +90,16 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   return self;
 }
 
+- (void)showOverlay:(NSDictionary *)params {
+  NSString *overlayScreen = [params valueForKeyPath:@"screen"];
+  NSDictionary *overlayProps = [params valueForKeyPath:@"passProps"];
+  self.overlayView = [[RCTRootView alloc] initWithBridge:[[RCCManager sharedInstance] getBridge] moduleName:overlayScreen initialProperties:overlayProps];
+}
+
+- (void)removeOverlay {
+  self.overlayView = nil;
+}
+
 - (void)setOverlayView:(RCTRootView *)overlayView {
   RCTRootView *previousOverlayView = _overlayView;
 

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -103,6 +103,14 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   [self.view addSubview:_overlayView];
 }
 
+- (void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
+  
+  if (_overlayView) {
+    [self.view bringSubviewToFront:_overlayView];
+  }
+}
+
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge
 {
   BOOL animated = actionParams[@"animated"] ? [actionParams[@"animated"] boolValue] : YES;

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -74,8 +74,8 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
 
   [self setRotation:props];
 
-  NSString *overlayView = [props valueForKeyPath:@"overlay.view"];
-  if (overlayView) {
+  NSString *overlayScreen = [props valueForKeyPath:@"overlay.screen"];
+  if (overlayScreen) {
     // Pass navigation props
     NSMutableDictionary *mutablePassPropsOverlay = [passProps mutableCopy];
     NSDictionary *overlayProps = [props valueForKeyPath:@"overlay.passProps"];
@@ -84,7 +84,7 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
     }
 
     NSDictionary *passPropsOverlay = [NSDictionary dictionaryWithDictionary:mutablePassPropsOverlay];
-    self.overlayView = [[RCTRootView alloc] initWithBridge:bridge moduleName:overlayView initialProperties:passPropsOverlay];
+    self.overlayView = [[RCTRootView alloc] initWithBridge:bridge moduleName:overlayScreen initialProperties:passPropsOverlay];
   }
 
   return self;

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -67,10 +67,41 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   
 
   [self setRotation:props];
-  
+
+  NSString *overlayView = [props valueForKeyPath:@"overlay.view"];
+  if (overlayView) {
+    // Pass navigation props
+    NSMutableDictionary *mutablePassPropsOverlay = [passProps mutableCopy];
+    NSDictionary *overlayProps = [props valueForKeyPath:@"overlay.passProps"];
+    if (overlayProps) {
+      [mutablePassPropsOverlay addEntriesFromDictionary:overlayProps];
+    }
+
+    NSDictionary *passPropsOverlay = [NSDictionary dictionaryWithDictionary:mutablePassPropsOverlay];
+    self.overlayView = [[RCTRootView alloc] initWithBridge:bridge moduleName:overlayView initialProperties:passPropsOverlay];
+  }
+
   return self;
 }
 
+- (void)setOverlayView:(RCTRootView *)overlayView {
+  RCTRootView *previousOverlayView = _overlayView;
+
+  if (previousOverlayView) {
+    [previousOverlayView removeFromSuperview];
+  }
+
+  _overlayView = overlayView;
+
+  if (!_overlayView) {
+    return;
+  }
+
+  _overlayView.passThroughTouches = YES;
+  _overlayView.backgroundColor = [UIColor clearColor];
+  _overlayView.frame = self.view.bounds;
+  [self.view addSubview:_overlayView];
+}
 
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge
 {

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -42,6 +42,8 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   NSString *component = props[@"component"];
   if (!component) return nil;
   
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onRNReload) name:RCTJavaScriptWillStartLoadingNotification object:nil];
+  
   NSDictionary *passProps = props[@"passProps"];
   NSDictionary *navigatorStyle = props[@"style"];
   
@@ -88,6 +90,16 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   }
 
   return self;
+}
+
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTJavaScriptWillStartLoadingNotification object:nil];
+  self.overlayView = nil;
+}
+
+- (void)onRNReload {
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTJavaScriptWillStartLoadingNotification object:nil];
+  self.overlayView = nil;
 }
 
 - (void)showOverlay:(NSDictionary *)params {

--- a/ios/RCCTabBarController.h
+++ b/ios/RCCTabBarController.h
@@ -5,5 +5,7 @@
 
 - (instancetype)initWithProps:(NSDictionary *)props children:(NSArray *)children globalProps:(NSDictionary*)globalProps bridge:(RCTBridge *)bridge;
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge completion:(void (^)(void))completion;
+- (void)showOverlay:(NSDictionary *)params;
+- (void)removeOverlay;
 
 @end

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -14,6 +14,12 @@
 
 @end
 
+@interface RCCTabBarController()
+
+@property (strong, nonatomic) RCTRootView *overlayView;
+
+@end
+
 @implementation RCCTabBarController
 
 
@@ -84,6 +90,7 @@
   UIColor *selectedButtonColor = nil;
   UIColor *labelColor = nil;
   UIColor *selectedLabelColor = nil;
+  NSDictionary *passProps = props[@"passProps"];
   NSDictionary *tabsStyle = props[@"style"];
   if (tabsStyle)
   {
@@ -131,6 +138,19 @@
     {
       self.tabBar.clipsToBounds = [tabBarHideShadow boolValue] ? YES : NO;
     }
+  }
+  
+  NSString *overlayView = [props valueForKeyPath:@"overlay.view"];
+  if (overlayView) {
+    self.overlayView = [[RCTRootView alloc] initWithBridge:bridge moduleName:overlayView initialProperties:passPropsOverlay];
+    // Pass navigation props
+    NSMutableDictionary *mutablePassPropsOverlay = [passProps mutableCopy];
+    NSDictionary *overlayProps = [props valueForKeyPath:@"overlay.passProps"];
+    if (overlayProps) {
+      [mutablePassPropsOverlay addEntriesFromDictionary:overlayProps];
+    }
+    
+    NSDictionary *passPropsOverlay = [NSDictionary dictionaryWithDictionary:mutablePassPropsOverlay];
   }
   
   NSMutableArray *viewControllers = [NSMutableArray array];
@@ -229,6 +249,33 @@
   [self setRotation:props];
   
   return self;
+}
+
+- (void)setOverlayView:(RCTRootView *)overlayView {
+  RCTRootView *previousOverlayView = _overlayView;
+  
+  if (previousOverlayView) {
+    [previousOverlayView removeFromSuperview];
+  }
+  
+  _overlayView = overlayView;
+  
+  if (!_overlayView) {
+    return;
+  }
+  
+  _overlayView.passThroughTouches = YES;
+  _overlayView.backgroundColor = [UIColor clearColor];
+  _overlayView.frame = self.view.bounds;
+  [self.view addSubview:_overlayView];
+}
+
+- (void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
+  
+  if (_overlayView) {
+    [self.view bringSubviewToFront:_overlayView];
+  }
 }
 
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge completion:(void (^)(void))completion

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -83,8 +83,9 @@
   if (!self) return nil;
   
   self.delegate = self;
-  
   self.tabBar.translucent = YES; // default
+
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onRNReload) name:RCTJavaScriptWillStartLoadingNotification object:nil];
   
   UIColor *buttonColor = nil;
   UIColor *selectedButtonColor = nil;
@@ -286,6 +287,16 @@
   if (_overlayView) {
     [self.view bringSubviewToFront:_overlayView];
   }
+}
+
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTJavaScriptWillStartLoadingNotification object:nil];
+  self.overlayView = nil;
+}
+
+- (void)onRNReload {
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTJavaScriptWillStartLoadingNotification object:nil];
+  self.overlayView = nil;
 }
 
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge completion:(void (^)(void))completion

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -251,6 +251,16 @@
   return self;
 }
 
+- (void)showOverlay:(NSDictionary *)params {
+  NSString *overlayScreen = [params valueForKeyPath:@"screen"];
+  NSDictionary *overlayProps = [params valueForKeyPath:@"passProps"];
+  self.overlayView = [[RCTRootView alloc] initWithBridge:[[RCCManager sharedInstance] getBridge] moduleName:overlayScreen initialProperties:overlayProps];
+}
+
+- (void)removeOverlay {
+  self.overlayView = nil;
+}
+
 - (void)setOverlayView:(RCTRootView *)overlayView {
   RCTRootView *previousOverlayView = _overlayView;
   

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -140,9 +140,8 @@
     }
   }
   
-  NSString *overlayView = [props valueForKeyPath:@"overlay.view"];
-  if (overlayView) {
-    self.overlayView = [[RCTRootView alloc] initWithBridge:bridge moduleName:overlayView initialProperties:passPropsOverlay];
+  NSString *overlayScreen = [props valueForKeyPath:@"overlay.screen"];
+  if (overlayScreen) {
     // Pass navigation props
     NSMutableDictionary *mutablePassPropsOverlay = [passProps mutableCopy];
     NSDictionary *overlayProps = [props valueForKeyPath:@"overlay.passProps"];
@@ -151,6 +150,7 @@
     }
     
     NSDictionary *passPropsOverlay = [NSDictionary dictionaryWithDictionary:mutablePassPropsOverlay];
+    self.overlayView = [[RCTRootView alloc] initWithBridge:bridge moduleName:overlayScreen initialProperties:passPropsOverlay];
   }
   
   NSMutableArray *viewControllers = [NSMutableArray array];

--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -174,6 +174,14 @@ function getCurrentlyVisibleScreenId() {
   return platformSpecific.getCurrentlyVisibleScreenId();
 }
 
+function showOverlay(params = {}) {
+  return platformSpecific.showOverlay(params);
+}
+
+function removeOverlay() {
+  return platformSpecific.removeOverlay();
+}
+
 export default {
   getRegisteredScreen,
   getCurrentlyVisibleScreenId,
@@ -192,5 +200,7 @@ export default {
   clearEventHandler: clearEventHandler,
   handleDeepLink: handleDeepLink,
   isAppLaunched: isAppLaunched,
-  isRootLaunched: isRootLaunched
+  isRootLaunched: isRootLaunched,
+  showOverlay: showOverlay,
+  removeOverlay: removeOverlay
 };

--- a/src/deprecated/controllers/index.js
+++ b/src/deprecated/controllers/index.js
@@ -319,6 +319,12 @@ var Controllers = {
   ScreenUtils: {
     getCurrentlyVisibleScreenId: async function() {
       return await RCCManager.getCurrentlyVisibleScreenId();
+    },
+    showOverlay: function(params) {
+      RCCManager.showOverlay(params);
+    },
+    removeOverlay: function() {
+      RCCManager.removeOverlay();
     }
   },
 

--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -36,6 +36,10 @@ function startSingleScreenApp(params) {
   params.overrideBackPress = screen.overrideBackPress;
   params.animateShow = convertAnimationType(params.animationType);
 
+  if (params.overlay) {
+    params.overlay = createOverlay(params.overlay)
+  }
+
   newPlatformSpecific.startApp(params);
 }
 
@@ -231,6 +235,19 @@ function convertStyleParams(originalStyleObject) {
     ret.topBarReactViewInitialProps = {passPropsKey};  
   }
   return ret;
+}
+
+function createOverlay(overlayParams) {
+  if (!overlayParams.screen) {
+    console.error('createOverlay(overlayParams): overlay must include a screen property');
+    return;
+  }
+
+  let result = Object.assign({}, overlayParams);
+  result.screenId = result.screen;
+  addNavigatorParams(result);
+  result = adaptNavigationParams(result);
+  return result
 }
 
 function convertDrawerParamsToSideMenuParams(drawerParams) {
@@ -745,6 +762,13 @@ function dismissContextualMenu() {
   newPlatformSpecific.dismissContextualMenu();
 }
 
+function showOverlay(params) {
+}
+
+function removeOverlay() {
+}
+
+
 async function isAppLaunched() {
   return await newPlatformSpecific.isAppLaunched();
 }
@@ -789,5 +813,7 @@ export default {
   dismissContextualMenu,
   isAppLaunched,
   isRootLaunched,
-  getCurrentlyVisibleScreenId
+  getCurrentlyVisibleScreenId,
+  showOverlay,
+  removeOverlay
 };

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -660,6 +660,14 @@ function savePassProps(params) {
   }
 }
 
+function showOverlay(params) {
+  ScreenUtils.showOverlay(params)
+}
+
+function removeOverlay() {
+  ScreenUtils.removeOverlay()
+}
+
 function showContextualMenu() {
   // Android only
 }
@@ -723,5 +731,7 @@ export default {
   navigatorToggleNavBar,
   showContextualMenu,
   dismissContextualMenu,
-  getCurrentlyVisibleScreenId
+  getCurrentlyVisibleScreenId,
+  showOverlay,
+  removeOverlay
 };

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -183,6 +183,7 @@ function startSingleScreenApp(params) {
           subtitle={params.subtitle}
           titleImage={screen.titleImage}
           component={screen.screen}
+          overlay={params.overlay}
           passProps={{
             navigatorID: navigatorID,
             screenInstanceID: screenInstanceID,

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -88,6 +88,7 @@ function startTabBasedApp(params) {
           style={params.tabsStyle}
           appStyle={params.appStyle}
           initialTabIndex={params.initialTabIndex}>
+          overlay={params.overlay}
           {
             params.tabs.map(function(tab, index) {
               return (

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -87,8 +87,8 @@ function startTabBasedApp(params) {
           id={controllerID + '_tabs'}
           style={params.tabsStyle}
           appStyle={params.appStyle}
-          initialTabIndex={params.initialTabIndex}>
-          overlay={params.overlay}
+          initialTabIndex={params.initialTabIndex}
+          overlay={params.overlay}>
           {
             params.tabs.map(function(tab, index) {
               return (

--- a/src/platformSpecific.android.js
+++ b/src/platformSpecific.android.js
@@ -111,6 +111,10 @@ function savePassProps(params) {
   if (params.sideMenu && params.sideMenu.right) {
     PropRegistry.save(params.sideMenu.right.navigationParams.screenInstanceID, params.sideMenu.right.passProps);
   }
+
+  if (params.overlay) {
+    PropRegistry.save(params.overlay.navigationParams.screenInstanceID, params.overlay.passProps);
+  }
 }
 
 function toggleSideMenuVisible(animated, side) {


### PR DESCRIPTION
As discussed here https://github.com/wix/react-native-navigation/pull/1392

This PR introduces support of overlay view for iOS. The possibilities are endless :) Examples includes: custom drawers, player panels, chat heads, modals with animation and swipe dismissal etc.

Its worth noting that root view of overlay component might contain `pointerEvents="box-none"` in order to pass events to underlaying view which is app itself.