### PR TITLE
Allow users to provide a custom ReactNativeHost

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
@@ -19,8 +19,21 @@ public abstract class NavigationApplication extends Application implements React
 	public void onCreate() {
 		super.onCreate();
         instance = this;
-        reactGateway = new ReactGateway(this, isDebug(), createAdditionalReactPackages());
+        reactGateway = createReactGateway();
 	}
+
+    /**
+     * Subclasses of NavigationApplication may override this method to create the singleton instance
+     * of {@link ReactGateway}. For example, subclasses may wish to provide a custom {@link ReactNativeHost}
+     * with the ReactGateway. This method will be called exactly once, in the application's {@link #onCreate()} method.
+     *
+     * Custom {@link ReactNativeHost}s must be sure to include {@link com.reactnativenavigation.react.NavigationPackage}
+     *
+     * @return a singleton {@link ReactGateway}
+     */
+	protected ReactGateway createReactGateway() {
+	    return new ReactGateway(this, isDebug(), createAdditionalReactPackages());
+    }
 
 	public ReactGateway getReactGateway() {
 		return reactGateway;
@@ -33,6 +46,10 @@ public abstract class NavigationApplication extends Application implements React
 
 	public abstract boolean isDebug();
 
+    /**
+     * Create a list of additional {@link ReactPackage}s to include. This method will only be called by
+     * the default implementation of {@link #createReactGateway()}
+     */
 	@Nullable
 	public abstract List<ReactPackage> createAdditionalReactPackages();
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactNativeHost.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactNativeHost.java
@@ -9,6 +9,10 @@ import com.facebook.react.shell.MainReactPackage;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Default implementation of {@link ReactNativeHost} that includes {@link NavigationPackage}
+ * and user-defined additional packages.
+ */
 public class NavigationReactNativeHost extends ReactNativeHost {
 
 	private final boolean isDebug;
@@ -27,6 +31,8 @@ public class NavigationReactNativeHost extends ReactNativeHost {
 
 	@Override
 	protected List<ReactPackage> getPackages() {
+		// Please note that users may provide their own implementations of ReactNativeHost. Any additional
+		// package requirements should be documented in the changelog.
 		List<ReactPackage> packages = new ArrayList<>();
 		packages.add(new MainReactPackage());
 		packages.add(new NavigationPackage(this));

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/ReactGateway.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/ReactGateway.java
@@ -1,5 +1,7 @@
 package com.reactnativenavigation.react;
 
+import android.app.Application;
+
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
@@ -10,13 +12,17 @@ import java.util.List;
 
 public class ReactGateway {
 
-	private final NavigationReactNativeHost reactNativeHost;
+	private final ReactNativeHost reactNativeHost;
 	private final NavigationReactInitializer initializer;
 	private final JsDevReloadHandler jsDevReloadHandler;
 
-	public ReactGateway(final NavigationApplication application, final boolean isDebug, final List<ReactPackage> additionalReactPackages) {
+	public ReactGateway(final Application application, final boolean isDebug, final List<ReactPackage> additionalReactPackages) {
+		this(application, isDebug, new NavigationReactNativeHost(application, isDebug, additionalReactPackages));
+	}
+
+	public ReactGateway(final Application application, final boolean isDebug, final ReactNativeHost reactNativeHost) {
 		SoLoader.init(application, false);
-		reactNativeHost = new NavigationReactNativeHost(application, isDebug, additionalReactPackages);
+		this.reactNativeHost = reactNativeHost;
 		initializer = new NavigationReactInitializer(reactNativeHost.getReactInstanceManager(), isDebug);
 		jsDevReloadHandler = new JsDevReloadHandler(reactNativeHost.getReactInstanceManager());
 	}


### PR DESCRIPTION
Currently the default NavigationReactNativeHost only adds the NavigationPackage. Users may need to override additional methods in ReactNativeHost. This change allows advanced users to provide their own implementation of ReactNativeHost, with the requirement that they add the NavigationPackage themselves.