### PR TITLE
[iOS] Fix getCurrentlyVisibleScreenId with drawer

### DIFF
--- a/ios/RCCManagerModule.m
+++ b/ios/RCCManagerModule.m
@@ -371,6 +371,14 @@ RCT_EXPORT_METHOD(
     {
         return [self getVisibleViewControllerFor:vc.presentedViewController];
     }
+    else if ([vc isKindOfClass:[TheSidebarController class]]) {
+        TheSidebarController *drawerController = (TheSidebarController*) vc;
+        return [self getVisibleViewControllerFor:drawerController.contentViewController];
+    }
+    else if ([vc isKindOfClass:[MMDrawerController class]]) {
+        MMDrawerController *drawerController = (MMDrawerController*) vc;
+        return [self getVisibleViewControllerFor:drawerController.centerViewController];
+    }
     else
     {
         return vc;

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -36,7 +36,7 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   
   RCCViewController *viewController = [[RCCViewController alloc] initWithComponent:component passProps:passProps navigatorStyle:navigatorStyle globalProps:globalProps bridge:bridge];
   if (!viewController) return nil;
-  viewController.controllerId = props[@"id"];
+  viewController.controllerId = passProps[@"screenInstanceID"];
   
   NSArray *leftButtons = props[@"leftButtons"];
   if (leftButtons)


### PR DESCRIPTION
This fixes two issues with `Navigation.getCurrentlyVisibleScreenId` and `this.props.navigator.screenIsCurrentlyVisible()` on iOS.

- The wrong "controllerId" was being set for the initial screen/layout. `controllerId` is only used to return a `screenId` for Navigation.getCurrentlyVisibleScreenId.
- Take into account drawers, when trying to find the visible viewController.