### PR TITLE
Fix icon tint color when using setTabButton on iOS

### DIFF
--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -327,7 +327,6 @@
       if (icon && icon != (id)[NSNull null])
       {
         iconImage = [RCTConvert UIImage:icon];
-        iconImage = [[self image:iconImage withColor:self.tabBar.tintColor] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
         viewController.tabBarItem.image = iconImage;
       }
       


### PR DESCRIPTION
When using `tabBarSelectedButtonColor` in `tabsStyle`, the tint color would always be active on the new icon.

Not sure if my way is the best but I tested every possibility and it works great. 👍🏾

**Before:**
<img width="365" alt="screen shot 2017-09-19 at 1 20 43 am" src="https://user-images.githubusercontent.com/2040807/30569069-f36d0d42-9cd8-11e7-858a-2f6d43b7df5f.png">


**After:**
<img width="365" alt="screen shot 2017-09-19 at 1 21 39 am" src="https://user-images.githubusercontent.com/2040807/30569073-f77914c6-9cd8-11e7-81a4-066022d50a97.png">


