### PR TITLE
Bug fixed - the UIScrollView will break on iOS10 when building by XCode9

### DIFF
--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -292,7 +292,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 // rnn issue - https://github.com/wix/react-native-navigation/issues/1858
 - (void)_traverseAndFixScrollViewSafeArea:(UIView *)view {
 #ifdef __IPHONE_11_0
-  if ([view isKindOfClass:UIScrollView.class]) {
+  if ([view isKindOfClass:UIScrollView.class] && [view respondsToSelector:@selector(setContentInsetAdjustmentBehavior:)]) {
     [((UIScrollView*)view) setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
   }
   


### PR DESCRIPTION
This only happens when you are using react-native@0.48.3, and build your APP by XCode9. When you run your APP in iOS10 or below, it will throw `unrecognized selector` error. The new iOS11 has new design on StatusBar which behaves weird on UIScrollView, so that the react-native team added this new selector to fix it. This PR will help to address this problem when you are also using the amazing `react-native-navigation`.

Here's the error details:
> Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[RCTCustomScrollView setContentInsetAdjustmentBehavior:]: unrecognized selector sent to instance 0x7ffab9891a00'

Reference:
https://github.com/facebook/react-native/issues/15957
https://github.com/wix/react-native-navigation/issues/1886