### PR TITLE
Support re-enabling top bar elevation

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/TopBar.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/TopBar.java
@@ -10,6 +10,7 @@ import android.support.v4.util.Pair;
 import android.support.v7.app.ActionBar;
 import android.view.Gravity;
 import android.view.ViewGroup;
+import android.view.ViewOutlineProvider;
 import android.widget.FrameLayout;
 
 import com.facebook.react.bridge.Callback;
@@ -36,12 +37,16 @@ public class TopBar extends AppBarLayout {
     private VisibilityAnimator visibilityAnimator;
     @Nullable
     private Pair<String, ContentView> reactView;
+    private ViewOutlineProvider outlineProvider;
 
     public TopBar(Context context) {
         super(context);
         setId(ViewUtils.generateViewId());
         createTopBarVisibilityAnimator();
         createLayout();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            outlineProvider = getOutlineProvider();
+        }
     }
 
     private void createTopBarVisibilityAnimator() {
@@ -167,19 +172,17 @@ public class TopBar extends AppBarLayout {
         titleBar.setStyle(styleParams);
         setReactView(styleParams);
         setTopTabsStyle(styleParams);
-        if (!styleParams.topBarElevationShadowEnabled) {
-            disableElevationShadow();
-        }
+        setElevationEnabled(styleParams.topBarElevationShadowEnabled);
     }
 
     private void setTransparent() {
         setBackgroundColor(Color.TRANSPARENT);
-        disableElevationShadow();
+        setElevationEnabled(false);
     }
 
-    private void disableElevationShadow() {
+    private void setElevationEnabled (boolean enabled) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            setOutlineProvider(null);
+            setOutlineProvider(enabled ? outlineProvider : null);
         }
     }
 


### PR DESCRIPTION
When disabling elevation by setting `topBarElevationShadowEnabled` to `false`, this commit allows to re-enable it by setting the same property to true.
Elevation was previously disabled by using `setOutlineProvider(null)`, with `ViewOutlineProvider` being an Android 5.0+ object responsible for determining how views draw their outline. To allow re-enabling elevation, we keep our original `ViewOutlineProvider` and restore it when elevation is enabled again.

Tested on Android 4.4 (no elevation appears at all as designed) and Android 6.0.
Fixes #1495.