### PR TITLE
IOS: modal tab bar scene and modalTransitionStyle

### DIFF
--- a/lib/ios/RNNModalManager.m
+++ b/lib/ios/RNNModalManager.m
@@ -37,7 +37,13 @@
 	self.toVC = (UIViewController<RNNRootViewProtocol>*)viewController;
 	_completionBlock = completion;
 	
-	if ([self.toVC isCustomViewController]) {
+    if ([self.toVC respondsToSelector:@selector(applyModalOptions)]) {
+        [self.toVC applyModalOptions];
+    }
+    
+    if ([self.toVC respondsToSelector:@selector(isCustomViewController)] &&
+        [self.toVC isCustomViewController]
+    ) {
 		[self showModalAfterLoad:nil];
 	} else {
 		[self waitForContentToAppearAndThen:@selector(showModalAfterLoad:)];
@@ -60,19 +66,19 @@
 
 -(void)removePendingNextModalIfOnTop {
 	NSString *componentId = [[_store pendingModalIdsToDismiss] lastObject];
-	
+
 	UIViewController<RNNRootViewProtocol> *modalToDismiss = (UIViewController<RNNRootViewProtocol>*)[_store findComponentForId:componentId];
-	
+
 	if(!modalToDismiss) {
 		return;
 	}
-	
+
 	UIViewController* topPresentedVC = [self topPresentedVC];
-	
+
 	if (modalToDismiss.options.animations.showModal) {
 		modalToDismiss.transitioningDelegate = modalToDismiss;
 	}
-	
+
 	if (modalToDismiss == topPresentedVC || [[topPresentedVC childViewControllers] containsObject:modalToDismiss]) {
 		[modalToDismiss dismissViewControllerAnimated:modalToDismiss.options.animations.dismissModal.enable completion:^{
 			[[_store pendingModalIdsToDismiss] removeObject:componentId];

--- a/lib/ios/RNNNavigationOptions.h
+++ b/lib/ios/RNNNavigationOptions.h
@@ -38,8 +38,10 @@ extern const NSInteger TOP_BAR_TRANSPARENT_TAG;
 @property (nonatomic, strong) NSDictionary* backgroundImage;
 @property (nonatomic, strong) NSDictionary* rootBackgroundImage;
 @property (nonatomic, strong) NSString* modalPresentationStyle;
+@property (nonatomic, strong) NSString* modalTransitionStyle;
 
 - (UIInterfaceOrientationMask)supportedOrientations;
 
+- (void)applyModalOptions:(UIViewController*)viewController;
 
 @end

--- a/lib/ios/RNNNavigationOptions.m
+++ b/lib/ios/RNNNavigationOptions.m
@@ -27,6 +27,17 @@ RCT_ENUM_CONVERTER(UIModalPresentationStyle,
 
 @end
 
+@implementation RCTConvert (UIModalTransitionStyle)
+
+RCT_ENUM_CONVERTER(UIModalTransitionStyle,
+                   (@{@"coverVertical": @(UIModalTransitionStyleCoverVertical),
+                      @"flipHorizontal": @(UIModalTransitionStyleFlipHorizontal),
+                      @"crossDissolve": @(UIModalTransitionStyleCrossDissolve),
+                      @"partialCurl": @(UIModalTransitionStylePartialCurl)
+                      }), UIModalTransitionStyleCoverVertical, integerValue)
+
+@end
+
 @implementation RNNNavigationOptions
 
 
@@ -91,10 +102,17 @@ RCT_ENUM_CONVERTER(UIModalPresentationStyle,
 		backgroundImageView.image = [RCTConvert UIImage:self.rootBackgroundImage];
 		[backgroundImageView setContentMode:UIViewContentModeScaleAspectFill];
 	}
-	
-	if (self.modalPresentationStyle) {
-		viewController.modalPresentationStyle = [RCTConvert UIModalPresentationStyle:self.modalPresentationStyle];
-	}
+    
+    [self applyModalOptions:viewController];
+}
+
+- (void)applyModalOptions:(UIViewController*)viewController {
+    if (self.modalPresentationStyle) {
+        viewController.modalPresentationStyle = [RCTConvert UIModalPresentationStyle:self.modalPresentationStyle];
+    }
+    if (self.modalTransitionStyle) {
+        viewController.modalTransitionStyle = [RCTConvert UIModalTransitionStyle:self.modalTransitionStyle];
+    }
 }
 
 - (UIInterfaceOrientationMask)supportedOrientations {

--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -80,6 +80,10 @@
 	[self setCustomNavigationComponentBackground];
 }
 
+- (void)applyModalOptions {
+    [self.options applyModalOptions:self];
+}
+
 - (void)mergeOptions:(NSDictionary *)options {
 	[self.options mergeIfEmptyWith:options];
 }

--- a/lib/ios/RNNRootViewProtocol.h
+++ b/lib/ios/RNNRootViewProtocol.h
@@ -7,6 +7,7 @@
 - (BOOL)isCustomViewController;
 - (void)performOnRotation:(void (^)(void))block;
 - (void)optionsUpdated;
+- (void)applyModalOptions;
 
 @required
 - (BOOL)isCustomTransitioned;


### PR DESCRIPTION
- IOS: allow tab bar / bottom tabs scene to be presented modally (it only wasn't bc showModal was calling an optional protocol method)
- IOS: fix bug where modal options weren't being applied before viewController was presented
- IOS: add UIKit `modalTransitionStyle` enum.