### PR TITLE
[v2] Remove hardcoded title.fontSize to reset to defaults

### DIFF
--- a/lib/ios/RNNTitleOptions.m
+++ b/lib/ios/RNNTitleOptions.m
@@ -43,7 +43,7 @@
 }
 
 - (NSNumber *)fontSize {
-	return _fontSize ? _fontSize : @(20);
+	return _fontSize ? _fontSize : nil;
 }
 
 @end


### PR DESCRIPTION
Now it uses hardcoded 20pt, which of course one can override, but in case of largerTitles, it's easier to stick with defaults.
![image](https://user-images.githubusercontent.com/1004115/38990352-966421f6-43e2-11e8-939c-9e553d603e76.png)
