### PR TITLE
Side Drawer Toggle Problem Resolved for Android

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/SideMenu.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/SideMenu.java
@@ -58,11 +58,11 @@ public class SideMenu extends DrawerLayout {
     }
 
     public void setVisible(boolean visible, boolean animated, Side side) {
-        if (!isShown() && visible) {
+        if (visible) {
             openDrawer(animated, side);
         }
 
-        if (isShown() && !visible) {
+        if (!visible) {
             closeDrawer(animated, side);
         }
     }


### PR DESCRIPTION
While working I got a situation in which I wanted to open the side drawer on a button click.
But I was not able to do that. So I made some changes and now I am able to achieve the required functionality.