### PR TITLE
Error in documentation - AppDelegate.m has no return statement.

### DIFF
--- a/docs/docs/installation-ios.md
+++ b/docs/docs/installation-ios.md
@@ -21,4 +21,6 @@ remove everything in the method didFinishLaunchingWithOptions and add:
 ```
 NSURL *jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
 [ReactNativeNavigation bootstrap:jsCodeLocation launchOptions:launchOptions];
+
+return YES;
 ```


### PR DESCRIPTION
Since the docs suggested we remove everything inside the `didFinishLaunchingWithOptions`, without the return statement there was an `Control reaches end of non-void function` error since the function expects a boolean return. After adding this, the error goes away.