### PR TITLE
Add ability to set badge=null to hide it

### DIFF
--- a/lib/ios/RNNBottomTabOptions.m
+++ b/lib/ios/RNNBottomTabOptions.m
@@ -19,7 +19,10 @@
 	}
 	
 	if (self.badge) {
-		NSString *badge = [RCTConvert NSString:self.badge];
+		NSString *badge = nil;
+		if (self.badge != nil && ![self.badge isEqual:[NSNull null]]) {
+			badge = [RCTConvert NSString:self.badge];
+		}
 		if (viewController.navigationController) {
 			viewController.navigationController.tabBarItem.badgeValue = badge;
 		} else {


### PR DESCRIPTION
Not sure about adding tests for this small fix. Would you like me adding bottomTab tests, or you can merge it without it for now?

p.s. Maybe I'm wrong and there is another way to dismiss a bottomTab badge?