### PR TITLE
[BREAKING] BottomTabs refactor

### DIFF
--- a/docs/docs/Installing.md
+++ b/docs/docs/Installing.md
@@ -80,6 +80,7 @@
 	           // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
 	           url "$rootDir/../node_modules/react-native/android"
 			}
+  +		maven { url 'https://jitpack.io' }
 		}
 	}
 	```

--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -118,17 +118,19 @@ Navigation.mergeOptions(this.props.componentId, {
     currentTabId: 'currentTabId',
     testID: 'bottomTabsTestID',
     drawBehind: false,
-    backgroundColor: 'white',
-    tabColor: 'red',
-    selectedTabColor: 'blue',
-    fontFamily: 'Helvetica',
-    fontSize: 10
+    backgroundColor: 'white'
   },
   bottomTab: {
     title: 'Tab 1',
     badge: '2',
     testID: 'bottomTabTestID',
-    icon: require('tab.png')
+    icon: require('tab.png'),
+    iconColor: 'red',
+    selectedIconColor: 'blue',
+    textColor: 'red',
+    selectedTextColor: 'blue',
+    fontFamily: 'Helvetica',
+    fontSize: 10
   },
   sideMenu: {
     left: {

--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -69,7 +69,8 @@ dependencies {
     implementation 'com.android.support:design:26.1.0'
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:support-v4:26.1.0'
-    implementation 'com.aurelhubert:ahbottomnavigation:2.1.0'
+    implementation 'com.github.wix-playground:ahbottomnavigation:v2.2.0'
+
     implementation 'com.github.clans:fab:1.6.4'
 
     //noinspection GradleDynamicVersion

--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     implementation 'com.android.support:design:26.1.0'
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:support-v4:26.1.0'
-    implementation 'com.github.wix-playground:ahbottomnavigation:v2.2.0'
+    implementation 'com.github.wix-playground:ahbottomnavigation:v2.3.0'
 
     implementation 'com.github.clans:fab:1.6.4'
 

--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -62,9 +62,6 @@ allprojects { p ->
         p.android.compileOptions.sourceCompatibility JavaVersion.VERSION_1_8
         p.android.compileOptions.targetCompatibility JavaVersion.VERSION_1_8
     }
-    p.repositories {
-        maven { url "https://jitpack.io" }
-    }
 }
 
 dependencies {
@@ -72,7 +69,7 @@ dependencies {
     implementation 'com.android.support:design:26.1.0'
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:support-v4:26.1.0'
-    implementation 'com.github.wix-playground:ahbottomnavigation:v2.3.0'
+    implementation 'com.github.wix-playground:ahbottomnavigation:2.4.3'
 
     implementation 'com.github.clans:fab:1.6.4'
 

--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -62,6 +62,9 @@ allprojects { p ->
         p.android.compileOptions.sourceCompatibility JavaVersion.VERSION_1_8
         p.android.compileOptions.targetCompatibility JavaVersion.VERSION_1_8
     }
+    p.repositories {
+        maven { url "https://jitpack.io" }
+    }
 }
 
 dependencies {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabOptions.java
@@ -1,17 +1,21 @@
 package com.reactnativenavigation.parse;
 
+import android.graphics.Typeface;
+import android.support.annotation.Nullable;
+
 import com.reactnativenavigation.parse.params.Color;
 import com.reactnativenavigation.parse.params.NullColor;
 import com.reactnativenavigation.parse.params.NullText;
 import com.reactnativenavigation.parse.params.Text;
 import com.reactnativenavigation.parse.parsers.ColorParser;
 import com.reactnativenavigation.parse.parsers.TextParser;
+import com.reactnativenavigation.utils.TypefaceLoader;
 
 import org.json.JSONObject;
 
 public class BottomTabOptions {
 
-    public static BottomTabOptions parse(JSONObject json) {
+    public static BottomTabOptions parse(TypefaceLoader typefaceManager, JSONObject json) {
         BottomTabOptions options = new BottomTabOptions();
         if (json == null) return options;
 
@@ -23,6 +27,7 @@ public class BottomTabOptions {
         options.selectedIconColor = ColorParser.parse(json, "selectedIconColor");
         options.badge = TextParser.parse(json, "badge");
         options.testId = TextParser.parse(json, "testID");
+        options.fontFamily = typefaceManager.getTypeFace(json.optString("fontFamily", ""));
         return options;
     }
 
@@ -34,6 +39,8 @@ public class BottomTabOptions {
     public Color selectedIconColor = new NullColor();
     public Text testId = new NullText();
     public Text badge = new NullText();
+    @Nullable public Typeface fontFamily;
+
 
     void mergeWith(final BottomTabOptions other) {
         if (other.text.hasValue()) text = other.text;
@@ -44,6 +51,7 @@ public class BottomTabOptions {
         if (other.selectedIconColor.hasValue()) selectedIconColor = other.selectedIconColor;
         if (other.badge.hasValue()) badge = other.badge;
         if (other.testId.hasValue()) testId = other.testId;
+        if (other.fontFamily != null) fontFamily = other.fontFamily;
     }
 
     void mergeWithDefault(final BottomTabOptions defaultOptions) {
@@ -54,5 +62,6 @@ public class BottomTabOptions {
         if (!iconColor.hasValue()) iconColor = defaultOptions.iconColor;
         if (!selectedIconColor.hasValue()) selectedIconColor = defaultOptions.selectedIconColor;
         if (!badge.hasValue()) badge = defaultOptions.badge;
+        if (fontFamily == null) fontFamily = defaultOptions.fontFamily;
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabOptions.java
@@ -1,7 +1,10 @@
 package com.reactnativenavigation.parse;
 
+import com.reactnativenavigation.parse.params.Color;
+import com.reactnativenavigation.parse.params.NullColor;
 import com.reactnativenavigation.parse.params.NullText;
 import com.reactnativenavigation.parse.params.Text;
+import com.reactnativenavigation.parse.parsers.ColorParser;
 import com.reactnativenavigation.parse.parsers.TextParser;
 
 import org.json.JSONObject;
@@ -12,44 +15,44 @@ public class BottomTabOptions {
         BottomTabOptions options = new BottomTabOptions();
         if (json == null) return options;
 
-        options.title = TextParser.parse(json, "title");
-        if (json.has("icon")) {
-            options.icon = TextParser.parse(json.optJSONObject("icon"), "uri");
-        }
+        options.text = TextParser.parse(json, "text");
+        options.textColor = ColorParser.parse(json, "textColor");
+        options.selectedTextColor = ColorParser.parse(json, "selectedTextColor");
+        if (json.has("icon")) options.icon = TextParser.parse(json.optJSONObject("icon"), "uri");
+        options.iconColor = ColorParser.parse(json, "iconColor");
+        options.selectedIconColor = ColorParser.parse(json, "selectedIconColor");
         options.badge = TextParser.parse(json, "badge");
         options.testId = TextParser.parse(json, "testID");
         return options;
     }
 
-    public Text title = new NullText();
+    public Text text = new NullText();
+    public Color textColor = new NullColor();
+    public Color selectedTextColor = new NullColor();
     public Text icon = new NullText();
+    public Color iconColor = new NullColor();
+    public Color selectedIconColor = new NullColor();
     public Text testId = new NullText();
     public Text badge = new NullText();
 
     void mergeWith(final BottomTabOptions other) {
-        if (other.title.hasValue()) {
-            title = other.title;
-        }
-        if (other.icon.hasValue()) {
-            icon = other.icon;
-        }
-        if (other.badge.hasValue()) {
-            badge = other.badge;
-        }
-        if (other.testId.hasValue()) {
-            testId = other.testId;
-        }
+        if (other.text.hasValue()) text = other.text;
+        if (other.textColor.hasValue()) textColor = other.textColor;
+        if (other.selectedTextColor.hasValue()) selectedTextColor = other.selectedTextColor;
+        if (other.icon.hasValue()) icon = other.icon;
+        if (other.iconColor.hasValue()) iconColor = other.iconColor;
+        if (other.selectedIconColor.hasValue()) selectedIconColor = other.selectedIconColor;
+        if (other.badge.hasValue()) badge = other.badge;
+        if (other.testId.hasValue()) testId = other.testId;
     }
 
     void mergeWithDefault(final BottomTabOptions defaultOptions) {
-        if (!title.hasValue()) {
-            title = defaultOptions.title;
-        }
-        if (!icon.hasValue()) {
-            icon = defaultOptions.icon;
-        }
-        if (!badge.hasValue()) {
-            badge = defaultOptions.badge;
-        }
+        if (!text.hasValue()) text = defaultOptions.text;
+        if (!textColor.hasValue()) textColor = defaultOptions.textColor;
+        if (!selectedTextColor.hasValue()) selectedTextColor = defaultOptions.selectedTextColor;
+        if (!icon.hasValue()) icon = defaultOptions.icon;
+        if (!iconColor.hasValue()) iconColor = defaultOptions.iconColor;
+        if (!selectedIconColor.hasValue()) selectedIconColor = defaultOptions.selectedIconColor;
+        if (!badge.hasValue()) badge = defaultOptions.badge;
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabsOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabsOptions.java
@@ -23,8 +23,6 @@ public class BottomTabsOptions {
 		if (json == null) return options;
 
         options.backgroundColor = ColorParser.parse(json, "backgroundColor");
-        options.tabColor = ColorParser.parse(json, "tabColor");
-        options.selectedTabColor = ColorParser.parse(json, "selectedTabColor");
         options.currentTabId = TextParser.parse(json, "currentTabId");
 		options.currentTabIndex = NumberParser.parse(json,"currentTabIndex");
 		options.visible = BoolParser.parse(json,"visible");
@@ -37,8 +35,6 @@ public class BottomTabsOptions {
 	}
 
     public Color backgroundColor = new NullColor();
-    public Color tabColor = new NullColor();
-    public Color selectedTabColor = new NullColor();
 	public Bool visible = new NullBool();
     public Bool drawBehind = new NullBool();
 	public Bool animate = new NullBool();
@@ -53,8 +49,6 @@ public class BottomTabsOptions {
 		if (other.visible.hasValue()) visible = other.visible;
         if (other.drawBehind.hasValue()) drawBehind = other.drawBehind;
 		if (other.animate.hasValue()) animate = other.animate;
-        if (other.tabColor.hasValue()) tabColor = other.tabColor;
-        if (other.selectedTabColor.hasValue()) selectedTabColor = other.selectedTabColor;
         if (other.backgroundColor.hasValue()) backgroundColor = other.backgroundColor;
         if (other.testId.hasValue()) testId = other.testId;
         if (other.titleDisplayMode.hasValue()) titleDisplayMode = other.titleDisplayMode;
@@ -66,8 +60,6 @@ public class BottomTabsOptions {
         if (!visible.hasValue()) visible = defaultOptions.visible;
         if (!drawBehind.hasValue()) drawBehind = defaultOptions.drawBehind;
         if (!animate.hasValue()) animate = defaultOptions.animate;
-        if (!tabColor.hasValue()) tabColor = defaultOptions.tabColor;
-        if (!selectedTabColor.hasValue()) selectedTabColor = defaultOptions.selectedTabColor;
         if (!backgroundColor.hasValue()) backgroundColor = defaultOptions.backgroundColor;
         if (!titleDisplayMode.hasValue()) titleDisplayMode = defaultOptions.titleDisplayMode;
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutFactory.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutFactory.java
@@ -8,18 +8,16 @@ import com.reactnativenavigation.presentation.BottomTabsOptionsPresenter;
 import com.reactnativenavigation.presentation.OptionsPresenter;
 import com.reactnativenavigation.presentation.StackOptionsPresenter;
 import com.reactnativenavigation.react.EventEmitter;
-import com.reactnativenavigation.utils.CommandListenerAdapter;
 import com.reactnativenavigation.utils.ImageLoader;
 import com.reactnativenavigation.utils.TypefaceLoader;
 import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
 import com.reactnativenavigation.viewcontrollers.ComponentViewController;
 import com.reactnativenavigation.viewcontrollers.SideMenuController;
-import com.reactnativenavigation.viewcontrollers.stack.StackController;
-import com.reactnativenavigation.viewcontrollers.stack.StackControllerBuilder;
 import com.reactnativenavigation.viewcontrollers.ViewController;
 import com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabsController;
 import com.reactnativenavigation.viewcontrollers.externalcomponent.ExternalComponentCreator;
 import com.reactnativenavigation.viewcontrollers.externalcomponent.ExternalComponentViewController;
+import com.reactnativenavigation.viewcontrollers.stack.StackControllerBuilder;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarBackgroundViewController;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarController;
 import com.reactnativenavigation.viewcontrollers.toptabs.TopTabsController;
@@ -160,7 +158,8 @@ public class LayoutFactory {
     }
 
 	private ViewController createStack(LayoutNode node) {
-        StackController stackController = new StackControllerBuilder(activity)
+        return new StackControllerBuilder(activity)
+                .setChildren(createChildredn(node.children))
                 .setChildRegistry(childRegistry)
                 .setTopBarButtonCreator(new TitleBarButtonCreator(reactInstanceManager))
                 .setTitleBarReactViewCreator(new TitleBarReactViewCreator(reactInstanceManager))
@@ -171,14 +170,14 @@ public class LayoutFactory {
                 .setOptionsPresenter(new OptionsPresenter(activity, defaultOptions))
                 .setStackPresenter(new StackOptionsPresenter(activity, defaultOptions))
                 .build();
-        addChildrenToStack(node.children, stackController);
-        return stackController;
 	}
 
-    private void addChildrenToStack(List<LayoutNode> children, StackController stackController) {
+    private List<ViewController> createChildredn(List<LayoutNode> children) {
+        List<ViewController> result = new ArrayList<>();
         for (LayoutNode child : children) {
-            stackController.push(create(child), new CommandListenerAdapter());
+            result.add(create(child));
         }
+        return result;
     }
 
     private ViewController createBottomTabs(LayoutNode node) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutFactory.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutFactory.java
@@ -97,11 +97,6 @@ public class LayoutFactory {
 			}
 		}
 
-		// Need to set the center controller first, otherwise "onPress" events on the JS components
-		// of the left and right drawers are not handled properly.
-		//
-		// See https://github.com/wix/react-native-navigation/issues/2835
-		//
 		if (childControllerCenter != null) {
 			sideMenuController.setCenterController(childControllerCenter);
 		}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutNode.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutNode.java
@@ -35,7 +35,7 @@ public class LayoutNode {
 		this.children = children;
 	}
 
-    JSONObject getNavigationOptions() {
+    JSONObject getOptions() {
 	    return data.optJSONObject("options");
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/Options.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/Options.java
@@ -13,13 +13,8 @@ public class Options {
 
     @NonNull
     public static Options parse(TypefaceLoader typefaceManager, JSONObject json) {
-        return parse(typefaceManager, json, new Options());
-    }
-
-    @NonNull
-    public static Options parse(TypefaceLoader typefaceManager, JSONObject json, @NonNull Options defaultOptions) {
         Options result = new Options();
-        if (json == null) return result.withDefaultOptions(defaultOptions);
+        if (json == null) return result;
 
         result.topBar = TopBarOptions.parse(typefaceManager, json.optJSONObject("topBar"));
         result.topTabs = TopTabsOptions.parse(json.optJSONObject("topTabs"));
@@ -34,7 +29,7 @@ public class Options {
         result.statusBar = StatusBarOptions.parse(json.optJSONObject("statusBar"));
         result.layout = LayoutOptions.parse(json.optJSONObject("layout"));
 
-        return result.withDefaultOptions(defaultOptions);
+        return result;
     }
 
     @NonNull public TopBarOptions topBar = new TopBarOptions();
@@ -89,7 +84,7 @@ public class Options {
         return result;
     }
 
-    Options withDefaultOptions(final Options defaultOptions) {
+    public Options withDefaultOptions(final Options defaultOptions) {
         topBar.mergeWithDefault(defaultOptions.topBar);
         topTabOptions.mergeWithDefault(defaultOptions.topTabOptions);
         topTabs.mergeWithDefault(defaultOptions.topTabs);

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/Options.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/Options.java
@@ -19,7 +19,7 @@ public class Options {
         result.topBar = TopBarOptions.parse(typefaceManager, json.optJSONObject("topBar"));
         result.topTabs = TopTabsOptions.parse(json.optJSONObject("topTabs"));
         result.topTabOptions = TopTabOptions.parse(typefaceManager, json.optJSONObject("topTab"));
-        result.bottomTabOptions = BottomTabOptions.parse(json.optJSONObject("bottomTab"));
+        result.bottomTabOptions = BottomTabOptions.parse(typefaceManager, json.optJSONObject("bottomTab"));
         result.bottomTabsOptions = BottomTabsOptions.parse(json.optJSONObject("bottomTabs"));
         result.overlayOptions = OverlayOptions.parse(json.optJSONObject("overlay"));
         result.fabOptions = FabOptions.parse(json.optJSONObject("fab"));

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/OrientationOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/OrientationOptions.java
@@ -1,5 +1,7 @@
 package com.reactnativenavigation.parse;
 
+import android.support.annotation.CheckResult;
+
 import com.reactnativenavigation.parse.params.Orientation;
 
 import org.json.JSONArray;
@@ -50,6 +52,18 @@ public class OrientationOptions {
 
     public boolean hasValue() {
         return !orientations.isEmpty();
+    }
+
+    @CheckResult
+    public OrientationOptions copy() {
+        OrientationOptions result = new OrientationOptions();
+        result.orientations = new ArrayList<>(orientations);
+        return result;
+    }
+
+    public OrientationOptions mergeWithDefault(OrientationOptions defaultOptions) {
+        if (!hasValue()) orientations = defaultOptions.orientations;
+        return this;
     }
 
     @Override

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabOptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabOptionsPresenter.java
@@ -17,16 +17,16 @@ public class BottomTabOptionsPresenter {
     private Options defaultOptions;
     private final BottomTabFinder bottomTabFinder;
     private BottomTabs bottomTabs;
-    private final int defaultSelectedTabColor;
-    private final int defaultTabColor;
+    private final int defaultSelectedTextColor;
+    private final int defaultTextColor;
     private final List<ViewController> tabs;
 
     public BottomTabOptionsPresenter(Context context, List<ViewController> tabs, Options defaultOptions) {
         this.tabs = tabs;
         this.bottomTabFinder = new BottomTabFinder(tabs);
         this.defaultOptions = defaultOptions;
-        defaultSelectedTabColor = defaultOptions.bottomTabOptions.selectedIconColor.get(ContextCompat.getColor(context, com.aurelhubert.ahbottomnavigation.R.color.colorBottomNavigationAccent));
-        defaultTabColor = defaultOptions.bottomTabOptions.iconColor.get(ContextCompat.getColor(context, com.aurelhubert.ahbottomnavigation.R.color.colorBottomNavigationInactive));
+        defaultSelectedTextColor = defaultOptions.bottomTabOptions.selectedIconColor.get(ContextCompat.getColor(context, com.aurelhubert.ahbottomnavigation.R.color.colorBottomNavigationAccent));
+        defaultTextColor = defaultOptions.bottomTabOptions.iconColor.get(ContextCompat.getColor(context, com.aurelhubert.ahbottomnavigation.R.color.colorBottomNavigationInactive));
     }
 
     public void setDefaultOptions(Options defaultOptions) {
@@ -42,10 +42,10 @@ public class BottomTabOptionsPresenter {
             BottomTabOptions bottomTab = tabs.get(i).options.copy().withDefaultOptions(defaultOptions).bottomTabOptions;
             bottomTabs.setBadge(i, bottomTab.badge.get(""));
             bottomTabs.setTitleTypeface(i, bottomTab.fontFamily);
-            if (bottomTab.selectedIconColor.hasValue()) bottomTabs.setIconActiveColor(i, bottomTab.selectedIconColor.get());
-            if (bottomTab.iconColor.hasValue()) bottomTabs.setIconInactiveColor(i, bottomTab.iconColor.get());
-            if (bottomTab.selectedTextColor.hasValue()) bottomTabs.setTitleActiveColor(i, bottomTab.selectedTextColor.get());
-            if (bottomTab.textColor.hasValue()) bottomTabs.setTitleInactiveColor(i, bottomTab.textColor.get());
+            bottomTabs.setIconActiveColor(i, bottomTab.selectedIconColor.get(null));
+            bottomTabs.setIconInactiveColor(i, bottomTab.iconColor.get(null));
+            bottomTabs.setTitleActiveColor(i, bottomTab.selectedTextColor.get(null));
+            bottomTabs.setTitleInactiveColor(i, bottomTab.textColor.get(null));
         }
     }
 
@@ -61,12 +61,12 @@ public class BottomTabOptionsPresenter {
     }
 
     @VisibleForTesting
-    public int getDefaultSelectedTabColor() {
-        return defaultSelectedTabColor;
+    public int getDefaultSelectedTextColor() {
+        return defaultSelectedTextColor;
     }
 
     @VisibleForTesting
-    public int getDefaultTabColor() {
-        return defaultTabColor;
+    public int getDefaultTextColor() {
+        return defaultTextColor;
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabOptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabOptionsPresenter.java
@@ -1,0 +1,66 @@
+package com.reactnativenavigation.presentation;
+
+import android.content.Context;
+import android.support.annotation.VisibleForTesting;
+import android.support.v4.content.ContextCompat;
+
+import com.reactnativenavigation.parse.BottomTabOptions;
+import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.viewcontrollers.ViewController;
+import com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabFinder;
+import com.reactnativenavigation.views.BottomTabs;
+import com.reactnativenavigation.views.Component;
+
+import java.util.List;
+
+public class BottomTabOptionsPresenter {
+    private Options defaultOptions;
+    private final BottomTabFinder bottomTabFinder;
+    private BottomTabs bottomTabs;
+    private final int defaultSelectedTabColor;
+    private final int defaultTabColor;
+    private final List<ViewController> tabs;
+
+    public BottomTabOptionsPresenter(Context context, List<ViewController> tabs, Options defaultOptions) {
+        this.tabs = tabs;
+        this.bottomTabFinder = new BottomTabFinder(tabs);
+        this.defaultOptions = defaultOptions;
+        defaultSelectedTabColor = defaultOptions.bottomTabOptions.selectedIconColor.get(ContextCompat.getColor(context, com.aurelhubert.ahbottomnavigation.R.color.colorBottomNavigationAccent));
+        defaultTabColor = defaultOptions.bottomTabOptions.iconColor.get(ContextCompat.getColor(context, com.aurelhubert.ahbottomnavigation.R.color.colorBottomNavigationInactive));
+    }
+
+    public void setDefaultOptions(Options defaultOptions) {
+        this.defaultOptions = defaultOptions;
+    }
+
+    public void bindView(BottomTabs bottomTabs) {
+        this.bottomTabs = bottomTabs;
+    }
+
+    public void present() {
+        for (int i = 0; i < tabs.size(); i++) {
+            BottomTabOptions bottomTab = tabs.get(i).options.bottomTabOptions;
+            bottomTabs.setAccentColor(i, bottomTab.selectedIconColor.get(defaultSelectedTabColor));
+            bottomTabs.setInactiveColor(i, bottomTab.iconColor.get(defaultTabColor));
+            bottomTabs.setBadge(i, bottomTab.badge.get(""));
+        }
+    }
+
+    public void mergeChildOptions(Options options, Component child) {
+        BottomTabOptions withDefaultOptions = options.withDefaultOptions(defaultOptions).bottomTabOptions;
+        int tabIndex = bottomTabFinder.findByComponent(child);
+        if (withDefaultOptions.badge.hasValue()) bottomTabs.setBadge(tabIndex, withDefaultOptions.badge.get());
+        if (withDefaultOptions.selectedIconColor.hasValue()) bottomTabs.setAccentColor(tabIndex, withDefaultOptions.selectedIconColor.get());
+        if (withDefaultOptions.iconColor.hasValue()) bottomTabs.setInactiveColor(tabIndex, withDefaultOptions.iconColor.get());
+    }
+
+    @VisibleForTesting
+    public int getDefaultSelectedTabColor() {
+        return defaultSelectedTabColor;
+    }
+
+    @VisibleForTesting
+    public int getDefaultTabColor() {
+        return defaultTabColor;
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabOptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabOptionsPresenter.java
@@ -39,19 +39,25 @@ public class BottomTabOptionsPresenter {
 
     public void present() {
         for (int i = 0; i < tabs.size(); i++) {
-            BottomTabOptions bottomTab = tabs.get(i).options.bottomTabOptions;
-            bottomTabs.setAccentColor(i, bottomTab.selectedIconColor.get(defaultSelectedTabColor));
-            bottomTabs.setInactiveColor(i, bottomTab.iconColor.get(defaultTabColor));
+            BottomTabOptions bottomTab = tabs.get(i).options.copy().withDefaultOptions(defaultOptions).bottomTabOptions;
             bottomTabs.setBadge(i, bottomTab.badge.get(""));
+            bottomTabs.setTitleTypeface(i, bottomTab.fontFamily);
+            if (bottomTab.selectedIconColor.hasValue()) bottomTabs.setIconActiveColor(i, bottomTab.selectedIconColor.get());
+            if (bottomTab.iconColor.hasValue()) bottomTabs.setIconInactiveColor(i, bottomTab.iconColor.get());
+            if (bottomTab.selectedTextColor.hasValue()) bottomTabs.setTitleActiveColor(i, bottomTab.selectedTextColor.get());
+            if (bottomTab.textColor.hasValue()) bottomTabs.setTitleInactiveColor(i, bottomTab.textColor.get());
         }
     }
 
     public void mergeChildOptions(Options options, Component child) {
         BottomTabOptions withDefaultOptions = options.withDefaultOptions(defaultOptions).bottomTabOptions;
-        int tabIndex = bottomTabFinder.findByComponent(child);
-        if (withDefaultOptions.badge.hasValue()) bottomTabs.setBadge(tabIndex, withDefaultOptions.badge.get());
-        if (withDefaultOptions.selectedIconColor.hasValue()) bottomTabs.setAccentColor(tabIndex, withDefaultOptions.selectedIconColor.get());
-        if (withDefaultOptions.iconColor.hasValue()) bottomTabs.setInactiveColor(tabIndex, withDefaultOptions.iconColor.get());
+        int index = bottomTabFinder.findByComponent(child);
+        if (withDefaultOptions.badge.hasValue()) bottomTabs.setBadge(index, withDefaultOptions.badge.get());
+        if (withDefaultOptions.fontFamily != null) bottomTabs.setTitleTypeface(index, withDefaultOptions.fontFamily);
+        if (withDefaultOptions.selectedIconColor.hasValue()) bottomTabs.setIconActiveColor(index, withDefaultOptions.selectedIconColor.get());
+        if (withDefaultOptions.iconColor.hasValue()) bottomTabs.setIconInactiveColor(index, withDefaultOptions.iconColor.get());
+        if (withDefaultOptions.selectedTextColor.hasValue()) bottomTabs.setTitleActiveColor(index, withDefaultOptions.selectedTextColor.get());
+        if (withDefaultOptions.textColor.hasValue()) bottomTabs.setTitleInactiveColor(index, withDefaultOptions.textColor.get());
     }
 
     @VisibleForTesting

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsOptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsOptionsPresenter.java
@@ -12,6 +12,7 @@ import com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabFinder;
 import com.reactnativenavigation.viewcontrollers.bottomtabs.TabSelector;
 import com.reactnativenavigation.views.BottomTabs;
 import com.reactnativenavigation.views.Component;
+import com.reactnativenavigation.views.bottomtabs.TabResolver;
 
 import java.util.List;
 
@@ -21,6 +22,7 @@ public class BottomTabsOptionsPresenter {
     private final BottomTabFinder bottomTabFinder;
     private final BottomTabsAnimator animator;
     private final List<ViewController> tabs;
+    private final TabResolver tabResolver;
 
     public BottomTabsOptionsPresenter(BottomTabs bottomTabs, List<ViewController> tabs, TabSelector tabSelector, BottomTabFinder bottomTabFinder) {
         this.bottomTabs = bottomTabs;
@@ -28,6 +30,7 @@ public class BottomTabsOptionsPresenter {
         this.tabSelector = tabSelector;
         this.bottomTabFinder = bottomTabFinder;
         animator = new BottomTabsAnimator(bottomTabs);
+        tabResolver = new TabResolver(bottomTabs);
     }
 
     public void present(Options options) {
@@ -45,6 +48,19 @@ public class BottomTabsOptionsPresenter {
         if (options.badge.hasValue()) {
             bottomTabs.setBadge(tabIndex, options.badge);
         }
+        TabResolver.Tab tab = tabResolver.resolve(tabIndex);
+        if (options.iconColor.hasValue()) tab.setIconColor(options.iconColor);
+        if (options.textColor.hasValue()) tab.setTextColor(options.textColor);
+    }
+
+    public void onTabSelected(int selectedTabIndex, int unselectedTabIndex, BottomTabOptions unselected, BottomTabOptions selected) {
+        TabResolver.Tab selectedTab = tabResolver.resolve(selectedTabIndex);
+        TabResolver.Tab unselectedTab = tabResolver.resolve(unselectedTabIndex);
+
+        if (unselected.iconColor.hasValue()) unselectedTab.setIconColor(unselected.iconColor);
+        if (unselected.textColor.hasValue()) unselectedTab.setTextColor(unselected.textColor);
+        if (selected.iconColor.hasValue()) selectedTab.setIconColor(selected.selectedIconColor);
+        if (selected.textColor.hasValue()) selectedTab.setTextColor(selected.selectedTextColor);
     }
 
     private void applyDrawBehind(BottomTabsOptions options, int tabIndex) {
@@ -70,12 +86,6 @@ public class BottomTabsOptionsPresenter {
         }
         if (options.testId.hasValue()) {
             bottomTabs.setTag(options.testId.get());
-        }
-        if (options.selectedTabColor.hasValue()) {
-            bottomTabs.setAccentColor(options.selectedTabColor.get());
-        }
-        if (options.tabColor.hasValue()) {
-            bottomTabs.setInactiveColor(options.tabColor.get());
         }
         if (options.currentTabId.hasValue()) {
             int tabIndex = bottomTabFinder.findByControllerId(options.currentTabId.get());

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsOptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsOptionsPresenter.java
@@ -1,11 +1,13 @@
 package com.reactnativenavigation.presentation;
 
+import android.view.ViewGroup;
 import android.view.ViewGroup.MarginLayoutParams;
 
 import com.reactnativenavigation.anim.BottomTabsAnimator;
 import com.reactnativenavigation.parse.AnimationsOptions;
 import com.reactnativenavigation.parse.BottomTabsOptions;
 import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.utils.UiUtils;
 import com.reactnativenavigation.viewcontrollers.ViewController;
 import com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabFinder;
 import com.reactnativenavigation.viewcontrollers.bottomtabs.TabSelector;
@@ -38,6 +40,11 @@ public class BottomTabsOptionsPresenter {
         animator = new BottomTabsAnimator(bottomTabs);
     }
 
+    public void applyLayoutParamsOptions(Options options, int tabIndex) {
+        Options withDefaultOptions = options.copy().withDefaultOptions(defaultOptions);
+        applyDrawBehind(withDefaultOptions.bottomTabsOptions, tabIndex);
+    }
+
     public void present(Options options) {
         Options withDefaultOptions = options.copy().withDefaultOptions(defaultOptions);
         applyBottomTabsOptions(withDefaultOptions.bottomTabsOptions, withDefaultOptions.animations);
@@ -51,12 +58,17 @@ public class BottomTabsOptionsPresenter {
     }
 
     private void applyDrawBehind(BottomTabsOptions options, int tabIndex) {
-        MarginLayoutParams lp = (MarginLayoutParams) tabs.get(tabIndex).getView().getLayoutParams();
+        ViewGroup tab = tabs.get(tabIndex).getView();
+        MarginLayoutParams lp = (MarginLayoutParams) tab.getLayoutParams();
         if (options.drawBehind.isTrue()) {
             lp.bottomMargin = 0;
         }
         if (options.visible.isTrueOrUndefined() && options.drawBehind.isFalseOrUndefined()) {
-            lp.bottomMargin = bottomTabs.getHeight();
+            if (bottomTabs.getHeight() == 0) {
+                UiUtils.runOnPreDrawOnce(bottomTabs, () -> lp.bottomMargin = bottomTabs.getHeight());
+            } else {
+                lp.bottomMargin = bottomTabs.getHeight();
+            }
         }
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsOptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsOptionsPresenter.java
@@ -1,12 +1,9 @@
 package com.reactnativenavigation.presentation;
 
-import android.content.Context;
-import android.support.v4.content.ContextCompat;
 import android.view.ViewGroup.MarginLayoutParams;
 
 import com.reactnativenavigation.anim.BottomTabsAnimator;
 import com.reactnativenavigation.parse.AnimationsOptions;
-import com.reactnativenavigation.parse.BottomTabOptions;
 import com.reactnativenavigation.parse.BottomTabsOptions;
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.viewcontrollers.ViewController;
@@ -18,41 +15,39 @@ import com.reactnativenavigation.views.Component;
 import java.util.List;
 
 public class BottomTabsOptionsPresenter {
-    private final BottomTabs bottomTabs;
-    private final TabSelector tabSelector;
     private final BottomTabFinder bottomTabFinder;
-    private final BottomTabsAnimator animator;
     private final List<ViewController> tabs;
-    private final int defaultSelectedTabColor;
-    private final int defaultTabColor;
+    private Options defaultOptions;
+    private BottomTabs bottomTabs;
+    private BottomTabsAnimator animator;
+    private TabSelector tabSelector;
 
-    public BottomTabsOptionsPresenter(Context context, BottomTabs bottomTabs, List<ViewController> tabs, TabSelector tabSelector, BottomTabFinder bottomTabFinder) {
-        this.bottomTabs = bottomTabs;
+    public BottomTabsOptionsPresenter(List<ViewController> tabs, Options defaultOptions) {
         this.tabs = tabs;
+        this.defaultOptions = defaultOptions;
+        this.bottomTabFinder = new BottomTabFinder(tabs);
+    }
+
+    public void setDefaultOptions(Options defaultOptions) {
+        this.defaultOptions = defaultOptions;
+    }
+
+    public void bindView(BottomTabs bottomTabs, TabSelector tabSelector) {
+        this.bottomTabs = bottomTabs;
         this.tabSelector = tabSelector;
-        this.bottomTabFinder = bottomTabFinder;
         animator = new BottomTabsAnimator(bottomTabs);
-        defaultSelectedTabColor = ContextCompat.getColor(context, com.aurelhubert.ahbottomnavigation.R.color.colorBottomNavigationAccent);
-        defaultTabColor = ContextCompat.getColor(context, com.aurelhubert.ahbottomnavigation.R.color.colorBottomNavigationInactive);
     }
 
     public void present(Options options) {
-        applyBottomTabsOptions(options.bottomTabsOptions, options.animations);
+        Options withDefaultOptions = options.copy().withDefaultOptions(defaultOptions);
+        applyBottomTabsOptions(withDefaultOptions.bottomTabsOptions, withDefaultOptions.animations);
     }
 
     public void presentChildOptions(Options options, Component child) {
-        applyBottomTabsOptions(options.bottomTabsOptions, options.animations);
+        Options withDefaultOptions = options.copy().withDefaultOptions(defaultOptions);
+        applyBottomTabsOptions(withDefaultOptions.bottomTabsOptions, withDefaultOptions.animations);
         int tabIndex = bottomTabFinder.findByComponent(child);
-        applyBottomTabOptions(options.bottomTabOptions, tabIndex);
-        applyDrawBehind(options.bottomTabsOptions, tabIndex);
-    }
-
-    private void applyBottomTabOptions(BottomTabOptions options, int tabIndex) {
-        if (options.badge.hasValue()) {
-            bottomTabs.setBadge(tabIndex, options.badge);
-        }
-        bottomTabs.setAccentColor(tabIndex, options.selectedIconColor.get(defaultSelectedTabColor));
-        bottomTabs.setInactiveColor(tabIndex, options.iconColor.get(defaultTabColor));
+        applyDrawBehind(withDefaultOptions.bottomTabsOptions, tabIndex);
     }
 
     private void applyDrawBehind(BottomTabsOptions options, int tabIndex) {
@@ -96,10 +91,6 @@ public class BottomTabsOptionsPresenter {
             } else {
                 bottomTabs.hideBottomNavigation(false);
             }
-        }
-        for (int i = 0; i < tabs.size(); i++) {
-            bottomTabs.setAccentColor(i, tabs.get(i).options.bottomTabOptions.selectedIconColor.get(defaultSelectedTabColor));
-            bottomTabs.setInactiveColor(i, tabs.get(i).options.bottomTabOptions.iconColor.get(defaultTabColor));
         }
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsOptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsOptionsPresenter.java
@@ -1,5 +1,7 @@
 package com.reactnativenavigation.presentation;
 
+import android.content.Context;
+import android.support.v4.content.ContextCompat;
 import android.view.ViewGroup.MarginLayoutParams;
 
 import com.reactnativenavigation.anim.BottomTabsAnimator;
@@ -12,7 +14,6 @@ import com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabFinder;
 import com.reactnativenavigation.viewcontrollers.bottomtabs.TabSelector;
 import com.reactnativenavigation.views.BottomTabs;
 import com.reactnativenavigation.views.Component;
-import com.reactnativenavigation.views.bottomtabs.TabResolver;
 
 import java.util.List;
 
@@ -22,15 +23,17 @@ public class BottomTabsOptionsPresenter {
     private final BottomTabFinder bottomTabFinder;
     private final BottomTabsAnimator animator;
     private final List<ViewController> tabs;
-    private final TabResolver tabResolver;
+    private final int defaultSelectedTabColor;
+    private final int defaultTabColor;
 
-    public BottomTabsOptionsPresenter(BottomTabs bottomTabs, List<ViewController> tabs, TabSelector tabSelector, BottomTabFinder bottomTabFinder) {
+    public BottomTabsOptionsPresenter(Context context, BottomTabs bottomTabs, List<ViewController> tabs, TabSelector tabSelector, BottomTabFinder bottomTabFinder) {
         this.bottomTabs = bottomTabs;
         this.tabs = tabs;
         this.tabSelector = tabSelector;
         this.bottomTabFinder = bottomTabFinder;
         animator = new BottomTabsAnimator(bottomTabs);
-        tabResolver = new TabResolver(bottomTabs);
+        defaultSelectedTabColor = ContextCompat.getColor(context, com.aurelhubert.ahbottomnavigation.R.color.colorBottomNavigationAccent);
+        defaultTabColor = ContextCompat.getColor(context, com.aurelhubert.ahbottomnavigation.R.color.colorBottomNavigationInactive);
     }
 
     public void present(Options options) {
@@ -48,19 +51,8 @@ public class BottomTabsOptionsPresenter {
         if (options.badge.hasValue()) {
             bottomTabs.setBadge(tabIndex, options.badge);
         }
-        TabResolver.Tab tab = tabResolver.resolve(tabIndex);
-        if (options.iconColor.hasValue()) tab.setIconColor(options.iconColor);
-        if (options.textColor.hasValue()) tab.setTextColor(options.textColor);
-    }
-
-    public void onTabSelected(int selectedTabIndex, int unselectedTabIndex, BottomTabOptions unselected, BottomTabOptions selected) {
-        TabResolver.Tab selectedTab = tabResolver.resolve(selectedTabIndex);
-        TabResolver.Tab unselectedTab = tabResolver.resolve(unselectedTabIndex);
-
-        if (unselected.iconColor.hasValue()) unselectedTab.setIconColor(unselected.iconColor);
-        if (unselected.textColor.hasValue()) unselectedTab.setTextColor(unselected.textColor);
-        if (selected.iconColor.hasValue()) selectedTab.setIconColor(selected.selectedIconColor);
-        if (selected.textColor.hasValue()) selectedTab.setTextColor(selected.selectedTextColor);
+        bottomTabs.setAccentColor(tabIndex, options.selectedIconColor.get(defaultSelectedTabColor));
+        bottomTabs.setInactiveColor(tabIndex, options.iconColor.get(defaultTabColor));
     }
 
     private void applyDrawBehind(BottomTabsOptions options, int tabIndex) {
@@ -104,6 +96,10 @@ public class BottomTabsOptionsPresenter {
             } else {
                 bottomTabs.hideBottomNavigation(false);
             }
+        }
+        for (int i = 0; i < tabs.size(); i++) {
+            bottomTabs.setAccentColor(i, tabs.get(i).options.bottomTabOptions.selectedIconColor.get(defaultSelectedTabColor));
+            bottomTabs.setInactiveColor(i, tabs.get(i).options.bottomTabOptions.iconColor.get(defaultTabColor));
         }
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/OptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/OptionsPresenter.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.graphics.Color;
 import android.os.Build;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewGroup.MarginLayoutParams;
 
 import com.reactnativenavigation.parse.Options;
@@ -26,6 +27,10 @@ public class OptionsPresenter {
 
     public void setDefaultOptions(Options defaultOptions) {
         this.defaultOptions = defaultOptions;
+    }
+
+    public void applyLayoutOptions(ViewGroup.LayoutParams layoutParams) {
+
     }
 
     public void present(View view, Options options) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/OptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/OptionsPresenter.java
@@ -17,19 +17,32 @@ import com.reactnativenavigation.utils.UiUtils;
 public class OptionsPresenter {
 
     private Activity activity;
+    private Options defaultOptions;
 
-    public OptionsPresenter(Activity activity) {
+    public OptionsPresenter(Activity activity, Options defaultOptions) {
         this.activity = activity;
+        this.defaultOptions = defaultOptions;
+    }
+
+    public void setDefaultOptions(Options defaultOptions) {
+        this.defaultOptions = defaultOptions;
     }
 
     public void present(View view, Options options) {
-        applyOrientation(options.layout.orientation);
-        applyViewOptions(view, options);
-        applyStatusBarOptions(view, options.statusBar);
+        Options withDefaultOptions = options.copy().withDefaultOptions(defaultOptions);
+        applyOrientation(withDefaultOptions.layout.orientation);
+        applyViewOptions(view, withDefaultOptions);
+        applyStatusBarOptions(view, withDefaultOptions.statusBar);
     }
 
     public void applyRootOptions(View view, Options options) {
-        setDrawBehindStatusBar(view, options.statusBar);
+        Options withDefaultOptions = options.copy().withDefaultOptions(defaultOptions);
+        setDrawBehindStatusBar(view, withDefaultOptions.statusBar);
+    }
+
+    public void onViewBroughtToFront(View view, Options options) {
+        Options withDefaultOptions = options.copy().withDefaultOptions(defaultOptions);
+        applyStatusBarOptions(view, withDefaultOptions.statusBar);
     }
 
     private void applyOrientation(OrientationOptions options) {
@@ -43,10 +56,6 @@ public class OptionsPresenter {
         if (options.layout.topMargin.hasValue()) {
             ((MarginLayoutParams) view.getLayoutParams()).topMargin = options.layout.topMargin.get();
         }
-    }
-
-    public void onViewBroughtToFront(View view, Options options) {
-        applyStatusBarOptions(view, options.statusBar);
     }
 
     private void applyStatusBarOptions(View view, StatusBarOptions statusBar) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/StackOptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/StackOptionsPresenter.java
@@ -1,6 +1,7 @@
 package com.reactnativenavigation.presentation;
 
 import android.app.Activity;
+import android.content.Context;
 import android.graphics.Color;
 import android.view.ViewGroup.LayoutParams;
 
@@ -24,23 +25,34 @@ public class StackOptionsPresenter {
     private final double defaultSubtitleFontSize;
 
     private TopBar topBar;
+    private Options defaultOptions;
 
-    public StackOptionsPresenter(TopBar topBar) {
+    public StackOptionsPresenter(Context context, Options defaultOptions) {
+        defaultTitleFontSize = UiUtils.dpToSp(context, 18);
+        defaultSubtitleFontSize = UiUtils.dpToSp(context, 14);
+        this.defaultOptions = defaultOptions;
+    }
+
+    public void setDefaultOptions(Options defaultOptions) {
+        this.defaultOptions = defaultOptions;
+    }
+
+    public void bindView(TopBar topBar) {
         this.topBar = topBar;
-        defaultTitleFontSize = UiUtils.dpToSp(topBar.getContext(), 18);
-        defaultSubtitleFontSize = UiUtils.dpToSp(topBar.getContext(), 14);
     }
 
     public void applyChildOptions(Options options, Component child) {
-        applyOrientation(options.layout.orientation);
-        applyButtons(options.topBar.buttons);
-        applyTopBarOptions(options.topBar, options.animations, child, options);
-        applyTopTabsOptions(options.topTabs);
-        applyTopTabOptions(options.topTabOptions);
+        Options withDefaultOptions = options.copy().withDefaultOptions(defaultOptions);
+        applyOrientation(withDefaultOptions.layout.orientation);
+        applyButtons(withDefaultOptions.topBar.buttons);
+        applyTopBarOptions(withDefaultOptions.topBar, withDefaultOptions.animations, child, options);
+        applyTopTabsOptions(withDefaultOptions.topTabs);
+        applyTopTabOptions(withDefaultOptions.topTabOptions);
     }
 
     public void applyOrientation(OrientationOptions options) {
-        ((Activity) topBar.getContext()).setRequestedOrientation(options.getValue());
+        OrientationOptions withDefaultOptions = options.copy().mergeWithDefault(defaultOptions.layout.orientation);
+        ((Activity) topBar.getContext()).setRequestedOrientation(withDefaultOptions.getValue());
     }
 
     private void applyTopBarOptions(TopBarOptions options, AnimationsOptions animationOptions, Component component, Options componentOptions) {
@@ -124,11 +136,12 @@ public class StackOptionsPresenter {
     }
 
     public void mergeChildOptions(Options options, Component child) {
-        mergeOrientation(options.layout.orientation);
-        mergeButtons(options.topBar.buttons);
-        mergeTopBarOptions(options.topBar, options.animations, child);
-        mergeTopTabsOptions(options.topTabs);
-        mergeTopTabOptions(options.topTabOptions);
+        Options withDefaultOptions = options.copy().withDefaultOptions(defaultOptions);
+        mergeOrientation(withDefaultOptions.layout.orientation);
+        mergeButtons(withDefaultOptions.topBar.buttons);
+        mergeTopBarOptions(withDefaultOptions.topBar, withDefaultOptions.animations, child);
+        mergeTopTabsOptions(withDefaultOptions.topTabs);
+        mergeTopTabOptions(withDefaultOptions.topTabOptions);
     }
 
     private void mergeOrientation(OrientationOptions orientationOptions) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/StackOptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/StackOptionsPresenter.java
@@ -3,6 +3,7 @@ package com.reactnativenavigation.presentation;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
+import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 
 import com.reactnativenavigation.parse.AnimationsOptions;
@@ -39,6 +40,17 @@ public class StackOptionsPresenter {
 
     public void bindView(TopBar topBar) {
         this.topBar = topBar;
+    }
+
+    public void applyLayoutParamsOptions(Options options, View view) {
+        Options withDefaultOptions = options.copy().withDefaultOptions(defaultOptions);
+        if (view instanceof Component) {
+            if (withDefaultOptions.topBar.drawBehind.isTrue() && !withDefaultOptions.layout.topMargin.hasValue()) {
+                ((Component) view).drawBehindTopBar();
+            } else if (options.topBar.drawBehind.isFalseOrUndefined()) {
+                ((Component) view).drawBelowTopBar(topBar);
+            }
+        }
     }
 
     public void applyChildOptions(Options options, Component child) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/ViewUtils.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/ViewUtils.java
@@ -76,6 +76,7 @@ public class ViewUtils {
     }
 
     public static int getPreferredHeight(View view) {
+        if (view.getLayoutParams() == null) return 0;
         return view.getLayoutParams().height < 0 ? view.getHeight() : view.getLayoutParams().height;
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ChildController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ChildController.java
@@ -21,6 +21,11 @@ public abstract class ChildController<T extends ViewGroup> extends ViewControlle
     }
 
     @Override
+    public void setDefaultOptions(Options defaultOptions) {
+        presenter.setDefaultOptions(defaultOptions);
+    }
+
+    @Override
     public void onViewAppeared() {
         super.onViewAppeared();
         childRegistry.onViewAppeared(this);

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ComponentViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ComponentViewController.java
@@ -19,8 +19,9 @@ public class ComponentViewController extends ChildController<ComponentLayout> {
                                    final String id,
                                    final String componentName,
                                    final ReactViewCreator viewCreator,
-                                   final Options initialOptions) {
-        super(activity, childRegistry, id, new OptionsPresenter(activity), initialOptions);
+                                   final Options initialOptions,
+                                   final OptionsPresenter presenter) {
+        super(activity, childRegistry, id, presenter, initialOptions);
         this.componentName = componentName;
         this.viewCreator = viewCreator;
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/Navigator.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/Navigator.java
@@ -33,8 +33,10 @@ public class Navigator extends ParentController implements JsDevReloadHandler.Re
     private final OverlayManager overlayManager;
     private Options defaultOptions = new Options();
 
+    @Override
     public void setDefaultOptions(Options defaultOptions) {
         this.defaultOptions = defaultOptions;
+        if (root != null) root.setDefaultOptions(defaultOptions);
     }
 
     public Options getDefaultOptions() {
@@ -42,7 +44,7 @@ public class Navigator extends ParentController implements JsDevReloadHandler.Re
     }
 
     public Navigator(final Activity activity, ChildControllersRegistry childRegistry, OverlayManager overlayManager) {
-        super(activity, childRegistry,"navigator" + CompatUtils.generateViewId(), new OptionsPresenter(activity), new Options());
+        super(activity, childRegistry,"navigator" + CompatUtils.generateViewId(), new OptionsPresenter(activity, new Options()), new Options());
         modalStack = new ModalStack(new ModalPresenter(new ModalAnimator(activity)));
         this.overlayManager = overlayManager;
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/Navigator.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/Navigator.java
@@ -76,6 +76,11 @@ public class Navigator extends ParentController implements JsDevReloadHandler.Re
     }
 
     @Override
+    protected ViewController getCurrentChild() {
+        return root;
+    }
+
+    @Override
     public void onReload() {
         destroyViews();
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ParentController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ParentController.java
@@ -9,6 +9,7 @@ import android.view.ViewGroup;
 
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.presentation.OptionsPresenter;
+import com.reactnativenavigation.utils.CollectionUtils;
 import com.reactnativenavigation.views.Component;
 
 import java.util.Collection;
@@ -18,6 +19,16 @@ public abstract class ParentController<T extends ViewGroup> extends ChildControl
 	public ParentController(Activity activity, ChildControllersRegistry childRegistry, String id, OptionsPresenter presenter, Options initialOptions) {
 		super(activity, childRegistry, id, presenter, initialOptions);
 	}
+
+	@Override
+    public void setDefaultOptions(Options defaultOptions) {
+        Collection<? extends ViewController> children = getChildControllers();
+        if (!CollectionUtils.isNullOrEmpty(children)) {
+            for (ViewController child : children) {
+                child.setDefaultOptions(defaultOptions);
+            }
+        }
+    }
 
 	@NonNull
 	@Override

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ParentController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ParentController.java
@@ -2,6 +2,7 @@ package com.reactnativenavigation.viewcontrollers;
 
 import android.app.Activity;
 import android.support.annotation.CallSuper;
+import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.view.ViewPager;
@@ -30,7 +31,14 @@ public abstract class ParentController<T extends ViewGroup> extends ChildControl
         }
     }
 
-	@NonNull
+    @Override
+    @CheckResult
+    public Options resolveCurrentOptions() {
+	    if (CollectionUtils.isNullOrEmpty(getChildControllers())) return options;
+        Options o = getCurrentChild().resolveCurrentOptions();
+        return o.copy().mergeWith(options);
+    }
+
     protected abstract ViewController getCurrentChild();
 
     @NonNull

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ParentController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ParentController.java
@@ -31,6 +31,9 @@ public abstract class ParentController<T extends ViewGroup> extends ChildControl
     }
 
 	@NonNull
+    protected abstract ViewController getCurrentChild();
+
+    @NonNull
 	@Override
 	public T getView() {
 		return (T) super.getView();

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/SideMenuController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/SideMenuController.java
@@ -23,8 +23,8 @@ public class SideMenuController extends ParentController<DrawerLayout> {
 	private ViewController leftController;
 	private ViewController rightController;
 
-	public SideMenuController(Activity activity, ChildControllersRegistry childRegistry, String id, Options initialOptions) {
-		super(activity, childRegistry, id, new OptionsPresenter(activity), initialOptions);
+	public SideMenuController(Activity activity, ChildControllersRegistry childRegistry, String id, Options initialOptions, OptionsPresenter presenter) {
+		super(activity, childRegistry, id, presenter, initialOptions);
 	}
 
 	@NonNull

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/SideMenuController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/SideMenuController.java
@@ -27,7 +27,17 @@ public class SideMenuController extends ParentController<DrawerLayout> {
 		super(activity, childRegistry, id, presenter, initialOptions);
 	}
 
-	@NonNull
+    @Override
+    protected ViewController getCurrentChild() {
+	    if (getView().isDrawerOpen(Gravity.LEFT)) {
+            return leftController;
+        } else if (getView().isDrawerOpen(Gravity.RIGHT)) {
+            return rightController;
+        }
+        return centerController;
+    }
+
+    @NonNull
 	@Override
 	protected DrawerLayout createView() {
         return new DrawerLayout(getActivity());

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ViewController.java
@@ -6,7 +6,6 @@ import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewManager;

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ViewController.java
@@ -86,6 +86,10 @@ public abstract class ViewController<T extends ViewGroup> implements ViewTreeObs
 
     }
 
+    public void setDefaultOptions(Options defaultOptions) {
+        
+    }
+
     public Activity getActivity() {
         return activity;
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ViewController.java
@@ -2,9 +2,11 @@ package com.reactnativenavigation.viewcontrollers;
 
 import android.app.Activity;
 import android.support.annotation.CallSuper;
+import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewManager;
@@ -72,6 +74,11 @@ public abstract class ViewController<T extends ViewGroup> implements ViewTreeObs
 
     public boolean handleBack(CommandListener listener) {
         return false;
+    }
+
+    @CheckResult
+    public Options resolveCurrentOptions() {
+        return options;
     }
 
     @CallSuper

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabFinder.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabFinder.java
@@ -10,6 +10,10 @@ import java.util.List;
 public class BottomTabFinder {
     private List<ViewController> tabs;
 
+    public BottomTabFinder(List<ViewController> tabs) {
+        this.tabs = tabs;
+    }
+
     @IntRange(from = -1)
     public int findByComponent(Component component) {
         for (int i = 0; i < tabs.size(); i++) {
@@ -28,9 +32,5 @@ public class BottomTabFinder {
             }
         }
         return -1;
-    }
-
-    void setTabs(List<ViewController> tabs) {
-        this.tabs = tabs;
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -106,10 +106,11 @@ public class BottomTabsController extends ParentController implements AHBottomNa
 
     @Override
     public void sendOnNavigationButtonPressed(String buttonId) {
-        getCurrentTab().sendOnNavigationButtonPressed(buttonId);
+        getCurrentChild().sendOnNavigationButtonPressed(buttonId);
     }
 
-    private ViewController getCurrentTab() {
+    @Override
+    protected ViewController getCurrentChild() {
         return tabs.get(bottomTabs.getCurrentItem());
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -104,8 +104,11 @@ public class BottomTabsController extends ParentController implements AHBottomNa
     public boolean onTabSelected(int index, boolean wasSelected) {
         if (wasSelected) return false;
         eventEmitter.emitBottomTabSelected(bottomTabs.getCurrentItem(), index);
+        BottomTabOptions unselected = tabs.get(bottomTabs.getCurrentItem()).options.bottomTabOptions;
+        BottomTabOptions selected = tabs.get(index).options.bottomTabOptions;
         selectTab(index);
-        return true;
+        bottomTabs.post(() -> presenter.onTabSelected(bottomTabs.getCurrentItem(), index, unselected, selected));
+        return false;
 	}
 
 	private void createTabs(final List<ViewController> tabs) {
@@ -133,7 +136,7 @@ public class BottomTabsController extends ParentController implements AHBottomNa
             public void onComplete(@NonNull List<Drawable> drawables) {
                 List<AHBottomNavigationItem> tabs = new ArrayList<>();
                 for (int i = 0; i < drawables.size(); i++) {
-                    tabs.add(new AHBottomNavigationItem(bottomTabOptionsList.get(i).title.get(""), drawables.get(i)));
+                    tabs.add(new AHBottomNavigationItem(bottomTabOptionsList.get(i).text.get(""), drawables.get(i)));
                 }
                 bottomTabs.addItems(tabs);
                 bottomTabs.post(() -> {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -54,7 +54,7 @@ public class BottomTabsController extends ParentController implements AHBottomNa
 	protected ViewGroup createView() {
 		RelativeLayout root = new RelativeLayout(getActivity());
 		bottomTabs = new BottomTabs(getActivity());
-        presenter = new BottomTabsOptionsPresenter(bottomTabs, tabs, this, bottomTabFinder);
+        presenter = new BottomTabsOptionsPresenter(getActivity(), bottomTabs, tabs, this, bottomTabFinder);
         bottomTabs.setOnTabSelectedListener(this);
 		RelativeLayout.LayoutParams lp = new RelativeLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT);
 		lp.addRule(ALIGN_PARENT_BOTTOM);
@@ -104,10 +104,7 @@ public class BottomTabsController extends ParentController implements AHBottomNa
     public boolean onTabSelected(int index, boolean wasSelected) {
         if (wasSelected) return false;
         eventEmitter.emitBottomTabSelected(bottomTabs.getCurrentItem(), index);
-        BottomTabOptions unselected = tabs.get(bottomTabs.getCurrentItem()).options.bottomTabOptions;
-        BottomTabOptions selected = tabs.get(index).options.bottomTabOptions;
         selectTab(index);
-        bottomTabs.post(() -> presenter.onTabSelected(bottomTabs.getCurrentItem(), index, unselected, selected));
         return false;
 	}
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -165,6 +165,9 @@ public class BottomTabsController extends ParentController implements AHBottomNa
     private void attachTabs(RelativeLayout root) {
         for (int i = (tabs.size() - 1); i >= 0; i--) {
             ViewGroup tab = tabs.get(i).getView();
+            tab.setLayoutParams(new RelativeLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT));
+            Options options = resolveCurrentOptions();
+            presenter.applyLayoutParamsOptions(options, i);
             if (i != 0) tab.setVisibility(View.INVISIBLE);
             root.addView(tab);
         }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/BackButtonHelper.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/BackButtonHelper.java
@@ -1,13 +1,20 @@
 package com.reactnativenavigation.viewcontrollers.stack;
 
 import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.parse.params.Bool;
 import com.reactnativenavigation.viewcontrollers.ViewController;
 
 public class BackButtonHelper {
-    public void addToChild(StackController stack, ViewController child) {
+    public void addToPushedChild(StackController stack, ViewController child) {
         if (stack.size() <= 1 || child.options.topBar.buttons.left != null || child.options.topBar.buttons.back.visible.isFalse()) return;
         Options options = new Options();
         options.topBar.buttons.back.setVisible();
         child.mergeOptions(options);
+    }
+
+    public void clear(ViewController child) {
+        if (!child.options.topBar.buttons.back.hasValue()) {
+            child.options.topBar.buttons.back.visible = new Bool(false);
+        }
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
@@ -122,8 +122,8 @@ public class StackController extends ParentController<StackLayout> {
         final ViewController toRemove = stack.peek();
         child.setParentController(this);
         stack.push(child.getId(), child);
-        addBackButton(child);
         getView().addView(child.getView(), MATCH_PARENT, MATCH_PARENT);
+        backButtonHelper.addToPushedChild(this, child);
 
         if (toRemove != null) {
             if (child.options.animations.push.enable.isTrueOrUndefined()) {
@@ -140,11 +140,8 @@ public class StackController extends ParentController<StackLayout> {
         }
     }
 
-    private void addBackButton(ViewController child) {
-        backButtonHelper.addToChild(this, child);
-    }
-
     public void setRoot(ViewController child, CommandListener listener) {
+        backButtonHelper.clear(child);
         push(child, new CommandListenerAdapter() {
             @Override
             public void onSuccess(String childId) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
@@ -60,6 +60,11 @@ public class StackController extends ParentController<StackLayout> {
     }
 
     @Override
+    protected ViewController getCurrentChild() {
+        return stack.peek();
+    }
+
+    @Override
     public void applyChildOptions(Options options, Component child) {
         super.applyChildOptions(options, child);
         presenter.applyChildOptions(options, child);

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerBuilder.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerBuilder.java
@@ -8,9 +8,13 @@ import com.reactnativenavigation.presentation.OptionsPresenter;
 import com.reactnativenavigation.presentation.StackOptionsPresenter;
 import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
 import com.reactnativenavigation.viewcontrollers.ReactViewCreator;
+import com.reactnativenavigation.viewcontrollers.ViewController;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarBackgroundViewController;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarController;
 import com.reactnativenavigation.views.titlebar.TitleBarReactViewCreator;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class StackControllerBuilder {
     private Activity activity;
@@ -25,11 +29,17 @@ public class StackControllerBuilder {
     private BackButtonHelper backButtonHelper = new BackButtonHelper();
     private OptionsPresenter presenter;
     private StackOptionsPresenter stackPresenter;
+    private List<ViewController> children = new ArrayList<>();
 
     public StackControllerBuilder(Activity activity) {
         this.activity = activity;
         presenter = new OptionsPresenter(activity, new Options());
         animator = new NavigationAnimator(activity);
+    }
+
+    public StackControllerBuilder setChildren(List<ViewController> children) {
+        this.children = children;
+        return this;
     }
 
     public StackControllerBuilder setOptionsPresenter(OptionsPresenter presenter) {
@@ -89,6 +99,7 @@ public class StackControllerBuilder {
 
     public StackController build() {
         return new StackController(activity,
+                children,
                 childRegistry,
                 topBarButtonCreator,
                 titleBarReactViewCreator,

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerBuilder.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerBuilder.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 
 import com.reactnativenavigation.anim.NavigationAnimator;
 import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.presentation.OptionsPresenter;
+import com.reactnativenavigation.presentation.StackOptionsPresenter;
 import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
 import com.reactnativenavigation.viewcontrollers.ReactViewCreator;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarBackgroundViewController;
@@ -21,10 +23,23 @@ public class StackControllerBuilder {
     private Options initialOptions = new Options();
     private NavigationAnimator animator;
     private BackButtonHelper backButtonHelper = new BackButtonHelper();
+    private OptionsPresenter presenter;
+    private StackOptionsPresenter stackPresenter;
 
     public StackControllerBuilder(Activity activity) {
         this.activity = activity;
+        presenter = new OptionsPresenter(activity, new Options());
         animator = new NavigationAnimator(activity);
+    }
+
+    public StackControllerBuilder setOptionsPresenter(OptionsPresenter presenter) {
+        this.presenter = presenter;
+        return this;
+    }
+
+    public StackControllerBuilder setStackPresenter(StackOptionsPresenter stackPresenter) {
+        this.stackPresenter = stackPresenter;
+        return this;
     }
 
     public StackControllerBuilder setChildRegistry(ChildControllersRegistry childRegistry) {
@@ -73,6 +88,18 @@ public class StackControllerBuilder {
     }
 
     public StackController build() {
-        return new StackController(activity, childRegistry, topBarButtonCreator, titleBarReactViewCreator, topBarBackgroundViewController, topBarController, animator, id, initialOptions, backButtonHelper);
+        return new StackController(activity,
+                childRegistry,
+                topBarButtonCreator,
+                titleBarReactViewCreator,
+                topBarBackgroundViewController,
+                topBarController,
+                animator,
+                id,
+                initialOptions,
+                backButtonHelper,
+                stackPresenter,
+                presenter
+        );
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/toptabs/TopTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/toptabs/TopTabsController.java
@@ -39,6 +39,11 @@ public class TopTabsController extends ParentController<TopTabsViewPager> {
         }
     }
 
+    @Override
+    protected ViewController getCurrentChild() {
+        return tabs.get(getView().getCurrentItem());
+    }
+
     @NonNull
     @Override
     protected TopTabsViewPager createView() {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/toptabs/TopTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/toptabs/TopTabsController.java
@@ -24,8 +24,8 @@ public class TopTabsController extends ParentController<TopTabsViewPager> {
     private List<ViewController> tabs;
     private TopTabsLayoutCreator viewCreator;
 
-    public TopTabsController(Activity activity, ChildControllersRegistry childRegistry, String id, List<ViewController> tabs, TopTabsLayoutCreator viewCreator, Options options) {
-        super(activity, childRegistry, id, new OptionsPresenter(activity), options);
+    public TopTabsController(Activity activity, ChildControllersRegistry childRegistry, String id, List<ViewController> tabs, TopTabsLayoutCreator viewCreator, Options options, OptionsPresenter presenter) {
+        super(activity, childRegistry, id, presenter, options);
         this.viewCreator = viewCreator;
         this.tabs = tabs;
         for (ViewController tab : tabs) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
@@ -35,16 +35,6 @@ public class BottomTabs extends AHBottomNavigation {
     }
 
     @Override
-    public void setAccentColor(int tabIndex, int accentColor) {
-        if (getAccentColor(tabIndex) != accentColor) super.setAccentColor(tabIndex, accentColor);
-    }
-
-    @Override
-    public void setInactiveColor(int tabIndex, int inactiveColor) {
-        if (getInactiveColor(tabIndex) != inactiveColor) super.setInactiveColor(tabIndex, inactiveColor);
-    }
-
-    @Override
     public void setTitleState(TitleState titleState) {
         if (getTitleState() != titleState) super.setTitleState(titleState);
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
@@ -35,13 +35,13 @@ public class BottomTabs extends AHBottomNavigation {
     }
 
     @Override
-    public void setAccentColor(int accentColor) {
-        if (getAccentColor() != accentColor) super.setAccentColor(accentColor);
+    public void setAccentColor(int tabIndex, int accentColor) {
+        if (getAccentColor(tabIndex) != accentColor) super.setAccentColor(tabIndex, accentColor);
     }
 
     @Override
-    public void setInactiveColor(int inactiveColor) {
-        if (getInactiveColor() != inactiveColor) super.setInactiveColor(inactiveColor);
+    public void setInactiveColor(int tabIndex, int inactiveColor) {
+        if (getInactiveColor(tabIndex) != inactiveColor) super.setInactiveColor(tabIndex, inactiveColor);
     }
 
     @Override

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
@@ -25,8 +25,8 @@ public class BottomTabs extends AHBottomNavigation {
         if (BuildConfig.DEBUG) view.setContentDescription(testId.get());
     }
 
-    public void setBadge(int bottomTabIndex, Text badge) {
-        setNotification(badge.get(), bottomTabIndex);
+    public void setBadge(int bottomTabIndex, String badge) {
+        setNotification(badge, bottomTabIndex);
     }
 
     @Override

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/ComponentLayout.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/ComponentLayout.java
@@ -9,6 +9,7 @@ import android.widget.RelativeLayout;
 
 import com.reactnativenavigation.interfaces.ScrollEventListener;
 import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.utils.UiUtils;
 import com.reactnativenavigation.utils.ViewUtils;
 import com.reactnativenavigation.viewcontrollers.IReactView;
 import com.reactnativenavigation.viewcontrollers.TopBarButtonController;
@@ -77,7 +78,7 @@ public class ComponentLayout extends FrameLayout implements ReactComponent, TopB
 
     @Override
     public void drawBehindTopBar() {
-        if (getParent() instanceof RelativeLayout) {
+        if (getLayoutParams() instanceof RelativeLayout.LayoutParams) {
             RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) getLayoutParams();
             layoutParams.topMargin = 0;
             setLayoutParams(layoutParams);
@@ -86,9 +87,14 @@ public class ComponentLayout extends FrameLayout implements ReactComponent, TopB
 
     @Override
     public void drawBelowTopBar(TopBar topBar) {
-        if (getParent() instanceof RelativeLayout) {
+        if (getLayoutParams() instanceof RelativeLayout.LayoutParams) {
             RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) getLayoutParams();
-            layoutParams.topMargin = ViewUtils.getPreferredHeight(topBar);
+            int topBarHeight = ViewUtils.getPreferredHeight(topBar);
+            if (topBarHeight == 0) {
+                UiUtils.runOnPreDrawOnce(topBar, () -> layoutParams.topMargin = topBar.getHeight());
+            } else {
+                layoutParams.topMargin = ViewUtils.getPreferredHeight(topBar);
+            }
             setLayoutParams(layoutParams);
         }
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/ComponentLayout.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/ComponentLayout.java
@@ -93,7 +93,7 @@ public class ComponentLayout extends FrameLayout implements ReactComponent, TopB
             if (topBarHeight == 0) {
                 UiUtils.runOnPreDrawOnce(topBar, () -> layoutParams.topMargin = topBar.getHeight());
             } else {
-                layoutParams.topMargin = ViewUtils.getPreferredHeight(topBar);
+                layoutParams.topMargin = topBarHeight;
             }
             setLayoutParams(layoutParams);
         }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/StackLayout.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/StackLayout.java
@@ -4,11 +4,8 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.widget.RelativeLayout;
 
-import com.reactnativenavigation.parse.Options;
-import com.reactnativenavigation.presentation.StackOptionsPresenter;
 import com.reactnativenavigation.viewcontrollers.ReactViewCreator;
 import com.reactnativenavigation.viewcontrollers.TopBarButtonController;
-import com.reactnativenavigation.viewcontrollers.ViewController;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarBackgroundViewController;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarController;
 import com.reactnativenavigation.views.titlebar.TitleBarReactViewCreator;
@@ -19,34 +16,16 @@ import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 @SuppressLint("ViewConstructor")
 public class StackLayout extends RelativeLayout {
     private String stackId;
-    private final StackOptionsPresenter optionsPresenter;
 
     public StackLayout(Context context, ReactViewCreator topBarButtonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarController topBarController, TopBarButtonController.OnClickListener topBarButtonClickListener, String stackId) {
         super(context);
         this.stackId = stackId;
         createLayout(topBarButtonCreator, titleBarReactViewCreator, topBarBackgroundViewController, topBarController, topBarButtonClickListener);
-        optionsPresenter = new StackOptionsPresenter(topBarController.getView());
         setContentDescription("StackLayout");
     }
 
     private void createLayout(ReactViewCreator buttonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarController topBarController, TopBarButtonController.OnClickListener topBarButtonClickListener) {
         addView(topBarController.createView(getContext(), buttonCreator, titleBarReactViewCreator, topBarBackgroundViewController, topBarButtonClickListener, this), MATCH_PARENT, WRAP_CONTENT);
-    }
-
-    public void applyChildOptions(Options options) {
-        optionsPresenter.applyOrientation(options.layout.orientation);
-    }
-
-    public void applyChildOptions(Options options, Component child) {
-        optionsPresenter.applyChildOptions(options, child);
-    }
-
-    public void onChildWillAppear(ViewController appearing, ViewController disappearing) {
-        optionsPresenter.onChildWillAppear(appearing.options, disappearing.options);
-    }
-
-    public void mergeChildOptions(Options options, Component child) {
-        optionsPresenter.mergeChildOptions(options, child);
     }
 
     public String getStackId() {

--- a/lib/android/app/src/test/java/com/reactnativenavigation/TestUtils.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/TestUtils.java
@@ -1,16 +1,23 @@
 package com.reactnativenavigation;
 
 import android.app.Activity;
+import android.content.Context;
 
 import com.reactnativenavigation.mocks.TitleBarReactViewCreatorMock;
 import com.reactnativenavigation.mocks.TopBarBackgroundViewCreatorMock;
 import com.reactnativenavigation.mocks.TopBarButtonCreatorMock;
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.presentation.StackOptionsPresenter;
+import com.reactnativenavigation.utils.ImageLoader;
 import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
+import com.reactnativenavigation.viewcontrollers.ReactViewCreator;
+import com.reactnativenavigation.viewcontrollers.TopBarButtonController;
 import com.reactnativenavigation.viewcontrollers.stack.StackControllerBuilder;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarBackgroundViewController;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarController;
+import com.reactnativenavigation.views.StackLayout;
+import com.reactnativenavigation.views.titlebar.TitleBarReactViewCreator;
+import com.reactnativenavigation.views.topbar.TopBar;
 
 public class TestUtils {
     public static StackControllerBuilder newStackController(Activity activity) {
@@ -20,7 +27,14 @@ public class TestUtils {
                 .setTopBarButtonCreator(new TopBarButtonCreatorMock())
                 .setTitleBarReactViewCreator(new TitleBarReactViewCreatorMock())
                 .setTopBarBackgroundViewController(new TopBarBackgroundViewController(activity, new TopBarBackgroundViewCreatorMock()))
-                .setTopBarController(new TopBarController())
+                .setTopBarController(new TopBarController() {
+                    @Override
+                    protected TopBar createTopBar(Context context, ReactViewCreator buttonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener topBarButtonClickListener, StackLayout stackLayout, ImageLoader imageLoader) {
+                        TopBar topBar = super.createTopBar(context, buttonCreator, titleBarReactViewCreator, topBarBackgroundViewController, topBarButtonClickListener, stackLayout, imageLoader);
+                        topBar.layout(0, 0, 1000, 100);
+                        return topBar;
+                    }
+                })
                 .setStackPresenter(new StackOptionsPresenter(activity, new Options()))
                 .setInitialOptions(new Options());
     }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/TestUtils.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/TestUtils.java
@@ -6,6 +6,7 @@ import com.reactnativenavigation.mocks.TitleBarReactViewCreatorMock;
 import com.reactnativenavigation.mocks.TopBarBackgroundViewCreatorMock;
 import com.reactnativenavigation.mocks.TopBarButtonCreatorMock;
 import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.presentation.StackOptionsPresenter;
 import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
 import com.reactnativenavigation.viewcontrollers.stack.StackControllerBuilder;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarBackgroundViewController;
@@ -20,6 +21,7 @@ public class TestUtils {
                 .setTitleBarReactViewCreator(new TitleBarReactViewCreatorMock())
                 .setTopBarBackgroundViewController(new TopBarBackgroundViewController(activity, new TopBarBackgroundViewCreatorMock()))
                 .setTopBarController(new TopBarController())
+                .setStackPresenter(new StackOptionsPresenter(activity, new Options()))
                 .setInitialOptions(new Options());
     }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/mocks/SimpleComponentViewController.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/mocks/SimpleComponentViewController.java
@@ -3,10 +3,11 @@ package com.reactnativenavigation.mocks;
 import android.app.*;
 
 import com.reactnativenavigation.parse.*;
+import com.reactnativenavigation.presentation.OptionsPresenter;
 import com.reactnativenavigation.viewcontrollers.*;
 
 public class SimpleComponentViewController extends ComponentViewController {
     public SimpleComponentViewController(Activity activity, ChildControllersRegistry childRegistry, String id, Options initialOptions) {
-        super(activity, childRegistry,id, "theComponentName", new TestComponentViewCreator(), initialOptions);
+        super(activity, childRegistry,id, "theComponentName", new TestComponentViewCreator(), initialOptions, new OptionsPresenter(activity, new Options()));
     }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/mocks/SimpleViewController.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/mocks/SimpleViewController.java
@@ -6,10 +6,12 @@ import android.support.annotation.NonNull;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.FrameLayout;
+import android.widget.RelativeLayout;
 
 import com.reactnativenavigation.interfaces.ScrollEventListener;
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.presentation.OptionsPresenter;
+import com.reactnativenavigation.utils.ViewUtils;
 import com.reactnativenavigation.viewcontrollers.ChildController;
 import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
 import com.reactnativenavigation.views.ReactComponent;
@@ -57,12 +59,22 @@ public class SimpleViewController extends ChildController<SimpleViewController.S
 
         @Override
         public void drawBehindTopBar() {
-
+            if (getLayoutParams() instanceof RelativeLayout.LayoutParams) {
+                RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) getLayoutParams();
+                if (layoutParams.topMargin == 0) return;
+                layoutParams.topMargin = 0;
+                setLayoutParams(layoutParams);
+            }
         }
 
         @Override
         public void drawBelowTopBar(TopBar topBar) {
-
+            if (getLayoutParams() instanceof RelativeLayout.LayoutParams) {
+                RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) getLayoutParams();
+                if (layoutParams.topMargin == ViewUtils.getPreferredHeight(topBar)) return;
+                layoutParams.topMargin = ViewUtils.getPreferredHeight(topBar);
+//                setLayoutParams(layoutParams);
+            }
         }
 
         @Override

--- a/lib/android/app/src/test/java/com/reactnativenavigation/mocks/SimpleViewController.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/mocks/SimpleViewController.java
@@ -20,7 +20,7 @@ public class SimpleViewController extends ChildController<SimpleViewController.S
     private SimpleView simpleView;
 
     public SimpleViewController(Activity activity, ChildControllersRegistry childRegistry, String id, Options options) {
-        this(activity, childRegistry, id, new OptionsPresenter(activity), options);
+        this(activity, childRegistry, id, new OptionsPresenter(activity, new Options()), options);
     }
 
     public SimpleViewController(Activity activity, ChildControllersRegistry childRegistry, String id, OptionsPresenter presenter, Options options) {

--- a/lib/android/app/src/test/java/com/reactnativenavigation/parse/OptionsTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/parse/OptionsTest.java
@@ -269,9 +269,9 @@ public class OptionsTest extends BaseTest {
     @Test
     public void clear_bottomTabsOptions() {
         Options uut = new Options();
-        uut.bottomTabsOptions.tabColor = new com.reactnativenavigation.parse.params.Color(android.graphics.Color.RED);
+        uut.bottomTabsOptions.backgroundColor = new com.reactnativenavigation.parse.params.Color(android.graphics.Color.RED);
         uut.clearBottomTabsOptions();
-        assertThat(uut.bottomTabsOptions.tabColor.hasValue()).isFalse();
+        assertThat(uut.bottomTabsOptions.backgroundColor.hasValue()).isFalse();
     }
 
     @Test

--- a/lib/android/app/src/test/java/com/reactnativenavigation/utils/OptionHelper.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/utils/OptionHelper.java
@@ -9,7 +9,7 @@ public class OptionHelper {
     public static Options createBottomTabOptions() {
         Options options = new Options();
         options.topBar.buttons.left = new ArrayList<>();
-        options.bottomTabOptions.title = new Text("Tab");
+        options.bottomTabOptions.text = new Text("Tab");
         options.bottomTabOptions.icon = new Text("http://127.0.0.1/icon.png");
         return options;
     }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabOptionsPresenterTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabOptionsPresenterTest.java
@@ -1,0 +1,105 @@
+package com.reactnativenavigation.viewcontrollers;
+
+import android.app.Activity;
+
+import com.reactnativenavigation.BaseTest;
+import com.reactnativenavigation.mocks.SimpleViewController;
+import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.parse.params.Color;
+import com.reactnativenavigation.parse.params.Text;
+import com.reactnativenavigation.presentation.BottomTabOptionsPresenter;
+import com.reactnativenavigation.views.BottomTabs;
+import com.reactnativenavigation.views.Component;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class BottomTabOptionsPresenterTest extends BaseTest {
+    private Options tab1Options = createTab1Options();
+    private Options tab2Options = createTab2Options();
+    private BottomTabOptionsPresenter uut;
+    private BottomTabs bottomTabs;
+    private List<ViewController> tabs;
+    private ViewController child3;
+
+    @Override
+    public void beforeEach() {
+        Activity activity = newActivity();
+        ChildControllersRegistry childRegistry = new ChildControllersRegistry();
+        bottomTabs = Mockito.mock(BottomTabs.class);
+        ViewController child1 = spy(new SimpleViewController(activity, childRegistry, "child1", tab1Options));
+        ViewController child2 = spy(new SimpleViewController(activity, childRegistry, "child2", tab2Options));
+        child3 = spy(new SimpleViewController(activity, childRegistry, "child2", new Options()));
+        tabs = Arrays.asList(child1, child2, child3);
+        uut = new BottomTabOptionsPresenter(activity, tabs, new Options());
+        uut.bindView(bottomTabs);
+        uut.setDefaultOptions(new Options());
+    }
+
+    @Test
+    public void present() {
+        uut.present();
+        for (int i = 0; i < tabs.size(); i++) {
+            verify(bottomTabs, times(1)).setBadge(eq(i), eq(tabs.get(i).options.bottomTabOptions.badge.get("")));
+            verify(bottomTabs, times(1)).setInactiveColor(eq(i), anyInt());
+            verify(bottomTabs, times(1)).setAccentColor(eq(i), anyInt());
+        }
+        verifyNoMoreInteractions(bottomTabs);
+    }
+
+    @Test
+    public void present_resetsOptions() {
+        uut.present();
+        verify(bottomTabs, times(1)).setBadge(2, "");
+        verify(bottomTabs, times(1)).setInactiveColor(2, uut.getDefaultTabColor());
+        verify(bottomTabs, times(1)).setAccentColor(2, uut.getDefaultSelectedTabColor());
+    }
+
+    @Test
+    public void mergeChildOptions() {
+        for (int i = 0; i < 2; i++) {
+            Options options = tabs.get(i).options;
+            uut.mergeChildOptions(options, (Component) tabs.get(i).getView());
+            verify(bottomTabs, times(1)).setBadge(i, options.bottomTabOptions.badge.get());
+            verify(bottomTabs, times(1)).setAccentColor(eq(i), anyInt());
+            verify(bottomTabs, times(1)).setInactiveColor(eq(i), anyInt());
+        }
+        verifyNoMoreInteractions(bottomTabs);
+    }
+
+    @Test
+    public void mergeChildOptions_onlySetsDefinedOptions() {
+        uut.mergeChildOptions(child3.options, (Component) child3.getView());
+        verify(bottomTabs, times(0)).setBadge(eq(2), anyString());
+        verify(bottomTabs, times(0)).setInactiveColor(eq(2), anyInt());
+        verify(bottomTabs, times(0)).setAccentColor(eq(2), anyInt());
+        verifyNoMoreInteractions(bottomTabs);
+    }
+
+    private Options createTab1Options() {
+        Options options = new Options();
+        options.bottomTabOptions.badge = new Text("tab1badge");
+        options.bottomTabOptions.iconColor = new Color(android.graphics.Color.RED);
+        options.bottomTabOptions.selectedIconColor = new Color(android.graphics.Color.RED);
+        return options;
+    }
+
+    private Options createTab2Options() {
+        Options options = new Options();
+        options.bottomTabOptions.badge = new Text("tab2badge");
+        options.bottomTabOptions.iconColor = new Color(android.graphics.Color.RED);
+        options.bottomTabOptions.selectedIconColor = new Color(android.graphics.Color.RED);
+        return options;
+    }
+}

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabOptionsPresenterTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabOptionsPresenterTest.java
@@ -51,19 +51,10 @@ public class BottomTabOptionsPresenterTest extends BaseTest {
     public void present() {
         uut.present();
         for (int i = 0; i < tabs.size(); i++) {
-            verify(bottomTabs, times(1)).setBadge(eq(i), eq(tabs.get(i).options.bottomTabOptions.badge.get("")));
-            verify(bottomTabs, times(1)).setInactiveColor(eq(i), anyInt());
-            verify(bottomTabs, times(1)).setAccentColor(eq(i), anyInt());
+            verify(bottomTabs, times(1)).setBadge(i, tabs.get(i).options.bottomTabOptions.badge.get(""));
+            verify(bottomTabs, times(1)).setTitleInactiveColor(i, tabs.get(i).options.bottomTabOptions.textColor.get(null));
+            verify(bottomTabs, times(1)).setTitleActiveColor(i, tabs.get(i).options.bottomTabOptions.selectedTextColor.get(null));
         }
-        verifyNoMoreInteractions(bottomTabs);
-    }
-
-    @Test
-    public void present_resetsOptions() {
-        uut.present();
-        verify(bottomTabs, times(1)).setBadge(2, "");
-        verify(bottomTabs, times(1)).setInactiveColor(2, uut.getDefaultTabColor());
-        verify(bottomTabs, times(1)).setAccentColor(2, uut.getDefaultSelectedTabColor());
     }
 
     @Test
@@ -72,8 +63,8 @@ public class BottomTabOptionsPresenterTest extends BaseTest {
             Options options = tabs.get(i).options;
             uut.mergeChildOptions(options, (Component) tabs.get(i).getView());
             verify(bottomTabs, times(1)).setBadge(i, options.bottomTabOptions.badge.get());
-            verify(bottomTabs, times(1)).setAccentColor(eq(i), anyInt());
-            verify(bottomTabs, times(1)).setInactiveColor(eq(i), anyInt());
+            verify(bottomTabs, times(1)).setIconActiveColor(eq(i), anyInt());
+            verify(bottomTabs, times(1)).setIconInactiveColor(eq(i), anyInt());
         }
         verifyNoMoreInteractions(bottomTabs);
     }
@@ -82,8 +73,8 @@ public class BottomTabOptionsPresenterTest extends BaseTest {
     public void mergeChildOptions_onlySetsDefinedOptions() {
         uut.mergeChildOptions(child3.options, (Component) child3.getView());
         verify(bottomTabs, times(0)).setBadge(eq(2), anyString());
-        verify(bottomTabs, times(0)).setInactiveColor(eq(2), anyInt());
-        verify(bottomTabs, times(0)).setAccentColor(eq(2), anyInt());
+        verify(bottomTabs, times(0)).setIconInactiveColor(eq(2), anyInt());
+        verify(bottomTabs, times(0)).setIconActiveColor(eq(2), anyInt());
         verifyNoMoreInteractions(bottomTabs);
     }
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabsControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabsControllerTest.java
@@ -51,6 +51,7 @@ public class BottomTabsControllerTest extends BaseTest {
     private ViewController child3;
     private StackController child4;
     private ViewController child5;
+    private ViewController child6;
     private Options tabOptions = OptionHelper.createBottomTabOptions();
     private ImageLoader imageLoaderMock = ImageLoaderMock.mock();
     private EventEmitter eventEmitter;
@@ -68,6 +69,7 @@ public class BottomTabsControllerTest extends BaseTest {
         child3 = spy(new SimpleViewController(activity, childRegistry, "child3", tabOptions));
         child4 = spy(createStack("someStack"));
         child5 = spy(new SimpleViewController(activity, childRegistry, "child5", tabOptions));
+        child6 = spy(new SimpleViewController(activity, childRegistry, "child6", tabOptions));
         when(child5.handleBack(any())).thenReturn(true);
         tabs = createTabs();
         uut = createBottomTabs();
@@ -222,6 +224,25 @@ public class BottomTabsControllerTest extends BaseTest {
         assertThat(child4.size()).isOne();
         child4.push(stackChild2, new CommandListenerAdapter());
         assertThat(child4.size()).isEqualTo(2);
+    }
+
+    @Test
+    public void deepChildOptionsAreApplied() {
+        BottomTabsController spy = spy(uut);
+        activity.setContentView(spy.getView());
+
+        child6.options.topBar.drawBehind = new Bool(false);
+        disablePushAnimation(child6);
+        child4.push(child6, new CommandListenerAdapter());
+        assertThat(child4.size()).isOne();
+
+
+        verify(spy, times(1)).onViewAppeared();
+        assertThat(spy.getSelectedIndex()).isZero();
+        verify(child6, times(0)).onViewAppeared();
+        assertThat(child4.getTopBar().getHeight())
+                .isNotZero()
+                .isEqualTo(((ViewGroup.MarginLayoutParams) child6.getView().getLayoutParams()).topMargin);
     }
 
     @NonNull

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabsControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabsControllerTest.java
@@ -155,7 +155,7 @@ public class BottomTabsControllerTest extends BaseTest {
     @Test
     public void applyOptions_bottomTabsOptionsAreClearedAfterApply() {
         Options options = new Options();
-        options.bottomTabsOptions.tabColor = new Color(android.graphics.Color.RED);
+        options.bottomTabsOptions.backgroundColor = new Color(android.graphics.Color.RED);
         child1.mergeOptions(options);
         uut.ensureViewIsCreated();
 
@@ -168,7 +168,7 @@ public class BottomTabsControllerTest extends BaseTest {
         ArgumentCaptor<ReactComponent> viewCaptor = ArgumentCaptor.forClass(ReactComponent.class);
         verify(stack, times(1)).applyChildOptions(optionsCaptor.capture(), viewCaptor.capture());
         assertThat(viewCaptor.getValue()).isEqualTo(child1.getView());
-        assertThat(optionsCaptor.getValue().bottomTabsOptions.tabColor.hasValue()).isFalse();
+        assertThat(optionsCaptor.getValue().bottomTabsOptions.backgroundColor.hasValue()).isFalse();
     }
 
     @Test

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabsControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabsControllerTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -57,6 +58,7 @@ public class BottomTabsControllerTest extends BaseTest {
     private EventEmitter eventEmitter;
     private ChildControllersRegistry childRegistry;
     private List<ViewController> tabs;
+    private BottomTabsOptionsPresenter presenter;
 
     @Override
     public void beforeEach() {
@@ -72,6 +74,7 @@ public class BottomTabsControllerTest extends BaseTest {
         child6 = spy(new SimpleViewController(activity, childRegistry, "child6", tabOptions));
         when(child5.handleBack(any())).thenReturn(true);
         tabs = createTabs();
+        presenter = spy(new BottomTabsOptionsPresenter(tabs, new Options()));
         uut = createBottomTabs();
     }
 
@@ -101,6 +104,16 @@ public class BottomTabsControllerTest extends BaseTest {
         uut.onViewAppeared();
         for (int i = 0; i < uut.getChildControllers().size(); i++) {
             assertThat(uut.getView().getChildAt(i).getVisibility()).isEqualTo(i == 0 ? View.VISIBLE : View.INVISIBLE);
+        }
+    }
+
+    @Test
+    public void createView_layoutOptionsAreAppliedToTabs() {
+        uut.ensureViewIsCreated();
+        for (int i = 0; i < tabs.size(); i++) {
+            verify(presenter, times(1)).applyLayoutParamsOptions(any(), eq(i));
+            assertThat(childLayoutParams(i).width).isEqualTo(ViewGroup.LayoutParams.MATCH_PARENT);
+            assertThat(childLayoutParams(i).height).isEqualTo(ViewGroup.LayoutParams.MATCH_PARENT);
         }
     }
 
@@ -271,7 +284,7 @@ public class BottomTabsControllerTest extends BaseTest {
                 "uut",
                 new Options(),
                 new OptionsPresenter(activity, new Options()),
-                new BottomTabsOptionsPresenter(tabs, new Options()),
+                presenter,
                 new BottomTabOptionsPresenter(activity, tabs, new Options())) {
             @Override
             public void ensureViewIsCreated() {

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/ComponentViewControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/ComponentViewControllerTest.java
@@ -7,6 +7,7 @@ import com.reactnativenavigation.TestUtils;
 import com.reactnativenavigation.mocks.TestComponentLayout;
 import com.reactnativenavigation.mocks.TestReactView;
 import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.presentation.OptionsPresenter;
 import com.reactnativenavigation.views.StackLayout;
 
 import org.junit.Test;
@@ -27,7 +28,8 @@ public class ComponentViewControllerTest extends BaseTest {
         Activity activity = newActivity();
         view = spy(new TestComponentLayout(activity, new TestReactView(activity)));
         ParentController<StackLayout> parentController = TestUtils.newStackController(activity).build();
-        uut = new ComponentViewController(activity, new ChildControllersRegistry(), "componentId1", "componentName", (activity1, componentId, componentName) -> view, new Options());
+        OptionsPresenter presenter = new OptionsPresenter(activity, new Options());
+        uut = new ComponentViewController(activity, new ChildControllersRegistry(), "componentId1", "componentName", (activity1, componentId, componentName) -> view, new Options(), presenter);
         uut.setParentController(parentController);
         parentController.ensureViewIsCreated();
     }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/FloatingActionButtonTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/FloatingActionButtonTest.java
@@ -37,6 +37,7 @@ public class FloatingActionButtonTest extends BaseTest {
         activity = newActivity();
         childRegistry = new ChildControllersRegistry();
         stackController = TestUtils.newStackController(activity).build();
+        stackController.ensureViewIsCreated();
         Options options = getOptionsWithFab();
         childFab = new SimpleViewController(activity, childRegistry, "child1", options);
         childNoFab = new SimpleViewController(activity, childRegistry, "child2", new Options());

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/NavigatorTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/NavigatorTest.java
@@ -11,6 +11,9 @@ import com.reactnativenavigation.mocks.SimpleViewController;
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.parse.params.Bool;
 import com.reactnativenavigation.parse.params.Text;
+import com.reactnativenavigation.presentation.BottomTabOptionsPresenter;
+import com.reactnativenavigation.presentation.BottomTabsOptionsPresenter;
+import com.reactnativenavigation.presentation.OptionsPresenter;
 import com.reactnativenavigation.presentation.OverlayManager;
 import com.reactnativenavigation.react.EventEmitter;
 import com.reactnativenavigation.utils.CommandListener;
@@ -72,6 +75,17 @@ public class NavigatorTest extends BaseTest {
         activity.setContentView(uut.getView());
 
         activityController.visible();
+    }
+
+    @Test
+    public void setDefaultOptions() {
+        uut.setDefaultOptions(new Options());
+
+        SimpleViewController spy = spy(child1);
+        uut.setRoot(spy, new CommandListenerAdapter());
+        Options defaultOptions = new Options();
+        uut.setDefaultOptions(defaultOptions);
+        verify(spy, times(1)).setDefaultOptions(defaultOptions);
     }
 
     @Test
@@ -271,7 +285,7 @@ public class NavigatorTest extends BaseTest {
 
     @NonNull
     private BottomTabsController newTabs(List<ViewController> tabs) {
-        return new BottomTabsController(activity, tabs, childRegistry, eventEmitter, imageLoaderMock, "tabsController", new Options());
+        return new BottomTabsController(activity, tabs, childRegistry, eventEmitter, imageLoaderMock, "tabsController", new Options(), new OptionsPresenter(activity, new Options()), new BottomTabsOptionsPresenter(tabs, new Options()), new BottomTabOptionsPresenter(activity, tabs, new Options()));
     }
 
     @NonNull

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/OptionsApplyingTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/OptionsApplyingTest.java
@@ -107,6 +107,7 @@ public class OptionsApplyingTest extends BaseTest {
                         .setInitialOptions(new Options())
                         .setStackPresenter(new StackOptionsPresenter(activity, new Options()))
                         .build();
+        stackController.ensureViewIsCreated();
         stackController.push(uut, new CommandListenerAdapter());
         assertThat(stackController.getTopBar().getTitle()).isEmpty();
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/OptionsApplyingTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/OptionsApplyingTest.java
@@ -21,6 +21,8 @@ import com.reactnativenavigation.parse.TopBarBackgroundOptions;
 import com.reactnativenavigation.parse.params.Bool;
 import com.reactnativenavigation.parse.params.Fraction;
 import com.reactnativenavigation.parse.params.Text;
+import com.reactnativenavigation.presentation.OptionsPresenter;
+import com.reactnativenavigation.presentation.StackOptionsPresenter;
 import com.reactnativenavigation.utils.CommandListenerAdapter;
 import com.reactnativenavigation.utils.ImageLoader;
 import com.reactnativenavigation.viewcontrollers.stack.StackController;
@@ -62,7 +64,8 @@ public class OptionsApplyingTest extends BaseTest {
                 "componentId1",
                 "componentName",
                 (activity1, componentId, componentName) -> view,
-                initialNavigationOptions
+                initialNavigationOptions,
+                new OptionsPresenter(activity, new Options())
         );
         TopBarController topBarController = new TopBarController() {
             @Override
@@ -102,6 +105,7 @@ public class OptionsApplyingTest extends BaseTest {
                         .setTopBarController(new TopBarController())
                         .setId("stackId")
                         .setInitialOptions(new Options())
+                        .setStackPresenter(new StackOptionsPresenter(activity, new Options()))
                         .build();
         stackController.push(uut, new CommandListenerAdapter());
         assertThat(stackController.getTopBar().getTitle()).isEmpty();
@@ -162,6 +166,7 @@ public class OptionsApplyingTest extends BaseTest {
         });
     }
 
+    @SuppressWarnings("MagicNumber")
     @Test
     public void appliesTopBarTextSize() {
         assertThat(uut.initialOptions).isSameAs(initialNavigationOptions);

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/ParentControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/ParentControllerTest.java
@@ -45,7 +45,7 @@ public class ParentControllerTest extends BaseTest {
         children = new ArrayList<>();
         Options initialOptions = new Options();
         initialOptions.topBar.title.text = new Text(INITIAL_TITLE);
-        presenter = spy(new OptionsPresenter(activity));
+        presenter = spy(new OptionsPresenter(activity, new Options()));
         uut = spy(new ParentController(activity, childRegistry, "uut", presenter, initialOptions) {
 
             @NonNull

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/ParentControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/ParentControllerTest.java
@@ -48,6 +48,11 @@ public class ParentControllerTest extends BaseTest {
         presenter = spy(new OptionsPresenter(activity, new Options()));
         uut = spy(new ParentController(activity, childRegistry, "uut", presenter, initialOptions) {
 
+            @Override
+            protected ViewController getCurrentChild() {
+                return children.get(0);
+            }
+
             @NonNull
             @Override
             protected ViewGroup createView() {
@@ -96,6 +101,7 @@ public class ParentControllerTest extends BaseTest {
     @Test
     public void findControllerById_Recursive() {
         StackController stackController = TestUtils.newStackController(activity).build();
+        stackController.ensureViewIsCreated();
         SimpleViewController child1 = new SimpleViewController(activity, childRegistry, "child1", new Options());
         SimpleViewController child2 = new SimpleViewController(activity, childRegistry, "child2", new Options());
         stackController.push(child1, new CommandListenerAdapter());
@@ -118,6 +124,7 @@ public class ParentControllerTest extends BaseTest {
     @Test
     public void optionsAreClearedWhenChildIsAppeared() {
         StackController stackController = spy(TestUtils.newStackController(activity).build());
+        stackController.ensureViewIsCreated();
         SimpleViewController child1 = new SimpleViewController(activity, childRegistry, "child1", new Options());
         stackController.push(child1, new CommandListenerAdapter());
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/SideMenuControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/SideMenuControllerTest.java
@@ -7,6 +7,7 @@ import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.mocks.SimpleComponentViewController;
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.parse.params.Bool;
+import com.reactnativenavigation.presentation.OptionsPresenter;
 
 import org.junit.Test;
 
@@ -21,7 +22,8 @@ public class SideMenuControllerTest extends BaseTest {
     public void beforeEach() {
         activity = newActivity();
         childRegistry = new ChildControllersRegistry();
-        uut = new SideMenuController(activity, childRegistry, "sideMenu", new Options());
+        OptionsPresenter presenter = new OptionsPresenter(activity, new Options());
+        uut = new SideMenuController(activity, childRegistry, "sideMenu", new Options(), presenter);
     }
 
     @Test

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/StackOptionsPresenterTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/StackOptionsPresenterTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class OptionsMergingTest extends BaseTest {
+public class StackOptionsPresenterTest extends BaseTest {
 
     private StackOptionsPresenter uut;
     private TestComponentLayout child;
@@ -43,8 +43,9 @@ public class OptionsMergingTest extends BaseTest {
     @Override
     public void beforeEach() {
         activity = spy(newActivity());
+        uut = spy(new StackOptionsPresenter(activity, new Options()));
         topBar = mockTopBar();
-        uut = spy(new StackOptionsPresenter(topBar));
+        uut.bindView(topBar);
         child = spy(new TestComponentLayout(activity, new TestReactView(activity)));
     }
 
@@ -80,16 +81,16 @@ public class OptionsMergingTest extends BaseTest {
     public void mergeTopBarOptions() {
         Options options = new Options();
         uut.mergeChildOptions(options, child);
-        assertTopBarOptions(0);
+        assertTopBarOptions(options, 0);
 
-        TitleOptions titleOptions = new TitleOptions();
-        titleOptions.text = new Text("abc");
-        titleOptions.component.name = new Text("someComponent");
-        titleOptions.component.componentId = new Text("compId");
-        titleOptions.color = new Color(0);
-        titleOptions.fontSize = new Fraction(1.0f);
-        titleOptions.fontFamily = Typeface.DEFAULT_BOLD;
-        options.topBar.title = titleOptions;
+        TitleOptions title = new TitleOptions();
+        title.text = new Text("abc");
+        title.component.name = new Text("someComponent");
+        title.component.componentId = new Text("compId");
+        title.color = new Color(0);
+        title.fontSize = new Fraction(1.0f);
+        title.fontFamily = Typeface.DEFAULT_BOLD;
+        options.topBar.title = title;
         SubtitleOptions subtitleOptions = new SubtitleOptions();
         subtitleOptions.text = new Text("Sub");
         subtitleOptions.color = new Color(1);
@@ -102,7 +103,7 @@ public class OptionsMergingTest extends BaseTest {
         options.topBar.hideOnScroll = new Bool(false);
         uut.mergeChildOptions(options, child);
 
-        assertTopBarOptions(1);
+        assertTopBarOptions(options, 1);
 
         options.topBar.drawBehind = new Bool(true);
         uut.mergeChildOptions(options, child);
@@ -141,9 +142,14 @@ public class OptionsMergingTest extends BaseTest {
         verify(topBar, times(1)).setTopTabFontFamily(1, Typeface.DEFAULT_BOLD);
     }
 
-    private void assertTopBarOptions(int t) {
-        verify(topBar, times(t)).setTitle(any());
-        verify(topBar, times(t)).setSubtitle(any());
+    private void assertTopBarOptions(Options options, int t) {
+        if (options.topBar.title.component.hasValue()) {
+            verify(topBar, times(0)).setTitle(any());
+            verify(topBar, times(0)).setSubtitle(any());
+        } else {
+            verify(topBar, times(t)).setTitle(any());
+            verify(topBar, times(t)).setSubtitle(any());
+        }
         verify(topBar, times(t)).setTitleComponent(any());
         verify(topBar, times(t)).setBackgroundColor(any());
         verify(topBar, times(t)).setTitleTextColor(anyInt());

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TopTabsViewControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TopTabsViewControllerTest.java
@@ -63,6 +63,7 @@ public class TopTabsViewControllerTest extends BaseTest {
         tabControllers.forEach(viewController -> viewController.setParentController(uut));
 
         stack = spy(TestUtils.newStackController(activity).build());
+        stack.ensureViewIsCreated();
         stack.push(uut, new CommandListenerAdapter());
         uut.setParentController(stack);
     }
@@ -210,6 +211,7 @@ public class TopTabsViewControllerTest extends BaseTest {
         stack.getView().removeAllViews();
 
         StackController stackController = spy(TestUtils.newStackController(activity).build());
+        stackController.ensureViewIsCreated();
         ComponentViewController first = new ComponentViewController(
                 activity,
                 childRegistry,

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TopTabsViewControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TopTabsViewControllerTest.java
@@ -11,6 +11,7 @@ import com.reactnativenavigation.mocks.TestReactView;
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.parse.params.Bool;
 import com.reactnativenavigation.parse.params.Text;
+import com.reactnativenavigation.presentation.OptionsPresenter;
 import com.reactnativenavigation.utils.CommandListenerAdapter;
 import com.reactnativenavigation.utils.ViewHelper;
 import com.reactnativenavigation.viewcontrollers.stack.StackController;
@@ -57,7 +58,8 @@ public class TopTabsViewControllerTest extends BaseTest {
         topTabsLayout = spy(new TopTabsViewPager(activity, tabControllers, new TopTabsAdapter(tabControllers)));
         TopTabsLayoutCreator layoutCreator = Mockito.mock(TopTabsLayoutCreator.class);
         Mockito.when(layoutCreator.create()).thenReturn(topTabsLayout);
-        uut = spy(new TopTabsController(activity, childRegistry, "componentId", tabControllers, layoutCreator, options));
+        OptionsPresenter presenter = new OptionsPresenter(activity, new Options());
+        uut = spy(new TopTabsController(activity, childRegistry, "componentId", tabControllers, layoutCreator, options, presenter));
         tabControllers.forEach(viewController -> viewController.setParentController(uut));
 
         stack = spy(TestUtils.newStackController(activity).build());
@@ -86,7 +88,8 @@ public class TopTabsViewControllerTest extends BaseTest {
                     "idTab" + i,
                     "theComponentName",
                     new TestComponentViewCreator(),
-                    tabOptions.get(i)
+                    tabOptions.get(i),
+                    new OptionsPresenter(activity, new Options())
             );
             tabControllers.add(spy(viewController));
         }
@@ -213,7 +216,8 @@ public class TopTabsViewControllerTest extends BaseTest {
                 "firstScreen",
                 "comp1",
                 new TestComponentViewCreator(),
-                new Options()
+                new Options(),
+                new OptionsPresenter(activity, new Options())
         );
         first.options.animations.push.enable = new Bool(false);
         uut.options.animations.push.enable = new Bool(false);

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/ViewControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/ViewControllerTest.java
@@ -75,6 +75,7 @@ public class ViewControllerTest extends BaseTest {
 
         assertThat(uut.getParentController()).isNull();
         StackController nav = TestUtils.newStackController(activity).build();
+        nav.ensureViewIsCreated();
         nav.push(uut, new CommandListenerAdapter());
         assertThat(uut.getParentController()).isEqualTo(nav);
     }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/BackButtonHelperTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/BackButtonHelperTest.java
@@ -37,6 +37,7 @@ public class BackButtonHelperTest extends BaseTest {
                 .build();
         child1 = spy(new SimpleViewController(activity, childRegistry, "child1", new Options()));
         child2 = spy(new SimpleViewController(activity, childRegistry, "child2", new Options()));
+        stack.ensureViewIsCreated();
     }
 
     @Test

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/BackButtonHelperTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/BackButtonHelperTest.java
@@ -41,7 +41,7 @@ public class BackButtonHelperTest extends BaseTest {
 
     @Test
     public void addToChild_doesNotAddIfStackContainsOneChild() {
-        uut.addToChild(stack, child1);
+        uut.addToPushedChild(stack, child1);
         verify(child1, times(0)).mergeOptions(any());
     }
 
@@ -64,5 +64,12 @@ public class BackButtonHelperTest extends BaseTest {
         stack.push(child2, new CommandListenerAdapter());
 
         verify(child2, times(0)).mergeOptions(any());
+    }
+
+    @Test
+    public void clear() {
+        child1.options.topBar.buttons.back.visible = new Bool(true);
+        uut.clear(child1);
+        assertThat(child1.options.topBar.buttons.back.visible.get()).isFalse();
     }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
@@ -3,6 +3,7 @@ package com.reactnativenavigation.viewcontrollers.stack;
 import android.app.Activity;
 import android.content.Context;
 import android.view.View;
+import android.view.ViewGroup;
 
 import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.TestUtils;
@@ -41,7 +42,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -71,16 +74,33 @@ public class StackControllerTest extends BaseTest {
         activity = newActivity();
         childRegistry = new ChildControllersRegistry();
         presenter = new StackOptionsPresenter(activity, new Options());
-        uut = createStackController();
         child1 = spy(new SimpleViewController(activity, childRegistry, "child1", new Options()));
         child2 = spy(new SimpleViewController(activity, childRegistry, "child2", new Options()));
         child3 = spy(new SimpleViewController(activity, childRegistry, "child3", new Options()));
         child4 = spy(new SimpleViewController(activity, childRegistry, "child4", new Options()));
+        uut = createStack();
+        uut.ensureViewIsCreated();
     }
 
     @Test
     public void isAViewController() {
         assertThat(uut).isInstanceOf(ViewController.class);
+    }
+
+    @Test
+    public void childrenAreAssignedParent() {
+        StackController uut = createStack(Arrays.asList(child1, child2));
+        for (ViewController child : uut.getChildControllers()) {
+            assertThat(child.getParentController().equals(uut));
+        }
+    }
+
+    @Test
+    public void createView_currentChildIsAdded() {
+        StackController uut = createStack(Arrays.asList(child1, child2, child3, child4));
+        assertThat(uut.getChildControllers().size()).isEqualTo(4);
+        assertThat(uut.getView().getChildCount()).isEqualTo(2);
+        assertThat(uut.getView().getChildAt(1)).isEqualTo(child4.getView());
     }
 
     @Test
@@ -140,6 +160,7 @@ public class StackControllerTest extends BaseTest {
 
     @Test
     public void animateSetRoot() {
+        disablePushAnimation(child1, child2, child3);
         assertThat(uut.isEmpty()).isTrue();
         uut.push(child1, new CommandListenerAdapter());
         uut.push(child2, new CommandListenerAdapter());
@@ -154,7 +175,7 @@ public class StackControllerTest extends BaseTest {
     @Test
     public void setRoot() {
         activity.setContentView(uut.getView());
-        disablePushAnimation(child1, child2);
+        disablePushAnimation(child1, child2, child3);
 
         assertThat(uut.isEmpty()).isTrue();
         uut.push(child1, new CommandListenerAdapter());
@@ -170,7 +191,8 @@ public class StackControllerTest extends BaseTest {
     }
 
     @Test
-    public void pop() {
+    public synchronized void pop() {
+        disablePushAnimation(child1, child2);
         uut.push(child1, new CommandListenerAdapter());
         uut.push(child2, new CommandListenerAdapter() {
             @Override
@@ -302,7 +324,8 @@ public class StackControllerTest extends BaseTest {
         uut.push(child1, new CommandListenerAdapter());
         assertThat(child1.getParentController()).isEqualTo(uut);
 
-        StackController anotherNavController = createStackController("another");
+        StackController anotherNavController = createStack("another");
+        anotherNavController.ensureViewIsCreated();
         anotherNavController.push(child2, new CommandListenerAdapter());
         assertThat(child2.getParentController()).isEqualTo(anotherNavController);
     }
@@ -381,6 +404,25 @@ public class StackControllerTest extends BaseTest {
                 });
             }
         });
+    }
+
+    @Test
+    public void pop_appearingChildHasCorrectLayoutParams() {
+        child2.options.animations.pop.enable = new Bool(false);
+        child1.options.topBar.drawBehind = new Bool(false);
+
+        StackController uut = createStack(Arrays.asList(child1, child2));
+        uut.ensureViewIsCreated();
+
+        assertThat(child2.getView().getParent()).isEqualTo(uut.getView());
+        uut.pop(new CommandListenerAdapter());
+        assertThat(child1.getView().getParent()).isEqualTo(uut.getView());
+
+        assertThat(child1.getView().getLayoutParams().width).isEqualTo(ViewGroup.LayoutParams.MATCH_PARENT);
+        assertThat(child1.getView().getLayoutParams().height).isEqualTo(ViewGroup.LayoutParams.MATCH_PARENT);
+        assertThat(((ViewGroup.MarginLayoutParams) child1.getView().getLayoutParams()).topMargin).isEqualTo(uut
+                .getTopBar()
+                .getHeight());
     }
 
     @Test
@@ -523,7 +565,8 @@ public class StackControllerTest extends BaseTest {
 
     @Test
     public void findControllerById_Deeply() {
-        StackController stack = createStackController("another");
+        StackController stack = createStack("another");
+        stack.ensureViewIsCreated();
         stack.push(child2, new CommandListenerAdapter());
         uut.push(stack, new CommandListenerAdapter());
         assertThat(uut.findControllerById(child2.getId())).isEqualTo(child2);
@@ -649,7 +692,7 @@ public class StackControllerTest extends BaseTest {
 
     @Test
     public void stackCanBePushed() {
-        StackController parent = createStackController("someStack");
+        StackController parent = createStack("someStack");
         parent.ensureViewIsCreated();
         parent.push(uut, new CommandListenerAdapter());
         uut.onViewAppeared();
@@ -658,7 +701,7 @@ public class StackControllerTest extends BaseTest {
 
     @Test
     public void applyOptions_applyOnlyOnFirstStack() {
-        StackController parent = spy(createStackController("someStack"));
+        StackController parent = spy(createStack("someStack"));
         parent.ensureViewIsCreated();
         parent.push(uut, new CommandListenerAdapter());
 
@@ -777,13 +820,22 @@ public class StackControllerTest extends BaseTest {
         assertThat(uut.getChildControllers()).extracting((Extractor<ViewController, String>) ViewController::getId).containsOnly(ids);
     }
 
-    private StackController createStackController() {
-        return createStackController("stack");
+    private StackController createStack() {
+        return createStack("stack", new ArrayList<>());
     }
 
-    private StackController createStackController(String id) {
+    private StackController createStack(String id) {
+        return createStack(id, new ArrayList<>());
+    }
+
+    private StackController createStack(List<ViewController> children) {
+        return createStack("stack", children);
+    }
+
+    private StackController createStack(String id, List<ViewController> children) {
         createTopBarController();
         return TestUtils.newStackController(activity)
+                .setChildren(children)
                 .setId(id)
                 .setTopBarController(topBarController)
                 .setChildRegistry(childRegistry)
@@ -796,7 +848,9 @@ public class StackControllerTest extends BaseTest {
         topBarController = spy(new TopBarController() {
             @Override
             protected TopBar createTopBar(Context context, ReactViewCreator buttonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener topBarButtonClickListener, StackLayout stackLayout, ImageLoader imageLoader) {
-                return spy(super.createTopBar(context, buttonCreator, titleBarReactViewCreator, topBarBackgroundViewController, topBarButtonClickListener, stackLayout, ImageLoaderMock.mock()));
+                TopBar spy = spy(super.createTopBar(context, buttonCreator, titleBarReactViewCreator, topBarBackgroundViewController, topBarButtonClickListener, stackLayout, ImageLoaderMock.mock()));
+                spy.layout(0, 0, 1000, 100);
+                return spy;
             }
         });
     }

--- a/lib/ios/RNNBottomTabOptions.h
+++ b/lib/ios/RNNBottomTabOptions.h
@@ -3,7 +3,7 @@
 @interface RNNBottomTabOptions : RNNOptions
 
 @property (nonatomic) NSUInteger tag;
-@property (nonatomic, strong) NSString* title;
+@property (nonatomic, strong) NSString* text;
 @property (nonatomic, strong) NSString* badge;
 @property (nonatomic, strong) NSString* testID;
 @property (nonatomic, strong) NSNumber* visible;

--- a/lib/ios/RNNBottomTabOptions.h
+++ b/lib/ios/RNNBottomTabOptions.h
@@ -9,8 +9,13 @@
 @property (nonatomic, strong) NSNumber* visible;
 @property (nonatomic, strong) NSDictionary* icon;
 @property (nonatomic, strong) NSDictionary* selectedIcon;
-@property (nonatomic, strong) NSDictionary* disableIconTint;
-@property (nonatomic, strong) NSDictionary* disableSelectedIconTint;
+@property (nonatomic, strong) NSDictionary* iconColor;
+@property (nonatomic, strong) NSDictionary* selectedIconColor;
+@property (nonatomic, strong) NSDictionary* textColor;
+@property (nonatomic, strong) NSDictionary* selectedTextColor;
+@property (nonatomic, strong) NSString* fontFamily;
+@property (nonatomic, strong) NSNumber* fontSize;
+
 @property (nonatomic, strong) NSDictionary* iconInsets;
 
 @end

--- a/lib/ios/RNNBottomTabOptions.m
+++ b/lib/ios/RNNBottomTabOptions.m
@@ -13,12 +13,12 @@
 }
 
 - (void)applyOn:(UIViewController *)viewController {
-	if (self.title || self.icon || self.selectedIcon) {
+	if (self.text || self.icon || self.selectedIcon) {
 		UITabBarItem* tabItem = viewController.tabBarItem;
 		
 		tabItem.selectedImage = [self getSelectedIconImage];
 		tabItem.image = [self getIconImage];
-		tabItem.title = self.title;
+		tabItem.title = self.text;
 		tabItem.tag = self.tag;
 		tabItem.accessibilityIdentifier = self.testID;
 		
@@ -35,9 +35,7 @@
 			
 			tabItem.imageInsets = UIEdgeInsetsMake(top, left, bottom, right);
 		}
-//		[tabItem setTitleTextAttributes:[NSDictionary dictionaryWithObjectsAndKeys:[UIFont fontWithName:@"HelveticaLTStd-Roman" size:10.0f], NSFontAttributeName,  [UIColor yellowColor], NSForegroundColorAttributeName,nil] forState:UIControlStateNormal];
-//
-//		[tabItem setTitleTextAttributes:[NSDictionary dictionaryWithObjectsAndKeys:[UIFont fontWithName:@"HelveticaLTStd-Roman" size:10.0f], NSFontAttributeName,  [UIColor blackColor], NSForegroundColorAttributeName,nil] forState:UIControlStateHighlighted];
+		
 		[self appendTitleAttributes:tabItem];
 		
 		[viewController setTabBarItem:tabItem];
@@ -71,7 +69,7 @@
 		if (self.selectedIconColor) {
 			return [[[RCTConvert UIImage:self.selectedIcon] withTintColor:[RCTConvert UIColor:self.selectedIconColor]] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
 		} else {
-			return [RCTConvert UIImage:self.selectedIcon];
+			return [[RCTConvert UIImage:self.selectedIcon] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
 		}
 	} else {
 		return [self getIconImageWithTint:self.selectedIconColor];
@@ -85,7 +83,7 @@
 		if (tintColor) {
 			return [[[RCTConvert UIImage:self.icon] withTintColor:[RCTConvert UIColor:tintColor]] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
 		} else {
-			return [RCTConvert UIImage:self.icon];
+			return [[RCTConvert UIImage:self.icon] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
 		}
 	}
 	
@@ -96,7 +94,10 @@
 	NSMutableDictionary* selectedAttributes = [NSMutableDictionary dictionaryWithDictionary:[tabItem titleTextAttributesForState:UIControlStateNormal]];
 	if (self.selectedTextColor) {
 		selectedAttributes[NSForegroundColorAttributeName] = [RCTConvert UIColor:self.selectedTextColor];
+	} else {
+		selectedAttributes[NSForegroundColorAttributeName] = [UIColor blackColor];
 	}
+	
 	selectedAttributes[NSFontAttributeName] = [self tabBarTextFont];
 	[tabItem setTitleTextAttributes:selectedAttributes forState:UIControlStateSelected];
 
@@ -104,7 +105,10 @@
 	NSMutableDictionary* normalAttributes = [NSMutableDictionary dictionaryWithDictionary:[tabItem titleTextAttributesForState:UIControlStateNormal]];
 	if (self.textColor) {
 		normalAttributes[NSForegroundColorAttributeName] = [RCTConvert UIColor:self.textColor];
+	} else {
+		normalAttributes[NSForegroundColorAttributeName] = [UIColor blackColor];
 	}
+	
 	normalAttributes[NSFontAttributeName] = [self tabBarTextFont];
 	[tabItem setTitleTextAttributes:normalAttributes forState:UIControlStateNormal];
 }
@@ -127,7 +131,7 @@
 }
 
 -(void)resetOptions {
-	self.title = nil;
+	self.text = nil;
 	self.badge = nil;
 	self.visible = nil;
 	self.icon = nil;

--- a/lib/ios/RNNBottomTabsOptions.h
+++ b/lib/ios/RNNBottomTabsOptions.h
@@ -9,8 +9,12 @@
 @property (nonatomic, strong) NSNumber* drawBehind;
 @property (nonatomic, strong) NSString* currentTabId;
 
+@property (nonatomic, strong) NSNumber* tabColor;
+@property (nonatomic, strong) NSNumber* selectedTabColor;
 @property (nonatomic, strong) NSNumber* translucent;
 @property (nonatomic, strong) NSNumber* hideShadow;
 @property (nonatomic, strong) NSNumber* backgroundColor;
+@property (nonatomic, strong) NSString* fontFamily;
+@property (nonatomic, strong) NSNumber* fontSize;
 
 @end

--- a/lib/ios/RNNBottomTabsOptions.h
+++ b/lib/ios/RNNBottomTabsOptions.h
@@ -12,9 +12,5 @@
 @property (nonatomic, strong) NSNumber* translucent;
 @property (nonatomic, strong) NSNumber* hideShadow;
 @property (nonatomic, strong) NSNumber* backgroundColor;
-@property (nonatomic, strong) NSNumber* tabColor;
-@property (nonatomic, strong) NSNumber* selectedTabColor;
-@property (nonatomic, strong) NSString* fontFamily;
-@property (nonatomic, strong) NSNumber* fontSize;
 
 @end

--- a/lib/ios/RNNBottomTabsOptions.m
+++ b/lib/ios/RNNBottomTabsOptions.m
@@ -48,24 +48,6 @@ extern const NSInteger BLUR_TOPBAR_TAG;
 	if (self.hideShadow) {
 		viewController.tabBarController.tabBar.clipsToBounds = [self.hideShadow boolValue];
 	}
-	
-	if (self.tabColor) {
-		viewController.tabBarController.tabBar.unselectedItemTintColor = [RCTConvert UIColor:self.tabColor];
-	}
-	
-	if (self.selectedTabColor) {
-		viewController.tabBarController.tabBar.tintColor = [RCTConvert UIColor:self.selectedTabColor];
-	}
-	
-	if (self.tabBarTextFont) {
-		NSMutableDictionary* tabBarTitleTextAttributes = [NSMutableDictionary new];
-		tabBarTitleTextAttributes[NSFontAttributeName] = self.tabBarTextFont;
-		
-		for (UITabBarItem* item in viewController.tabBarController.tabBar.items) {
-			[item setTitleTextAttributes:tabBarTitleTextAttributes forState:UIControlStateNormal];
-		}
-	}
-
 
 	[self resetOptions];
 }

--- a/lib/ios/RNNBottomTabsOptions.m
+++ b/lib/ios/RNNBottomTabsOptions.m
@@ -46,8 +46,42 @@ extern const NSInteger BLUR_TOPBAR_TAG;
 	if (self.hideShadow) {
 		viewController.tabBarController.tabBar.clipsToBounds = [self.hideShadow boolValue];
 	}
+	
+	if (self.tabColor) {
+		viewController.tabBarController.tabBar.unselectedItemTintColor = [RCTConvert UIColor:self.tabColor];
+	}
+	
+	if (self.selectedTabColor) {
+		viewController.tabBarController.tabBar.tintColor = [RCTConvert UIColor:self.selectedTabColor];
+	}
+	
+	if (self.tabBarTextFont) {
+		NSMutableDictionary* tabBarTitleTextAttributes = [NSMutableDictionary new];
+		tabBarTitleTextAttributes[NSFontAttributeName] = self.tabBarTextFont;
+		
+		for (UITabBarItem* item in viewController.tabBarController.tabBar.items) {
+			[item setTitleTextAttributes:tabBarTitleTextAttributes forState:UIControlStateNormal];
+		}
+	}
+
 
 	[self resetOptions];
+}
+
+-(UIFont *)tabBarTextFont {
+	if (self.fontFamily) {
+		return [UIFont fontWithName:self.fontFamily size:self.tabBarTextFontSizeValue];
+	}
+	else if (self.fontSize) {
+		return [UIFont systemFontOfSize:self.tabBarTextFontSizeValue];
+	}
+	else {
+		return nil;
+	}
+}
+
+-(CGFloat)tabBarTextFontSizeValue {
+	return self.fontSize ? [self.fontSize floatValue] : 10;
 }
 
 - (void)resetOptions {

--- a/lib/ios/RNNBottomTabsOptions.m
+++ b/lib/ios/RNNBottomTabsOptions.m
@@ -46,41 +46,8 @@ extern const NSInteger BLUR_TOPBAR_TAG;
 	if (self.hideShadow) {
 		viewController.tabBarController.tabBar.clipsToBounds = [self.hideShadow boolValue];
 	}
-	
-	if (self.tabBarTextFont) {
-		NSMutableDictionary* tabBarTitleTextAttributes = [NSMutableDictionary new];
-		tabBarTitleTextAttributes[NSFontAttributeName] = self.tabBarTextFont;
-		
-		for (UITabBarItem* item in viewController.tabBarController.tabBar.items) {
-			[item setTitleTextAttributes:tabBarTitleTextAttributes forState:UIControlStateNormal];
-		}
-	}
-	
-	if (self.tabColor) {
-		viewController.tabBarController.tabBar.unselectedItemTintColor = [RCTConvert UIColor:self.tabColor];
-	}
-	
-	if (self.selectedTabColor) {
-		viewController.tabBarController.tabBar.tintColor = [RCTConvert UIColor:self.selectedTabColor];
-	}
-	
+
 	[self resetOptions];
-}
-
--(UIFont *)tabBarTextFont {
-	if (self.fontFamily) {
-		return [UIFont fontWithName:self.fontFamily size:self.tabBarTextFontSizeValue];
-	}
-	else if (self.fontSize) {
-		return [UIFont systemFontOfSize:self.tabBarTextFontSizeValue];
-	}
-	else {
-		return nil;
-	}
-}
-
--(CGFloat)tabBarTextFontSizeValue {
-	return self.fontSize ? [self.fontSize floatValue] : 10;
 }
 
 - (void)resetOptions {

--- a/lib/ios/RNNControllerFactory.m
+++ b/lib/ios/RNNControllerFactory.m
@@ -233,8 +233,9 @@
 }
 
 - (RNNNavigationOptions *)createOptions:(NSDictionary *)optionsDict {
-	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:_defaultOptionsDict];
-	[options mergeWith:optionsDict];
+	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:optionsDict];
+	options.defaultOptions = [[RNNNavigationOptions alloc] initWithDict:_defaultOptionsDict];
+	
 	return options;
 }
 

--- a/lib/ios/RNNNavigationOptions.h
+++ b/lib/ios/RNNNavigationOptions.h
@@ -30,6 +30,8 @@ extern const NSInteger TOP_BAR_TRANSPARENT_TAG;
 @property (nonatomic, strong) RNNPreviewOptions* preview;
 @property (nonatomic, strong) RNNLayoutOptions* layout;
 
+@property (nonatomic, strong) RNNOptions* defaultOptions;
+
 @property (nonatomic, strong) NSMutableDictionary* originalTopBarImages;
 @property (nonatomic, strong) NSNumber* popGesture;
 @property (nonatomic, strong) NSDictionary* backgroundImage;

--- a/lib/ios/RNNNavigationOptions.m
+++ b/lib/ios/RNNNavigationOptions.m
@@ -43,6 +43,7 @@ RCT_ENUM_CONVERTER(UIModalTransitionStyle,
 
 
 -(void)applyOn:(UIViewController<RNNRootViewProtocol> *)viewController {
+	[self mergeOptions:_defaultOptions overrideOptions:NO];
 	[self.topBar applyOn:viewController];
 	[self.bottomTabs applyOn:viewController];
 	[self.topTab applyOn:viewController];

--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -125,7 +125,7 @@
 }
 
 - (void)mergeOptions:(RNNOptions *)options {
-	[self.options mergeOptions:options overrideOptions:NO];
+	[self.options mergeOptions:options overrideOptions:YES];
 }
 
 - (void)setCustomNavigationTitleView {

--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -125,7 +125,7 @@
 }
 
 - (void)mergeOptions:(RNNOptions *)options {
-	[self.options mergeOptions:options overrideOptions:YES];
+	[self.options mergeOptions:options overrideOptions:NO];
 }
 
 - (void)setCustomNavigationTitleView {

--- a/lib/ios/RNNUtils.h
+++ b/lib/ios/RNNUtils.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface RNNUtils : NSObject
 

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -91,6 +91,8 @@
 		50570BEB2063E09B006A1B5C /* RNNTitleViewHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 50570BE92063E09B006A1B5C /* RNNTitleViewHelper.m */; };
 		506A2B1420973DFD00F43A95 /* RNNErrorHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 506A2B1220973DFD00F43A95 /* RNNErrorHandler.h */; };
 		506A2B1520973DFD00F43A95 /* RNNErrorHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 506A2B1320973DFD00F43A95 /* RNNErrorHandler.m */; };
+		50706E6D20CE7CA5003345C3 /* UIImage+tint.h in Headers */ = {isa = PBXBuildFile; fileRef = 50706E6B20CE7CA5003345C3 /* UIImage+tint.h */; };
+		50706E6E20CE7CA5003345C3 /* UIImage+tint.m in Sources */ = {isa = PBXBuildFile; fileRef = 50706E6C20CE7CA5003345C3 /* UIImage+tint.m */; };
 		50762D08205E96C200E3D18A /* RNNModalAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 50762D06205E96C200E3D18A /* RNNModalAnimation.h */; };
 		50762D09205E96C200E3D18A /* RNNModalAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = 50762D07205E96C200E3D18A /* RNNModalAnimation.m */; };
 		507E7D57201DDD3000444E6C /* RNNAnimationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 507E7D55201DDD3000444E6C /* RNNAnimationOptions.h */; };
@@ -303,6 +305,8 @@
 		50570BE92063E09B006A1B5C /* RNNTitleViewHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNTitleViewHelper.m; sourceTree = "<group>"; };
 		506A2B1220973DFD00F43A95 /* RNNErrorHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNErrorHandler.h; sourceTree = "<group>"; };
 		506A2B1320973DFD00F43A95 /* RNNErrorHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNErrorHandler.m; sourceTree = "<group>"; };
+		50706E6B20CE7CA5003345C3 /* UIImage+tint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+tint.h"; sourceTree = "<group>"; };
+		50706E6C20CE7CA5003345C3 /* UIImage+tint.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+tint.m"; sourceTree = "<group>"; };
 		50762D06205E96C200E3D18A /* RNNModalAnimation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNModalAnimation.h; sourceTree = "<group>"; };
 		50762D07205E96C200E3D18A /* RNNModalAnimation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNModalAnimation.m; sourceTree = "<group>"; };
 		507E7D55201DDD3000444E6C /* RNNAnimationOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNAnimationOptions.h; sourceTree = "<group>"; };
@@ -458,6 +462,8 @@
 				390AD476200F499D00A8250D /* RNNSwizzles.m */,
 				506A2B1220973DFD00F43A95 /* RNNErrorHandler.h */,
 				506A2B1320973DFD00F43A95 /* RNNErrorHandler.m */,
+				50706E6B20CE7CA5003345C3 /* UIImage+tint.h */,
+				50706E6C20CE7CA5003345C3 /* UIImage+tint.m */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -862,6 +868,7 @@
 				50451D0D2042F70900695F00 /* RNNTransition.h in Headers */,
 				507F43F81FF525B500D9425B /* RNNSegmentedControl.h in Headers */,
 				50175CD1207A2AA1004FE91B /* RNNComponentOptions.h in Headers */,
+				50706E6D20CE7CA5003345C3 /* UIImage+tint.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1032,6 +1039,7 @@
 				507F43F51FF4FCFE00D9425B /* HMSegmentedControl.m in Sources */,
 				50451D0A2042E20600695F00 /* RNNTransitionsOptions.m in Sources */,
 				507F43C61FF4F17C00D9425B /* RNNTopTabsViewController.m in Sources */,
+				50706E6E20CE7CA5003345C3 /* UIImage+tint.m in Sources */,
 				50A00C38200F84D6000F01A6 /* RNNOverlayOptions.m in Sources */,
 				50762D09205E96C200E3D18A /* RNNModalAnimation.m in Sources */,
 				50EB93421FE14A3E00BD8EEE /* RNNBottomTabOptions.m in Sources */,

--- a/lib/ios/ReactNativeNavigationTests/RNNRootViewControllerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNRootViewControllerTest.m
@@ -671,25 +671,10 @@
 	XCTAssertTrue([self.uut.tabBarController.tabBar.barTintColor isEqual:expectedColor]);
 }
 
--(void)testTabBarSelectedColor_validColor{
-	NSNumber* inputColor = @(0xFFFF0000);
-	self.options.bottomTabs.tabColor = inputColor;
-	[self.uut embedInTabBarController];
-	UIColor* expectedColor = [UIColor colorWithRed:1 green:0 blue:0 alpha:1];
-	XCTAssertTrue([self.uut.tabBarController.tabBar.unselectedItemTintColor isEqual:expectedColor]);
-}
-
--(void)testTabBarUnselectedColor_validColor{
-	NSNumber* inputColor = @(0xFFFF0000);
-	self.options.bottomTabs.selectedTabColor = inputColor;
-	[self.uut embedInTabBarController];
-	UIColor* expectedColor = [UIColor colorWithRed:1 green:0 blue:0 alpha:1];
-	XCTAssertTrue([self.uut.tabBarController.tabBar.tintColor isEqual:expectedColor]);
-}
-
 -(void)testTabBarTextFontFamily_validFont{
 	NSString* inputFont = @"HelveticaNeue";
-	self.options.bottomTabs.fontFamily = inputFont;
+	self.options.bottomTab.fontFamily = inputFont;
+	self.options.bottomTab.text = @"Tab 1";
 	[self.uut embedInTabBarController];
 	UIFont* expectedFont = [UIFont fontWithName:inputFont size:10];
 	NSDictionary* attributes = [self.uut.tabBarController.tabBar.items.firstObject titleTextAttributesForState:UIControlStateNormal];
@@ -697,7 +682,8 @@
 }
 
 -(void)testTabBarTextFontSize_withoutTextFontFamily_withoutTextColor {
-	self.options.bottomTabs.fontSize = @(15);
+	self.options.bottomTab.fontSize = @(15);
+	self.options.bottomTab.text = @"Tab 1";
 	[self.uut embedInTabBarController];
 	UIFont* expectedFont = [UIFont systemFontOfSize:15];
 	NSDictionary* attributes = [self.uut.tabBarController.tabBar.items.firstObject titleTextAttributesForState:UIControlStateNormal];
@@ -705,7 +691,8 @@
 }
 
 -(void)testTabBarTextFontSize_withoutTextFontFamily {
-	self.options.bottomTabs.fontSize = @(15);
+	self.options.bottomTab.fontSize = @(15);
+	self.options.bottomTab.text = @"Tab 1";
 	[self.uut embedInTabBarController];
 	UIFont* expectedFont = [UIFont systemFontOfSize:15];
 	NSDictionary* attributes = [self.uut.tabBarController.tabBar.items.firstObject titleTextAttributesForState:UIControlStateNormal];
@@ -714,8 +701,9 @@
 
 -(void)testTabBarTextFontSize_withTextFontFamily_withTextColor {
 	NSString* inputFont = @"HelveticaNeue";
-	self.options.bottomTabs.fontSize = @(15);
-	self.options.bottomTabs.fontFamily = inputFont;
+	self.options.bottomTab.text = @"Tab 1";
+	self.options.bottomTab.fontSize = @(15);
+	self.options.bottomTab.fontFamily = inputFont;
 	[self.uut embedInTabBarController];
 	UIFont* expectedFont = [UIFont fontWithName:inputFont size:15];
 	NSDictionary* attributes = [self.uut.tabBarController.tabBar.items.firstObject titleTextAttributesForState:UIControlStateNormal];
@@ -724,8 +712,9 @@
 
 -(void)testTabBarTextFontSize_withTextFontFamily_withoutTextColor {
 	NSString* inputFont = @"HelveticaNeue";
-	self.options.bottomTabs.fontSize = @(15);
-	self.options.bottomTabs.fontFamily = inputFont;
+	self.options.bottomTab.text = @"Tab 1";
+	self.options.bottomTab.fontSize = @(15);
+	self.options.bottomTab.fontFamily = inputFont;
 	[self.uut embedInTabBarController];
 	UIFont* expectedFont = [UIFont fontWithName:inputFont size:15];
 	NSDictionary* attributes = [self.uut.tabBarController.tabBar.items.firstObject titleTextAttributesForState:UIControlStateNormal];

--- a/lib/ios/UIImage+tint.h
+++ b/lib/ios/UIImage+tint.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface UIImage (tint)
+
+- (UIImage *)withTintColor:(UIColor *)color;
+
+@end

--- a/lib/ios/UIImage+tint.m
+++ b/lib/ios/UIImage+tint.m
@@ -1,0 +1,29 @@
+#import "UIImage+tint.h"
+
+@implementation UIImage (tint)
+
+- (UIImage *)withTintColor:(UIColor *)color {
+	UIGraphicsBeginImageContext(self.size);
+	CGContextRef context = UIGraphicsGetCurrentContext();
+	
+	CGContextTranslateCTM(context, 0, self.size.height);
+	CGContextScaleCTM(context, 1.0, -1.0);
+	
+	CGRect rect = CGRectMake(0, 0, self.size.width, self.size.height);
+	
+	// draw alpha-mask
+	CGContextSetBlendMode(context, kCGBlendModeNormal);
+	CGContextDrawImage(context, rect, self.CGImage);
+	
+	// draw tint color, preserving alpha values of original image
+	CGContextSetBlendMode(context, kCGBlendModeSourceIn);
+	[color setFill];
+	CGContextFillRect(context, rect);
+	
+	UIImage *coloredImage = UIGraphicsGetImageFromCurrentImageContext();
+	UIGraphicsEndImageContext();
+	
+	return coloredImage;
+}
+
+@end

--- a/playground/android/build.gradle
+++ b/playground/android/build.gradle
@@ -25,5 +25,6 @@ allprojects {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../../node_modules/react-native/android"
         }
+        maven { url 'https://jitpack.io' }
     }
 }

--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -25,10 +25,10 @@ function start() {
   Navigation.events().registerAppLaunchedListener(() => {
     Navigation.setDefaultOptions({
       bottomTab: {
-        iconColor: 'black',
-        selectedIconColor: 'red',
-        textColor: 'black',
-        selectedTextColor: 'red',
+        iconColor: '#1B4C77',
+        selectedIconColor: '#f00',
+        textColor: '#1B4C77',
+        selectedTextColor: '#f00',
         fontFamily: 'HelveticaNeue-Italic',
         fontSize: 13
       },

--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -26,9 +26,9 @@ function start() {
     Navigation.setDefaultOptions({
       bottomTab: {
         iconColor: '#1B4C77',
-        selectedIconColor: '#f00',
+        selectedIconColor: '#0f0',
         textColor: '#1B4C77',
-        selectedTextColor: '#f00',
+        selectedTextColor: '#0f0',
         fontFamily: 'HelveticaNeue-Italic',
         fontSize: 13
       },

--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -24,6 +24,14 @@ function start() {
   registerScreens();
   Navigation.events().registerAppLaunchedListener(() => {
     Navigation.setDefaultOptions({
+      bottomTab: {
+        iconColor: 'black',
+        selectedIconColor: 'red',
+        textColor: 'black',
+        selectedTextColor: 'red',
+        fontFamily: 'HelveticaNeue-Italic',
+        fontSize: 13
+      },
       _animations: {
         startApp: {
           y: {

--- a/playground/src/screens/TextScreen.js
+++ b/playground/src/screens/TextScreen.js
@@ -25,7 +25,7 @@ class TextScreen extends Component {
         <Text style={styles.h1} testID={testIDs.CENTERED_TEXT_HEADER}>{this.props.text || 'Text Screen'}</Text>
         {this.renderTextFromFunctionInProps()}
         <Text style={styles.footer}>{`this.props.componentId = ${this.props.componentId}`}</Text>
-        <Button title={'Set Tab Badge'} testID={testIDs.SET_TAB_BADGE_BUTTON} onPress={() => this.onButtonPress()} />
+        <Button title={'Set Tab Badge'} testID={testIDs.SET_TAB_BADGE_BUTTON} onPress={() => this.onClickSetBadge()} />
         <Button title={'Switch To Tab 2'} testID={testIDs.SWITCH_SECOND_TAB_BUTTON} onPress={() => this.onClickSwitchToTab()} />
         <Button title={'Switch To Tab 1 by componentID'} testID={testIDs.SWITCH_FIRST_TAB_BUTTON} onPress={() => this.onClickSwitchToTabByComponentID()} />
         <Button title='Hide Tab Bar' testID={testIDs.HIDE_BOTTOM_TABS_BUTTON} onPress={() => this.hideTabBar(false)} />
@@ -59,7 +59,7 @@ class TextScreen extends Component {
     );
   }
 
-  onButtonPress() {
+  onClickSetBadge() {
     Navigation.mergeOptions(this.props.componentId, {
       bottomTab: {
         badge: `TeSt`

--- a/playground/src/screens/TextScreen.js
+++ b/playground/src/screens/TextScreen.js
@@ -73,9 +73,7 @@ class TextScreen extends Component {
         currentTabIndex: 1,
         visible: false,
         drawBehind: true,
-        animate: true,
-        tabColor: 'blue',
-        selectedTabColor: 'red'
+        animate: true
       }
     });
   }

--- a/playground/src/screens/WelcomeScreen.js
+++ b/playground/src/screens/WelcomeScreen.js
@@ -160,15 +160,23 @@ class WelcomeScreen extends Component {
                           name: 'navigation.playground.TextScreen',
                           passProps: {
                             text: 'This is a side menu center screen tab 1'
-                          }
+                          },
+                          // options: {
+                          //   bottomTab: {
+                          //     iconColor: 'red',
+                          //     textColor: 'red',
+                          //     selectedIconColor: 'purple',
+                          //     selectedTextColor: 'purple',
+                          //   }
+                          // }
                         }
                       }
                     ],
                     options: {
                       bottomTab: {
                         iconColor: 'red',
-                        selectedIconColor: 'red',
-                        textColor: 'purple',
+                        textColor: 'red',
+                        selectedIconColor: 'purple',
                         selectedTextColor: 'purple',
                         text: 'Tab 1',
                         icon: require('../images/one.png'),
@@ -222,10 +230,10 @@ class WelcomeScreen extends Component {
               ],
               options: {
                 bottomTab: {
-                  textColor: 'red',
-                  iconColor: 'red',
-                  selectedTextColor: 'blue',
-                  selectedIconColor: 'blue',
+                  textColor: '#AED581',
+                  iconColor: '#AED581',
+                  selectedTextColor: '#90CAF9',
+                  selectedIconColor: '#90CAF9',
                   fontFamily: 'HelveticaNeue-Italic',
                   fontSize: 13
                 }

--- a/playground/src/screens/WelcomeScreen.js
+++ b/playground/src/screens/WelcomeScreen.js
@@ -92,7 +92,7 @@ class WelcomeScreen extends Component {
                 ],
                 options: {
                   bottomTab: {
-                    title: 'Tab 1',
+                    text: 'Tab 1',
                     icon: require('../images/one.png'),
                     selectedIcon: require('../images/one.png'),
                     testID: testIDs.FIRST_TAB_BAR_BUTTON
@@ -117,7 +117,7 @@ class WelcomeScreen extends Component {
                 ],
                 options: {
                   bottomTab: {
-                    title: 'Tab 2',
+                    text: 'Tab 2',
                     icon: require('../images/two.png'),
                     testID: testIDs.SECOND_TAB_BAR_BUTTON
                   }
@@ -166,7 +166,7 @@ class WelcomeScreen extends Component {
                     ],
                     options: {
                       bottomTab: {
-                        title: 'Tab 1',
+                        text: 'Tab 1',
                         icon: require('../images/one.png'),
                         testID: testIDs.FIRST_TAB_BAR_BUTTON
                       }
@@ -187,7 +187,7 @@ class WelcomeScreen extends Component {
                     ],
                     options: {
                       bottomTab: {
-                        title: 'Tab 2',
+                        text: 'Tab 2',
                         icon: require('../images/two.png'),
                         testID: testIDs.SECOND_TAB_BAR_BUTTON
                       }
@@ -208,7 +208,7 @@ class WelcomeScreen extends Component {
                     ],
                     options: {
                       bottomTab: {
-                        title: 'Tab 3',
+                        text: 'Tab 3',
                         icon: require('../images/three.png'),
                         testID: testIDs.SECOND_TAB_BAR_BUTTON
                       }

--- a/playground/src/screens/WelcomeScreen.js
+++ b/playground/src/screens/WelcomeScreen.js
@@ -94,6 +94,7 @@ class WelcomeScreen extends Component {
                   bottomTab: {
                     title: 'Tab 1',
                     icon: require('../images/one.png'),
+                    selectedIcon: require('../images/one.png'),
                     testID: testIDs.FIRST_TAB_BAR_BUTTON
                   },
                   topBar: {
@@ -126,11 +127,7 @@ class WelcomeScreen extends Component {
           ],
           options: {
             bottomTabs: {
-              tabColor: 'red',
               titleDisplayMode: 'alwaysShow',
-              selectedTabColor: 'blue',
-              fontFamily: 'HelveticaNeue-Italic',
-              fontSize: 13,
               testID: testIDs.BOTTOM_TABS_ELEMENT
             }
           }
@@ -220,9 +217,11 @@ class WelcomeScreen extends Component {
                 }
               ],
               options: {
-                bottomTabs: {
-                  tabColor: 'red',
-                  selectedTabColor: 'blue',
+                bottomTab: {
+                  textColor: 'red',
+                  iconColor: 'red',
+                  selectedTextColor: 'blue',
+                  selectedIconColor: 'blue',
                   fontFamily: 'HelveticaNeue-Italic',
                   fontSize: 13
                 }

--- a/playground/src/screens/WelcomeScreen.js
+++ b/playground/src/screens/WelcomeScreen.js
@@ -166,6 +166,10 @@ class WelcomeScreen extends Component {
                     ],
                     options: {
                       bottomTab: {
+                        iconColor: 'red',
+                        selectedIconColor: 'red',
+                        textColor: 'purple',
+                        selectedTextColor: 'purple',
                         text: 'Tab 1',
                         icon: require('../images/one.png'),
                         testID: testIDs.FIRST_TAB_BAR_BUTTON


### PR DESCRIPTION
This PR slightly changes the BottomTabs color related api in a none backwards compatible manner.

Previously icon and text colors were configured in `options.bottomTab` using:

```js
options: {
  bottomTabs: {
    tabColor: 'red',
    selectedTabColor: 'blue'
  }
}
```
This api assumes that all tabs share the same color configuration, meaning that all icons are tinted with the same colors, and it's not possible to tint an individual tab with different color.
Another limitation this assumption causes, is that in order to **not** tint a certain tab, users had to disable the color options in the `bottomTab` level:

```js
options: {  
  bottomTab: {
    disableIconTint: true, 😭
    disableSelectedIconTint: true 😭
  }
}
```

**New API** (#3341)
```js
bottomTab: {
  iconColor: 'red', // unselected color
  selectedIconColor: 'green',
  textColor: 'red', // Unselected color
  selectedTextColor: 'green'
  // disableIconTint: true,  Obsolete
  // disableSelectedIconTint: true Obsolete
}
```

If a `BottomTab` doesn't contain color options - the icon will not be tinted there for both `disableIconTint` and `disableSelectedIconTint` are no longer supported.

To support this change, we decided to fork [AHBottomNavigation](https://github.com/aurelhubert/ahbottomnavigation) as it doesn't support this api. We're publishing our [fork](https://github.com/wix-playground/ahbottomnavigation) to JitPack and are accepting pull requests.
You'll need to add the JitPack repository to your `build.grade` file:

```diff
allprojects {
    repositories {
        mavenLocal()
        mavenCentral()
        google()
        jcenter()
        maven {
            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
            url "$rootDir/../../node_modules/react-native/android"
        }
+        maven { url 'https://jitpack.io' } // <-- add this
    }
}
```