### PR TITLE
Enable RTL support on LeftButton

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/LeftButton.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/LeftButton.java
@@ -5,6 +5,7 @@ import android.graphics.Color;
 import android.view.View;
 
 import com.balysv.materialmenu.MaterialMenuDrawable;
+import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.params.TitleBarButtonParams;
 import com.reactnativenavigation.params.TitleBarLeftButtonParams;
@@ -33,6 +34,7 @@ class LeftButton extends MaterialMenuDrawable implements View.OnClickListener {
         this.onClickListener = onClickListener;
         this.navigatorEventId = navigatorEventId;
         this.overrideBackPressInJs = overrideBackPressInJs;
+        setRTLEnabled(I18nUtil.getInstance().isRTL(context));
         setInitialState();
         setColor();
     }


### PR DESCRIPTION
By default RTL is not enabled on the MaterialMenuDrawable from which the LeftButton extends. This results in the back button not being flipped when running your app against a right-to-left language. Enabling RTL for the LeftButton fixes this behavior and correctly flips the button when needed.