### PR TITLE
Added optional fixedWidth property to the Android side menu

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/params/SideMenuParams.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/SideMenuParams.java
@@ -5,4 +5,5 @@ import com.reactnativenavigation.views.SideMenu;
 public class SideMenuParams extends BaseScreenParams {
     public boolean disableOpenGesture;
     public SideMenu.Side side;
+    public int fixedWidth;
 }

--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/SideMenuParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/SideMenuParamsParser.java
@@ -23,6 +23,7 @@ class SideMenuParamsParser extends Parser {
         result.screenId = sideMenu.getString("screenId");
         result.navigationParams = new NavigationParams(sideMenu.getBundle("navigationParams"));
         result.disableOpenGesture = sideMenu.getBoolean("disableOpenGesture", false);
+        result.fixedWidth = sideMenu.getInt("fixedWidth", 0);
         result.side = side;
         return result;
     }

--- a/android/app/src/main/java/com/reactnativenavigation/views/SideMenu.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/SideMenu.java
@@ -121,17 +121,23 @@ public class SideMenu extends DrawerLayout {
         ContentView sideMenuView = new ContentView(getContext(), params.screenId, params.navigationParams);
         LayoutParams lp = new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT);
         lp.gravity = params.side.gravity;
-        setSideMenuWidth(sideMenuView);
+        setSideMenuWidth(sideMenuView, params);
         addView(sideMenuView, lp);
         return sideMenuView;
     }
 
-    private void setSideMenuWidth(final ContentView sideMenuView) {
+    private void setSideMenuWidth(final ContentView sideMenuView, @Nullable final SideMenuParams params) {
         sideMenuView.setOnDisplayListener(new Screen.OnDisplayListener() {
             @Override
             public void onDisplay() {
                 ViewGroup.LayoutParams lp = sideMenuView.getLayoutParams();
-                lp.width = sideMenuView.getChildAt(0).getWidth();
+                if (params != null
+                    && params.fixedWidth > 0) {
+                    lp.width = params.fixedWidth;
+                } else {
+                    lp.width = sideMenuView.getChildAt(0).getWidth();
+                }
+
                 sideMenuView.setLayoutParams(lp);
             }
         });

--- a/docs/top-level-api.md
+++ b/docs/top-level-api.md
@@ -65,11 +65,13 @@ Navigation.startTabBasedApp({
   drawer: { // optional, add this if you want a side menu drawer in your app
     left: { // optional, define if you want a drawer from the left
       screen: 'example.FirstSideMenu', // unique ID registered with Navigation.registerScreen
-      passProps: {} // simple serializable object that will pass as props to all top screens (optional)
+      passProps: {} // simple serializable object that will pass as props to all top screens (optional),
+      fixedWidth: 500, // a fixed width you want your left drawer to have (optional)
     },
     right: { // optional, define if you want a drawer from the right
       screen: 'example.SecondSideMenu', // unique ID registered with Navigation.registerScreen
       passProps: {} // simple serializable object that will pass as props to all top screens (optional)
+      fixedWidth: 500, // a fixed width you want your right drawer to have (optional)
     },
     style: { // ( iOS only )
       drawerShadow: true, // optional, add this if you want a side menu drawer shadow
@@ -105,11 +107,13 @@ Navigation.startSingleScreenApp({
       screen: 'example.FirstSideMenu', // unique ID registered with Navigation.registerScreen
       passProps: {}, // simple serializable object that will pass as props to all top screens (optional)
       disableOpenGesture: false // can the drawer be opened with a swipe instead of button (optional, Android only)
+      fixedWidth: 500, // a fixed width you want your left drawer to have (optional)
     },
     right: { // optional, define if you want a drawer from the right
       screen: 'example.SecondSideMenu', // unique ID registered with Navigation.registerScreen
       passProps: {} // simple serializable object that will pass as props to all top screens (optional)
       disableOpenGesture: false // can the drawer be opened with a swipe instead of button (optional, Android only)
+      fixedWidth: 500, // a fixed width you want your right drawer to have (optional)
     },
     style: { // ( iOS only )
       drawerShadow: true, // optional, add this if you want a side menu drawer shadow

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-navigation",
-  "version": "1.1.85",
+  "version": "1.1.314",
   "description": "React Native Navigation - truly native navigation for iOS and Android",
   "license": "MIT",
   "nativePackage": true,

--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -257,9 +257,15 @@ function convertDrawerParamsToSideMenuParams(drawerParams) {
       result[key] = adaptNavigationParams(result[key]);
       result[key].passProps = drawer[key].passProps;
       if (drawer.disableOpenGesture) {
-        result[key].disableOpenGesture = drawer.disableOpenGesture;
+        result[key].disableOpenGesture = parseInt(drawer.disableOpenGesture);
       } else {
-        result[key].disableOpenGesture = drawer[key].disableOpenGesture;
+        let fixedWidth = drawer[key].disableOpenGesture;
+        result[key].disableOpenGesture = fixedWidth ? parseInt(fixedWidth) : null;
+      }
+      if (drawer.fixedWidth) {
+        result[key].fixedWidth = drawer.fixedWidth;
+      } else {
+        result[key].fixedWidth = drawer[key].fixedWidth;
       }
       
     } else {


### PR DESCRIPTION
- Fixes: https://github.com/wix/react-native-navigation/issues/510

Example:

	Navigation.startSingleScreenApp({
	    screen: 'Welcome'
	    drawer: {
	      left: {
	        screen: 'SideMenu',
	        fixedWidth: 400,
	      },
	    },
	  });
	}