### PR TITLE
Remove broken link in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,5 +19,5 @@ One of the major things missing from React Native core is fully featured native 
 
 If you're trying to deliver a user experience that's on par with the best native apps out there, you simply can't compromise on JS-based components trying to fake the real thing.
 
-For example, this package replaces the native [NavigatorIOS](https://facebook.github.io/react-native/docs/navigatorios.html) that has been [abandoned](https://facebook.github.io/react-native/docs/navigator-comparison.html) in favor of JS-based solutions that are easier to maintain. For more details see in-depth discussion [here](https://github.com/wix/react-native-controllers#why-do-we-need-this-package).
+For example, this package replaces the native [NavigatorIOS](https://facebook.github.io/react-native/docs/navigatorios.html) that has been abandoned in favor of JS-based solutions that are easier to maintain. For more details see in-depth discussion [here](https://github.com/wix/react-native-controllers#why-do-we-need-this-package).
 


### PR DESCRIPTION
A similar link would be React Native's [navigation guide](https://facebook.github.io/react-native/docs/0.54/navigation.html).