### PR TITLE
IOS: Fix custom top bar from disappearing after a push

### DIFF
--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -100,7 +100,12 @@
 		} if ([self.navigationItem.title isKindOfClass:[RNNCustomTitleView class]] && !_customTitleView) {
 			self.navigationItem.title = nil;
 		}
-	}
+    } else if (_customTitleView.superview == nil) {
+        if ([self.navigationItem.title isKindOfClass:[RNNCustomTitleView class]] && !_customTitleView) {
+            self.navigationItem.title = nil;
+        }
+        self.navigationItem.titleView = _customTitleView;
+    }
 }
 
 - (void)setCustomNavigationBarView {
@@ -115,7 +120,12 @@
 		} else if ([[self.navigationController.navigationBar.subviews lastObject] isKindOfClass:[RNNCustomTitleView class]] && !_customTopBar) {
 			[[self.navigationController.navigationBar.subviews lastObject] removeFromSuperview];
 		}
-	}
+    } else if (_customTopBar.superview == nil) {
+        if ([[self.navigationController.navigationBar.subviews lastObject] isKindOfClass:[RNNCustomTitleView class]] && !_customTopBar) {
+            [[self.navigationController.navigationBar.subviews lastObject] removeFromSuperview];
+        }
+        [self.navigationController.navigationBar addSubview:_customTopBar];
+    }
 }
 
 - (void)setCustomNavigationComponentBackground {
@@ -130,7 +140,13 @@
 			[[self.navigationController.navigationBar.subviews objectAtIndex:1] removeFromSuperview];
 			self.navigationController.navigationBar.clipsToBounds = NO;
 		}
-	}
+    } if (_customTopBarBackground.superview == nil) {
+        if ([[self.navigationController.navigationBar.subviews objectAtIndex:1] isKindOfClass:[RNNCustomTitleView class]]) {
+            [[self.navigationController.navigationBar.subviews objectAtIndex:1] removeFromSuperview];
+        }
+        [self.navigationController.navigationBar insertSubview:_customTopBarBackground atIndex:1];
+        self.navigationController.navigationBar.clipsToBounds = YES;
+    }
 }
 
 -(BOOL)isCustomTransitioned {


### PR DESCRIPTION
Hey guys, 
wanted to get your input on this.

Basically what's happening is that when you push a view controller on a navigationController with a custom view, the new ViewController will get rid of the custom view (as it should) but going back to the original ViewController won't restore the custom view.

the `if` inside the `else if` is checking if the pushed ViewController has a custom title at which point we should pop that outta the navigationController's top bar before presenting it's custom view.

i wish there was some kind of animation for when you do the edge to edge swipe 😆 