### PR TITLE
Backwards compatibility for clearHostOnActivityDestroy

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactGateway.java
+++ b/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactGateway.java
@@ -64,14 +64,22 @@ public class NavigationReactGateway implements ReactGateway {
 	}
 
 	public void onDestroyApp(Activity activity) {
-		getReactInstanceManager().onHostDestroy(activity);
+        if (NavigationApplication.instance.clearHostOnActivityDestroy()) {
+            getReactInstanceManager().onHostDestroy();
+        } else if (hasStartedCreatingContext()) {
+            getReactInstanceManager().onHostDestroy(activity);
+        }
         if (NavigationApplication.instance.clearHostOnActivityDestroy()) {
             host.clear();
         }
     }
 
 	public void onPauseActivity(Activity activity) {
-		getReactInstanceManager().onHostPause(activity);
+        if (NavigationApplication.instance.clearHostOnActivityDestroy()) {
+            getReactInstanceManager().onHostPause();
+        } else if (hasStartedCreatingContext()) {
+		    getReactInstanceManager().onHostPause(activity);
+        }
 		jsDevReloadHandler.onPauseActivity();
 	}
 


### PR DESCRIPTION
This commit fixes two issues found in #1838. Fixes #1924
1. Keeps calling the deprecated reactInstanceManager methods when host is cleared
    to not introduce undesired behavior when clearHostOnActivityDestroy return true (old and default behavior).
2. call onHostDestroy and onHostPause only if react context exists or is being created.