### PR TITLE
A few improvements for Android

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutFactory.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutFactory.java
@@ -75,24 +75,45 @@ public class LayoutFactory {
 	}
 
     private ViewController createSideMenuRoot(LayoutNode node) {
-        SideMenuController sideMenuController = new SideMenuController(activity, childRegistry, node.id, parseNodeOptions(node));
+		SideMenuController sideMenuController = new SideMenuController(activity, childRegistry, node.id, parseNodeOptions(node));
+		ViewController childControllerCenter = null, childControllerLeft = null, childControllerRight = null;
+
 		for (LayoutNode child : node.children) {
-			ViewController childController = create(child);
-            childController.setParentController(sideMenuController);
 			switch (child.type) {
 				case SideMenuCenter:
-					sideMenuController.setCenterController(childController);
+					childControllerCenter = create(child);
+					childControllerCenter.setParentController(sideMenuController);
 					break;
 				case SideMenuLeft:
-					sideMenuController.setLeftController(childController);
+					childControllerLeft = create(child);
+					childControllerLeft.setParentController(sideMenuController);
 					break;
 				case SideMenuRight:
-					sideMenuController.setRightController(childController);
+					childControllerRight = create(child);
+					childControllerRight.setParentController(sideMenuController);
 					break;
 				default:
 					throw new IllegalArgumentException("Invalid node type in sideMenu: " + node.type);
 			}
-        }
+		}
+
+		// Need to set the center controller first, otherwise "onPress" events on the JS components
+		// of the left and right drawers are not handled properly.
+		//
+		// See https://github.com/wix/react-native-navigation/issues/2835
+		//
+		if (childControllerCenter != null) {
+			sideMenuController.setCenterController(childControllerCenter);
+		}
+
+		if (childControllerLeft != null) {
+			sideMenuController.setLeftController(childControllerLeft);
+		}
+
+		if (childControllerRight != null) {
+			sideMenuController.setRightController(childControllerRight);
+		}
+
 		return sideMenuController;
 	}
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsOptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsOptionsPresenter.java
@@ -52,7 +52,9 @@ public class BottomTabsOptionsPresenter {
         if (options.drawBehind.isTrue()) {
             lp.bottomMargin = 0;
         }
-        if (options.drawBehind.isFalseOrUndefined()) {
+
+        // Allocate space for the bottom tabs only if it is visible and it should not draw behind.
+        if (options.visible.isTrueOrUndefined() && options.drawBehind.isFalseOrUndefined()) {
             lp.bottomMargin = bottomTabs.getHeight();
         }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/SideMenuOptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/SideMenuOptionsPresenter.java
@@ -16,9 +16,16 @@ public class SideMenuOptionsPresenter {
     public void present(SideMenuRootOptions options) {
         if (options.left.visible.isTrue()) {
             sideMenu.openDrawer(Gravity.LEFT);
+
+        } else if (options.left.visible.isFalse() && sideMenu.isDrawerOpen(Gravity.LEFT)) {
+            sideMenu.closeDrawer(Gravity.LEFT);
         }
+
         if (options.right.visible.isTrue()) {
             sideMenu.openDrawer(Gravity.RIGHT);
+
+        } else if (options.right.visible.isFalse() && sideMenu.isDrawerOpen(Gravity.RIGHT)){
+            sideMenu.closeDrawer(Gravity.RIGHT);
         }
     }
 }


### PR DESCRIPTION
### 1

Sidemenus weren't clickable on Android. It seems the order in which child views were being added to parent controllers, left or right before center, was affecting the ability to interact with the menus.  I've changed the code to always add them in a specific order: center, then left, then right.

I believe this closes issue #2835.

### 2

On Android, merging options to open a menu works.

```
  Navigation.mergeOptions(currentComponentId, {
      sideMenu: {
          left: {
              visible: true
          }
      }
  })
```

But merging options to close it wasn't working.

```
  Navigation.mergeOptions(currentComponentId, {
      sideMenu: {
          left: {
              visible: false
          }
      }
  })
```

### 3

The bottom tabs controller was reserving a margin space for the bottom tabs when switching from one to another, regardless of its visibility settings.