### PR TITLE
Add iPhone X launch image

### DIFF
--- a/ios/RCCManager.m
+++ b/ios/RCCManager.m
@@ -208,6 +208,8 @@
         imageName = [imageName stringByAppendingString:@"-800-667h"];
       else if (screenHeight == 736)
         imageName = [imageName stringByAppendingString:@"-800-Portrait-736h"];
+      else if (screenHeight == 812)
+        imageName = [imageName stringByAppendingString:@"-1100-Portrait-2436h"];
       
       image = [UIImage imageNamed:imageName];
     }


### PR DESCRIPTION
This will add the iPhone X launch screen if found in the LaunchImages. I wasn't sure about the **Default** naming convention though, can someone confirm that this would be `Default-2436h`?