### PR TITLE
When no label is passed in, the icon is centered

### DIFF
--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -170,9 +170,19 @@
       iconImageSelected = [RCTConvert UIImage:icon];
     }
     
-    viewController.tabBarItem = [[UITabBarItem alloc] initWithTitle:title image:iconImage tag:0];
-    viewController.tabBarItem.accessibilityIdentifier = tabItemLayout[@"props"][@"testID"];
-    viewController.tabBarItem.selectedImage = iconImageSelected;
+    if (!title) {
+      UITabBarItem *tabItem = [[UITabBarItem alloc] init];
+      viewController.tabBarItem = tabItem;
+      tabItem.image = iconImage;
+      tabItem.tag = 0;
+      tabItem.imageInsets = UIEdgeInsetsMake(6, 0, -6, 0);
+      viewController.tabBarItem.accessibilityIdentifier = tabItemLayout[@"props"][@"testID"];
+      viewController.tabBarItem.selectedImage = iconImageSelected;
+    } else {
+      viewController.tabBarItem = [[UITabBarItem alloc] initWithTitle:title image:iconImage tag:0];
+      viewController.tabBarItem.accessibilityIdentifier = tabItemLayout[@"props"][@"testID"];
+      viewController.tabBarItem.selectedImage = iconImageSelected;
+    }
     
     id imageInsets = tabItemLayout[@"props"][@"iconInsets"];
     if (imageInsets && imageInsets != (id)[NSNull null])


### PR DESCRIPTION
When you don't pass in a label to a tab item, the UI acts as if an empty label is there, so the icons look as if they are positioned incorrectly.

<img width="129" alt="screen shot 2018-03-12 at 4 17 05 pm" src="https://user-images.githubusercontent.com/2851951/37314815-7802745c-2613-11e8-9932-4dbaacc30c07.png">

The fix checks if a label was provided to the tab, and if it was not provided, it positions the icon in a more natural position:

<img width="119" alt="screen shot 2018-03-12 at 4 17 01 pm" src="https://user-images.githubusercontent.com/2851951/37314842-93779082-2613-11e8-9e91-ffd8f6795b76.png">

When labels are passed in, the display looks as usual.

<img width="131" alt="screen shot 2018-03-12 at 4 19 42 pm" src="https://user-images.githubusercontent.com/2851951/37314856-a21102ae-2613-11e8-9486-83e218f5a7d9.png">

Related Issues:
https://github.com/wix/react-native-navigation/issues/420
https://github.com/wix/react-native-navigation/issues/676
