### PR TITLE
[iOS] Apply title parameter in resetTo

### DIFF
--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -282,6 +282,11 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
                                                               rightButtons:rightButtons
                                                                     bridge:bridge];
 
+      NSDictionary *navigatorStyle = actionParams[@"style"];
+      [self processTitleView:viewController
+                       props:actionParams
+                       style:navigatorStyle];
+
       viewControllers = @[viewController];
     } else if (componentConfigs) {
       NSMutableArray *mutableViewControllers = [NSMutableArray arrayWithCapacity:[componentConfigs count]];
@@ -300,6 +305,10 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
                                                                  leftButtons:leftButtons
                                                                 rightButtons:rightButtons
                                                                       bridge:bridge];
+
+        [self processTitleView:viewController
+                         props:actionParams
+                         style:style];
 
         [mutableViewControllers addObject:viewController];
       }];


### PR DESCRIPTION
Fixed bug with `title` parameter in `resetTo` Screen API. Method `resetTo` should respect screen title and apply it to ViewController.

#### Steps to reproduce bug:
`props.navigator.resetTo({ screen: 'test.screen', title: 'First Screen' });`
#### Result:
Display screen with empty title.
[Result GIF](https://gfycat.com/ifr/WhichArtisticAlbino)
#### Expected Result:
Display screen with title 'First Screen'.
[Expected Result GIF](https://gfycat.com/ifr/QuickSlimyDove)
#### Solution:
Looks like `resetTo` behavior was broken in #2247. Code with `processTitleView` was removed in resetTo handler.
I've added `processTitleView` to viewController with support of view controller with multiple components (changes in #2247).

#### Code example:
```javascript
import { Navigation } from "react-native-navigation";
import React from "react";
import { View, Text, StyleSheet, Button } from "react-native";

const styles = StyleSheet.create({
  page: {
    flex: 1,
    justifyContent: "center",
    alignItems: "center"
  }
});

const resetTo = (navigator, screen, title) =>
  navigator.resetTo({ screen, title });

const FirstScreen = props => (
  <View style={styles.page}>
    <Text>First Screen</Text>
    <Button title="Go to Second Screen" onPress={() => resetTo(props.navigator, 'SecondScreen', 'Second Screen')} />
  </View>
);

const SecondScreen = props => (
  <View style={styles.page}>
    <Text>Second Screen</Text>
    <Button title="Go to First Screen" onPress={() => resetTo(props.navigator, 'FirstScreen', 'First Screen')} />
  </View>
);

Navigation.registerComponent("FirstScreen", () => FirstScreen);
Navigation.registerComponent("SecondScreen", () => SecondScreen);

Navigation.startSingleScreenApp({
  screen: {
    screen: "FirstScreen"
  }
});
```