### PR TITLE
Fix failing test

### DIFF
--- a/lib/ios/ReactNativeNavigationTests/RNNCommandsHandlerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNCommandsHandlerTest.m
@@ -26,13 +26,11 @@
 	NSArray* methods = [self getPublicMethodNamesForObject:self.uut];
 	
 	for (NSString* methodName in methods) {
-		
-		__strong id uut = self.uut;
 		SEL s = NSSelectorFromString(methodName);
-		IMP imp = [uut methodForSelector:s];
-		void (*func)(id, SEL) = (void *)imp;
-		
-		XCTAssertThrowsSpecificNamed(func(uut,s), NSException, @"BridgeNotLoadedError");
+		NSMethodSignature* signature = [self.uut methodSignatureForSelector:s];
+		NSInvocation* invocation = [NSInvocation invocationWithMethodSignature:signature];
+		invocation.selector = s;
+		XCTAssertThrowsSpecificNamed([invocation invokeWithTarget:self.uut], NSException, @"BridgeNotLoadedError");
 	}
 }
 


### PR DESCRIPTION
Address issue  #2183

I still do not understand why original implementation works on CI (and failed in my environment), but think that this implementation slightly cleaner because use more high-level APIs.

Tested locally with `npm run test-unit-ios`, `npm run test-unit-ios -- --release` and from Xcode