### PR TITLE
Check whether the sharedBridge is valid

### DIFF
--- a/ios/RCCManager.m
+++ b/ios/RCCManager.m
@@ -153,7 +153,7 @@
 
 -(void)initBridgeWithBundleURL:(NSURL *)bundleURL launchOptions:(NSDictionary *)launchOptions
 {
-  if (self.sharedBridge) return;
+  if (self.sharedBridge && [self.sharedBridge isValid]) return;
   
   self.bundleURL = bundleURL;
   self.sharedBridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];


### PR DESCRIPTION
Checking whether the `sharedBridge` is valid instead of only checking whether it is not null. This allows us to initialise a new bridge if the bridge was invalidated. This is useful when creating an app that loads other React Native apps, and the user wants to close the loaded app manually to try and load another.