### PR TITLE
Fix icon color when using setTabButton on iOS

### DIFF
--- a/ios/RCCTabBarController.h
+++ b/ios/RCCTabBarController.h
@@ -7,5 +7,6 @@
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge completion:(void (^)(void))completion;
 
 @property (nonatomic) BOOL tabBarHidden;
+@property (nonatomic) UIColor *buttonColor;
 
 @end

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -78,7 +78,7 @@
     
     self.tabBar.translucent = YES; // default
     
-    UIColor *buttonColor = nil;
+    self.buttonColor = nil;
     UIColor *selectedButtonColor = nil;
     UIColor *labelColor = nil;
     UIColor *selectedLabelColor = nil;
@@ -88,7 +88,7 @@
         if (tabBarButtonColor) {
             UIColor *color = tabBarButtonColor != (id)[NSNull null] ? [RCTConvert UIColor:tabBarButtonColor] : nil;
             self.tabBar.tintColor = color;
-            buttonColor = color;
+            self.buttonColor = color;
             selectedButtonColor = color;
         }
         NSString *tabBarSelectedButtonColor = tabsStyle[@"tabBarSelectedButtonColor"];
@@ -147,8 +147,8 @@
         id icon = tabItemLayout[@"props"][@"icon"];
         if (icon) {
             iconImage = [RCTConvert UIImage:icon];
-            if (buttonColor) {
-                iconImage = [[self image:iconImage withColor:buttonColor] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+            if (self.buttonColor) {
+                iconImage = [[self image:iconImage withColor:self.buttonColor] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
             }
         }
         UIImage *iconImageSelected = nil;
@@ -293,7 +293,9 @@
             id icon = actionParams[@"icon"];
             if (icon && icon != (id)[NSNull null]) {
                 iconImage = [RCTConvert UIImage:icon];
-                iconImage = [[self image:iconImage withColor:self.tabBar.tintColor] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+                if (self.buttonColor) {
+                    iconImage = [[self image:iconImage withColor:self.buttonColor] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+                }
                 viewController.tabBarItem.image = iconImage;
             }
             


### PR DESCRIPTION
Based on the fix by @Bhullnatik in https://github.com/wix/react-native-navigation/pull/1885 I added code to keep the buttonColor for unselected items when both `tabBarSelectedButtonColor` and `tabBarButtonColor` are set.

This fixes the issue described by @jpls93 in https://github.com/wix/react-native-navigation/pull/1885#issuecomment-370806051

