### PR TITLE
[v2] Pull tab title from screens navigationOptions

### DIFF
--- a/lib/ios/RNNControllerFactory.m
+++ b/lib/ios/RNNControllerFactory.m
@@ -101,8 +101,10 @@
 	NSMutableArray* controllers = [NSMutableArray new];
 	for (NSDictionary *child in node.children) {
 		UIViewController* childVc = [self fromTree:child];
-		
-		UITabBarItem* item = [[UITabBarItem alloc] initWithTitle:@"A Tab" image:nil tag:1];
+
+		NSDictionary* firstChild = [child[@"children"] firstObject];
+		NSString* title = firstChild[@"data"][@"navigationOptions"][@"title"] ?: @"A Tab";
+		UITabBarItem* item = [[UITabBarItem alloc] initWithTitle:title image:nil tag:1];
 		[childVc setTabBarItem:item];
 		[controllers addObject:childVc];
 	}


### PR DESCRIPTION
Does what it says on the tin. I looked at adding it in `-[RNNavigationOptions applyOn:]` but because that only gets called in `viewWillAppear` the tab title doesn't get set until you navigate to the tab.