### PR TITLE
Revert "Fixes NPE when initializing twice"

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactInitializer.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactInitializer.java
@@ -45,14 +45,14 @@ public class NavigationReactInitializer implements ReactInstanceManager.ReactIns
 	private void prepareReactApp() {
 		if (shouldCreateContext()) {
 			reactInstanceManager.createReactContextInBackground();
+		} else if (waitingForAppLaunchEvent) {
+			emitAppLaunched();
 		}
 	}
 
-	private void emitAppLaunched(final ReactContext context) {
-		if (waitingForAppLaunchEvent) {
-			waitingForAppLaunchEvent = false;
-			new NavigationEvent(context).appLaunched();
-		}
+	private void emitAppLaunched() {
+		waitingForAppLaunchEvent = false;
+		new NavigationEvent(reactInstanceManager.getCurrentReactContext()).appLaunched();
 	}
 
 	private boolean shouldCreateContext() {
@@ -61,6 +61,6 @@ public class NavigationReactInitializer implements ReactInstanceManager.ReactIns
 
 	@Override
 	public void onReactContextInitialized(final ReactContext context) {
-		emitAppLaunched(context);
+		emitAppLaunched();
 	}
 }


### PR DESCRIPTION
Reverts wix/react-native-navigation#3128

`ApplicationLifecycleTest.test.js` broke after merging this