### PR TITLE
Fix Redux example broken link

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,6 @@
 # example
 
-A simple usage example. If you're using redux, take a look at [example-redux](../example-redux).
+A simple usage example. If you're using redux, take a look at [example-redux](https://github.com/JuneDomingo/movieapp).
 
 ## Installation - iOS
 


### PR DESCRIPTION
The original link in the README was broken. Since `junedomingo/movieapp` was mentioned in the project root README, I am using it as the feature-rich redux example.