### PR TITLE
RN 0.49 with Single Entry Point

### DIFF
--- a/example/ios/example/AppDelegate.m
+++ b/example/ios/example/AppDelegate.m
@@ -18,8 +18,14 @@
   NSURL *jsCodeLocation;
 #ifdef DEBUG
 //  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/index.ios.bundle?platform=ios&dev=true"];
-  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
-#else
+
+  //  IMPORTANT: If you using ReactNative version <= 0.48, use this code below.
+  //  https://github.com/facebook/react-native/releases/tag/v0.49.0
+  //  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
+
+  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+
+  #else
    jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
 


### PR DESCRIPTION
According to 0.49 changes,
https://github.com/facebook/react-native/releases/tag/v0.49.0

New projects have a single entry-point `index.js` from `index.ios.js`