### PR TITLE
Update with helpful Github link

### DIFF
--- a/example/ios/example/AppDelegate.m
+++ b/example/ios/example/AppDelegate.m
@@ -6,8 +6,8 @@
 // **********************************************
 #import "RCCManager.h"
 
-// IMPORTANT: if you're getting an Xcode error that RCCManager.h isn't found, you've probably ran "npm install"
-// with npm ver 2. You'll need to "npm install" with npm 3 (see https://github.com/wix/react-native-navigation/issues/1)
+// IMPORTANT: This App Delegate example is outdated, and the docs haven't been updated yet. Some recommended fixes are here:
+// https://github.com/wix/react-native-navigation/issues/876
 
 #import <React/RCTRootView.h>
 


### PR DESCRIPTION
Helping new users who might not know that the installation instructions are out of date. An earlier version left them with the impression that it was a simple NPM version problem and not a major change to where to find headers.