### PR TITLE
WIP - allow tabBar to set selected index

### DIFF
--- a/lib/ios/RNNBridgeModule.m
+++ b/lib/ios/RNNBridgeModule.m
@@ -67,9 +67,9 @@ RCT_EXPORT_METHOD(popToRoot:(NSString*)componentId resolver:(RCTPromiseResolveBl
 }
 
 RCT_EXPORT_METHOD(showModal:(NSDictionary*)layout resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-	[_commandsHandler showModal:layout completion:^{
-		resolve(nil);
-	}];
+    [_commandsHandler showModal:layout completion:^(NSString *componentId) {
+        resolve(componentId);
+    }];
 }
 
 RCT_EXPORT_METHOD(dismissModal:(NSString*)componentId resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
@@ -94,6 +94,12 @@ RCT_EXPORT_METHOD(dismissOverlay:(NSString*)componentId resolve:(RCTPromiseResol
 	[_commandsHandler dismissOverlay:componentId completion:^{
 		resolve(@(1));
 	}];
+}
+
+RCT_EXPORT_METHOD(setTabIndex:(NSString*)componentId index:(int)index resolve:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    [_commandsHandler setTabIndex:componentId index:index completion:^{
+        resolve(nil);
+    }];
 }
 
 @end

--- a/lib/ios/RNNCommandsHandler.h
+++ b/lib/ios/RNNCommandsHandler.h
@@ -24,7 +24,7 @@
 
 -(void)setStackRoot:(NSString*)componentId layout:(NSDictionary*)layout completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;
 
--(void)showModal:(NSDictionary*)layout completion:(RNNTransitionCompletionBlock)completion;
+-(void)showModal:(NSDictionary*)layout completion:(RNNTransitionComponentIdCompletionBlock)completion;
 
 -(void)dismissModal:(NSString*)componentId completion:(RNNTransitionCompletionBlock)completion;
 
@@ -33,5 +33,7 @@
 -(void)showOverlay:(NSDictionary *)layout completion:(RNNTransitionCompletionBlock)completion;
 
 -(void)dismissOverlay:(NSString*)componentId completion:(RNNTransitionCompletionBlock)completion;
+
+-(void)setTabIndex:(NSString *)componentId index:(int)index completion:(RNNTransitionCompletionBlock)completion;
 
 @end

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -4,6 +4,7 @@
 #import "RNNOverlayManager.h"
 #import "RNNNavigationOptions.h"
 #import "RNNRootViewController.h"
+#import "RNNTabBarController.h"
 #import "React/RCTUIManager.h"
 
 static NSString* const setRoot	= @"setRoot";
@@ -142,12 +143,13 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	[CATransaction commit];
 }
 
--(void) showModal:(NSDictionary*)layout completion:(RNNTransitionCompletionBlock)completion {
+-(void)showModal:(NSDictionary*)layout completion:(RNNTransitionComponentIdCompletionBlock)completion {
 	[self assertReady];
 	[_eventEmitter sendOnNavigationComment:showModal params:@{@"layout": layout}];
 	UIViewController<RNNRootViewProtocol> *newVc = [_controllerFactory createLayoutAndSaveToStore:layout];
+    NSString *componentId = [_controllerFactory componentIdForViewController:newVc];
 	[_modalManager showModal:newVc completion:^{
-		completion();
+		completion(componentId);
 	}];
 }
 
@@ -192,6 +194,16 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	[_overlayManager dismissOverlay:componentId completion:^{	
 		completion();
 	}];
+}
+
+-(void)setTabIndex:(NSString *)componentId index:(int)index completion:(RNNTransitionCompletionBlock)completion {
+    [self assertReady];
+    
+    UIViewController *viewController = [_store findComponentForId:componentId];
+    if ([viewController isKindOfClass:[RNNTabBarController class]]) {
+        RNNTabBarController *tabVc = (RNNTabBarController *)viewController;
+        tabVc.selectedIndex = index;
+    }
 }
 
 #pragma mark - private

--- a/lib/ios/RNNControllerFactory.h
+++ b/lib/ios/RNNControllerFactory.h
@@ -15,7 +15,9 @@
 
 -(UIViewController<RNNRootViewProtocol> *)createLayoutAndSaveToStore:(NSDictionary*)layout;
 
-- (UIViewController<RNNRootViewProtocol> *)createOverlay:(NSDictionary*)layout;
+-(UIViewController<RNNRootViewProtocol> *)createOverlay:(NSDictionary*)layout;
+
+-(NSString *)componentIdForViewController:(UIViewController<RNNRootViewProtocol> *)viewController;
 
 @property (nonatomic, strong) NSDictionary* defaultOptionsDict;
 @property (nonatomic, strong) RNNEventEmitter *eventEmitter;

--- a/lib/ios/RNNControllerFactory.m
+++ b/lib/ios/RNNControllerFactory.m
@@ -36,6 +36,10 @@
 	return [self fromTree:layout];
 }
 
+- (NSString *)componentIdForViewController:(UIViewController<RNNRootViewProtocol> *)viewController {
+    return [_store componentKeyForInstance:viewController];
+}
+
 # pragma mark private
 
 - (UIViewController<RNNRootViewProtocol> *)fromTree:(NSDictionary*)json {

--- a/lib/ios/RNNStore.h
+++ b/lib/ios/RNNStore.h
@@ -6,6 +6,7 @@
 
 typedef void (^RNNTransitionCompletionBlock)(void);
 //typedef void (^RNNTransitionRejectionBlock)(NSString *code, NSString *message, NSError *error);
+typedef void (^RNNTransitionComponentIdCompletionBlock)(NSString *);
 
 @interface RNNStore : NSObject
 

--- a/lib/src/Navigation.ts
+++ b/lib/src/Navigation.ts
@@ -145,6 +145,13 @@ export class Navigation {
   }
 
   /**
+   * sets tab bar to desired index
+   */
+  public setTabIndex(componentId: string, index: number): Promise<any> {
+    return this.commands.setTabIndex(componentId, index);
+  }
+
+  /**
    * Obtain the events registry instance
    */
   public events(): EventsRegistry {

--- a/lib/src/adapters/NativeCommandsSender.ts
+++ b/lib/src/adapters/NativeCommandsSender.ts
@@ -57,4 +57,8 @@ export class NativeCommandsSender {
   dismissOverlay(componentId: string) {
     return this.nativeCommandsModule.dismissOverlay(componentId);
   }
+
+  setTabIndex(componentId: string, index: number) {
+    return this.nativeCommandsModule.setTabIndex(componentId, index);
+  }
 }

--- a/lib/src/commands/Commands.ts
+++ b/lib/src/commands/Commands.ts
@@ -113,4 +113,10 @@ export class Commands {
     this.commandsObserver.notify('dismissOverlay', { componentId });
     return result;
   }
+
+  public setTabIndex(componentId, index) {
+    const result = this.nativeCommandsSender.setTabIndex(componentId, index);
+    this.commandsObserver.notify('setTabIndex', { componentId, index });
+    return result;
+  }
 }


### PR DESCRIPTION
api is up for discussion. some more work needs to be done around `setRoot` and other apis passing back a componentId.

i'm not sure how this would work for android.
Basically the code on the client APIs would be something like this
```
const componentId = await Navigation.showModal({
    bottomTabs: {...}
});

// show the 3rd tab here
Navigation.setTabIndex(componentId, 2);
```

@andresesfm can you take a look and see if that sounds like something we can do on android?
and can somebody from wix let me know if i'm going down the correct rabbit hole?