### PR TITLE
Apply styled buttons to all UIControlState

### DIFF
--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -42,65 +42,65 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 {
   UIViewController* controller = nil;
   if (!layout) return nil;
-  
+
   // get props
   if (!layout[@"props"]) return nil;
   if (![layout[@"props"] isKindOfClass:[NSDictionary class]]) return nil;
   NSDictionary *props = layout[@"props"];
-  
+
   // get children
   if (!layout[@"children"]) return nil;
   if (![layout[@"children"] isKindOfClass:[NSArray class]]) return nil;
   NSArray *children = layout[@"children"];
-  
+
   // create according to type
   NSString *type = layout[@"type"];
   if (!type) return nil;
-  
+
   // regular view controller
   if ([type isEqualToString:@"ViewControllerIOS"])
   {
     controller = [[RCCViewController alloc] initWithProps:props children:children globalProps:globalProps bridge:bridge];
   }
-  
+
   // navigation controller
   if ([type isEqualToString:@"NavigationControllerIOS"])
   {
     controller = [[RCCNavigationController alloc] initWithProps:props children:children globalProps:globalProps bridge:bridge];
   }
-  
+
   // tab bar controller
   if ([type isEqualToString:@"TabBarControllerIOS"])
   {
     controller = [[RCCTabBarController alloc] initWithProps:props children:children globalProps:globalProps bridge:bridge];
   }
-  
+
   // side menu controller
   if ([type isEqualToString:@"DrawerControllerIOS"])
   {
     NSString *drawerType = props[@"type"];
-    
+
     if ([drawerType isEqualToString:@"TheSideBar"]) {
-      
+
       controller = [[RCCTheSideBarManagerViewController alloc] initWithProps:props children:children globalProps:globalProps bridge:bridge];
     }
     else {
       controller = [[RCCDrawerController alloc] initWithProps:props children:children globalProps:globalProps bridge:bridge];
     }
   }
-  
+
   // register the controller if we have an id
   NSString *componentId = props[@"id"];
   if (controller && componentId)
   {
     [[RCCManager sharedInstance] registerController:controller componentId:componentId componentType:type];
-    
+
     if([controller isKindOfClass:[RCCViewController class]])
     {
       ((RCCViewController*)controller).controllerId = componentId;
     }
   }
-  
+
   // set background image at root level
   NSString *rootBackgroundImageName = props[@"style"][@"rootBackgroundImageName"];
   if (rootBackgroundImageName) {
@@ -108,18 +108,18 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
     UIImageView *imageView = [[UIImageView alloc] initWithImage:image];
     [controller.view insertSubview:imageView atIndex:0];
   }
-  
+
   return controller;
 }
 
 -(NSDictionary*)addCommandTypeAndTimestampIfExists:(NSDictionary*)globalProps passProps:(NSDictionary*)passProps {
   NSMutableDictionary *modifiedPassProps = [NSMutableDictionary dictionaryWithDictionary:passProps];
-  
+
   NSString *commandType = globalProps[GLOBAL_SCREEN_ACTION_COMMAND_TYPE];
   if (commandType) {
     modifiedPassProps[GLOBAL_SCREEN_ACTION_COMMAND_TYPE] = commandType;
   }
-  
+
   NSString *timestamp = globalProps[GLOBAL_SCREEN_ACTION_TIMESTAMP];
   if (timestamp) {
     modifiedPassProps[GLOBAL_SCREEN_ACTION_TIMESTAMP] = timestamp;
@@ -133,23 +133,23 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 {
   NSString *component = props[@"component"];
   if (!component) return nil;
-  
+
   NSDictionary *passProps = props[@"passProps"];
   NSDictionary *navigatorStyle = props[@"style"];
-  
+
   NSMutableDictionary *mergedProps = [NSMutableDictionary dictionaryWithDictionary:globalProps];
   [mergedProps addEntriesFromDictionary:passProps];
-  
+
   RCTRootView *reactView = [[RCTRootView alloc] initWithBridge:bridge moduleName:component initialProperties:mergedProps];
   if (!reactView) return nil;
-  
+
   self = [super init];
   if (!self) return nil;
-  
+
   [self commonInit:reactView navigatorStyle:navigatorStyle props:props];
-  
+
   self.navigationController.interactivePopGestureRecognizer.delegate = self;
-  
+
   return self;
 }
 
@@ -157,40 +157,40 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 {
   NSMutableDictionary *mergedProps = [NSMutableDictionary dictionaryWithDictionary:globalProps];
   [mergedProps addEntriesFromDictionary:passProps];
-  
+
   RCTRootView *reactView = [[RCTRootView alloc] initWithBridge:bridge moduleName:component initialProperties:mergedProps];
   if (!reactView) return nil;
-  
+
   self = [super init];
   if (!self) return nil;
-  
+
   NSDictionary *modifiedPassProps = [self addCommandTypeAndTimestampIfExists:globalProps passProps:passProps];
 
   [self commonInit:reactView navigatorStyle:navigatorStyle props:modifiedPassProps];
-  
+
   return self;
 }
 
 - (void)commonInit:(RCTRootView*)reactView navigatorStyle:(NSDictionary*)navigatorStyle props:(NSDictionary*)props
 {
   self.view = reactView;
-  
+
   self.edgesForExtendedLayout = UIRectEdgeNone; // default
   self.automaticallyAdjustsScrollViewInsets = NO; // default
-  
+
   self.navigatorStyle = [NSMutableDictionary dictionaryWithDictionary:[[RCCManager sharedInstance] getAppStyle]];
   [self.navigatorStyle addEntriesFromDictionary:navigatorStyle];
 
-  
+
   [self setStyleOnInit];
-  
+
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onRNReload) name:RCTJavaScriptWillStartLoadingNotification object:nil];
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onCancelReactTouches) name:RCCViewControllerCancelReactTouchesNotification object:nil];
-  
+
   self.commandType = props[GLOBAL_SCREEN_ACTION_COMMAND_TYPE];
   self.timestamp = props[GLOBAL_SCREEN_ACTION_TIMESTAMP];
-  
-  
+
+
   // In order to support 3rd party native ViewControllers, we support passing a class name as a prop named `ExternalNativeScreenClass`
   // In this case, we create an instance and add it as a child ViewController which preserves the VC lifecycle.
   // In case some props are necessary in the native ViewController, the ExternalNativeScreenProps can be used to pass them
@@ -219,11 +219,11 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 - (void)sendScreenChangedEvent:(NSString *)eventName
 {
   if ([self.view isKindOfClass:[RCTRootView class]]){
-    
+
     RCTRootView *rootView = (RCTRootView *)self.view;
-    
+
     if (rootView.appProperties && rootView.appProperties[@"navigatorEventID"]) {
-      
+
       [[[RCCManager sharedInstance] getBridge].eventDispatcher sendAppEventWithName:rootView.appProperties[@"navigatorEventID"] body:@
        {
          @"type": @"ScreenChangedEvent",
@@ -234,12 +234,12 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 }
 
 - (void)sendGlobalScreenEvent:(NSString *)eventName endTimestampString:(NSString *)endTimestampStr shouldReset:(BOOL)shouldReset {
-  
+
   if (!self.commandType) return;
-  
+
   if ([self.view isKindOfClass:[RCTRootView class]]){
     NSString *screenName = [((RCTRootView*)self.view) moduleName];
-    
+
     [[[RCCManager sharedInstance] getBridge].eventDispatcher sendAppEventWithName:eventName body:@
      {
        @"commandType": self.commandType ? self.commandType : @"",
@@ -247,7 +247,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
        @"startTime": self.timestamp ? self.timestamp : @"",
        @"endTime": endTimestampStr ? endTimestampStr : @""
      }];
-    
+
     if (shouldReset) {
       self.commandType = nil;
       self.timestamp = nil;
@@ -259,7 +259,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 -(BOOL)isDisappearTriggeredFromPop:(NSString *)eventName {
 
   NSArray *navigationViewControllers = self.navigationController.viewControllers;
-  
+
   if (navigationViewControllers.lastObject == self || [navigationViewControllers indexOfObject:self] == NSNotFound) {
     return YES;
   }
@@ -282,7 +282,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   if([view isKindOfClass:[UIScrollView class]] && ([[(UIScrollView*)view delegate] respondsToSelector:@selector(scrollViewDidEndDecelerating:)]) ) {
     [[(UIScrollView*)view delegate] scrollViewDidEndDecelerating:(id)view];
   }
-  
+
   [view.subviews enumerateObjectsUsingBlock:^(__kindof UIView * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
     [self _traverseAndCall:obj];
   }];
@@ -292,15 +292,15 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 // rnn issue - https://github.com/wix/react-native-navigation/issues/1858
 - (void)_traverseAndFixScrollViewSafeArea:(UIView *)view {
 #ifdef __IPHONE_11_0
-  if ([view isKindOfClass:UIScrollView.class] && [view respondsToSelector:@selector(setContentInsetAdjustmentBehavior:)]) {
+  if ([view isKindOfClass:UIScrollView.class]) {
     [((UIScrollView*)view) setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
   }
-  
+
   [view.subviews enumerateObjectsUsingBlock:^(__kindof UIView * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
     [self _traverseAndFixScrollViewSafeArea:obj];
   }];
 #endif
-  
+
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -308,7 +308,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   [super viewDidAppear:animated];
   [self sendGlobalScreenEvent:@"didAppear" endTimestampString:[self getTimestampString] shouldReset:YES];
   [self sendScreenChangedEvent:@"didAppear"];
-  
+
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -350,121 +350,141 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 
 -(void)setStyleOnAppearForViewController:(UIViewController*)viewController appeared:(BOOL)appeared
 {
-  
+
   NSString *screenBackgroundColor = self.navigatorStyle[@"screenBackgroundColor"];
   if (screenBackgroundColor) {
-    
+
     UIColor *color = screenBackgroundColor != (id)[NSNull null] ? [RCTConvert UIColor:screenBackgroundColor] : nil;
     viewController.view.backgroundColor = color;
   }
-  
+
   NSString *screenBackgroundImageName = self.navigatorStyle[@"screenBackgroundImageName"];
   if (screenBackgroundImageName) {
-    
+
     UIImage *image = [UIImage imageNamed: screenBackgroundImageName];
     viewController.view.layer.contents = (__bridge id _Nullable)(image.CGImage);
   }
-  
+
   NSString *navBarBackgroundColor = self.navigatorStyle[@"navBarBackgroundColor"];
   if (navBarBackgroundColor) {
-    
+
     UIColor *color = navBarBackgroundColor != (id)[NSNull null] ? [RCTConvert UIColor:navBarBackgroundColor] : nil;
     viewController.navigationController.navigationBar.barTintColor = color;
-    
+
   } else {
     viewController.navigationController.navigationBar.barTintColor = nil;
   }
-  
+
   NSMutableDictionary *titleTextAttributes = [RCTHelpers textAttributesFromDictionary:self.navigatorStyle withPrefix:@"navBarText" baseFont:[UIFont boldSystemFontOfSize:17]];
   [self.navigationController.navigationBar setTitleTextAttributes:titleTextAttributes];
-  
+
   if (self.navigationItem.titleView && [self.navigationItem.titleView isKindOfClass:[RCCTitleView class]]) {
-    
+
     RCCTitleView *titleView = (RCCTitleView *)self.navigationItem.titleView;
     RCCTitleViewHelper *helper = [[RCCTitleViewHelper alloc] init:viewController navigationController:viewController.navigationController title:titleView.titleLabel.text subtitle:titleView.subtitleLabel.text titleImageData:nil isSetSubtitle:NO];
     [helper setup:self.navigatorStyle];
   }
-  
+
   NSMutableDictionary *navButtonTextAttributes = [RCTHelpers textAttributesFromDictionary:self.navigatorStyle withPrefix:@"navBarButton"];
   NSMutableDictionary *leftNavButtonTextAttributes = [RCTHelpers textAttributesFromDictionary:self.navigatorStyle withPrefix:@"navBarLeftButton"];
   NSMutableDictionary *rightNavButtonTextAttributes = [RCTHelpers textAttributesFromDictionary:self.navigatorStyle withPrefix:@"navBarRightButton"];
-  
+
   if (
       navButtonTextAttributes.allKeys.count > 0 ||
       leftNavButtonTextAttributes.allKeys.count > 0 ||
       rightNavButtonTextAttributes.allKeys.count > 0
       ) {
-    
+
     for (UIBarButtonItem *item in viewController.navigationItem.leftBarButtonItems) {
       [item setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateNormal];
-      
+      [item setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateSelected];
+      [item setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateDisabled];
+      [item setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateHighlighted];
+      [item setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateFocused];
+
       if (leftNavButtonTextAttributes.allKeys.count > 0) {
         [item setTitleTextAttributes:leftNavButtonTextAttributes forState:UIControlStateNormal];
+        [item setTitleTextAttributes:leftNavButtonTextAttributes forState:UIControlStateSelected];
+        [item setTitleTextAttributes:leftNavButtonTextAttributes forState:UIControlStateDisabled];
+        [item setTitleTextAttributes:leftNavButtonTextAttributes forState:UIControlStateHighlighted];
+        [item setTitleTextAttributes:leftNavButtonTextAttributes forState:UIControlStateFocused];
       }
     }
-    
+
     for (UIBarButtonItem *item in viewController.navigationItem.rightBarButtonItems) {
       [item setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateNormal];
-      
+      [item setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateSelected];
+      [item setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateDisabled];
+      [item setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateHighlighted];
+      [item setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateFocused];
+
       if (rightNavButtonTextAttributes.allKeys.count > 0) {
         [item setTitleTextAttributes:rightNavButtonTextAttributes forState:UIControlStateNormal];
+        [item setTitleTextAttributes:rightNavButtonTextAttributes forState:UIControlStateSelected];
+        [item setTitleTextAttributes:rightNavButtonTextAttributes forState:UIControlStateDisabled];
+        [item setTitleTextAttributes:rightNavButtonTextAttributes forState:UIControlStateHighlighted];
+        [item setTitleTextAttributes:rightNavButtonTextAttributes forState:UIControlStateFocused];
       }
     }
-    
+
     // At the moment, this seems to be the only thing that gets the back button correctly
     [navButtonTextAttributes removeObjectForKey:NSForegroundColorAttributeName];
     [[UIBarButtonItem appearance] setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateNormal];
+    [[UIBarButtonItem appearance] setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateSelected];
+    [[UIBarButtonItem appearance] setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateDisabled];
+    [[UIBarButtonItem appearance] setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateHighlighted];
+    [[UIBarButtonItem appearance] setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateFocused];
   }
-  
+
   NSString *navBarButtonColor = self.navigatorStyle[@"navBarButtonColor"];
   if (navBarButtonColor) {
-    
+
     UIColor *color = navBarButtonColor != (id)[NSNull null] ? [RCTConvert UIColor:navBarButtonColor] : nil;
     viewController.navigationController.navigationBar.tintColor = color;
-    
+
   } else
   {
     viewController.navigationController.navigationBar.tintColor = nil;
   }
-  
+
   BOOL viewControllerBasedStatusBar = false;
-  
+
   NSObject *viewControllerBasedStatusBarAppearance = [[NSBundle mainBundle] infoDictionary][@"UIViewControllerBasedStatusBarAppearance"];
   if (viewControllerBasedStatusBarAppearance && [viewControllerBasedStatusBarAppearance isKindOfClass:[NSNumber class]]) {
     viewControllerBasedStatusBar = [(NSNumber *)viewControllerBasedStatusBarAppearance boolValue];
   }
-  
+
   NSString *statusBarTextColorSchemeSingleScreen = self.navigatorStyle[@"statusBarTextColorSchemeSingleScreen"];
   NSString *statusBarTextColorScheme = self.navigatorStyle[@"statusBarTextColorScheme"];
   NSString *finalColorScheme = statusBarTextColorSchemeSingleScreen ? : statusBarTextColorScheme;
-  
+
   if (finalColorScheme && [finalColorScheme isEqualToString:@"light"]) {
-    
+
     if (!statusBarTextColorSchemeSingleScreen) {
       viewController.navigationController.navigationBar.barStyle = UIBarStyleBlack;
     }
-    
+
     self._statusBarTextColorSchemeLight = true;
     if (!viewControllerBasedStatusBarAppearance) {
       [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent];
     }
-    
+
     [viewController setNeedsStatusBarAppearanceUpdate];
-    
+
   } else {
-    
+
     if (!statusBarTextColorSchemeSingleScreen) {
       viewController.navigationController.navigationBar.barStyle = UIBarStyleDefault;
     }
-    
+
     self._statusBarTextColorSchemeLight = false;
-    
+
     if (!viewControllerBasedStatusBarAppearance) {
       [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault];
     }
     [viewController setNeedsStatusBarAppearanceUpdate];
   }
-  
+
   NSNumber *tabBarHidden = self.navigatorStyle[@"tabBarHidden"];
   BOOL tabBarHiddenBool = tabBarHidden ? [tabBarHidden boolValue] : NO;
   if (tabBarHiddenBool) {
@@ -477,7 +497,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   if (viewController.navigationController.navigationBarHidden != navBarHiddenBool) {
     [viewController.navigationController setNavigationBarHidden:navBarHiddenBool animated:YES];
   }
-  
+
   NSNumber *navBarHideOnScroll = self.navigatorStyle[@"navBarHideOnScroll"];
   BOOL navBarHideOnScrollBool = navBarHideOnScroll ? [navBarHideOnScroll boolValue] : NO;
   if (navBarHideOnScrollBool) {
@@ -485,24 +505,24 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   } else {
     viewController.navigationController.hidesBarsOnSwipe = NO;
   }
-  
+
   NSNumber *statusBarBlur = self.navigatorStyle[@"statusBarBlur"];
   BOOL statusBarBlurBool = statusBarBlur ? [statusBarBlur boolValue] : NO;
   if (statusBarBlurBool && ![viewController.view viewWithTag:BLUR_STATUS_TAG]) {
-    
+
     UIVisualEffectView *blur = [[UIVisualEffectView alloc] initWithEffect:[UIBlurEffect effectWithStyle:UIBlurEffectStyleLight]];
     blur.frame = [[UIApplication sharedApplication] statusBarFrame];
     blur.tag = BLUR_STATUS_TAG;
     [viewController.view insertSubview:blur atIndex:0];
   }
-  
+
   NSNumber *navBarBlur = self.navigatorStyle[@"navBarBlur"];
   BOOL navBarBlurBool = navBarBlur ? [navBarBlur boolValue] : NO;
   if (navBarBlurBool) {
-    
+
     if (![viewController.navigationController.navigationBar viewWithTag:BLUR_NAVBAR_TAG]) {
       [self storeOriginalNavBarImages];
-      
+
       [viewController.navigationController.navigationBar setBackgroundImage:[UIImage new] forBarMetrics:UIBarMetricsDefault];
       viewController.navigationController.navigationBar.shadowImage = [UIImage new];
       UIVisualEffectView *blur = [[UIVisualEffectView alloc] initWithEffect:[UIBlurEffect effectWithStyle:UIBlurEffectStyleLight]];
@@ -513,9 +533,9 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
       [viewController.navigationController.navigationBar insertSubview:blur atIndex:0];
       [viewController.navigationController.navigationBar sendSubviewToBack:blur];
     }
-    
+
   } else {
-    
+
     UIView *blur = [viewController.navigationController.navigationBar viewWithTag:BLUR_NAVBAR_TAG];
     if (blur) {
       [blur removeFromSuperview];
@@ -524,17 +544,17 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
       self.originalNavBarImages = nil;
     }
   }
-  
+
   NSNumber *navBarTransparent = self.navigatorStyle[@"navBarTransparent"];
   BOOL navBarTransparentBool = navBarTransparent ? [navBarTransparent boolValue] : NO;
-  
+
   void (^action)() = ^ {
     if (navBarTransparentBool)
     {
       if (![viewController.navigationController.navigationBar viewWithTag:TRANSPARENT_NAVBAR_TAG])
       {
         [self storeOriginalNavBarImages];
-        
+
         [viewController.navigationController.navigationBar setBackgroundImage:[UIImage new] forBarMetrics:UIBarMetricsDefault];
         viewController.navigationController.navigationBar.shadowImage = [UIImage new];
         UIView *transparentView = [[UIView alloc] initWithFrame:CGRectZero];
@@ -554,7 +574,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
       }
     }
   };
-  
+
   if (!self.transitionCoordinator || self.transitionCoordinator.initiallyInteractive || !navBarTransparentBool || appeared) {
     action();
   } else {
@@ -566,10 +586,10 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
       backgroundView.alpha = originalAlpha;
     }];
   }
-  
+
   NSNumber *autoAdjustsScrollViewInsets = self.navigatorStyle[@"autoAdjustScrollViewInsets"];
   viewController.automaticallyAdjustsScrollViewInsets = autoAdjustsScrollViewInsets ? [autoAdjustsScrollViewInsets boolValue] : false;
-  
+
   NSNumber *navBarTranslucent = self.navigatorStyle[@"navBarTranslucent"];
   BOOL navBarTranslucentBool = navBarTranslucent ? [navBarTranslucent boolValue] : NO;
   if (navBarTranslucentBool || navBarBlurBool) {
@@ -577,11 +597,11 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   } else {
     viewController.navigationController.navigationBar.translucent = NO;
   }
-  
+
   NSNumber *extendedLayoutIncludesOpaqueBars = self.navigatorStyle[@"extendedLayoutIncludesOpaqueBars"];
   BOOL extendedLayoutIncludesOpaqueBarsBool = extendedLayoutIncludesOpaqueBars ? [extendedLayoutIncludesOpaqueBars boolValue] : NO;
   viewController.extendedLayoutIncludesOpaqueBars = extendedLayoutIncludesOpaqueBarsBool;
-  
+
   NSNumber *drawUnderNavBar = self.navigatorStyle[@"drawUnderNavBar"];
   BOOL drawUnderNavBarBool = drawUnderNavBar ? [drawUnderNavBar boolValue] : NO;
   if (drawUnderNavBarBool) {
@@ -590,7 +610,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   else {
     viewController.edgesForExtendedLayout &= ~UIRectEdgeTop;
   }
-  
+
   NSNumber *drawUnderTabBar = self.navigatorStyle[@"drawUnderTabBar"];
   BOOL drawUnderTabBarBool = drawUnderTabBar ? [drawUnderTabBar boolValue] : NO;
   if (drawUnderTabBarBool) {
@@ -598,7 +618,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   } else {
     viewController.edgesForExtendedLayout &= ~UIRectEdgeBottom;
   }
-  
+
   NSNumber *removeNavBarBorder = self.navigatorStyle[@"navBarNoBorder"];
   BOOL removeNavBarBorderBool = removeNavBarBorder ? [removeNavBarBorder boolValue] : NO;
   if (removeNavBarBorderBool) {
@@ -606,7 +626,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   } else {
     self.navBarHairlineImageView.hidden = NO;
   }
-  
+
  //Bug fix: in case there is a interactivePopGestureRecognizer, it prevents react-native from getting touch events on the left screen area that the gesture handles
  //overriding the delegate of the gesture prevents this from happening while keeping the gesture intact (another option was to disable it completely by demand)
  if(self.navigationController.viewControllers.count > 1){
@@ -620,22 +640,22 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
      }
    }
  }
-  
+
   NSString *navBarCustomView = self.navigatorStyle[@"navBarCustomView"];
   if (navBarCustomView && ![self.navigationItem.titleView isKindOfClass:[RCCCustomTitleView class]]) {
     if ([self.view isKindOfClass:[RCTRootView class]]) {
-      
+
       RCTBridge *bridge = ((RCTRootView*)self.view).bridge;
-      
+
       NSDictionary *initialProps = self.navigatorStyle[@"navBarCustomViewInitialProps"];
       RCTRootView *reactView = [[RCTRootView alloc] initWithBridge:bridge moduleName:navBarCustomView initialProperties:initialProps];
-      
+
       RCCCustomTitleView *titleView = [[RCCCustomTitleView alloc] initWithFrame:self.navigationController.navigationBar.bounds subView:reactView alignment:self.navigatorStyle[@"navBarComponentAlignment"]];
       titleView.backgroundColor = [UIColor clearColor];
       reactView.backgroundColor = [UIColor clearColor];
-      
+
       self.navigationItem.titleView = titleView;
-      
+
       self.navigationItem.titleView.backgroundColor = [UIColor clearColor];
       self.navigationItem.titleView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
       self.navigationItem.titleView.clipsToBounds = YES;
@@ -645,7 +665,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 
 
 -(void)storeOriginalNavBarImages {
-  
+
   NSMutableDictionary *originalNavBarImages = [@{} mutableCopy];
   UIImage *bgImage = [self.navigationController.navigationBar backgroundImageForBarMetrics:UIBarMetricsDefault];
   if (bgImage != nil) {
@@ -656,12 +676,12 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
     originalNavBarImages[@"shadowImage"] = shadowImage;
   }
   self.originalNavBarImages = originalNavBarImages;
-  
+
 }
 
 -(void)setStyleOnDisappear {
   self.navBarHairlineImageView.hidden = NO;
-  
+
   if (self.navigationController != nil && self.navigationController.interactivePopGestureRecognizer != nil && self.originalInteractivePopGestureDelegate != nil)
   {
     self.navigationController.interactivePopGestureRecognizer.delegate = self.originalInteractivePopGestureDelegate;
@@ -679,7 +699,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   } else {
     self._hidesBottomBarWhenPushed = NO;
   }
-  
+
   NSNumber *statusBarHideWithNavBar = self.navigatorStyle[@"statusBarHideWithNavBar"];
   BOOL statusBarHideWithNavBarBool = statusBarHideWithNavBar ? [statusBarHideWithNavBar boolValue] : NO;
   if (statusBarHideWithNavBarBool) {
@@ -687,7 +707,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   } else {
     self._statusBarHideWithNavBar = NO;
   }
-  
+
   NSNumber *statusBarHidden = self.navigatorStyle[@"statusBarHidden"];
   BOOL statusBarHiddenBool = statusBarHidden ? [statusBarHidden boolValue] : NO;
   if (statusBarHiddenBool) {
@@ -708,7 +728,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   if (self._statusBarHidden) {
     return YES;
   }
-  
+
   if (self._statusBarHideWithNavBar) {
     return self.navigationController.isNavigationBarHidden;
   } else {
@@ -756,7 +776,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
       {
         ((id <RCCExternalViewControllerProtocol>)obj).controllerDelegate = self;
         [obj setProps:props[@"externalNativeScreenProps"]];
-        
+
         UIViewController *viewController = (UIViewController*)obj;
         [self addChildViewController:viewController];
         viewController.view.frame = self.view.bounds;
@@ -780,7 +800,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 - (NSString*) customNewRelicInteractionName
 {
   NSString *interactionName = nil;
-  
+
   if (self.view != nil && [self.view isKindOfClass:[RCTRootView class]])
   {
     NSString *moduleName = ((RCTRootView*)self.view).moduleName;
@@ -789,12 +809,12 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
       interactionName = [NSString stringWithFormat:@"RCCViewController: %@", moduleName];
     }
   }
-  
+
   if (interactionName == nil)
   {
     interactionName = [NSString stringWithFormat:@"RCCViewController with title: %@", self.title];
   }
-  
+
   return interactionName;
 }
 


### PR DESCRIPTION
Applying a custom size/font/etc to navBar buttons is now applied to all `UIControlState`s.  Previously it was only applied to the normal state (ie, not select/focused/highlighted/disabled states).

This PR fixes that.