### PR TITLE
Documentation - tabs is not a valid LayoutType

### DIFF
--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -55,7 +55,7 @@ Navigation.setRoot({
 Start a tab based app:
 ```js
 Navigation.setRoot({
-  tabs: [
+  bottomTabs: [
     {
       container: {
         name: 'navigation.playground.TextScreen',


### PR DESCRIPTION
In the list of `LayoutTypes`, `tabs` is not defined, hence this throws an error. Replaced it with `bottomTabs`.