### PR TITLE
Fixes NPE when initializing twice

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactInitializer.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactInitializer.java
@@ -45,14 +45,14 @@ public class NavigationReactInitializer implements ReactInstanceManager.ReactIns
 	private void prepareReactApp() {
 		if (shouldCreateContext()) {
 			reactInstanceManager.createReactContextInBackground();
-		} else if (waitingForAppLaunchEvent) {
-			emitAppLaunched();
 		}
 	}
 
-	private void emitAppLaunched() {
-		waitingForAppLaunchEvent = false;
-		new NavigationEvent(reactInstanceManager.getCurrentReactContext()).appLaunched();
+	private void emitAppLaunched(final ReactContext context) {
+		if (waitingForAppLaunchEvent) {
+			waitingForAppLaunchEvent = false;
+			new NavigationEvent(context).appLaunched();
+		}
 	}
 
 	private boolean shouldCreateContext() {
@@ -61,6 +61,6 @@ public class NavigationReactInitializer implements ReactInstanceManager.ReactIns
 
 	@Override
 	public void onReactContextInitialized(final ReactContext context) {
-		emitAppLaunched();
+		emitAppLaunched(context);
 	}
 }


### PR DESCRIPTION
When refreshing multiple times, the asynchronous process that creates React Navigation causes a crash. Looking at the code, there was a lint warning as the context that was being used might be null (as it's being recreated). This PR addresses the issue by passing the freshly created process and checking for flag before emitting event