### PR TITLE
Add paddingTop to android ToolBar.

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/params/StyleParams.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/StyleParams.java
@@ -117,6 +117,7 @@ public class StyleParams {
     public int titleBarHeight;
     public boolean backButtonHidden;
     public Font titleBarButtonFontFamily;
+    public int titleBarTopPadding;
 
     public Color topTabTextColor;
     public Color topTabIconColor;

--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/StyleParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/StyleParamsParser.java
@@ -68,6 +68,7 @@ public class StyleParamsParser {
         result.titleBarHeight = getInt("titleBarHeight", getDefaultTitleBarHeight());
         result.backButtonHidden = getBoolean("backButtonHidden", getDefaultBackButtonHidden());
         result.topTabsHidden = getBoolean("topTabsHidden", getDefaultTopTabsHidden());
+        result.titleBarTopPadding = getInt("titleBarTopPadding", getTitleBarTopPadding());
 
         result.topTabTextColor = getColor("topTabTextColor", getDefaultTopTabTextColor());
         result.topTabIconColor = getColor("topTabIconColor", getDefaultTopTabIconColor());
@@ -315,6 +316,10 @@ public class StyleParamsParser {
 
     private int getDefaultTitleBarHeight() {
         return AppStyle.appStyle == null ? -1 : AppStyle.appStyle.titleBarHeight;
+    }
+
+    private int getTitleBarTopPadding() {
+        return AppStyle.appStyle == null ? 0 : AppStyle.appStyle.titleBarTopPadding;
     }
 
     private boolean getBoolean(String key, boolean defaultValue) {

--- a/android/app/src/main/java/com/reactnativenavigation/views/TitleBar.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/TitleBar.java
@@ -85,6 +85,7 @@ public class TitleBar extends Toolbar {
         colorOverflowButton(params);
         setBackground(params);
         centerTitle(params);
+        setTopPadding(params);
     }
 
     public void setVisibility(boolean titleBarHidden) {
@@ -132,6 +133,10 @@ public class TitleBar extends Toolbar {
                 }
             }
         });
+    }
+
+    private void setTopPadding(final StyleParams params) {
+        setPadding(0, params.titleBarTopPadding, 0,0);
     }
 
     private void colorOverflowButton(StyleParams params) {

--- a/docs/styling-the-navigator.md
+++ b/docs/styling-the-navigator.md
@@ -106,6 +106,7 @@ this.props.navigator.setStyle({
   collapsingToolBarCollapsedColor: '#0f2362', // Collapsing Toolbar scrim color.
   navBarTextFontBold: false, // Optional. Set the title to bold.
   navBarHeight: 70, // Optional, set the navBar height in pixels.
+  navBarTopPadding: 24, // Optional, set navBar top padding in pixels. Useful when StatusBar.translucent=true on Android Lollipop and above.
   topTabsHeight: 70, // Optional, set topTabs height in pixels.
   topBarBorderColor: 'red', Optional, set a flat border under the TopBar.
   topBarBorderWidth: 5.5, // Optional, set the width of the border.

--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -174,6 +174,7 @@ function convertStyleParams(originalStyleObject) {
     titleBarTitleFontBold: originalStyleObject.navBarTextFontBold,
     titleBarTitleTextCentered: originalStyleObject.navBarTitleTextCentered,
     titleBarHeight: originalStyleObject.navBarHeight,
+    titleBarTopPadding: originalStyleObject.navBarTopPadding,
     backButtonHidden: originalStyleObject.backButtonHidden,
     topTabsHidden: originalStyleObject.topTabsHidden,
     contextualMenuStatusBarColor: processColor(originalStyleObject.contextualMenuStatusBarColor),


### PR DESCRIPTION
On Android to draw under the StatusBar we have to set translucent=true on StatusBar. This will remove paddingBottom from the StatusBar and the ToolBar will move up. With this fix, we can add a top padding to the navBar on Android. 