### PR TITLE
addOnNavigatorEvent: defensive try-catch wrapping for handlers

### DIFF
--- a/src/Screen.js
+++ b/src/Screen.js
@@ -181,7 +181,13 @@ class Navigator {
     if (this.navigatorEventHandler) {
       this.navigatorEventHandler(event);
     }
-    this.navigatorEventHandlers.forEach(handler => handler(event));
+    this.navigatorEventHandlers.forEach(handler => {
+      try {
+        handler(event);
+      } catch (exception) {
+        console.warn(exception);
+      }
+    });
   }
 
   handleDeepLink(params = {}) {


### PR DESCRIPTION
When iterating over event handlers, it's possible one of them is in inactive state, or will fail for some reason. We do not want to terminate execution for the rest of the handlers queue in such a case.