### PR TITLE
Set titleBarSubTitleTextCentered as navigator style for android

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/params/StyleParams.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/StyleParams.java
@@ -120,6 +120,7 @@ public class StyleParams {
     public int titleBarTitleFontSize;
     public boolean titleBarTitleFontBold;
     public boolean titleBarTitleTextCentered;
+    public boolean titleBarSubTitleTextCentered;
     public int titleBarHeight;
     public boolean backButtonHidden;
     public Font titleBarButtonFontFamily;

--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/StyleParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/StyleParamsParser.java
@@ -66,6 +66,7 @@ public class StyleParamsParser {
         result.titleBarTitleFontSize = getInt("titleBarTitleFontSize", getDefaultTitleTextFontSize());
         result.titleBarTitleFontBold = getBoolean("titleBarTitleFontBold", getDefaultTitleTextFontBold());
         result.titleBarTitleTextCentered = getBoolean("titleBarTitleTextCentered", getDefaultTitleBarTextCentered());
+        result.titleBarSubTitleTextCentered = getBoolean("titleBarSubTitleTextCentered", getDefaultTitleBarTextCentered());
         result.titleBarHeight = getInt("titleBarHeight", getDefaultTitleBarHeight());
         result.backButtonHidden = getBoolean("backButtonHidden", getDefaultBackButtonHidden());
         result.topTabsHidden = getBoolean("topTabsHidden", getDefaultTopTabsHidden());
@@ -324,6 +325,10 @@ public class StyleParamsParser {
 
     private boolean getDefaultTitleBarTextCentered() {
         return AppStyle.appStyle != null && AppStyle.appStyle.titleBarTitleTextCentered;
+    }
+
+    private boolean getDefaultSubTitleBarTextCentered() {
+        return AppStyle.appStyle != null && AppStyle.appStyle.titleBarSubTitleTextCentered;
     }
 
     private int getDefaultTitleBarHeight() {

--- a/android/app/src/main/java/com/reactnativenavigation/views/TitleBar.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/TitleBar.java
@@ -142,7 +142,7 @@ public class TitleBar extends Toolbar {
     }
 
     private void centerSubTitle(final StyleParams params) {
-        final View subTitleView = getSubTitleView();
+        final TextView subTitleView = getSubtitleView();
         if (subTitleView == null) {
             return;
         }

--- a/android/app/src/main/java/com/reactnativenavigation/views/TitleBar.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/TitleBar.java
@@ -84,7 +84,7 @@ public class TitleBar extends Toolbar {
         setSubtitleFont(params);
         colorOverflowButton(params);
         setBackground(params);
-        centerTitle(params);
+        centerTopBarContent(params);
         setTopPadding(params);
     }
 
@@ -102,6 +102,7 @@ public class TitleBar extends Toolbar {
         super.setSubtitle(subtitle);
         setSubtitleFontSize(styleParams);
         setSubtitleFont(styleParams);
+        centerSubTitle(styleParams);
     }
 
     private void setSubtitleFontSize(StyleParams params) {
@@ -120,6 +121,11 @@ public class TitleBar extends Toolbar {
         }
     }
 
+    private void centerTopBarContent(final StyleParams params) {
+        centerTitle(params);
+        centerSubTitle(params);
+    }
+
     private void centerTitle(final StyleParams params) {
         final View titleView = getTitleView();
         if (titleView == null) {
@@ -130,6 +136,21 @@ public class TitleBar extends Toolbar {
             public void run() {
                 if (params.titleBarTitleTextCentered) {
                     titleView.setX(ViewUtils.getWindowWidth((Activity) getContext()) / 2 - titleView.getWidth() / 2);
+                }
+            }
+        });
+    }
+
+    private void centerSubTitle(final StyleParams params) {
+        final View subTitleView = getSubTitleView();
+        if (subTitleView == null) {
+            return;
+        }
+        ViewUtils.runOnPreDraw(subTitleView, new Runnable() {
+            @Override
+            public void run() {
+                if (params.titleBarSubTitleTextCentered) {
+                    subTitleView.setX(ViewUtils.getWindowWidth((Activity) getContext()) / 2 - subTitleView.getWidth() / 2);
                 }
             }
         });

--- a/docs/styling-the-navigator.md
+++ b/docs/styling-the-navigator.md
@@ -108,6 +108,7 @@ this.props.navigator.setStyle({
   // Android only
   navigationBarColor: '#000000', // change the background color of the bottom native navigation bar.
   navBarTitleTextCentered: true, // default: false. centers the title.
+  navBarSubTitleTextCentered: true, // (Android - default: false, iOS - default: depending on navBarTitleTextCentered). centers the subTitle.
   navBarButtonFontFamily: 'sans-serif-thin', // Change the font family of textual buttons
   statusBarColor: '#000000', // change the color of the status bar.
   drawUnderStatusBar: false, // default: false, will draw the screen underneath the statusbar. Useful togheter with statusBarColor: transparent

--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -180,6 +180,7 @@ function convertStyleParams(originalStyleObject) {
     titleBarTitleFontSize: originalStyleObject.navBarTextFontSize,
     titleBarTitleFontBold: originalStyleObject.navBarTextFontBold,
     titleBarTitleTextCentered: originalStyleObject.navBarTitleTextCentered,
+    titleBarSubTitleTextCentered: originalStyleObject.navBarSubTitleTextCentered,
     titleBarHeight: originalStyleObject.navBarHeight,
     titleBarTopPadding: originalStyleObject.navBarTopPadding,
     backButtonHidden: originalStyleObject.backButtonHidden,


### PR DESCRIPTION
Resolves [#2608](https://github.com/wix/react-native-navigation/issues/2608)
Problem: navBarTitleTextCentered doesn´t center the SubTitle. 
Solution: Introduce navBarSubTitleTextCentered for Android

Platform: Android
- Adapt title center
- Update docs