### PR TITLE
fix android lightbox error when dismissing

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/LightBox.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/LightBox.java
@@ -107,7 +107,7 @@ public class LightBox extends Dialog implements DialogInterface.OnDismissListene
     }
 
     public void destroy() {
-        content.unmountReactView();
+        //content.unmountReactView();
         dismiss();
     }
 


### PR DESCRIPTION
hack that was mentioned to have fixed issue in https://github.com/wix/react-native-navigation/issues/1502

This may interfere with `componentWillUnmount` 

Taken from a comment in the thread: 

@hemedani Thanks, your workaround works quite nice. But within my lightbox I'm dependent on the componentWillUnmount method beeing called. With your workaround this method is never called for my lightbox. So currently I have a really ugly hack for this: