### PR TITLE
merge component options with stackcontroller

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/StackController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/StackController.java
@@ -36,6 +36,7 @@ public class StackController extends ParentController <StackLayout> {
 
     @Override
     public void applyOptions(Options options, ReactComponent component) {
+        options.mergeWith(this.options);
         stackLayout.applyOptions(options, component);
     }
 


### PR DESCRIPTION
Issue:
Top level options will be ignored by children options when using a stack controller on Android (even though it works well in iOS)

```
stack: {
    name: 'Testing app',
    options: {
      topBar: {
        hidden: true,
        drawBehind: true,
      },
    },
    children: [{
      component: {
        name: 'startScreen',
        passProps: {
          store,
        },
      },
    },
    ],
  },
```

Solution:
Merge children options with stack controller options to avoid children options being merged with default options and ignore the top level options (a lot of options in that sentence :P ).