### PR TITLE
[Fix] badgeColor property not used when no tabIndex is provided

### DIFF
--- a/src/deprecated/platformSpecificDeprecated.ios.js
+++ b/src/deprecated/platformSpecificDeprecated.ios.js
@@ -518,7 +518,8 @@ function navigatorSetTabBadge(navigator, params) {
     Controllers.TabBarControllerIOS(controllerID + '_tabs').setBadge({
       contentId: navigator.navigatorID,
       contentType: 'NavigationControllerIOS',
-      badge: params.badge
+      badge: params.badge,
+      badgeColor: params.badgeColor
     });
   }
 }


### PR DESCRIPTION
This change will make sure the badgeColor property is transported to `RCCTabBarController` correctly, even when the `tabIndex` is not being used.