### PR TITLE
Stop calling host.clear() when activity is destroyed

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
+++ b/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
@@ -118,6 +118,10 @@ public abstract class NavigationApplication extends Application implements React
 
     public abstract boolean isDebug();
 
+    public boolean clearHostOnActivityDestroy() {
+        return true;
+    }
+
     @Nullable
     public abstract List<ReactPackage> createAdditionalReactPackages();
 }

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -135,7 +135,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
         super.onPause();
         currentActivity = null;
         IntentDataHandler.onPause(getIntent());
-        getReactGateway().onPauseActivity();
+        getReactGateway().onPauseActivity(this);
         NavigationApplication.instance.getActivityCallbacks().onActivityPaused(this);
         EventBus.instance.unregister(this);
     }
@@ -166,7 +166,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
 
     private void destroyJsIfNeeded() {
         if (currentActivity == null || currentActivity.isFinishing()) {
-            getReactGateway().onDestroyApp();
+            getReactGateway().onDestroyApp(this);
         }
     }
 

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
@@ -27,8 +27,6 @@ public abstract class SplashActivity extends AppCompatActivity {
 
         if (NavigationApplication.instance.getReactGateway().hasStartedCreatingContext()) {
             NavigationApplication.instance.getEventEmitter().sendAppLaunchedEvent();
-            overridePendingTransition(0, 0);
-            finish();
             return;
         }
 
@@ -38,7 +36,7 @@ public abstract class SplashActivity extends AppCompatActivity {
         }
 
         if (NavigationApplication.instance.isReactContextInitialized()) {
-            finish();
+            NavigationApplication.instance.getEventEmitter().sendAppLaunchedEvent();
             return;
         }
 

--- a/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactGateway.java
+++ b/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactGateway.java
@@ -63,13 +63,15 @@ public class NavigationReactGateway implements ReactGateway {
 		getReactInstanceManager().onBackPressed();
 	}
 
-	public void onDestroyApp() {
-		getReactInstanceManager().onHostDestroy();
-		host.clear();
-	}
+	public void onDestroyApp(Activity activity) {
+		getReactInstanceManager().onHostDestroy(activity);
+        if (NavigationApplication.instance.clearHostOnActivityDestroy()) {
+            host.clear();
+        }
+    }
 
-	public void onPauseActivity() {
-		getReactInstanceManager().onHostPause();
+	public void onPauseActivity(Activity activity) {
+		getReactInstanceManager().onHostPause(activity);
 		jsDevReloadHandler.onPauseActivity();
 	}
 

--- a/android/app/src/main/java/com/reactnativenavigation/react/ReactGateway.java
+++ b/android/app/src/main/java/com/reactnativenavigation/react/ReactGateway.java
@@ -23,9 +23,9 @@ public interface ReactGateway {
 
     void onResumeActivity(Activity activity, DefaultHardwareBackBtnHandler defaultHardwareBackBtnHandler);
 
-    void onPauseActivity();
+    void onPauseActivity(Activity activity);
 
-    void onDestroyApp();
+    void onDestroyApp(Activity activity);
 
     void onBackPressed();
 


### PR DESCRIPTION
This is a breaking change and has to be opt-in. To prevent host.clear from being called,
Override `clearHostOnActivityDestroy` in MainApplication and return false:

```java
    @Override
    public boolean clearHostOnActivityDestroy() {
        return false;
    }
```

If host isn't cleared, the next time the app is opened react context might still be initialized.
In this case we emit appLaunched event which has to be handled in Js:

```js
  Promise.resolve(Navigation.isAppLaunched())
      .then((appLaunched) => {
        if (appLaunched) {
          startApp();
        }
        new NativeEventsReceiver().appLaunched(() => {
          startApp();
        });
      })
```