### PR TITLE
Register multiple navigatorEventListeners

### DIFF
--- a/src/Screen.js
+++ b/src/Screen.js
@@ -21,6 +21,7 @@ class Navigator {
     this.screenInstanceID = screenInstanceID;
     this.navigatorEventID = navigatorEventID;
     this.navigatorEventHandler = null;
+    this.navigatorEventHandlers = [];
     this.navigatorEventSubscription = null;
   }
 
@@ -141,7 +142,24 @@ class Navigator {
   }
 
   setOnNavigatorEvent(callback) {
+    if (this.navigatorEventHandlers.length > 0) {
+      throw 'setOnNavigatorEvent can not be used after addOnNavigatorEvent has been called';
+    }
     this.navigatorEventHandler = callback;
+    this._registerNavigatorEvent();
+  }
+
+  addOnNavigatorEvent(callback) {
+    if (this.navigatorEventHandler) {
+      throw 'addOnNavigatorEvent can not be used after setOnNavigatorEvent has been called';
+    }
+    if (this.navigatorEventHandlers.indexOf(callback) === -1) {
+      this.navigatorEventHandlers.push(callback);
+    }
+    this._registerNavigatorEvent();
+  }
+
+  _registerNavigatorEvent() {
     if (!this.navigatorEventSubscription) {
       let Emitter = Platform.OS === 'android' ? DeviceEventEmitter : NativeAppEventEmitter;
       this.navigatorEventSubscription = Emitter.addListener(this.navigatorEventID, (event) => this.onNavigatorEvent(event));
@@ -149,19 +167,28 @@ class Navigator {
     }
   }
 
-  handleDeepLink(params = {}) {
-    Navigation.handleDeepLink(params);
+  removeOnNavigatorEvent(callback) {
+    const index = this.navigatorEventHandlers.indexOf(callback);
+    if (index !== -1) {
+      this.navigatorEventHandlers.splice(index, 1);
+    }
   }
 
   onNavigatorEvent(event) {
     if (this.navigatorEventHandler) {
       this.navigatorEventHandler(event);
     }
+    this.navigatorEventHandlers.forEach(handler => handler(event));
+  }
+
+  handleDeepLink(params = {}) {
+    Navigation.handleDeepLink(params);
   }
 
   cleanup() {
     if (this.navigatorEventSubscription) {
       this.navigatorEventSubscription.remove();
+      this.navigatorEventHandlers = [];
       Navigation.clearEventHandler(this.navigatorEventID);
     }
   }


### PR DESCRIPTION
This commit adds ability to register multiple navigator event listeners:
navigator.addOnNavigatorEvent(func)
navigator.removeOnNavigatorEvent(func)

Event listeners are removed when the screen the navigator is bound to
is unmounted, calling `removeOnNavigatorEvent` isn't mandatory.

As this api conflicts with the current api, addOnNavigatorEvent can't be used
in a screen where setOnNavigatorEvent was used before.

closes #2157