### PR TITLE
Load icons on main thread

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
@@ -13,11 +13,13 @@ import java.util.List;
 public abstract class NavigationApplication extends Application implements ReactApplication {
 
 	private ReactGateway reactGateway;
+	public static NavigationApplication instance;
 
 	@Override
 	public void onCreate() {
 		super.onCreate();
-		reactGateway = new ReactGateway(this, isDebug(), createAdditionalReactPackages());
+        instance = this;
+        reactGateway = new ReactGateway(this, isDebug(), createAdditionalReactPackages());
 	}
 
 	public ReactGateway getReactGateway() {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/OptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/OptionsPresenter.java
@@ -23,8 +23,8 @@ public class OptionsPresenter {
     }
 
     public void applyOptions(Options options) {
-        applyTopBarOptions(options.topBarOptions);
         applyButtons(options.topBarOptions.leftButtons, options.topBarOptions.rightButtons);
+        applyTopBarOptions(options.topBarOptions);
         applyTopTabsOptions(options.topTabsOptions);
         applyTopTabOptions(options.topTabOptions);
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/TitleBarButton.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/TitleBarButton.java
@@ -57,39 +57,33 @@ public class TitleBarButton implements MenuItem.OnMenuItemClickListener {
 			return;
 		}
 
-		ImageUtils.tryLoadIcon(context, button.icon.get(), new ImageUtils.ImageLoadingListener() {
+		ImageUtils.loadIcon(context, button.icon.get(), new ImageUtils.ImageLoadingListener() {
 			@Override
 			public void onComplete(@NonNull Drawable drawable) {
 				icon = drawable;
-				UiUtils.runOnMainThread(() -> {
-                    setIconColor();
-                    setNavigationClickListener();
-                    toolbar.setNavigationIcon(icon);
-                });
+                setIconColor();
+                setNavigationClickListener();
+                toolbar.setNavigationIcon(icon);
 			}
 
 			@Override
 			public void onError(Throwable error) {
-				//TODO: handle
 				error.printStackTrace();
 			}
 		});
 	}
 
 	private void applyIcon(Context context, final MenuItem menuItem) {
-		ImageUtils.tryLoadIcon(context, button.icon.get(), new ImageUtils.ImageLoadingListener() {
+		ImageUtils.loadIcon(context, button.icon.get(), new ImageUtils.ImageLoadingListener() {
 			@Override
 			public void onComplete(@NonNull Drawable drawable) {
 				icon = drawable;
-				UiUtils.runOnMainThread(() -> {
-                    menuItem.setIcon(icon);
-                    setIconColor();
-                });
+                menuItem.setIcon(icon);
+                setIconColor();
 			}
 
 			@Override
 			public void onError(Throwable error) {
-				//TODO: handle
 				error.printStackTrace();
 			}
 		});


### PR DESCRIPTION
Only reason to offload icon loading to background thread is to avoid
supposed network on main thread calls which happen only in debug since
icons are passed loaded from localhost.