### PR TITLE
added tabBarHidden property to navigatorStyle

### DIFF
--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -465,6 +465,13 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
     [viewController setNeedsStatusBarAppearanceUpdate];
   }
   
+  NSNumber *tabBarHidden = self.navigatorStyle[@"tabBarHidden"];
+  BOOL tabBarHiddenBool = tabBarHidden ? [tabBarHidden boolValue] : NO;
+  if (tabBarHiddenBool) {
+    UITabBar *tabBar = viewController.tabBarController.tabBar;
+    tabBar.transform = CGAffineTransformMakeTranslation(0, tabBar.frame.size.height);
+  }
+
   NSNumber *navBarHidden = self.navigatorStyle[@"navBarHidden"];
   BOOL navBarHiddenBool = navBarHidden ? [navBarHidden boolValue] : NO;
   if (viewController.navigationController.navigationBarHidden != navBarHiddenBool) {


### PR DESCRIPTION
In ios `tabBarHidden` is not working and required bunch of js hack to getting the desire thing to work. Based on my observation `tabBarHidden` was never implemented for navigatorStyle and I simply added that functionality.