### PR TITLE
Support for transitions when presenting tab bar modally

### DIFF
--- a/lib/ios/RNNTabBarController.m
+++ b/lib/ios/RNNTabBarController.m
@@ -46,7 +46,11 @@
 }
 
 - (RNNOptions *)options {
-	return nil;
+	return [((UIViewController<RNNRootViewProtocol>*)self.selectedViewController) options];
+}
+
+- (void)applyModalOptions {
+	[self.options applyModalOptions:self];
 }
 
 - (void)mergeOptions:(NSDictionary *)options {


### PR DESCRIPTION
Allows tab bars based roots to be presented modally and with transition options such as crossDissolve