### PR TITLE
Fix when a title image has nil or NSNull

### DIFF
--- a/ios/Helpers/RCCTitleViewHelper.m
+++ b/ios/Helpers/RCCTitleViewHelper.m
@@ -115,7 +115,10 @@ navigationController:(UINavigationController*)navigationController
 
 -(BOOL)isTitleOnly
 {
-    return self.title && !self.subtitle && !self.titleImageData;
+    BOOL hasNoImageData = [[NSNull null] isEqual:self.titleImageData] || self.titleImageData == nil;
+    return self.title != nil &&
+        self.subtitle == nil &&
+        hasNoImageData;
 }
 
 


### PR DESCRIPTION
This was occuring if a title has no properties set initially, but then are configured later. The title image data would go from `[NSNull null]` to `nil`, breaking this check.

By comparing against both values, we can ensure the correct logic for all behaviors.