### PR TITLE
Fix EmptyStackException

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/SnackbarAndFabContainer.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/SnackbarAndFabContainer.java
@@ -11,6 +11,9 @@ import com.reactnativenavigation.events.Subscriber;
 import com.reactnativenavigation.layouts.Layout;
 import com.reactnativenavigation.params.FabParams;
 import com.reactnativenavigation.params.SnackbarParams;
+import com.reactnativenavigation.screens.Screen;
+
+import java.util.EmptyStackException;
 
 public class SnackbarAndFabContainer extends CoordinatorLayout implements Snakbar.OnDismissListener, Subscriber{
     private Snakbar snakbar;
@@ -67,7 +70,13 @@ public class SnackbarAndFabContainer extends CoordinatorLayout implements Snakba
             @Override
             public void run() {
                 if (fabParams != null) {
-                    if (layout.getCurrentScreen().getScreenInstanceId().equals(fabParams.screenInstanceId)) {
+                    Screen currentScreen = null;
+                    try {
+                        currentScreen = layout.getCurrentScreen();
+                    } catch(EmptyStackException exception) {
+                        currentScreen = null;
+                    }
+                    if (currentScreen != null && currentScreen.getScreenInstanceId().equals(fabParams.screenInstanceId)) {
                         fabCoordinator.add(fabParams);
                     }
                 }


### PR DESCRIPTION
Fix the below EmptyStackException

```java
java.util.EmptyStackException: null
    at java.util.Stack.peek(Stack.java:57)
    at com.reactnativenavigation.screens.ScreenStack.peek(ScreenStack.java:240)
    at com.reactnativenavigation.layouts.SingleScreenLayout.getCurrentScreen(SingleScreenLayout.java:323)
    at com.reactnativenavigation.views.SnackbarAndFabContainer$1.run(SnackbarAndFabContainer.java:70)
    at com.reactnativenavigation.views.FloatingActionButtonCoordinator$2.onAnimationEnd(FloatingActionButtonCoordinator.java:78)
    at com.reactnativenavigation.views.FloatingActionButtonAnimator$2.onAnimationEnd(FloatingActionButtonAnimator.java:96)
    at android.view.ViewPropertyAnimator$AnimatorEventListener.onAnimationEnd(ViewPropertyAnimator.java:1135)
    at android.animation.ValueAnimator.endAnimation(ValueAnimator.java:1239)
    at android.animation.ValueAnimator$AnimationHandler.doAnimationFrame(ValueAnimator.java:766)
    at android.animation.ValueAnimator$AnimationHandler$1.run(ValueAnimator.java:801)
    at android.view.Choreographer$CallbackRecord.run(Choreographer.java:894)
    at android.view.Choreographer.doCallbacks(Choreographer.java:696)
    at android.view.Choreographer.doFrame(Choreographer.java:628)
    at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:880)
    at android.os.Handler.handleCallback(Handler.java:822)
    at android.os.Handler.dispatchMessage(Handler.java:104)
    at android.os.Looper.loop(Looper.java:207)
    at android.app.ActivityThread.main(ActivityThread.java:5811)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:791)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:681)
```
