### PR TITLE
Update iOS installation docs

### DIFF
--- a/example/ios/example/AppDelegate.m
+++ b/example/ios/example/AppDelegate.m
@@ -18,7 +18,9 @@
   NSURL *jsCodeLocation;
 #ifdef DEBUG
 //  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/index.ios.bundle?platform=ios&dev=true"];
-  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
+  // As of React Native v0.49.0, iOS and Android share a common index.js file in the root directory of a React Native project.
+  // Prior to v0.49.0, use @"index.ios" instead:
+  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
 #else
    jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
@@ -43,7 +45,7 @@
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   */
-  
+
 
   return YES;
 }


### PR DESCRIPTION
### Updating iOS Installation Documentation: 

As of React Native v0.49.0, iOS and Android share a common `index.js` file in the root directory of the project.

The installation documentation for `react-native-navigation` currently expects the old paradigm of separate `index.ios.js` and `index.android.js` files and consequently includes `jsBundleURLForBundleRoot:@"index.ios"` when it should now be `jsBundleURLForBundleRoot:@"index"`.