### PR TITLE
The title child property is 'text' not 'title'.

### DIFF
--- a/playground/src/screens/WelcomeScreen.js
+++ b/playground/src/screens/WelcomeScreen.js
@@ -17,7 +17,7 @@ class WelcomeScreen extends Component {
       },
       topBar: {
         title: {
-          title: 'My Screen'
+          text: 'My Screen'
         },
         largeTitle: {
           visible: false,


### PR DESCRIPTION
I think this was just a typo. After changing title to text, and setting visible to true. the 'My Screen' text displays.