### PR TITLE
Transparent splash background color

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
@@ -94,7 +94,18 @@ public abstract class SplashActivity extends AppCompatActivity {
      */
     public View createSplashLayout() {
         View view = new View(this);
-        view.setBackgroundColor(Color.WHITE);
+        int splashBackgroundColor = Color.WHITE;
+        try {
+            Bundle bundle = this.getPackageManager().getApplicationInfo(this.getPackageName(), PackageManager.GET_META_DATA).metaData;
+            String color = bundle.getString("splashBackgroundColor");
+            if (color != null && color.equals("transparent")) {
+                splashBackgroundColor = Color.TRANSPARENT;
+            }
+
+        } catch (NameNotFoundException e) {
+            e.printStackTrace();
+        }
+        view.setBackgroundColor(splashBackgroundColor);
         return view;
     }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
@@ -12,6 +12,8 @@ import android.view.View;
 import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.react.ReactDevPermission;
 import com.reactnativenavigation.utils.CompatUtils;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
 
 public abstract class SplashActivity extends AppCompatActivity {
     public static boolean isResumed = false;


### PR DESCRIPTION
Add the ability to set the splash activity's background color to transparent. Defaults to white as it is now.

Add the following to AndroidManifest.xml
```
        <meta-data
                android:name="splashBackgroundColor"
                android:value="transparent"
        />
```

#### Notes:  
Not sure if setting this in AndroidManifest is the best way but I can't get to the styleParams because react context is not yet initialise?. All suggestions will be appreciated.

### Before 
<img src="https://user-images.githubusercontent.com/1422851/32878980-207c82aa-caa0-11e7-89cd-938040cf5897.gif" width="150" height="260">

### After
<img src="https://user-images.githubusercontent.com/1422851/32878984-2410b67a-caa0-11e7-806d-f2cc58ae8c2e.gif" width="150" height="260">