### PR TITLE
(Android) Allow disableOpenGesture right or left in the drawer

### DIFF
--- a/docs/top-level-api.md
+++ b/docs/top-level-api.md
@@ -104,10 +104,12 @@ Navigation.startSingleScreenApp({
     left: { // optional, define if you want a drawer from the left
       screen: 'example.FirstSideMenu', // unique ID registered with Navigation.registerScreen
       passProps: {}, // simple serializable object that will pass as props to all top screens (optional)
+      disableOpenGesture: false // optional, can the drawer be opened with a swipe instead of button
     },
     right: { // optional, define if you want a drawer from the right
       screen: 'example.SecondSideMenu', // unique ID registered with Navigation.registerScreen
       passProps: {} // simple serializable object that will pass as props to all top screens (optional)
+      disableOpenGesture: false // optional, can the drawer be opened with a swipe instead of button
     },
     style: { // ( iOS only )
       drawerShadow: true, // optional, add this if you want a side menu drawer shadow
@@ -118,7 +120,7 @@ Navigation.startSingleScreenApp({
     type: 'MMDrawer', // optional, iOS only, types: 'TheSideBar', 'MMDrawer' default: 'MMDrawer'
     animationType: 'door', //optional, iOS only, for MMDrawer: 'door', 'parallax', 'slide', 'slide-and-scale'
                                         // for TheSideBar: 'airbnb', 'facebook', 'luvocracy','wunder-list'
-    disableOpenGesture: false // optional, can the drawer be opened with a swipe instead of button
+    disableOpenGesture: false // optional, can the drawer, both right and left, be opened with a swipe instead of button
   },
   passProps: {}, // simple serializable object that will pass as props to all top screens (optional)
   animationType: 'slide-down' // optional, add transition animation to root change: 'none', 'slide-down', 'fade'

--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -242,7 +242,12 @@ function convertDrawerParamsToSideMenuParams(drawerParams) {
       addNavigatorParams(result[key]);
       result[key] = adaptNavigationParams(result[key]);
       result[key].passProps = drawer[key].passProps;
-      result[key].disableOpenGesture = drawer.disableOpenGesture;
+      if (drawer.disableOpenGesture) {
+        result[key].disableOpenGesture = drawer.disableOpenGesture;
+      } else {
+        result[key].disableOpenGesture = drawer[key].disableOpenGesture;
+      }
+      
     } else {
       result[key] = null;
     }


### PR DESCRIPTION
Hello! This is my first pull request here so apologize if I made any mistakes. I'm working on my first React  Native project and thought I could solve this problem that can happen to other people.

This pull request allows you to disable the open gesture only in one side of the drawer. In my current application, I want to have 2 drawers (on both sides). The left drawer is always enabled. The right drawer is only enabled in one screen.

This way I can startSingleScreenApp() and pass the two drawers, but only the left would be 'enabled':

```js
Navigation.startSingleScreenApp({
      screen: initialScreen,
      drawer: {
        left: {
          screen: DRAWER_SCREEN,
          disableOpenGesture: false,
        },
        right: {
          screen: SIDEBAR_FILTER_SCREEN,
          disableOpenGesture: true,
        },
      },
    });
```

If we pass disableOpenGesture to the drawer root object, like this: 

```js
Navigation.startSingleScreenApp({
      screen: initialScreen,
      drawer: {
        left: {
          screen: DRAWER_SCREEN,
          disableOpenGesture: false,
        },
        right: {
          screen: SIDEBAR_FILTER_SCREEN,
          disableOpenGesture: true,
        },
        disableOpenGesture: true <======
      },
    });
```

Then the two drawer positions would be gesture disabled and the specific disableOpenGesture would be ignored.

What do you guys think?