### PR TITLE
Prefer use of intrinsicContentSize

### DIFF
--- a/ios/RCCCustomBarButtonItem.m
+++ b/ios/RCCCustomBarButtonItem.m
@@ -22,7 +22,7 @@
 }
 
 - (void)rootViewDidChangeIntrinsicSize:(RCTRootView *)rootView {
-    CGSize size = rootView.intrinsicSize;
+    CGSize size = rootView.intrinsicContentSize;
     rootView.frame = CGRectMake(0, 0, size.width, size.height);
     self.width = size.width;
 }


### PR DESCRIPTION

<img width="504" alt="screen shot 2017-09-01 at 4 18 59 pm" src="https://user-images.githubusercontent.com/1051453/29986447-5b1b7e7a-8f31-11e7-8d7e-9fbe5414b358.png">
<img width="1960" alt="screen shot 2017-09-01 at 4 18 51 pm" src="https://user-images.githubusercontent.com/1051453/29986448-5b21e530-8f31-11e7-8d9b-83be55d492fb.png">

This converts from using a deprecated attribute.