### PR TITLE
[iOS] Correctly handle change of nav bar height

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationCommandsHandler.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationCommandsHandler.java
@@ -549,6 +549,6 @@ public class NavigationCommandsHandler {
 
     public static void getLaunchArgs(Promise promise) {
         Bundle bundle = LaunchArgs.instance.get();
-        promise.resolve(bundle);
+        promise.resolve(Arguments.fromBundle(bundle));
     }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/react/LaunchArgs.java
+++ b/android/app/src/main/java/com/reactnativenavigation/react/LaunchArgs.java
@@ -10,7 +10,7 @@ public enum LaunchArgs {
     private Bundle launchArgs;
 
     public void set(Intent intent) {
-        if (intent != null && intent.getExtras() != null && launchArgs != null) {
+        if (intent != null && intent.getExtras() != null && launchArgs == null) {
             this.launchArgs = intent.getExtras();
         }
     }

--- a/ios/Helpers/RCCTitleViewHelper.m
+++ b/ios/Helpers/RCCTitleViewHelper.m
@@ -81,7 +81,6 @@ navigationController:(UINavigationController*)navigationController
     
     self.titleView = [[RCCTitleView alloc] initWithFrame:navigationBarBounds];
     self.titleView.backgroundColor = [UIColor clearColor];
-    self.titleView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
     self.titleView.clipsToBounds = YES;
     
     self.viewController.navigationItem.title = self.title;

--- a/ios/Helpers/RCCTitleViewHelper.m
+++ b/ios/Helpers/RCCTitleViewHelper.m
@@ -129,7 +129,6 @@ navigationController:(UINavigationController*)navigationController
     UIImage *titleImage = [RCTConvert UIImage:self.titleImageData];
     UIImageView *imageView = [[UIImageView alloc] initWithImage:titleImage];
     imageView.contentMode = UIViewContentModeScaleAspectFit;
-    imageView.autoresizingMask = self.titleView.autoresizingMask;
     
     self.viewController.navigationItem.titleView = imageView;
 }

--- a/ios/Helpers/RCCTitleViewHelper.m
+++ b/ios/Helpers/RCCTitleViewHelper.m
@@ -115,7 +115,7 @@ navigationController:(UINavigationController*)navigationController
 
 -(BOOL)isTitleOnly
 {
-    return self.title && !self.subtitle && !self.titleImageData;
+    return self.title && !self.subtitle && ![self isTitleImage];
 }
 
 

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -429,6 +429,12 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
       [barButtonItem setImage:[barButtonItem.image imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal]];
     }
     
+    id buttonColor = button[@"buttonColor"];
+    if (buttonColor) {
+      UIColor *color = [RCTConvert UIColor:buttonColor];
+      barButtonItem.tintColor = color;
+    }
+
     if ([viewController isKindOfClass:[RCCViewController class]]) {
       RCCViewController *rccViewController = ((RCCViewController*)viewController);
       NSDictionary *navigatorStyle = rccViewController.navigatorStyle;


### PR DESCRIPTION
This pull request fixes 2 issues:

1) On iPhone, the height of the nav bar is different in portrait and landscape mode. Current code makes the titleView (which contains title and subtitle) automatically adapt to changing width but not to changing height. When using a subtitle, this may cause incorrect vertical alignment. 
The fix makes the titleView be sized to fit its contents and automatically centered in both directions.
The case when a title image is used is unaffected by this fix, it seems to work properly anyways.

2) (BOOL)isTitleOnly method was incorrectly returning NO when titleImage is not nil but NSNull*.  For whatever reason, this happened for root views in tab navigator.
