### PR TITLE
[Breaking] Exposed activity on clearHostOnActivityDestroy

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
+++ b/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
@@ -1,5 +1,6 @@
 package com.reactnativenavigation;
 
+import android.app.Activity;
 import android.app.Application;
 import android.content.Intent;
 import android.os.Bundle;
@@ -126,7 +127,7 @@ public abstract class NavigationApplication extends Application implements React
 
     public abstract boolean isDebug();
 
-    public boolean clearHostOnActivityDestroy() {
+    public boolean clearHostOnActivityDestroy(Activity activity) {
         return true;
     }
 

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
@@ -46,7 +46,7 @@ public abstract class SplashActivity extends AppCompatActivity {
                 return;
             }
             NavigationApplication.instance.getEventEmitter().sendAppLaunchedEvent();
-            if (NavigationApplication.instance.clearHostOnActivityDestroy()) {
+            if (NavigationApplication.instance.clearHostOnActivityDestroy(this)) {
                 overridePendingTransition(0, 0);
                 finish();
             }

--- a/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactGateway.java
+++ b/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactGateway.java
@@ -64,18 +64,18 @@ public class NavigationReactGateway implements ReactGateway {
 	}
 
 	public void onDestroyApp(Activity activity) {
-        if (NavigationApplication.instance.clearHostOnActivityDestroy()) {
+        if (NavigationApplication.instance.clearHostOnActivityDestroy(activity)) {
             getReactInstanceManager().onHostDestroy();
         } else if (hasStartedCreatingContext() && isInitialized()) {
             getReactInstanceManager().onHostDestroy(activity);
         }
-        if (NavigationApplication.instance.clearHostOnActivityDestroy()) {
+        if (NavigationApplication.instance.clearHostOnActivityDestroy(activity)) {
             host.clear();
         }
     }
 
 	public void onPauseActivity(Activity activity) {
-        if (NavigationApplication.instance.clearHostOnActivityDestroy()) {
+        if (NavigationApplication.instance.clearHostOnActivityDestroy(activity)) {
             getReactInstanceManager().onHostPause();
         } else if (hasStartedCreatingContext() && isInitialized()) {
 		    getReactInstanceManager().onHostPause(activity);


### PR DESCRIPTION
We do that in order to allow the end user to decide wether they want to destroy the host based on which activity we're about to destroy.

For example in our app we do the following:


```java
@Override
    public boolean clearHostOnActivityDestroy(Activity activity) {
        // If the activity about to be destroyed is the SplashActivity
        if (activity.getClass() == SplashActivity.class) {
            // a.k.a an Instant Link was passed
            return true; // we want to destroy the host for that activity
            // If we returned false here, that will make the instant links get stuck on the Splash Screen for ever
        }

        // on every other case (i.e if NavigationActivity) we want the host to be kept intact
        // Otherwise we run the risk of getting "Tried to enqueue runnable on already finished thread: 'native_modules...
        return false;

    }
```