### PR TITLE
iOS native event fix

### DIFF
--- a/lib/ios/RNNEventEmitter.m
+++ b/lib/ios/RNNEventEmitter.m
@@ -40,11 +40,11 @@ static NSString* const navigationEvent	= @"RNN.nativeEvent";
 }
 
 -(void)sendOnNavigationCommand:(NSString *)commandName params:(NSDictionary*)params {
-	[self send:navigationEvent body:@{@"commandName":commandName , @"params": params}];
+	[self send:navigationEvent body:@{@"name":commandName , @"params": params}];
 }
 
 -(void)sendOnNavigationEvent:(NSString *)commandName params:(NSDictionary*)params {
-	[self send:navigationEvent body:@{@"commandName":commandName , @"params": params}];
+	[self send:navigationEvent body:@{@"name":commandName , @"params": params}];
 }
 
 - (void)addListener:(NSString *)eventName {


### PR DESCRIPTION
Problem
---------------
I registered a nativeEventListener for detecting bottomTab changes. Everything was looking good, events were coming. Then I realized, event name is undefined but params object is coming as expected. 

Code
-----------
```
function commandListener(name, params) => { console.log(name, params) };
Navigation.events().registerNativeEventListener(commandListener);
```

Investigation
-------------
As you can see here: https://github.com/wix/react-native-navigation/blob/v2/lib/src/events/EventsRegistry.ts#L28 nativeEventListener expects an object which includes name and params but on the iOS side, the native code triggers the event listener but passes wrong object. iOS is passes commandName instead of name. This PR fixes the problem.