### PR TITLE
[V2] Update Android Install Dependencies Docs with Multidex Fix

### DIFF
--- a/docs/docs/Installing.md
+++ b/docs/docs/Installing.md
@@ -206,7 +206,7 @@ android {
 configurations.all {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
         def requested = details.requested
-        if (requested.group == 'com.android.support') {
+        if (requested.group == 'com.android.support' && requested.name != 'multidex') {
             details.useVersion "25.4.0" // <- Change this to whatever version you're using
         }
     }


### PR DESCRIPTION
I was unable to compile my android app because I use multidex this line of code forces the multidex library to be version 25.4.0 when the latest for this one is 1.0.3:
```groovy
if (requested.group == 'com.android.support') {
  details.useVersion "25.4.0"
}
```
This little fix may save some headches:
```groovy
if (requested.group == 'com.android.support' && requested.name != 'multidex') {
  details.useVersion "25.4.0"
}
...
dependecies {
  ...
  implementation 'com.android.support:multidex:1.0.3'
  implementation "com.android.support:appcompat-v7:25.4.0"
  implementation 'com.android.support:design:25.4.0'
  ...
}
```