### PR TITLE
Fixing NPE found on issue #2695

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactGateway.java
+++ b/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactGateway.java
@@ -110,8 +110,8 @@ public class NavigationReactGateway implements ReactGateway {
 	}
 
 	//TODO temp hack
-	private void onReactContextInitialized() {
-		reactEventEmitter = new NavigationReactEventEmitter(getReactContext());
+	private void onReactContextInitialized(ReactContext context) {
+		reactEventEmitter = new NavigationReactEventEmitter(context);
 	}
 
 	private static class ReactNativeHostImpl extends ReactNativeHost implements ReactInstanceManager.ReactInstanceEventListener {
@@ -171,7 +171,7 @@ public class NavigationReactGateway implements ReactGateway {
 
 		@Override
 		public void onReactContextInitialized(ReactContext context) {
-			((NavigationReactGateway) NavigationApplication.instance.getReactGateway()).onReactContextInitialized();
+			((NavigationReactGateway) NavigationApplication.instance.getReactGateway()).onReactContextInitialized(context);
 			NavigationApplication.instance.onReactInitialized(context);
 		}
 


### PR DESCRIPTION
There's a roundabout manner of obtaining the react context on initialisation that is null on some instances (https://github.com/wix/react-native-navigation/issues/2695), including errors on startup that prevents debugging on console. (For instance, throwing an error on index before starting the app)

It is solved by sending the same context given on method onReactContextInitialized, instead of discarding it and calling getReactContext.