### PR TITLE
Pass ActionMenuView as parent to right buttons instead of Toolbar

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/ContextualMenu.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/ContextualMenu.java
@@ -47,7 +47,7 @@ public class ContextualMenu extends TitleBar implements LeftButtonOnClickListene
 
     private void addButtonsToContextualMenu(List<ContextualMenuButtonParams> buttons, Menu menu) {
         for (int i = 0; i < buttons.size(); i++) {
-            final TitleBarButton button = new ContextualMenuButton(menu, this, buttons.get(i), this);
+            final TitleBarButton button = new ContextualMenuButton(menu, getActionMenuView(), buttons.get(i), this);
             addButtonInReverseOrder(buttons, i, button);
         }
     }

--- a/android/app/src/main/java/com/reactnativenavigation/views/ContextualMenuButton.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/ContextualMenuButton.java
@@ -1,8 +1,8 @@
 package com.reactnativenavigation.views;
 
+import android.support.v7.widget.ActionMenuView;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.ViewGroup;
 
 import com.reactnativenavigation.params.ContextualMenuButtonParams;
 
@@ -14,7 +14,7 @@ class ContextualMenuButton extends TitleBarButton {
         void onClick(int index);
     }
 
-    ContextualMenuButton(Menu menu, ViewGroup parent, ContextualMenuButtonParams contextualMenuButtonParams, ContextualButtonClickListener contextualButtonClickListener) {
+    ContextualMenuButton(Menu menu, ActionMenuView parent, ContextualMenuButtonParams contextualMenuButtonParams, ContextualButtonClickListener contextualButtonClickListener) {
         super(menu, parent, contextualMenuButtonParams, null);
         this.contextualMenuButtonParams = contextualMenuButtonParams;
         this.contextualButtonClickListener = contextualButtonClickListener;

--- a/android/app/src/main/java/com/reactnativenavigation/views/TitleBar.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/TitleBar.java
@@ -223,7 +223,7 @@ public class TitleBar extends Toolbar {
 
     private void addButtonsToTitleBar(String navigatorEventId, Menu menu) {
         for (int i = 0; i < rightButtons.size(); i++) {
-            final TitleBarButton button = new TitleBarButton(menu, this, rightButtons.get(i), navigatorEventId);
+            final TitleBarButton button = new TitleBarButton(menu, getActionMenuView(), rightButtons.get(i), navigatorEventId);
             addButtonInReverseOrder(rightButtons, i, button);
         }
     }
@@ -368,7 +368,7 @@ public class TitleBar extends Toolbar {
     }
 
     private void setButtonTextColor() {
-        final ActionMenuView buttonsContainer = ViewUtils.findChildByClass(this, ActionMenuView.class);
+        final ActionMenuView buttonsContainer = getActionMenuView();
         if (buttonsContainer != null) {
             for (int i = 0; i < buttonsContainer.getChildCount(); i++) {
                 if (buttonsContainer.getChildAt(i) instanceof TextView) {
@@ -376,6 +376,10 @@ public class TitleBar extends Toolbar {
                 }
             }
         }
+    }
+
+    protected ActionMenuView getActionMenuView() {
+        return ViewUtils.findChildByClass(this, ActionMenuView.class);
     }
 
     private void setButtonsIconColor() {

--- a/android/app/src/main/java/com/reactnativenavigation/views/TitleBarButton.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/TitleBarButton.java
@@ -8,7 +8,6 @@ import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.reactnativenavigation.NavigationApplication;
@@ -21,29 +20,28 @@ import java.util.ArrayList;
 class TitleBarButton implements MenuItem.OnMenuItemClickListener {
 
     protected final Menu menu;
-    protected final ViewGroup parent;
+    private final ActionMenuView actionMenuView;
     private TitleBarButtonParams buttonParams;
     @Nullable protected String navigatorEventId;
 
-    TitleBarButton(Menu menu, ViewGroup parent, TitleBarButtonParams buttonParams, @Nullable String navigatorEventId) {
+    TitleBarButton(Menu menu, ActionMenuView actionMenuView, TitleBarButtonParams buttonParams, @Nullable String navigatorEventId) {
         this.menu = menu;
-        this.parent = parent;
+        this.actionMenuView = actionMenuView;
         this.buttonParams = buttonParams;
         this.navigatorEventId = navigatorEventId;
     }
 
-    MenuItem addToMenu(int index) {
+    void addToMenu(int index) {
         MenuItem item = createMenuItem(index);
         item.setShowAsAction(buttonParams.showAsAction.action);
         item.setEnabled(buttonParams.enabled);
         if (buttonParams.hasComponent()) {
-            item.setActionView(new TitleBarButtonComponent(parent.getContext(), buttonParams.componentName, buttonParams.componentProps));
+            item.setActionView(new TitleBarButtonComponent(actionMenuView.getContext(), buttonParams.componentName, buttonParams.componentProps));
         }
         setIcon(item, index);
         setColor();
         setFont();
         item.setOnMenuItemClickListener(this);
-        return item;
     }
 
     private MenuItem createMenuItem(int index) {
@@ -66,10 +64,9 @@ class TitleBarButton implements MenuItem.OnMenuItemClickListener {
     }
 
     private void dontShowLabelOnLongPress(final int index) {
-        ViewUtils.runOnPreDraw(parent, new Runnable() {
+        ViewUtils.runOnPreDraw(actionMenuView, new Runnable() {
             @Override
             public void run() {
-                ActionMenuView actionMenuView = ViewUtils.findChildByClass(parent, ActionMenuView.class);
                 if (actionMenuView != null && actionMenuView.getChildAt(index) != null) {
                     actionMenuView.getChildAt(index).setOnLongClickListener(null);
                 }
@@ -94,7 +91,7 @@ class TitleBarButton implements MenuItem.OnMenuItemClickListener {
     }
 
     private void setTextColor() {
-        ViewUtils.runOnPreDraw(parent, new Runnable() {
+        ViewUtils.runOnPreDraw(actionMenuView, new Runnable() {
             @Override
             public void run() {
                 ArrayList<View> outViews = findActualTextViewInMenuByLabel();
@@ -114,7 +111,7 @@ class TitleBarButton implements MenuItem.OnMenuItemClickListener {
     @NonNull
     private ArrayList<View> findActualTextViewInMenuByLabel() {
         ArrayList<View> outViews = new ArrayList<>();
-        parent.findViewsWithText(outViews, buttonParams.label, View.FIND_VIEWS_WITH_TEXT);
+        actionMenuView.findViewsWithText(outViews, buttonParams.label, View.FIND_VIEWS_WITH_TEXT);
         return outViews;
     }
 


### PR DESCRIPTION
Motivation:
When searching for the button's concrete TextView by label, if the
title has the same text as the buttons, both views are returned.