### PR TITLE
Add disableIconTint option for TabBar icons (#1710)

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/params/StyleParams.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/StyleParams.java
@@ -135,6 +135,9 @@ public class StyleParams {
 
     public Color navigationBarColor;
 
+    public boolean disableIconTint;
+    public boolean disableSelectedIconTint;
+
     public boolean hasTopBarCustomComponent() {
         return !TextUtils.isEmpty(topBarReactView);
     }

--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/StyleParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/StyleParamsParser.java
@@ -96,6 +96,9 @@ public class StyleParamsParser {
 
         result.bottomTabFontFamily = getFont("bottomTabFontFamily", getDefaultBottomTabsFontFamily());
 
+        result.disableIconTint = getBoolean("disableIconTint", getDefaultDisableIconTint());
+        result.disableSelectedIconTint = getBoolean("disableSelectedIconTint", getDefaultDisableSelectedIconTint());
+
         return result;
     }
 
@@ -287,6 +290,14 @@ public class StyleParamsParser {
 
     private int getDefaultTitleBarHeight() {
         return AppStyle.appStyle == null ? -1 : AppStyle.appStyle.titleBarHeight;
+    }
+
+    private boolean getDefaultDisableIconTint() {
+        return AppStyle.appStyle != null && AppStyle.appStyle.disableIconTint;
+    }
+
+    private boolean getDefaultDisableSelectedIconTint() {
+        return AppStyle.appStyle != null && AppStyle.appStyle.disableSelectedIconTint;
     }
 
     private boolean getBoolean(String key, boolean defaultValue) {

--- a/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
@@ -42,12 +42,12 @@ public class BottomTabs extends AHBottomNavigation {
         if (params.bottomTabsColor.hasColor()) {
             setBackgroundColor(params.bottomTabsColor);
         }
-        if (params.bottomTabsButtonColor.hasColor()) {
+        if (params.bottomTabsButtonColor.hasColor() && !params.disableIconTint) {
             if (getInactiveColor() != params.bottomTabsButtonColor.getColor()) {
                 setInactiveColor(params.bottomTabsButtonColor.getColor());
             }
         }
-        if (params.selectedBottomTabsButtonColor.hasColor()) {
+        if (params.selectedBottomTabsButtonColor.hasColor() && !params.disableSelectedIconTint) {
             if (getAccentColor() != params.selectedBottomTabsButtonColor.getColor()) {
                 setAccentColor(params.selectedBottomTabsButtonColor.getColor());
             }

--- a/docs/styling-the-tab-bar.md
+++ b/docs/styling-the-tab-bar.md
@@ -18,13 +18,15 @@ Navigation.startTabBasedApp({
   tabBarHidden: false, // make the tab bar hidden
   tabBarButtonColor: '#ffff00', // change the color of the tab icons and text (also unselected)
   tabBarSelectedButtonColor: '#ff9900', // change the color of the selected tab icon and text (only selected)
-  tabBarBackgroundColor: '#551A8B' // change the background color of the tab bar
-  tabBarTranslucent: false // change the translucent of the tab bar to false
-  tabBarTextFontFamily: 'Avenir-Medium' //change the tab font family
+  tabBarBackgroundColor: '#551A8B', // change the background color of the tab bar
+  tabBarTranslucent: false, // change the translucent of the tab bar to false
+  tabBarTextFontFamily: 'Avenir-Medium', //change the tab font family
   tabBarLabelColor: '#ffb700', // iOS only. change the color of tab text
   tabBarSelectedLabelColor: 'red', // iOS only. change the color of the selected tab text
-  forceTitlesDisplay: true // Android only. If true - Show all bottom tab labels. If false - only the selected tab's label is visible.
-  tabBarHideShadow: true // iOS only. Remove default tab bar top shadow (hairline)
+  forceTitlesDisplay: true, // Android only. If true - Show all bottom tab labels. If false - only the selected tab's label is visible.
+  tabBarHideShadow: true, // iOS only. Remove default tab bar top shadow (hairline)
+  disableIconTint: true, // optional, by default the tab icons colors are overridden and tinted to tabBarButtonColor, set to true to keep the original icons colors
+  disableSelectedIconTint: true // optional, by default the selected tab icon color is overridden and tinted to tabBarSelectedButtonColor, set to true to keep the original icon color
 }
 ```
 

--- a/docs/styling-the-tab-bar.md
+++ b/docs/styling-the-tab-bar.md
@@ -25,8 +25,8 @@ Navigation.startTabBasedApp({
   tabBarSelectedLabelColor: 'red', // iOS only. change the color of the selected tab text
   forceTitlesDisplay: true, // Android only. If true - Show all bottom tab labels. If false - only the selected tab's label is visible.
   tabBarHideShadow: true, // iOS only. Remove default tab bar top shadow (hairline)
-  disableIconTint: true, // optional, by default the tab icons colors are overridden and tinted to tabBarButtonColor, set to true to keep the original icons colors
-  disableSelectedIconTint: true // optional, by default the selected tab icon color is overridden and tinted to tabBarSelectedButtonColor, set to true to keep the original icon color
+  disableIconTint: true, // iOS only. By default the tab icons colors are overridden and tinted to tabBarButtonColor, set to true to keep the original icons colors
+  disableSelectedIconTint: true // iOS only. By default the selected tab icon color is overridden and tinted to tabBarSelectedButtonColor, set to true to keep the original icon color
 }
 ```
 
@@ -40,7 +40,9 @@ Navigation.startTabBasedApp({
     tabBarButtonColor: '#ffffff',
     tabBarSelectedButtonColor: '#63d7cc',
     tabBarTranslucent: false,
-    tabFontFamily: 'Avenir-Medium.ttf'  // for asset file or use existing font family name
+    tabFontFamily: 'Avenir-Medium.ttf',  // for asset file or use existing font family name
+    disableIconTint: true, // optional, by default the tab icons colors are overridden and tinted to tabBarButtonColor, set to true to keep the original icons colors
+    disableSelectedIconTint: true // optional, by default the selected tab icon color is overridden and tinted to tabBarSelectedButtonColor, set to true to keep the original icon color
   },
 ...
 }

--- a/docs/styling-the-tab-bar.md
+++ b/docs/styling-the-tab-bar.md
@@ -24,9 +24,7 @@ Navigation.startTabBasedApp({
   tabBarLabelColor: '#ffb700', // iOS only. change the color of tab text
   tabBarSelectedLabelColor: 'red', // iOS only. change the color of the selected tab text
   forceTitlesDisplay: true, // Android only. If true - Show all bottom tab labels. If false - only the selected tab's label is visible.
-  tabBarHideShadow: true, // iOS only. Remove default tab bar top shadow (hairline)
-  disableIconTint: true, // iOS only. By default the tab icons colors are overridden and tinted to tabBarButtonColor, set to true to keep the original icons colors
-  disableSelectedIconTint: true // iOS only. By default the selected tab icon color is overridden and tinted to tabBarSelectedButtonColor, set to true to keep the original icon color
+  tabBarHideShadow: true // iOS only. Remove default tab bar top shadow (hairline)
 }
 ```
 
@@ -41,8 +39,20 @@ Navigation.startTabBasedApp({
     tabBarSelectedButtonColor: '#63d7cc',
     tabBarTranslucent: false,
     tabFontFamily: 'Avenir-Medium.ttf',  // for asset file or use existing font family name
-    disableIconTint: true, // optional, by default the tab icons colors are overridden and tinted to tabBarButtonColor, set to true to keep the original icons colors
-    disableSelectedIconTint: true // optional, by default the selected tab icon color is overridden and tinted to tabBarSelectedButtonColor, set to true to keep the original icon color
+  },
+...
+}
+```
+
+?> By default, the tab icons colors are overridden and tinted to `tabBarButtonColor`, use the settings below to keep the original icons colors:
+
+```js
+Navigation.startTabBasedApp({
+  tabs: [...],
+  appStyle: {
+    ...
+    disableIconTint: true,
+    disableSelectedIconTint: true
   },
 ...
 }

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -26,32 +26,32 @@
   dispatch_async(queue, ^{
     [[[RCCManager sharedInstance].getBridge uiManager] configureNextLayoutAnimation:nil withCallback:^(NSArray* arr){} errorCallback:^(NSArray* arr){}];
   });
-  
+
   if (tabBarController.selectedIndex != [tabBarController.viewControllers indexOfObject:viewController]) {
     NSDictionary *body = @{
                            @"selectedTabIndex": @([tabBarController.viewControllers indexOfObject:viewController]),
                            @"unselectedTabIndex": @(tabBarController.selectedIndex)
                            };
     [RCCTabBarController sendScreenTabChangedEvent:viewController body:body];
-    
+
     [[[RCCManager sharedInstance] getBridge].eventDispatcher sendAppEventWithName:@"bottomTabSelected" body:body];
     if ([viewController isKindOfClass:[UINavigationController class]]) {
       UINavigationController *navigationController = (UINavigationController*)viewController;
       UIViewController *topViewController = navigationController.topViewController;
-      
+
       if ([topViewController isKindOfClass:[RCCViewController class]]) {
         RCCViewController *topRCCViewController = (RCCViewController*)topViewController;
         topRCCViewController.commandType = COMMAND_TYPE_BOTTOME_TAB_SELECTED;
         topRCCViewController.timestamp = [RCTHelpers getTimestampString];
       }
     }
-    
+
   } else {
     [RCCTabBarController sendScreenTabPressedEvent:viewController body:nil];
   }
-  
-  
-  
+
+
+
   return YES;
 }
 
@@ -75,15 +75,17 @@
 {
   self = [super init];
   if (!self) return nil;
-  
+
   self.delegate = self;
-  
+
   self.tabBar.translucent = YES; // default
-  
+
   UIColor *buttonColor = nil;
   UIColor *selectedButtonColor = nil;
   UIColor *labelColor = nil;
   UIColor *selectedLabelColor = nil;
+  BOOL disableIconTint = NO;
+  BOOL disableSelectedIconTint = NO;
   NSDictionary *tabsStyle = props[@"style"];
   if (tabsStyle)
   {
@@ -131,17 +133,29 @@
     {
       self.tabBar.clipsToBounds = [tabBarHideShadow boolValue] ? YES : NO;
     }
+
+    NSString *disableIconTintString = tabsStyle[@"disableIconTint"];
+    if (disableIconTintString)
+    {
+      disableIconTint = [disableIconTintString boolValue] ? YES : NO;
+    }
+
+    NSString *disableSelectedIconTintString = tabsStyle[@"disableSelectedIconTint"];
+    if (disableSelectedIconTintString)
+    {
+      disableSelectedIconTint = [disableSelectedIconTintString boolValue] ? YES : NO;
+    }
   }
-  
+
   NSMutableArray *viewControllers = [NSMutableArray array];
-  
+
   // go over all the tab bar items
   for (NSDictionary *tabItemLayout in children)
   {
     // make sure the layout is valid
     if (![tabItemLayout[@"type"] isEqualToString:@"TabBarControllerIOS.Item"]) continue;
     if (!tabItemLayout[@"props"]) continue;
-    
+
     // get the view controller inside
     if (!tabItemLayout[@"children"]) continue;
     if (![tabItemLayout[@"children"] isKindOfClass:[NSArray class]]) continue;
@@ -149,31 +163,43 @@
     NSDictionary *childLayout = tabItemLayout[@"children"][0];
     UIViewController *viewController = [RCCViewController controllerWithLayout:childLayout globalProps:globalProps bridge:bridge];
     if (!viewController) continue;
-    
+
     // create the tab icon and title
     NSString *title = tabItemLayout[@"props"][@"title"];
     UIImage *iconImage = nil;
     id icon = tabItemLayout[@"props"][@"icon"];
     if (icon)
     {
-      iconImage = [RCTConvert UIImage:icon];
-      if (buttonColor)
-      {
-        iconImage = [[self image:iconImage withColor:buttonColor] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+      if (disableIconTint) {
+        iconImage = [[RCTConvert UIImage:icon] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+      } else {
+        iconImage = [RCTConvert UIImage:icon];
+        if (buttonColor)
+        {
+          iconImage = [[self image:iconImage withColor:buttonColor] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+        }
       }
     }
     UIImage *iconImageSelected = nil;
     id selectedIcon = tabItemLayout[@"props"][@"selectedIcon"];
     if (selectedIcon) {
-      iconImageSelected = [RCTConvert UIImage:selectedIcon];
+      if (disableSelectedIconTint) {
+        iconImageSelected = [[RCTConvert UIImage:selectedIcon] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+      } else {
+        iconImageSelected = [RCTConvert UIImage:selectedIcon];
+      }
     } else {
-      iconImageSelected = [RCTConvert UIImage:icon];
+      if (disableSelectedIconTint) {
+        iconImageSelected = [[RCTConvert UIImage:icon] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+      } else {
+        iconImageSelected = [RCTConvert UIImage:icon];
+      }
     }
-    
+
     viewController.tabBarItem = [[UITabBarItem alloc] initWithTitle:title image:iconImage tag:0];
     viewController.tabBarItem.accessibilityIdentifier = tabItemLayout[@"props"][@"testID"];
     viewController.tabBarItem.selectedImage = iconImageSelected;
-    
+
     id imageInsets = tabItemLayout[@"props"][@"iconInsets"];
     if (imageInsets && imageInsets != (id)[NSNull null])
     {
@@ -181,26 +207,26 @@
       id leftInset = imageInsets[@"left"];
       id bottomInset = imageInsets[@"bottom"];
       id rightInset = imageInsets[@"right"];
-      
+
       CGFloat top = topInset != (id)[NSNull null] ? [RCTConvert CGFloat:topInset] : 0;
       CGFloat left = topInset != (id)[NSNull null] ? [RCTConvert CGFloat:leftInset] : 0;
       CGFloat bottom = topInset != (id)[NSNull null] ? [RCTConvert CGFloat:bottomInset] : 0;
       CGFloat right = topInset != (id)[NSNull null] ? [RCTConvert CGFloat:rightInset] : 0;
-      
+
       viewController.tabBarItem.imageInsets = UIEdgeInsetsMake(top, left, bottom, right);
     }
     NSMutableDictionary *unselectedAttributes = [RCTHelpers textAttributesFromDictionary:tabsStyle withPrefix:@"tabBarText" baseFont:[UIFont systemFontOfSize:10]];
     if (!unselectedAttributes[NSForegroundColorAttributeName] && labelColor) {
       unselectedAttributes[NSForegroundColorAttributeName] = labelColor;
     }
-    
+
     [viewController.tabBarItem setTitleTextAttributes:unselectedAttributes forState:UIControlStateNormal];
-    
+
     NSMutableDictionary *selectedAttributes = [RCTHelpers textAttributesFromDictionary:tabsStyle withPrefix:@"tabBarSelectedText" baseFont:[UIFont systemFontOfSize:10]];
     if (!selectedAttributes[NSForegroundColorAttributeName] && selectedLabelColor) {
       selectedAttributes[NSForegroundColorAttributeName] = selectedLabelColor;
     }
-    
+
     [viewController.tabBarItem setTitleTextAttributes:selectedAttributes forState:UIControlStateSelected];
     // create badge
     NSObject *badge = tabItemLayout[@"props"][@"badge"];
@@ -212,10 +238,10 @@
     {
       viewController.tabBarItem.badgeValue = [NSString stringWithFormat:@"%@", badge];
     }
-    
+
     [viewControllers addObject:viewController];
   }
-  
+
   // replace the tabs
   self.viewControllers = viewControllers;
 
@@ -225,9 +251,9 @@
     NSInteger initialTabIndex = initialTab.integerValue;
     [self setSelectedIndex:initialTabIndex];
   }
-  
+
   [self setRotation:props];
-  
+
   return self;
 }
 
@@ -240,7 +266,7 @@
     if (tabIndex)
     {
       int i = (int)[tabIndex integerValue];
-      
+
       if ([self.viewControllers count] > i)
       {
         viewController = [self.viewControllers objectAtIndex:i];
@@ -252,11 +278,11 @@
     {
       viewController = [[RCCManager sharedInstance] getControllerWithId:contentId componentType:contentType];
     }
-    
+
     if (viewController)
     {
       NSObject *badge = actionParams[@"badge"];
-      
+
       if (badge == nil || [badge isEqual:[NSNull null]])
       {
         viewController.tabBarItem.badgeValue = nil;
@@ -267,7 +293,7 @@
       }
     }
   }
-  
+
   if ([performAction isEqualToString:@"switchTo"])
   {
     UIViewController *viewController = nil;
@@ -275,7 +301,7 @@
     if (tabIndex)
     {
       int i = (int)[tabIndex integerValue];
-      
+
       if ([self.viewControllers count] > i)
       {
         viewController = [self.viewControllers objectAtIndex:i];
@@ -287,13 +313,13 @@
     {
       viewController = [[RCCManager sharedInstance] getControllerWithId:contentId componentType:contentType];
     }
-    
+
     if (viewController)
     {
       [self setSelectedViewController:viewController];
     }
   }
-  
+
   if ([performAction isEqualToString:@"setTabButton"])
   {
     UIViewController *viewController = nil;
@@ -301,7 +327,7 @@
     if (tabIndex)
     {
       int i = (int)[tabIndex integerValue];
-      
+
       if ([self.viewControllers count] > i)
       {
         viewController = [self.viewControllers objectAtIndex:i];
@@ -313,7 +339,7 @@
     {
       viewController = [[RCCManager sharedInstance] getControllerWithId:contentId componentType:contentType];
     }
-    
+
     if (viewController)
     {
       UIImage *iconImage = nil;
@@ -323,7 +349,7 @@
         iconImage = [RCTConvert UIImage:icon];
         iconImage = [[self image:iconImage withColor:self.tabBar.tintColor] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
         viewController.tabBarItem.image = iconImage;
-      
+
       }
       UIImage *iconImageSelected = nil;
       id selectedIcon = actionParams[@"selectedIcon"];
@@ -334,7 +360,7 @@
       }
     }
   }
-  
+
   if ([performAction isEqualToString:@"setTabBarHidden"])
   {
     BOOL hidden = [actionParams[@"hidden"] boolValue];
@@ -373,28 +399,28 @@
 +(void)sendTabEvent:(NSString *)event controller:(UIViewController*)viewController body:(NSDictionary*)body{
   if ([viewController.view isKindOfClass:[RCTRootView class]]){
     RCTRootView *rootView = (RCTRootView *)viewController.view;
-    
+
     if (rootView.appProperties && rootView.appProperties[@"navigatorEventID"]) {
       NSString *navigatorID = rootView.appProperties[@"navigatorID"];
       NSString *screenInstanceID = rootView.appProperties[@"screenInstanceID"];
-      
-      
+
+
       NSMutableDictionary *screenDict = [NSMutableDictionary dictionaryWithDictionary:@
                                          {
                                            @"id": event,
                                            @"navigatorID": navigatorID,
                                            @"screenInstanceID": screenInstanceID
                                          }];
-      
-      
+
+
       if (body) {
         [screenDict addEntriesFromDictionary:body];
       }
-      
+
       [[[RCCManager sharedInstance] getBridge].eventDispatcher sendAppEventWithName:rootView.appProperties[@"navigatorEventID"] body:screenDict];
     }
   }
-  
+
   if ([viewController isKindOfClass:[UINavigationController class]]) {
     UINavigationController *navigationController = (UINavigationController*)viewController;
     UIViewController *topViewController = [navigationController topViewController];

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -84,8 +84,6 @@
   UIColor *selectedButtonColor = nil;
   UIColor *labelColor = nil;
   UIColor *selectedLabelColor = nil;
-  BOOL disableIconTint = NO;
-  BOOL disableSelectedIconTint = NO;
   NSDictionary *tabsStyle = props[@"style"];
   if (tabsStyle)
   {
@@ -133,18 +131,6 @@
     {
       self.tabBar.clipsToBounds = [tabBarHideShadow boolValue] ? YES : NO;
     }
-
-    NSString *disableIconTintString = tabsStyle[@"disableIconTint"];
-    if (disableIconTintString)
-    {
-      disableIconTint = [disableIconTintString boolValue] ? YES : NO;
-    }
-
-    NSString *disableSelectedIconTintString = tabsStyle[@"disableSelectedIconTint"];
-    if (disableSelectedIconTintString)
-    {
-      disableSelectedIconTint = [disableSelectedIconTintString boolValue] ? YES : NO;
-    }
   }
 
   NSMutableArray *viewControllers = [NSMutableArray array];
@@ -170,6 +156,7 @@
     id icon = tabItemLayout[@"props"][@"icon"];
     if (icon)
     {
+      BOOL disableIconTint = [[RCCManager sharedInstance] getAppStyle][@"disableIconTint"];
       if (disableIconTint) {
         iconImage = [[RCTConvert UIImage:icon] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
       } else {
@@ -182,6 +169,7 @@
     }
     UIImage *iconImageSelected = nil;
     id selectedIcon = tabItemLayout[@"props"][@"selectedIcon"];
+    BOOL disableSelectedIconTint = [[RCCManager sharedInstance] getAppStyle][@"disableSelectedIconTint"];
     if (selectedIcon) {
       if (disableSelectedIconTint) {
         iconImageSelected = [[RCTConvert UIImage:selectedIcon] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
@@ -346,16 +334,24 @@
       id icon = actionParams[@"icon"];
       if (icon && icon != (id)[NSNull null])
       {
-        iconImage = [RCTConvert UIImage:icon];
-        iconImage = [[self image:iconImage withColor:self.tabBar.tintColor] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+        BOOL disableIconTint = [[RCCManager sharedInstance] getAppStyle][@"disableIconTint"];
+        if (disableIconTint) {
+          iconImage = [[RCTConvert UIImage:icon] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+        } else {
+          iconImage = [RCTConvert UIImage:icon];
+        }
         viewController.tabBarItem.image = iconImage;
-
       }
       UIImage *iconImageSelected = nil;
       id selectedIcon = actionParams[@"selectedIcon"];
       if (selectedIcon && selectedIcon != (id)[NSNull null])
       {
-        iconImageSelected = [RCTConvert UIImage:selectedIcon];
+        BOOL disableSelectedIconTint = [[RCCManager sharedInstance] getAppStyle][@"disableSelectedIconTint"];
+        if (disableSelectedIconTint) {
+          iconImageSelected = [[RCTConvert UIImage:selectedIcon] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+        } else {
+          iconImageSelected = [RCTConvert UIImage:selectedIcon];
+        }
         viewController.tabBarItem.selectedImage = iconImageSelected;
       }
     }


### PR DESCRIPTION
This PR adds a `disableIconTint` and `disableSelectedIconTint` options in AppStyle to prevent the Tab Bar icons to be forced to `tabBarButtonColor` and `tabBarSelectedButtonColor`. As discussed in #1710, these properties live in AppStyle even for iOS to be able to access those when calling `setTabButton`. I think eventually all the Tab Bar styling settings should live in only one place for both platforms (whether it's TabsStyle or AppStyle) to make usage less confusing.