### PR TITLE
[Android] Add backwards compatible support for react-native 0.52.0

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -458,7 +458,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
                 modalController.destroy();
 
                 Object devSupportManager = ReflectionUtils.getDeclaredField(getReactGateway().getReactInstanceManager(), "mDevSupportManager");
-                if (ReflectionUtils.getDeclaredField(devSupportManager, "mRedBoxDialog") != null) {
+                if (ReflectionUtils.getDeclaredField(devSupportManager, "mRedBoxDialog") != null) { // RN >= 0.52
                     ReflectionUtils.setField(devSupportManager, "mRedBoxDialog", null);
                 }
             }

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -39,6 +39,7 @@ import com.reactnativenavigation.react.ReactGateway;
 import com.reactnativenavigation.screens.NavigationType;
 import com.reactnativenavigation.screens.Screen;
 import com.reactnativenavigation.utils.OrientationHelper;
+import com.reactnativenavigation.utils.ReflectionUtils;
 import com.reactnativenavigation.views.SideMenu.Side;
 
 import java.util.List;
@@ -455,6 +456,11 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
             public void run() {
                 layout.destroy();
                 modalController.destroy();
+
+                Object devSupportManager = ReflectionUtils.getDeclaredField(getReactGateway().getReactInstanceManager(), "mDevSupportManager");
+                if (ReflectionUtils.getDeclaredField(devSupportManager, "mRedBoxDialog") != null) {
+                    ReflectionUtils.setField(devSupportManager, "mRedBoxDialog", null);
+                }
             }
         });
     }


### PR DESCRIPTION
React Native 0.52.0 introduces a new way for rendering dev support related views on Android, so no SYSTEM_ALERT_WINDOW permission is required to display RedBox error dialog. Unfortunately, this change is breaking for this library because the interface `ReactInstanceDevCommandsHandler` has been renamed to `ReactInstanceManagerDevHelper`. 

In this PR I have rewritten `JsDevReloadListenerReplacer` so instead of a class implementing exactly interface, a dynamic proxy is used to create an implementation of a right interface at runtime. This way, backward compatibility with the previous versions is preserved, and RN 0.52.0 and up can be supported as well.

Also, I have added a small piece of code to `postHandleJsDevReloadEvent` method of `NavigationActivity` that check if `mRedBoxDialog` field of `DevSupportManager` is null and set it to null if not. Without this, the RedBox dialog doesn't get displayed if the original activity which was used to display it firstly doesn't longer exist (for example one error has been shown, you tap on reload, and new error occur). This change is not breaking too.

I have also created [repo](https://github.com/krystofcelba/react-native-navigation-rn52-demo) with demo app which I used for testing. There is RN 0.51.0 version in `rn51` branch so you can easily test it.