### PR TITLE
Fixes broken link to Screen API page in docs/usage.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -62,7 +62,7 @@ export function registerScreens() {
 
 #### Step 3 - That's it
 
-If you want to do a navigation action like push a new screen over an existing one, take a look at the [Screen API](#screen-api). It would look something like this:
+If you want to do a navigation action like push a new screen over an existing one, take a look at the [Screen API](./screen-api.md). It would look something like this:
 
 ```js
 // this would go inside the Component implementation of one of your screens, like FirstTabScreen.js


### PR DESCRIPTION
One-line fix to a broken link in`docs/usage.md` to `Screen API`