### PR TITLE
Resolved issues where Drawer did not work after dismissAllModals

### DIFF
--- a/ios/RCCManagerModule.m
+++ b/ios/RCCManagerModule.m
@@ -151,7 +151,10 @@ RCT_EXPORT_MODULE(RCCManager);
                            {
                                counter++;
                                
-                               [[RCCManager sharedIntance] unregisterController:viewController];
+                               if ([self viewControllerIsModal:viewController]) {
+                                   [[RCCManager sharedIntance] unregisterController:viewController];
+                               }
+                               
                                if (viewController.presentedViewController != nil)
                                {
                                    dispatch_semaphore_t dismiss_sema = dispatch_semaphore_create(0);

--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -543,8 +543,8 @@ async function dismissModal(params) {
   return await Modal.dismissController(params.animationType);
 }
 
-function dismissAllModals(params) {
-  Modal.dismissAllControllers(params.animationType);
+async function dismissAllModals(params) {
+  return await Modal.dismissAllControllers(params.animationType);
 }
 
 function showLightBox(params) {


### PR DESCRIPTION
I changed so we only clean up viewcontrollers if it is a modal. This should prevent the Drawer from stop working after an dismissAllModals.

Should resolve:
#1632, #1550

Might resolve:
#1598, #418