### PR TITLE
Fix rn 0.50 repeated calls to onMeasure.

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/ContentView.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/ContentView.java
@@ -66,9 +66,13 @@ public class ContentView extends ReactRootView {
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-        int measuredHeight = viewMeasurer.getMeasuredHeight(heightMeasureSpec);
-        setMeasuredDimension(viewMeasurer.getMeasuredWidth(widthMeasureSpec), measuredHeight);
+        int widthSpec = MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.AT_MOST);
+        int heightSpec = MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(heightMeasureSpec), MeasureSpec.AT_MOST);
+
+        super.onMeasure(widthSpec, heightSpec);
+
+        int measuredHeight = viewMeasurer.getMeasuredHeight(heightSpec);
+        setMeasuredDimension(viewMeasurer.getMeasuredWidth(widthSpec), measuredHeight);
     }
 
     @Override


### PR DESCRIPTION
RN 0.50 introduced a new feature to dynamically measure ReactRootView. Since RNN uses RelativeLayout for Screen and BottomTabsLayout child views added to the layout may have additional rules. When the child views are measured they are measured with respect to the LayoutParams set during Screen creation and the Parent MeasureSpec. In RNN, ContentView extends ReactRootView and it calls onMeasure using the widthMeasureSpec and heightMeasureSpec passed to it. If these measureSpecs are EXACTLY then ReactRootView will measure itself to fit the exact size requested by the parent. 

If ContentView was added with LayoutParams.MATCH_PARENT for height and/or width with additional rules eg. BELOW or ABOVE the effective height of this View may not be compatible with MATCH_PARENT. RelativeLayout does two passes over its children, in the first pass each child is measured as per their LayoutParams, in the second pass LayoutParam rules are applied and each child is measured. The problem occurs here, if ReactRootView was asked to measure itself with MeasureSpec.EXACTLY but the measuredHeight was less than expected it will trigger a requestLayout() causing the entire layout to be remeasured. 

The fix is to call super.onMeasure() in ContentView with MeasureSpec.AT_MOST.