### PR TITLE
Exposed getUiImplementationProvider for people to override if needed

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
+++ b/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
@@ -12,6 +12,7 @@ import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.uimanager.UIImplementationProvider;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.reactnativenavigation.bridge.EventEmitter;
 import com.reactnativenavigation.controllers.ActivityCallbacks;
@@ -34,7 +35,7 @@ public abstract class NavigationApplication extends Application implements React
         super.onCreate();
         instance = this;
         handler = new Handler(getMainLooper());
-        reactGateway = new NavigationReactGateway();
+        reactGateway = new NavigationReactGateway(getUIImplementationProvider());
         eventEmitter = new EventEmitter(reactGateway);
         activityCallbacks = new ActivityCallbacks();
     }
@@ -51,6 +52,11 @@ public abstract class NavigationApplication extends Application implements React
         } else {
             super.startActivity(intent);
         }
+    }
+
+    // here in case someone wants to override this
+    protected UIImplementationProvider getUIImplementationProvider() {
+        return null; // if null the default UIImplementationProvider will be used
     }
 
     public void startReactContextOnceInBackgroundAndExecuteJS() {

--- a/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactGateway.java
+++ b/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactGateway.java
@@ -10,6 +10,7 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.shell.MainReactPackage;
+import com.facebook.react.uimanager.UIImplementationProvider;
 import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.bridge.NavigationReactEventEmitter;
 import com.reactnativenavigation.bridge.NavigationReactPackage;
@@ -28,7 +29,28 @@ public class NavigationReactGateway implements ReactGateway {
 	private JsDevReloadHandler jsDevReloadHandler;
 
 	public NavigationReactGateway() {
-		host = new ReactNativeHostImpl();
+		this(null);
+	}
+
+	public NavigationReactGateway(final UIImplementationProvider customImplProvider) {
+
+		if (customImplProvider != null) {
+			host = new ReactNativeHostImpl() {
+				/**
+				 * This was added in case someone needs to provide a different UIImplementationProvider
+				 * @param {UIImplementationProvider} defaultProvider
+				 * @return {UIImplementationProvider}
+				 */
+				@Override
+				protected UIImplementationProvider getUIImplementationProvider() {
+					return customImplProvider;
+				}
+			};
+		} else {
+			host = new ReactNativeHostImpl();
+		}
+
+
 		jsDevReloadHandler = new JsDevReloadHandler();
 	}
 
@@ -40,6 +62,7 @@ public class NavigationReactGateway implements ReactGateway {
 	public boolean isInitialized() {
 		return host.hasInstance() && getReactInstanceManager().getCurrentReactContext() != null;
 	}
+
 
 	@Override
 	public boolean hasStartedCreatingContext() {
@@ -105,6 +128,7 @@ public class NavigationReactGateway implements ReactGateway {
 		}
 	}
 
+
 	public ReactNativeHost getReactNativeHost() {
 		return host;
 	}
@@ -114,11 +138,12 @@ public class NavigationReactGateway implements ReactGateway {
 		reactEventEmitter = new NavigationReactEventEmitter(context);
 	}
 
-	private static class ReactNativeHostImpl extends ReactNativeHost implements ReactInstanceManager.ReactInstanceEventListener {
+	public static class ReactNativeHostImpl extends ReactNativeHost implements ReactInstanceManager.ReactInstanceEventListener {
 
-		ReactNativeHostImpl() {
+		public ReactNativeHostImpl() {
 			super(NavigationApplication.instance);
 		}
+
 
 		@Override
 		public boolean getUseDeveloperSupport() {


### PR DESCRIPTION
Now allowing a `UIImplementationProvider` to be passed by overriding the `getUIImplementationProvider` method.

Inside `MainApplication.java` we can now override:

```
    @Override
    protected UIImplementationProvider getUIImplementationProvider() {
        return CalendarPackage.getCustomUIImplementationProvider(); // <-- pass a ui implementation provider here.
    }
```

And [here's the custom UIImplementation provider](https://gist.github.com/SudoPlz/23ea2dee9772cb39e1e742034cdf8b98) we used after all (for fixing all our  https://github.com/wix/react-native-navigation/issues/2892#issuecomment-393509428 related issues)