### PR TITLE
Update the document for tabsStyle in Android

### DIFF
--- a/docs/top-level-api.md
+++ b/docs/top-level-api.md
@@ -50,8 +50,8 @@ Navigation.startTabBasedApp({
     }
   ],
   tabsStyle: { // optional, add this if you want to style the tab bar beyond the defaults
-    tabBarButtonColor: '#ffff00', // optional, change the color of the tab icons and text (also unselected). For Android, add this to appStyle
-    tabBarSelectedButtonColor: '#ff9900', // optional, change the color of the selected tab icon and text (only selected). For Android, add this to appStyle
+    tabBarButtonColor: '#ffff00', // optional, change the color of the tab icons and text (also unselected). On Android, add this to appStyle
+    tabBarSelectedButtonColor: '#ff9900', // optional, change the color of the selected tab icon and text (only selected). On Android, add this to appStyle
     tabBarBackgroundColor: '#551A8B', // optional, change the background color of the tab bar
     initialTabIndex: 1, // optional, the default selected bottom tab. Default: 0
   },

--- a/docs/top-level-api.md
+++ b/docs/top-level-api.md
@@ -50,8 +50,8 @@ Navigation.startTabBasedApp({
     }
   ],
   tabsStyle: { // optional, add this if you want to style the tab bar beyond the defaults
-    tabBarButtonColor: '#ffff00', // optional, change the color of the tab icons and text (also unselected)
-    tabBarSelectedButtonColor: '#ff9900', // optional, change the color of the selected tab icon and text (only selected)
+    tabBarButtonColor: '#ffff00', // optional, change the color of the tab icons and text (also unselected). For Android, add this to appStyle
+    tabBarSelectedButtonColor: '#ff9900', // optional, change the color of the selected tab icon and text (only selected). For Android, add this to appStyle
     tabBarBackgroundColor: '#551A8B', // optional, change the background color of the tab bar
     initialTabIndex: 1, // optional, the default selected bottom tab. Default: 0
   },

--- a/docs/top-level-api.md
+++ b/docs/top-level-api.md
@@ -53,7 +53,7 @@ Navigation.startTabBasedApp({
     tabBarButtonColor: '#ffff00', // optional, change the color of the tab icons and text (also unselected). On Android, add this to appStyle
     tabBarSelectedButtonColor: '#ff9900', // optional, change the color of the selected tab icon and text (only selected). On Android, add this to appStyle
     tabBarBackgroundColor: '#551A8B', // optional, change the background color of the tab bar
-    initialTabIndex: 1, // optional, the default selected bottom tab. Default: 0
+    initialTabIndex: 1, // optional, the default selected bottom tab. Default: 0. On Android, add this to appStyle
   },
   appStyle: {
     orientation: 'portrait', // Sets a specific orientation to the entire app. Default: 'auto'. Supported values: 'auto', 'landscape', 'portrait'


### PR DESCRIPTION
This troubled me a lot before I finally realized that the tabStyle for andriod is actually in appStyle. The comment for selectedIcon made me think I should change tabBarSelectedButtonColor in tabStyle.

> selectedIcon: require('../img/one_selected.png'), // local image asset for the tab icon selected state (optional, iOS only. On Android, Use `tabBarSelectedButtonColor` instead)