### PR TITLE
Use `intrinsicContentSize` (`intrinsicSize` is deprecated')

### DIFF
--- a/ios/RCCCustomBarButtonItem.m
+++ b/ios/RCCCustomBarButtonItem.m
@@ -22,7 +22,7 @@
 }
 
 - (void)rootViewDidChangeIntrinsicSize:(RCTRootView *)rootView {
-    CGSize size = rootView.intrinsicSize;
+    CGSize size = rootView.intrinsicContentSize;
     rootView.frame = CGRectMake(0, 0, size.width, size.height);
     self.width = size.width;
 }


### PR DESCRIPTION
`intrinsicSize` is deprecated.
Use `intrinsicContentSize` instead.
https://github.com/facebook/react-native/blob/master/React/Base/RCTRootView.h#L162
😸 