### PR TITLE
Fix formatting of code block in installation-ios

### DIFF
--- a/docs/installation-ios.md
+++ b/docs/installation-ios.md
@@ -14,9 +14,10 @@
 
 4. In Xcode, in Project Navigator (left pane), click on your project (top), then click on your *project* row (on the "project and targets list") and select the `Build Settings` tab (right pane). In the `Header Search Paths` section add `$(SRCROOT)/../node_modules/react-native-navigation/ios`. Make sure on the right to mark this new path `recursive` ([screenshots](https://facebook.github.io/react-native/docs/linking-libraries-ios.html#step-3))
 
-5. In Xcode, you will need to edit this file: `AppDelegate.m`. 
-This function:
-````````
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions { ... }
-````````
-is the main entry point for your app. Its content must be replaced with the content of this [reference](https://github.com/wix/react-native-navigation/blob/master/example/ios/example/AppDelegate.m)
+5. In Xcode, you will need to edit this file: `AppDelegate.m`. This function is the main entry point for your app:
+
+    ```objc
+    - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions { ... }
+    ```
+
+Its content must be replaced with the content of this [reference](https://github.com/wix/react-native-navigation/blob/master/example/ios/example/AppDelegate.m)


### PR DESCRIPTION
This code block appears fine on GitHub, but is malformatted on the site:

![screen shot 2017-12-15 at 2 49 38 pm](https://user-images.githubusercontent.com/15832198/34057942-30bfe508-e1a7-11e7-86e5-b15fea18531e.png)

This PR updates it to fit the format of other code blocks in the docs, so it should appear okay.