### PR TITLE
Fix style

### DIFF
--- a/ios/RCCDrawerController/RCCDrawerController.m
+++ b/ios/RCCDrawerController/RCCDrawerController.m
@@ -22,40 +22,42 @@ UIViewController *rightViewController = nil;
 
 - (instancetype)initWithProps:(NSDictionary *)props children:(NSArray *)children globalProps:(NSDictionary*)globalProps bridge:(RCTBridge *)bridge
 {
-    
+
     self.drawerStyle = props[@"style"];
-    
+
     // center
     if ([children count] < 1) return nil;
     UIViewController *centerViewController = [RCCViewController controllerWithLayout:children[0] globalProps:globalProps bridge:bridge];
-    
+
     // left
     NSString *componentLeft = props[@"componentLeft"];
     NSDictionary *passPropsLeft = props[@"passPropsLeft"];
-    if (componentLeft) leftViewController = [[RCCViewController alloc] initWithComponent:componentLeft passProps:passPropsLeft navigatorStyle:nil globalProps:globalProps bridge:bridge];
-    
+		NSDictionary *styleLeft = props[@"styleLeft"];
+    if (componentLeft) leftViewController = [[RCCViewController alloc] initWithComponent:componentLeft passProps:passPropsLeft navigatorStyle:styleLeft globalProps:globalProps bridge:bridge];
+
     // right
     NSString *componentRight = props[@"componentRight"];
     NSDictionary *passPropsRight = props[@"passPropsRight"];
-    if (componentRight) rightViewController = [[RCCViewController alloc] initWithComponent:componentRight passProps:passPropsRight navigatorStyle:nil globalProps:globalProps bridge:bridge];
-    
+		NSDictionary *styleRight = props[@"styleRight"];
+    if (componentRight) rightViewController = [[RCCViewController alloc] initWithComponent:componentRight passProps:passPropsRight navigatorStyle:styleRight globalProps:globalProps bridge:bridge];
+
     self = [super initWithCenterViewController:centerViewController
                       leftDrawerViewController:leftViewController
                      rightDrawerViewController:rightViewController];
-    
+
     [self setAnimationTypeWithName:props[@"animationType"]];
-    
+
     // default is all MMOpenDrawerGestureModeAll and MMCloseDrawerGestureModeAll
     self.openDrawerGestureModeMask = MMOpenDrawerGestureModeAll;
     self.closeDrawerGestureModeMask = MMCloseDrawerGestureModeAll;
-    
+
     NSNumber *disableOpenGesture = props[@"disableOpenGesture"];
     if ([disableOpenGesture boolValue]) {
         self.openDrawerGestureModeMask = MMOpenDrawerGestureModeNone;
     }
-    
+
     [self setStyle];
-    
+
     [self setDrawerVisualStateBlock:^(MMDrawerController *drawerController, MMDrawerSide drawerSide, CGFloat percentVisible) {
         MMDrawerControllerDrawerVisualStateBlock block;
         block = [[MMExampleDrawerVisualStateManager sharedManager] drawerVisualStateBlockForDrawerSide:drawerSide];
@@ -63,44 +65,44 @@ UIViewController *rightViewController = nil;
             block(drawerController, drawerSide, percentVisible);
         }
     }];
-    
+
     [self setGestureStartBlock:^(MMDrawerController *drawerController, UIGestureRecognizer *gesture) {
         [RCCManagerModule cancelAllRCCViewControllerReactTouches];
      }];
-                                               
+
     self.view.backgroundColor = [UIColor clearColor];
-    
+
     [self setRotation:props];
-    
-    
+
+
     if (!self) return nil;
     return self;
 }
 
 
 -(void)setStyle {
-    
+
     if (self.drawerStyle[@"drawerShadow"]) {
         self.showsShadow = ([self.drawerStyle[@"drawerShadow"] boolValue]) ? YES : NO;
     }
-    
+
     NSNumber *leftDrawerWidth = self.drawerStyle[@"leftDrawerWidth"];
     if (leftDrawerWidth) {
         self.maximumLeftDrawerWidth = self.view.bounds.size.width * MIN(1, (leftDrawerWidth.floatValue/100.0));
     }
-    
+
     NSNumber *rightDrawerWidth = self.drawerStyle[@"rightDrawerWidth"];
     if (rightDrawerWidth) {
         self.maximumRightDrawerWidth = self.view.bounds.size.width * MIN(1, (rightDrawerWidth.floatValue/100.0));
     }
-    
+
     NSString *contentOverlayColor = self.drawerStyle[@"contentOverlayColor"];
     if (contentOverlayColor)
     {
         UIColor *color = contentOverlayColor != (id)[NSNull null] ? [RCTConvert UIColor:contentOverlayColor] : nil;
         [self setCenterOverlayColor:color];
     }
-    
+
     if (self.drawerStyle[@"shouldStretchDrawer"]) {
         self.shouldStretchDrawer = ([self.drawerStyle[@"shouldStretchDrawer"] boolValue]) ? YES : NO;
     }
@@ -112,21 +114,21 @@ UIViewController *rightViewController = nil;
     MMDrawerSide side = MMDrawerSideLeft;
     if ([actionParams[@"side"] isEqualToString:@"right"]) side = MMDrawerSideRight;
     BOOL animated = actionParams[@"animated"] ? [actionParams[@"animated"] boolValue] : YES;
-    
+
     // open
     if ([performAction isEqualToString:@"open"])
     {
         [self openDrawerSide:side animated:animated completion:nil];
         return;
     }
-    
+
     // close
     if ([performAction isEqualToString:@"close"])
     {
         if (self.openSide == side) {
             [self closeDrawerAnimated:animated completion:nil];
         }
-        
+
         return;
     }
 
@@ -147,7 +149,7 @@ UIViewController *rightViewController = nil;
         [super toggleDrawerSide:side animated:animated completion:nil];
         return;
     }
-    
+
     // setStyle
     if ([performAction isEqualToString:@"setStyle"])
     {
@@ -157,17 +159,17 @@ UIViewController *rightViewController = nil;
         }
         return;
     }
-    
+
 }
 
 -(void)setAnimationTypeWithName:(NSString*)animationTypeName {
     MMDrawerAnimationType animationType = MMDrawerAnimationTypeNone;
-    
+
     if ([animationTypeName isEqualToString:@"door"]) animationType = MMDrawerAnimationTypeSwingingDoor;
     else if ([animationTypeName isEqualToString:@"parallax"]) animationType = MMDrawerAnimationTypeParallax;
     else if ([animationTypeName isEqualToString:@"slide"]) animationType = MMDrawerAnimationTypeSlide;
     else if ([animationTypeName isEqualToString:@"slide-and-scale"]) animationType = MMDrawerAnimationTypeSlideAndScale;
-    
+
     [MMExampleDrawerVisualStateManager sharedManager].leftDrawerAnimationType = animationType;
     [MMExampleDrawerVisualStateManager sharedManager].rightDrawerAnimationType = animationType;
 }

--- a/ios/RCCDrawerController/RCCDrawerController.m
+++ b/ios/RCCDrawerController/RCCDrawerController.m
@@ -22,42 +22,42 @@ UIViewController *rightViewController = nil;
 
 - (instancetype)initWithProps:(NSDictionary *)props children:(NSArray *)children globalProps:(NSDictionary*)globalProps bridge:(RCTBridge *)bridge
 {
-
+    
     self.drawerStyle = props[@"style"];
-
+    
     // center
     if ([children count] < 1) return nil;
     UIViewController *centerViewController = [RCCViewController controllerWithLayout:children[0] globalProps:globalProps bridge:bridge];
-
+    
     // left
     NSString *componentLeft = props[@"componentLeft"];
     NSDictionary *passPropsLeft = props[@"passPropsLeft"];
-		NSDictionary *styleLeft = props[@"styleLeft"];
+    NSDictionary *styleLeft = props[@"styleLeft"];
     if (componentLeft) leftViewController = [[RCCViewController alloc] initWithComponent:componentLeft passProps:passPropsLeft navigatorStyle:styleLeft globalProps:globalProps bridge:bridge];
-
+    
     // right
     NSString *componentRight = props[@"componentRight"];
     NSDictionary *passPropsRight = props[@"passPropsRight"];
-		NSDictionary *styleRight = props[@"styleRight"];
+    NSDictionary *styleRight = props[@"styleRight"];
     if (componentRight) rightViewController = [[RCCViewController alloc] initWithComponent:componentRight passProps:passPropsRight navigatorStyle:styleRight globalProps:globalProps bridge:bridge];
-
+    
     self = [super initWithCenterViewController:centerViewController
                       leftDrawerViewController:leftViewController
                      rightDrawerViewController:rightViewController];
-
+    
     [self setAnimationTypeWithName:props[@"animationType"]];
-
+    
     // default is all MMOpenDrawerGestureModeAll and MMCloseDrawerGestureModeAll
     self.openDrawerGestureModeMask = MMOpenDrawerGestureModeAll;
     self.closeDrawerGestureModeMask = MMCloseDrawerGestureModeAll;
-
+    
     NSNumber *disableOpenGesture = props[@"disableOpenGesture"];
     if ([disableOpenGesture boolValue]) {
         self.openDrawerGestureModeMask = MMOpenDrawerGestureModeNone;
     }
-
+    
     [self setStyle];
-
+    
     [self setDrawerVisualStateBlock:^(MMDrawerController *drawerController, MMDrawerSide drawerSide, CGFloat percentVisible) {
         MMDrawerControllerDrawerVisualStateBlock block;
         block = [[MMExampleDrawerVisualStateManager sharedManager] drawerVisualStateBlockForDrawerSide:drawerSide];
@@ -65,44 +65,44 @@ UIViewController *rightViewController = nil;
             block(drawerController, drawerSide, percentVisible);
         }
     }];
-
+    
     [self setGestureStartBlock:^(MMDrawerController *drawerController, UIGestureRecognizer *gesture) {
         [RCCManagerModule cancelAllRCCViewControllerReactTouches];
      }];
-
+                                               
     self.view.backgroundColor = [UIColor clearColor];
-
+    
     [self setRotation:props];
-
-
+    
+    
     if (!self) return nil;
     return self;
 }
 
 
 -(void)setStyle {
-
+    
     if (self.drawerStyle[@"drawerShadow"]) {
         self.showsShadow = ([self.drawerStyle[@"drawerShadow"] boolValue]) ? YES : NO;
     }
-
+    
     NSNumber *leftDrawerWidth = self.drawerStyle[@"leftDrawerWidth"];
     if (leftDrawerWidth) {
         self.maximumLeftDrawerWidth = self.view.bounds.size.width * MIN(1, (leftDrawerWidth.floatValue/100.0));
     }
-
+    
     NSNumber *rightDrawerWidth = self.drawerStyle[@"rightDrawerWidth"];
     if (rightDrawerWidth) {
         self.maximumRightDrawerWidth = self.view.bounds.size.width * MIN(1, (rightDrawerWidth.floatValue/100.0));
     }
-
+    
     NSString *contentOverlayColor = self.drawerStyle[@"contentOverlayColor"];
     if (contentOverlayColor)
     {
         UIColor *color = contentOverlayColor != (id)[NSNull null] ? [RCTConvert UIColor:contentOverlayColor] : nil;
         [self setCenterOverlayColor:color];
     }
-
+    
     if (self.drawerStyle[@"shouldStretchDrawer"]) {
         self.shouldStretchDrawer = ([self.drawerStyle[@"shouldStretchDrawer"] boolValue]) ? YES : NO;
     }
@@ -114,21 +114,21 @@ UIViewController *rightViewController = nil;
     MMDrawerSide side = MMDrawerSideLeft;
     if ([actionParams[@"side"] isEqualToString:@"right"]) side = MMDrawerSideRight;
     BOOL animated = actionParams[@"animated"] ? [actionParams[@"animated"] boolValue] : YES;
-
+    
     // open
     if ([performAction isEqualToString:@"open"])
     {
         [self openDrawerSide:side animated:animated completion:nil];
         return;
     }
-
+    
     // close
     if ([performAction isEqualToString:@"close"])
     {
         if (self.openSide == side) {
             [self closeDrawerAnimated:animated completion:nil];
         }
-
+        
         return;
     }
 
@@ -149,7 +149,7 @@ UIViewController *rightViewController = nil;
         [super toggleDrawerSide:side animated:animated completion:nil];
         return;
     }
-
+    
     // setStyle
     if ([performAction isEqualToString:@"setStyle"])
     {
@@ -159,17 +159,17 @@ UIViewController *rightViewController = nil;
         }
         return;
     }
-
+    
 }
 
 -(void)setAnimationTypeWithName:(NSString*)animationTypeName {
     MMDrawerAnimationType animationType = MMDrawerAnimationTypeNone;
-
+    
     if ([animationTypeName isEqualToString:@"door"]) animationType = MMDrawerAnimationTypeSwingingDoor;
     else if ([animationTypeName isEqualToString:@"parallax"]) animationType = MMDrawerAnimationTypeParallax;
     else if ([animationTypeName isEqualToString:@"slide"]) animationType = MMDrawerAnimationTypeSlide;
     else if ([animationTypeName isEqualToString:@"slide-and-scale"]) animationType = MMDrawerAnimationTypeSlideAndScale;
-
+    
     [MMExampleDrawerVisualStateManager sharedManager].leftDrawerAnimationType = animationType;
     [MMExampleDrawerVisualStateManager sharedManager].rightDrawerAnimationType = animationType;
 }

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -46,19 +46,31 @@ function startTabBasedApp(params) {
         return this.renderBody();
       } else {
         const navigatorID = controllerID + '_drawer';
+
+        const leftScreenId = _.uniqueId('screenInstanceID');
+        const rightScreenId = _.uniqueId('screenInstanceID')
+
+        const { navigatorStyle: leftNavigatorStyle } = params.drawer.left
+          ? _mergeScreenSpecificSettings(params.drawer.left.screen, leftScreenId, params.drawer.left)
+          : {};
+
+        const { navigatorStyle: rightNavigatorStyle } = params.drawer.right
+          ? _mergeScreenSpecificSettings(params.drawer.right.screen, rightScreenId, params.drawer.right)
+          : {};
+
         return (
           <DrawerControllerIOS id={navigatorID}
-                               componentLeft={params.drawer.left ? params.drawer.left.screen : undefined}
-															 passPropsLeft={{navigatorID: navigatorID}}
-															 styleLeft={params.drawer.left ? params.drawer.left.navigatorStyle : {}}
-                               componentRight={params.drawer.right ? params.drawer.right.screen : undefined}
-															 passPropsRight={{navigatorID: navigatorID}}
-															 styleRight={params.drawer.right ? params.drawer.right.navigatorStyle : {}}
-                               disableOpenGesture={params.drawer.disableOpenGesture}
-                               type={params.drawer.type ? params.drawer.type : 'MMDrawer'}
-                               animationType={params.drawer.animationType ? params.drawer.animationType : 'slide'}
-                               style={params.drawer.style}
-                               appStyle={params.appStyle}
+            componentLeft={params.drawer.left ? params.drawer.left.screen : undefined}
+            styleLeft={leftNavigatorStyle}
+            passPropsLeft={{navigatorID: navigatorID}}
+            componentRight={params.drawer.right ? params.drawer.right.screen : undefined}
+            styleRight={rightNavigatorStyle}
+            passPropsRight={{navigatorID: navigatorID}}
+            disableOpenGesture={params.drawer.disableOpenGesture}
+            type={params.drawer.type ? params.drawer.type : 'MMDrawer'}
+            animationType={params.drawer.animationType ? params.drawer.animationType : 'slide'}
+            style={params.drawer.style}
+            appStyle={params.appStyle}
           >
             {this.renderBody()}
           </DrawerControllerIOS>

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -49,9 +49,11 @@ function startTabBasedApp(params) {
         return (
           <DrawerControllerIOS id={navigatorID}
                                componentLeft={params.drawer.left ? params.drawer.left.screen : undefined}
-                               passPropsLeft={{navigatorID: navigatorID}}
+															 passPropsLeft={{navigatorID: navigatorID}}
+															 styleLeft={params.drawer.left ? params.drawer.left.navigatorStyle : {}}
                                componentRight={params.drawer.right ? params.drawer.right.screen : undefined}
-                               passPropsRight={{navigatorID: navigatorID}}
+															 passPropsRight={{navigatorID: navigatorID}}
+															 styleRight={params.drawer.right ? params.drawer.right.navigatorStyle : {}}
                                disableOpenGesture={params.drawer.disableOpenGesture}
                                type={params.drawer.type ? params.drawer.type : 'MMDrawer'}
                                animationType={params.drawer.animationType ? params.drawer.animationType : 'slide'}
@@ -568,7 +570,7 @@ function showInAppNotification(params) {
     navigatorEventID,
     navigatorID
   };
-  
+
   savePassProps(params);
 
   let args = {


### PR DESCRIPTION
Fixes #754

This pull request correctly passes `navigatorStyle` of left/right controllers so that status bar styling doesn't get lost. Otherwise, default styling is respected by the iOS which reverts status bar to black. 

With this change, you can manipulate status bar (and other properties) as well as hide the status bar on menu opened.