### PR TITLE
[iOS] Ensure that styles set on individual buttons are not overridden

### DIFF
--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -399,21 +399,37 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
       ) {
     
     for (UIBarButtonItem *item in viewController.navigationItem.leftBarButtonItems) {
-      [item setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateNormal];
-      
       if (leftNavButtonTextAttributes.allKeys.count > 0) {
-        [item setTitleTextAttributes:leftNavButtonTextAttributes forState:UIControlStateNormal];
+        NSDictionary *previousAttributes = [item titleTextAttributesForState:UIControlStateNormal];
+        NSMutableDictionary *mergedAttributes;
+
+        if (leftNavButtonTextAttributes.allKeys.count > 0) {
+          mergedAttributes = [leftNavButtonTextAttributes mutableCopy];
+        } else {
+          mergedAttributes = [navButtonTextAttributes mutableCopy];
+        }
+
+        [mergedAttributes addEntriesFromDictionary:previousAttributes];
+
+        [item setTitleTextAttributes:[mergedAttributes copy] forState:UIControlStateNormal];
       }
     }
-    
+
     for (UIBarButtonItem *item in viewController.navigationItem.rightBarButtonItems) {
-      [item setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateNormal];
-      
+      NSDictionary *previousAttributes = [item titleTextAttributesForState:UIControlStateNormal];
+      NSMutableDictionary *mergedAttributes;
+
       if (rightNavButtonTextAttributes.allKeys.count > 0) {
-        [item setTitleTextAttributes:rightNavButtonTextAttributes forState:UIControlStateNormal];
+        mergedAttributes = [rightNavButtonTextAttributes mutableCopy];
+      } else {
+        mergedAttributes = [navButtonTextAttributes mutableCopy];
       }
+
+      [mergedAttributes addEntriesFromDictionary:previousAttributes];
+
+      [item setTitleTextAttributes:[mergedAttributes copy] forState:UIControlStateNormal];
     }
-    
+
     // At the moment, this seems to be the only thing that gets the back button correctly
     [navButtonTextAttributes removeObjectForKey:NSForegroundColorAttributeName];
     [[UIBarButtonItem appearance] setTitleTextAttributes:navButtonTextAttributes forState:UIControlStateNormal];


### PR DESCRIPTION
This fixes a bug where navigator-level styles could override styles on a specific button.

Fixes #2199