### PR TITLE
[iOS] Enable (Dis)Appear events for drawer

### DIFF
--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -62,10 +62,10 @@ function startTabBasedApp(params) {
           <DrawerControllerIOS id={navigatorID}
             componentLeft={params.drawer.left ? params.drawer.left.screen : undefined}
             styleLeft={leftNavigatorStyle}
-            passPropsLeft={{navigatorID: navigatorID}}
+            passPropsLeft={{navigatorID: navigatorID, navigatorEventID: `${navigatorID}_left_events`}}
             componentRight={params.drawer.right ? params.drawer.right.screen : undefined}
             styleRight={rightNavigatorStyle}
-            passPropsRight={{navigatorID: navigatorID}}
+            passPropsRight={{navigatorID: navigatorID, navigatorEventID: `${navigatorID}_right_events`}}
             disableOpenGesture={params.drawer.disableOpenGesture}
             type={params.drawer.type ? params.drawer.type : 'MMDrawer'}
             animationType={params.drawer.animationType ? params.drawer.animationType : 'slide'}
@@ -155,9 +155,9 @@ function startSingleScreenApp(params) {
         return (
           <DrawerControllerIOS id={navigatorID}
                                componentLeft={params.drawer.left ? params.drawer.left.screen : undefined}
-                               passPropsLeft={{navigatorID: navigatorID}}
+                               passPropsLeft={{navigatorID: navigatorID, navigatorEventID: `${navigatorID}_left_events`}}
                                componentRight={params.drawer.right ? params.drawer.right.screen : undefined}
-                               passPropsRight={{navigatorID: navigatorID}}
+                               passPropsRight={{navigatorID: navigatorID, navigatorEventID: `${navigatorID}_right_events`}}
                                disableOpenGesture={params.drawer.disableOpenGesture}
                                type={params.drawer.type ? params.drawer.type : 'MMDrawer'}
                                animationType={params.drawer.animationType ? params.drawer.animationType : 'slide'}


### PR DESCRIPTION
`navigatorEventId` is required for `[self sendScreenChangedEvent:@"didAppear"];` etc., so we should also provide it to the drawer screens.