### PR TITLE
Reverting ReactGateway constructor to `public`

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/ReactGateway.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/ReactGateway.java
@@ -19,7 +19,7 @@ public class ReactGateway {
 		this(application, isDebug, new NavigationReactNativeHost(application, isDebug, additionalReactPackages));
 	}
 
-	private ReactGateway(final Application application, final boolean isDebug, final ReactNativeHost reactNativeHost) {
+	public ReactGateway(final Application application, final boolean isDebug, final ReactNativeHost reactNativeHost) {
 		SoLoader.init(application, false);
 		this.reactNativeHost = reactNativeHost;
 		initializer = new NavigationReactInitializer(reactNativeHost.getReactInstanceManager(), isDebug);


### PR DESCRIPTION
We need this constructor to be accessible in order to integrate with CodePush