### PR TITLE
Fix: Bottom Nav Icons disappear when getting a CodePush (Android)

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/ImageLoader.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/ImageLoader.java
@@ -63,7 +63,7 @@ public class ImageLoader {
     }
 
     private Drawable loadFile(String uri) {
-        Bitmap bitmap = BitmapFactory.decodeFile(uri);
+        Bitmap bitmap = BitmapFactory.decodeFile(Uri.parse(uri).getPath());
         return new BitmapDrawable(NavigationApplication.instance.getResources(), bitmap);
     }
 


### PR DESCRIPTION
Steps to reproduce: 

- Implement Bottom Bar Navigation using Wix V2
- Add Microsoft CodePush.
- Launch app
- Background - Foreground app

Result Icons disappear and the following log shows in logcat:
```
BitmapFactory: Unable to decode stream: java.io.FileNotFoundException: file:/data/user/0/APP_NAME/files/CodePush/b3eb665d8241c3c032783e186d7611d4e235efc4a4a3d51d0a84ef9da1dfc9ff/bundle/drawable-xxhdpi/NAV_IMAGE.png (No such file or directory)
```
Expected: Updated/Existing icons should still be visible. 

The reason for this error is the attempt to load image using uri as string instead of the path

