### PR TITLE
Update package.json to reference typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "url": "https://github.com/wix/react-native-navigation.git"
   },
   "main": "lib/dist/index.js",
+  "typings": "lib/dist/index.d.ts",
   "scripts": {
     "build": "rm -rf ./lib/dist && tsc",
     "xcode": "open playground/ios/playground.xcodeproj",


### PR DESCRIPTION
According to https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html a package needs a `types` or `typings` field in the `package.json` that points to the correct declaration file.

Without this change I cannot import the typings.