### PR TITLE
Add support for drawer style params in Android

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/params/SideMenuParams.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/SideMenuParams.java
@@ -5,4 +5,5 @@ import com.reactnativenavigation.views.SideMenu;
 public class SideMenuParams extends BaseScreenParams {
     public boolean disableOpenGesture;
     public SideMenu.Side side;
+    public SideMenuStyle style;
 }

--- a/android/app/src/main/java/com/reactnativenavigation/params/SideMenuStyle.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/SideMenuStyle.java
@@ -1,0 +1,5 @@
+package com.reactnativenavigation.params;
+
+public class SideMenuStyle {
+    public int weight;
+}

--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/ActivityParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/ActivityParamsParser.java
@@ -24,7 +24,12 @@ public class ActivityParamsParser extends Parser {
         }
 
         if (hasKey(params, "sideMenu")) {
-            SideMenuParams[] sideMenus = SideMenuParamsParser.parse(params.getBundle("sideMenu"));
+            Bundle style = null;
+            if (hasKey(params, "drawer") && hasKey(params.getBundle("drawer"), "style")) {
+                style = params.getBundle("drawer").getBundle("style");
+            }
+
+            SideMenuParams[] sideMenus = SideMenuParamsParser.parse(params.getBundle("sideMenu"), style);
             result.leftSideMenuParams = sideMenus[SideMenu.Side.Left.ordinal()];
             result.rightSideMenuParams = sideMenus[SideMenu.Side.Right.ordinal()];
         }

--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/SideMenuParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/SideMenuParamsParser.java
@@ -5,17 +5,19 @@ import android.support.annotation.Nullable;
 
 import com.reactnativenavigation.params.NavigationParams;
 import com.reactnativenavigation.params.SideMenuParams;
+import com.reactnativenavigation.params.SideMenuStyle;
+import com.reactnativenavigation.views.SideMenu;
 import com.reactnativenavigation.views.SideMenu.Side;
 
 class SideMenuParamsParser extends Parser {
-    public static SideMenuParams[] parse(Bundle sideMenues) {
+    public static SideMenuParams[] parse(Bundle sideMenues, @Nullable Bundle style) {
         SideMenuParams[] result = new SideMenuParams[2];
-        result[Side.Left.ordinal()] = parseSideMenu(sideMenues.getBundle("left"), Side.Left);
-        result[Side.Right.ordinal()] = parseSideMenu(sideMenues.getBundle("right"), Side.Right);
+        result[Side.Left.ordinal()] = parseSideMenu(sideMenues.getBundle("left"), Side.Left, style);
+        result[Side.Right.ordinal()] = parseSideMenu(sideMenues.getBundle("right"), Side.Right, style);
         return result;
     }
 
-    private static SideMenuParams parseSideMenu(@Nullable Bundle sideMenu, Side side) {
+    private static SideMenuParams parseSideMenu(@Nullable Bundle sideMenu, Side side, Bundle style) {
         if (sideMenu == null || sideMenu.isEmpty()) {
             return null;
         }
@@ -24,6 +26,25 @@ class SideMenuParamsParser extends Parser {
         result.navigationParams = new NavigationParams(sideMenu.getBundle("navigationParams"));
         result.disableOpenGesture = sideMenu.getBoolean("disableOpenGesture", false);
         result.side = side;
+        result.style = parseStyle(style, side);
+        return result;
+    }
+
+    private static SideMenuStyle parseStyle(@Nullable Bundle style, Side side) {
+        if (style == null || style.isEmpty()) {
+            return null;
+        }
+
+        SideMenuStyle result = new SideMenuStyle();
+
+        if (side.equals(Side.Left) && hasKey(style, "leftDrawerWidth")) {
+            result.weight = style.getInt("leftDrawerWidth");
+        }
+
+        if (side.equals(Side.Right) && hasKey(style, "rightDrawerWidth")) {
+            result.weight = style.getInt("rightDrawerWidth");
+        }
+
         return result;
     }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/views/SideMenu.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/SideMenu.java
@@ -1,16 +1,20 @@
 package com.reactnativenavigation.views;
 
 import android.content.Context;
+import android.graphics.Point;
 import android.support.annotation.Nullable;
 import android.support.v4.widget.DrawerLayout;
+import android.view.Display;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.RelativeLayout;
 
 import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.params.BaseScreenParams;
 import com.reactnativenavigation.params.SideMenuParams;
+import com.reactnativenavigation.params.SideMenuStyle;
 import com.reactnativenavigation.screens.NavigationType;
 import com.reactnativenavigation.screens.Screen;
 import com.reactnativenavigation.utils.ViewUtils;
@@ -121,20 +125,18 @@ public class SideMenu extends DrawerLayout {
         ContentView sideMenuView = new ContentView(getContext(), params.screenId, params.navigationParams);
         LayoutParams lp = new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT);
         lp.gravity = params.side.gravity;
-        setSideMenuWidth(sideMenuView);
+
+        if (params.style != null && params.style.weight > 0) {
+            Point size = new Point();
+            Display display = ((WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
+            display.getSize(size);
+
+            int width = Math.round(size.x * params.style.weight/100);
+            lp.width = width;
+        }
+
         addView(sideMenuView, lp);
         return sideMenuView;
-    }
-
-    private void setSideMenuWidth(final ContentView sideMenuView) {
-        sideMenuView.setOnDisplayListener(new Screen.OnDisplayListener() {
-            @Override
-            public void onDisplay() {
-                ViewGroup.LayoutParams lp = sideMenuView.getLayoutParams();
-                lp.width = sideMenuView.getChildAt(0).getWidth();
-                sideMenuView.setLayoutParams(lp);
-            }
-        });
     }
 
     public void setScreenEventListener() {

--- a/docs/top-level-api.md
+++ b/docs/top-level-api.md
@@ -71,11 +71,11 @@ Navigation.startTabBasedApp({
       screen: 'example.SecondSideMenu', // unique ID registered with Navigation.registerScreen
       passProps: {} // simple serializable object that will pass as props to all top screens (optional)
     },
-    style: { // ( iOS only )
-      drawerShadow: true, // optional, add this if you want a side menu drawer shadow
-      contentOverlayColor: 'rgba(0,0,0,0.25)', // optional, add this if you want a overlay color when drawer is open
-      leftDrawerWidth: 50, // optional, add this if you want a define left drawer width (50=percent)
+    style: {
+      leftDrawerWidth: 50, // optional, add this if you want a define left drawer width (50=percent)
       rightDrawerWidth: 50 // optional, add this if you want a define right drawer width (50=percent)
+      drawerShadow: true, // optional, iOS only, add this if you want a side menu drawer shadow
+      contentOverlayColor: 'rgba(0,0,0,0.25)', // optional, iOS only, add this if you want a overlay color when drawer is open
       shouldStretchDrawer: true // optional, iOS only with 'MMDrawer' type, whether or not the panning gesture will “hard-stop” at the maximum width for a given drawer side, default : true
     },
     type: 'MMDrawer', // optional, iOS only, types: 'TheSideBar', 'MMDrawer' default: 'MMDrawer'
@@ -111,11 +111,11 @@ Navigation.startSingleScreenApp({
       passProps: {} // simple serializable object that will pass as props to all top screens (optional)
       disableOpenGesture: false // can the drawer be opened with a swipe instead of button (optional, Android only)
     },
-    style: { // ( iOS only )
-      drawerShadow: true, // optional, add this if you want a side menu drawer shadow
-      contentOverlayColor: 'rgba(0,0,0,0.25)', // optional, add this if you want a overlay color when drawer is open
+    style: {
       leftDrawerWidth: 50, // optional, add this if you want a define left drawer width (50=percent)
       rightDrawerWidth: 50 // optional, add this if you want a define right drawer width (50=percent)
+      drawerShadow: true, // optional, iOS only, add this if you want a side menu drawer shadow
+      contentOverlayColor: 'rgba(0,0,0,0.25)', // optional, iOS only, add this if you want a overlay color when drawer is open
     },
     type: 'MMDrawer', // optional, iOS only, types: 'TheSideBar', 'MMDrawer' default: 'MMDrawer'
     animationType: 'door', //optional, iOS only, for MMDrawer: 'door', 'parallax', 'slide', 'slide-and-scale'

--- a/example/src/app.js
+++ b/example/src/app.js
@@ -52,6 +52,10 @@ Navigation.startTabBasedApp({
   drawer: {
     left: {
       screen: 'example.Types.Drawer'
-    }
+    },
+    style: {
+      leftDrawerWidth: 50, // optional, add this if you want a define left drawer width (50=percent)
+      rightDrawerWidth: 50, // optional, add this if you want a define right drawer width (50=percent)
+    },
   }
 });


### PR DESCRIPTION
- Only `leftDrawerWidth` and `rightDrawerWidth` implemented

Drawer width is now not calculated from drawer screen but instead from initial params as in iOS. This will fix #1727, #1761, #1942 
