### PR TITLE
Fixed build error: undefined identifier RCTBridgeWillReloadNotificati…

### DIFF
--- a/ios/RCCManager.m
+++ b/ios/RCCManager.m
@@ -12,6 +12,8 @@
 @property (nonatomic, strong, readwrite) NSDictionary *globalAppStyle;
 @end
 
+NSString *const RCTBridgeWillReloadNotification = @"RCTBridgeWillReloadNotification";
+    
 @implementation RCCManager
 
 + (instancetype)sharedInstance {


### PR DESCRIPTION
…on in RCCManager.m

Fixes #2913 

Added the NSString const that line 41 requires. Not sure why it was missing, but the line in question was commented out until recently.

I'm not 100% familiar with `NSNotificationCenter` observers, so if this should really be commented out you are welcome to reject it.