### PR TITLE
Update Android Installing Section

### DIFF
--- a/docs/docs/Installing.md
+++ b/docs/docs/Installing.md
@@ -65,7 +65,7 @@
 	+        jcenter()
 	    }
 	    dependencies {
-	+        classpath 'com.android.tools.build:gradle:3.0.1'
+	+        classpath 'com.android.tools.build:gradle:3.1.3'
 	-        classpath 'com.android.tools.build:gradle:2.2.3'
 	    }
 	}
@@ -88,7 +88,7 @@
 
 	```groovy
 	android {
-	    compileSdkVersion 25
+	    compileSdkVersion 26
 	    buildToolsVersion "27.0.3"
 	    
 	    defaultConfig {
@@ -107,7 +107,8 @@
 	
 	dependencies {
 	    implementation fileTree(dir: "libs", include: ["*.jar"])
-	    implementation "com.android.support:appcompat-v7:25.4.0"
+	    implementation "com.android.support:design:26.1.0"
+	    implementation "com.android.support:appcompat-v7:26.1.0"
 	    implementation "com.facebook.react:react-native:+"
 	    implementation project(':react-native-navigation')
 	}
@@ -130,7 +131,7 @@
 	distributionPath=wrapper/dists
 	zipStoreBase=GRADLE_USER_HOME
 	zipStorePath=wrapper/dists
-	+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+	+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
 	-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
 	```
 


### PR DESCRIPTION
So today i tried to start a new temp project for some testing.
I made a new project using react-native init
these are the package versions installed based on package.json:
"react": "16.3.1"
"react-native": "0.55.4"

then i installed RNNv2 by yarn add react-native-navigation@alpha
The RNN version installed based on package.json is 2.0.2373.
Then i changed the project based on the docs to make sure everything is based on instructions.
But it looks like instructions are a little outdated so i made some changes by looking at playground app as reference to make it work.

I also updated gradle and gradle plugin to the latest minor release since there's no change except bug fixes.