### PR TITLE
[v2] support navigation button tintColor for iOS.

### DIFF
--- a/lib/ios/RNNNavigationButtons.m
+++ b/lib/ios/RNNNavigationButtons.m
@@ -83,6 +83,11 @@
 	barButtonItem.target = self;
 	barButtonItem.action = @selector(onButtonPress:);
 	
+	id tintColorId = dictionary[@"tintColor"];
+	if (tintColorId) {
+		[barButtonItem setTintColor:[RCTConvert UIColor: tintColorId]];
+	}
+	
 	NSNumber *disabled = dictionary[@"disabled"];
 	BOOL disabledBool = disabled ? [disabled boolValue] : NO;
 	if (disabledBool) {

--- a/lib/src/commands/LayoutTreeCrawler.test.js
+++ b/lib/src/commands/LayoutTreeCrawler.test.js
@@ -159,12 +159,6 @@ describe('LayoutTreeCrawler', () => {
       expect(node.data.navigationOptions.andAnotherColor).toEqual(0xff00ff00);
     });
 
-    it('keys ending with Color case sensitive', () => {
-      navigationOptions.otherKey_color = 'red'; // eslint-disable-line camelcase
-      uut.crawl(node);
-      expect(node.data.navigationOptions.otherKey_color).toEqual('red');
-    });
-
     it('any nested recursive keys ending with Color', () => {
       navigationOptions.innerObj = { theKeyColor: 'red' };
       navigationOptions.innerObj.innerMostObj = { anotherColor: 'yellow' };

--- a/lib/src/commands/OptionsProcessor.js
+++ b/lib/src/commands/OptionsProcessor.js
@@ -2,16 +2,17 @@ const _ = require('lodash');
 const { processColor } = require('react-native');
 const resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSource');
 
+const colorRegexp = /color$/i;
+const iconRegexp = /(icon|image)$/i;
+
 class OptionsProcessor {
   static processOptions(navigationOptions) {
     _.forEach(navigationOptions, (value, key) => {
-      if (_.endsWith(key, 'Color')) {
+      if (colorRegexp.test(key)) {
         navigationOptions[key] = processColor(value);
-      }
-      if (_.isEqual(key, 'icon') || _.endsWith(key, 'Icon') || _.endsWith(key, 'Image')) {
+      } else if (iconRegexp.test(key)) {
         navigationOptions[key] = resolveAssetSource(navigationOptions[key]);
-      }
-      if (_.isPlainObject(value) || _.isArray(value)) {
+      } else if (_.isPlainObject(value) || _.isArray(value)) {
         OptionsProcessor.processOptions(value);
       }
     });

--- a/lib/src/commands/OptionsProcessor.test.js
+++ b/lib/src/commands/OptionsProcessor.test.js
@@ -62,12 +62,6 @@ describe('navigation options', () => {
     expect(navigationOptions.andAnotherColor).toEqual(0xff00ff00);
   });
 
-  it('keys ending with Color case sensitive', () => {
-    navigationOptions.otherKey_color = 'red'; // eslint-disable-line camelcase
-    OptionsProcessor.processOptions(navigationOptions);
-    expect(navigationOptions.otherKey_color).toEqual('red');
-  });
-
   it('any nested recursive keys ending with Color', () => {
     navigationOptions.innerObj = { theKeyColor: 'red' };
     navigationOptions.innerObj.innerMostObj = { anotherColor: 'yellow' };


### PR DESCRIPTION
Also simply OptionsProcessor.processOptions:

keys ending with `color` should be treated as color.
keys ending with `icon` or `image` should be treated as image.

both in case insensitive way.