### PR TITLE
Make Left the default "side" for toggleDrawer

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/SideMenu.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/SideMenu.java
@@ -30,7 +30,7 @@ public class SideMenu extends DrawerLayout {
         }
 
         public static Side fromString(String side) {
-            return "left".equals(side.toLowerCase()) ? Left : Right;
+            return (side == null) || "left".equals(side.toLowerCase()) ? Left : Right;
         }
     }
 


### PR DESCRIPTION
Avoids a null pointer exception when not passing { side: "left" } to navigator.toggleDrawer() on Android