### PR TITLE
Fixed wrong field name of Snackbar

### DIFF
--- a/example/src/screens/Actions.js
+++ b/example/src/screens/Actions.js
@@ -71,7 +71,7 @@ class Actions extends React.Component {
 
   showSnackbar = () => {
     this.props.navigator.showSnackbar({
-      title: 'Woo Snacks!',
+      text: 'Woo Snacks!',
     });
   };
 


### PR DESCRIPTION
`title` field is no longer used.