### PR TITLE
Add hacky fix to make Lightbox dismiss not crash on Android for recent RN versions

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/LightBox.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/LightBox.java
@@ -107,7 +107,7 @@ public class LightBox extends Dialog implements DialogInterface.OnDismissListene
     }
 
     public void destroy() {
-        content.unmountReactView();
+        // content.unmountReactView();
         dismiss();
     }
 


### PR DESCRIPTION
Mainly submitting this PR to re-state the urgency of fixing #1502 and start a discussion about a better way to solve this issue than this hacky fix (proposed by @rauliyohmc).

EDIT: Upon further testing, this hack only fixes the problem some of the time.