### PR TITLE
[Android] fix conditions for  destroyJsIfNeeded

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -53,6 +53,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
      * Along with that, we should handle commands from the bridge using onNewIntent
      */
     static NavigationActivity currentActivity;
+    private static int activityCount;
 
     private ActivityParams activityParams;
     private ModalController modalController;
@@ -61,6 +62,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        activityCount++;
         super.onCreate(savedInstanceState);
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             NavigationApplication.instance.startReactContextOnceInBackgroundAndExecuteJS();
@@ -99,7 +101,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
 
     private boolean hasBackgroundColor() {
         return AppStyle.appStyle.screenBackgroundColor != null &&
-               AppStyle.appStyle.screenBackgroundColor.hasColor();
+                AppStyle.appStyle.screenBackgroundColor.hasColor();
     }
 
     @Override
@@ -148,6 +150,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
 
     @Override
     protected void onDestroy() {
+        activityCount--;
         destroyLayouts();
         destroyJsIfNeeded();
         NavigationApplication.instance.getActivityCallbacks().onActivityDestroyed(this);
@@ -165,7 +168,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     }
 
     private void destroyJsIfNeeded() {
-        if (currentActivity == null || currentActivity.isFinishing()) {
+        if (activityCount == 0) {
             getReactGateway().onDestroyApp();
         }
     }


### PR DESCRIPTION
Currently  ReactNativeHost will be cleared at  onDestroy callback when currentActivity is null or finishing. Mostly, it works well, but in some case, it will results in the app lost interaction with js context, Think about the case below 

steps:

1. startSingleScreenApp(A)
2. restart app by startSingleScreenApp(B)
3. start native activity C immediately
4. do some thing then fish C

complete lifecycle flow:

1. A onCreate - A onStart - A onResume 
2. A onPause - B onCreate - B onStart - B onResume 
3. **B onPause** - C onCreate - C onStart - C onResume - A onStop - **A onDestory**
4. C onStop - C onDestory - **B onResume**

It can be seen that B onPause before A onDestory，so the static reference currentActivity will set to null which results in ReactNativeHost be cleared onDestory

It an uncommon case I know, but I really meet the problem and need solve it