### PR TITLE
Fixing a crash upon rotating from locked landscape orientation to portrait

### DIFF
--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -413,5 +413,8 @@
 }
 
 
+- (BOOL)shouldAutorotate {
+  return NO;
+}
 
 @end


### PR DESCRIPTION
The crash is:

*** Terminating app due to uncaught exception 'UIApplicationInvalidInterfaceOrientation', reason: 'Supported orientations has no common orientation with the application, and [RCCTabBarController shouldAutorotate] is returning YES'

Setting shouldAutorotate to return NO fixes the crash