### PR TITLE
 Loading local resources into CollapsingTopBarBackground doesn't work in android in release mode

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/react/ResourceDrawableUriHelper.java
+++ b/android/app/src/main/java/com/reactnativenavigation/react/ResourceDrawableUriHelper.java
@@ -1,0 +1,26 @@
+package com.reactnativenavigation.react; // Copyright 2004-present Facebook. All Rights Reserved.
+
+import android.net.Uri;
+
+import com.reactnativenavigation.NavigationApplication;
+
+/**
+ * Taken from com.facebook.react.views.imagehelper.ImageSource
+ * Can be deleted in react-native ^0.29
+ */
+
+public class ResourceDrawableUriHelper {
+    public static Uri computeUri(String mSource) {
+        try {
+            Uri uri = Uri.parse(mSource);
+            // Verify scheme is set, so that relative uri (used by static resources) are not handled.
+            return uri.getScheme() == null ? computeLocalUri(mSource) : uri;
+        } catch (Exception e) {
+            return computeLocalUri(mSource);
+        }
+    }
+
+    private static Uri computeLocalUri(String mSource) {
+        return ResourceDrawableIdHelper.instance.getResourceDrawableUri(NavigationApplication.instance, mSource);
+    }
+}

--- a/android/app/src/main/java/com/reactnativenavigation/views/collapsingToolbar/CollapsingTopBarBackground.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/collapsingToolbar/CollapsingTopBarBackground.java
@@ -6,6 +6,7 @@ import android.widget.ImageView;
 
 import com.facebook.drawee.view.SimpleDraweeView;
 import com.reactnativenavigation.params.CollapsingTopBarParams;
+import com.reactnativenavigation.react.ResourceDrawableUriHelper;
 import com.reactnativenavigation.utils.ViewUtils;
 import com.reactnativenavigation.views.Scrim;
 
@@ -36,7 +37,7 @@ public class CollapsingTopBarBackground extends FrameLayout {
 
     private void setImageSource() {
         if (params.imageUri != null) {
-            backdrop.setImageURI(params.imageUri);
+            backdrop.setImageURI(ResourceDrawableUriHelper.computeUri(params.imageUri));
         }
     }
 

--- a/ios/RCCDrawerController/MMDrawerController/MMDrawerController.m
+++ b/ios/RCCDrawerController/MMDrawerController/MMDrawerController.m
@@ -1412,7 +1412,8 @@ static inline CGFloat originXForDrawerOriginAndTargetOriginOffset(CGFloat origin
 
 #pragma mark - UIGestureRecognizerDelegate
 -(BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch{
-    
+    if(self.leftDrawerViewController == nil && self.rightDrawerViewController == nil)
+        return false;
     if(self.openSide == MMDrawerSideNone){
         MMOpenDrawerGestureMode possibleOpenGestureModes = [self possibleOpenGestureModesForGestureRecognizer:gestureRecognizer
                                                                                                     withTouch:touch];

--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -273,7 +273,7 @@ function convertDrawerParamsToSideMenuParams(drawerParams) {
       result[key] = adaptNavigationParams(result[key]);
       result[key].passProps = drawer[key].passProps;
       if (drawer.disableOpenGesture) {
-        result[key].disableOpenGesture = parseInt(drawer.disableOpenGesture);
+        result[key].disableOpenGesture = drawer.disableOpenGesture;
       } else {
         let fixedWidth = drawer[key].disableOpenGesture;
         result[key].disableOpenGesture = fixedWidth ? parseInt(fixedWidth) : null;


### PR DESCRIPTION
Local resources are not being correctly loaded into collapsing top bar background  when building in release mode for android because of a missing translation step, keeping compatibility with react ^0.29 in this regard.