### PR TITLE
Update V2 usage documentation for screen lifecycle methods

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ We are rebuilding react-native-navigation.
 - [v2 Roadmap](#v2-roadmap)
 - [v1 vs v2 feature comparison](#v1-vs-v2-feature-comparison)
 - [Documentation](https://wix.github.io/react-native-navigation/v2/)
-- [Contributing](/docs/WorkingLocally.md)
+- [Contributing](/docs/docs/WorkingLocally.md)
 
 ## Why Rebuild react-native-navigation?
 

--- a/docs/docs/Usage.md
+++ b/docs/docs/Usage.md
@@ -176,7 +176,7 @@ Navigation.dismissModal(this.props.componentId);
 
 ## Screen Lifecycle
 
-The `didAppear` and `didDisappear` functions are lifecycle callbacks that are called by React Native Navigation on the component when it appears and disappears. 
+The `componentDidAppear` and `componentDidDisappear` functions are lifecycle callbacks that are called by React Native Navigation on the component when it appears and disappears. 
 
 These are similar to react's `componentDidMount` and `componentWillUnmount`, but are related to the actual visibility of a component to the user. While the component is `mounted` as soon as it's part of a layout, it is not always `visible` (for example, when another screen is `pushed` on top of it), and therefore React Native Navigation  takes some performance optimizations.
 
@@ -195,12 +195,12 @@ class LifecycleScreenExample extends Component {
     };
   }
 
-  didAppear() {
-    this.setState({ text: 'didAppear' });
+  componentDidAppear() {
+    this.setState({ text: 'componentDidAppear' });
   }
 
-  didDisappear() {
-    alert('didDisappear');
+  componentDidDisappear() {
+    alert('componentDidDisappear');
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Update the docs around a major naming change for screen lifecycle methods:

`didAppear`/`didDisappear`  to `componentDidAppear`/`componentDidDisappear`