### PR TITLE
[iOS] Fix swipe back after resetTo

### DIFF
--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -237,6 +237,8 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
     }
     
     BOOL animated = actionParams[@"animated"] ? [actionParams[@"animated"] boolValue] : YES;
+
+    [self.viewControllers.lastObject viewWillDisappear:animated];
     
     NSString *animationType = actionParams[@"animationType"];
     if ([animationType isEqualToString:@"fade"])

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -250,7 +250,10 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
     
     BOOL animated = actionParams[@"animated"] ? [actionParams[@"animated"] boolValue] : YES;
 
-    [self.viewControllers.lastObject viewWillDisappear:animated];
+    if (self.viewControllers.count > 0)
+    {
+      [self.viewControllers.lastObject viewWillDisappear:animated];
+    }
     
     NSString *animationType = actionParams[@"animationType"];
     if ([animationType isEqualToString:@"fade"])


### PR DESCRIPTION
Reproducible mini app is below.
After `Push` to push next screen, `Reset` button to call `resetTo` and `Push` to push next screen, then swipe to back function is now disabled.

It because `viewWillDisappear` will not be called via `setViewControllers`.

```
import React from 'react';
import { View, Text, TouchableOpacity } from 'react-native';
import { Navigation } from 'react-native-navigation';

function Home(props) {
  return (
    <View
      style={{
        flex: 1,
        justifyContent: 'center',
        alignItems: 'center'
      }} >
      <TouchableOpacity
        style={{
          width: 200,
          height: 50,
          borderColor: 'black',
          borderWidth: 1,
          borderRadius: 5,
          justifyContent: 'center',
          alignItems: 'center'
        }}
        onPress={() => {
          props.navigator.push({
            screen: 'example.Screen2'
          });
        }} >
        <Text>
          Push
        </Text>
      </TouchableOpacity>
      <TouchableOpacity
        style={{
          width: 200,
          height: 50,
          borderColor: 'black',
          borderWidth: 1,
          borderRadius: 5,
          justifyContent: 'center',
          alignItems: 'center',
          marginTop: 20
        }}
        onPress={() => {
          props.navigator.resetTo({
            screen: 'example.Home'
          });
        }} >
        <Text>
          Reset
        </Text>
      </TouchableOpacity>
    </View>
  );
}

function Screen2(props) {
  return (
    <View
      style={{
        flex: 1,
        justifyContent: 'center',
        alignItems: 'center'
      }} >
      <TouchableOpacity
        style={{
          width: 200,
          height: 50,
          borderColor: 'black',
          borderWidth: 1,
          borderRadius: 5,
          justifyContent: 'center',
          alignItems: 'center'
        }}
        onPress={() => {
          props.navigator.pop();
        }} >
        <Text>
          Back
        </Text>
      </TouchableOpacity>
      <TouchableOpacity
        style={{
          width: 200,
          height: 50,
          borderColor: 'black',
          borderWidth: 1,
          borderRadius: 5,
          justifyContent: 'center',
          alignItems: 'center',
          marginTop: 20
        }}
        onPress={() => {
          props.navigator.resetTo({
            screen: 'example.Home'
          });
        }} >
        <Text>
          Reset
        </Text>
      </TouchableOpacity>
    </View>
  )
}

Navigation.registerComponent('example.Home', () => Home);
Navigation.registerComponent('example.Screen2', () => Screen2);

Navigation.startSingleScreenApp({
  screen: {
    screen: 'example.Home',
  }
});
```