### PR TITLE
Destroy navigation activity layouts on catalyst instance destroy

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/bridge/NavigationReactModule.java
+++ b/android/app/src/main/java/com/reactnativenavigation/bridge/NavigationReactModule.java
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.reactnativenavigation.controllers.NavigationActivity;
 import com.reactnativenavigation.controllers.NavigationCommandsHandler;
 import com.reactnativenavigation.params.ContextualMenuParams;
 import com.reactnativenavigation.params.FabParams;
@@ -51,6 +52,12 @@ public class NavigationReactModule extends ReactContextBaseJavaModule {
     @Override
     public String getName() {
         return NAME;
+    }
+
+    @Override
+    public void onCatalystInstanceDestroy() {
+        super.onCatalystInstanceDestroy();
+        NavigationActivity.onCatalystInstanceDestroy();
     }
 
     @ReactMethod

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -498,4 +498,18 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     public static void setStartAppPromise(Promise promise) {
         NavigationActivity.startAppPromise = promise;
     }
+
+    public static void onCatalystInstanceDestroy() {
+        if (currentActivity == null) {
+            return;
+        }
+        currentActivity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                if (currentActivity != null) {
+                    currentActivity.destroyLayouts();
+                }
+            }
+        });
+    }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -511,6 +511,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
                 }
             }
         });
+    }
 
     public Layout getLayout() {
         return layout;


### PR DESCRIPTION
The changes in this PR are to address #2331 & Microsoft/react-native-code-push#1144.

I've tried it on a few devices and it seems to consistently prevent the crash from occurring; that said, I'm a bit wary that the `runOnUiThread` is introducing a race condition that may fail to prevent the bug under the right circumstances. Any thoughts on tackling this (potential) issue?

Edit: I should also mention I'm aware that V1 PRs are not being accepted at this time, but wanted to submit this at least for others that are struggling with this bug to implement the solution on their forks.