### PR TITLE
Ensure correct spelling of `commandType`

### DIFF
--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -257,7 +257,7 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
     if (!component) return;
     
     NSMutableDictionary *passProps = [actionParams[@"passProps"] mutableCopy];
-    passProps[@"commantType"] = @"resetTo";
+    passProps[@"commandType"] = @"resetTo";
     NSDictionary *navigatorStyle = actionParams[@"style"];
     
     RCCViewController *viewController = [[RCCViewController alloc] initWithComponent:component passProps:passProps navigatorStyle:navigatorStyle globalProps:nil bridge:bridge];


### PR DESCRIPTION
This now matches the same spelling as other references to `commandType`.