### PR TITLE
Unmount react views when bundle load completes

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
@@ -13,6 +13,7 @@ import android.view.View;
 
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.reactnativenavigation.presentation.OverlayManager;
+import com.reactnativenavigation.react.ReloadListener;
 import com.reactnativenavigation.react.ReactGateway;
 import com.reactnativenavigation.utils.CommandListenerAdapter;
 import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
@@ -26,13 +27,15 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     private PermissionListener mPermissionListener;
     
     protected Navigator navigator;
+    private ReloadListener reloadListener;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         navigator = new Navigator(this, new ChildControllersRegistry(), new OverlayManager());
+        reloadListener = new ReloadListener(navigator);
         getReactGateway().onActivityCreated(this);
-        getReactGateway().addReloadListener(navigator);
+        getReactGateway().setReloadListener(reloadListener);
         navigator.getView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
         setContentView(navigator.getView());
     }
@@ -52,8 +55,9 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     @Override
     protected void onDestroy() {
         super.onDestroy();
+        reloadListener.destroy();
         navigator.destroy();
-        getReactGateway().removeReloadListener(navigator);
+        getReactGateway().removeReloadListener(reloadListener);
         getReactGateway().onActivityDestroyed(this);
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
@@ -1,41 +1,36 @@
 package com.reactnativenavigation;
 
 import android.annotation.TargetApi;
-import android.support.annotation.NonNull;
-
 import android.content.Intent;
-import android.os.Bundle;
 import android.os.Build;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.view.KeyEvent;
 import android.view.View;
 
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
+import com.facebook.react.modules.core.PermissionAwareActivity;
+import com.facebook.react.modules.core.PermissionListener;
 import com.reactnativenavigation.presentation.OverlayManager;
-import com.reactnativenavigation.react.ReloadListener;
+import com.reactnativenavigation.react.JsDevReloadHandler;
 import com.reactnativenavigation.react.ReactGateway;
 import com.reactnativenavigation.utils.CommandListenerAdapter;
 import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
 import com.reactnativenavigation.viewcontrollers.Navigator;
 
-import com.facebook.react.modules.core.PermissionAwareActivity;
-import com.facebook.react.modules.core.PermissionListener;
-
-public class NavigationActivity extends AppCompatActivity implements DefaultHardwareBackBtnHandler, PermissionAwareActivity {
+public class NavigationActivity extends AppCompatActivity implements DefaultHardwareBackBtnHandler, PermissionAwareActivity, JsDevReloadHandler.ReloadListener {
     @Nullable
     private PermissionListener mPermissionListener;
     
     protected Navigator navigator;
-    private ReloadListener reloadListener;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         navigator = new Navigator(this, new ChildControllersRegistry(), new OverlayManager());
-        reloadListener = new ReloadListener(navigator);
         getReactGateway().onActivityCreated(this);
-        getReactGateway().setReloadListener(reloadListener);
         navigator.getView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
         setContentView(navigator.getView());
     }
@@ -55,9 +50,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        reloadListener.destroy();
         navigator.destroy();
-        getReactGateway().removeReloadListener(reloadListener);
         getReactGateway().onActivityDestroyed(this);
     }
 
@@ -108,5 +101,10 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
         if (mPermissionListener != null && mPermissionListener.onRequestPermissionsResult(requestCode, permissions, grantResults)) {
             mPermissionListener = null;
         }
+    }
+
+    @Override
+    public void onReload() {
+        navigator.destroyViews();
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/BundleDownloadListenerProvider.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/BundleDownloadListenerProvider.java
@@ -1,0 +1,7 @@
+package com.reactnativenavigation.react;
+
+import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+
+public interface BundleDownloadListenerProvider {
+    void setBundleLoaderListener(DevBundleDownloadListener listener);
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/DevBundleDownloadListenerAdapter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/DevBundleDownloadListenerAdapter.java
@@ -1,0 +1,22 @@
+package com.reactnativenavigation.react;
+
+import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+
+import javax.annotation.Nullable;
+
+public class DevBundleDownloadListenerAdapter implements DevBundleDownloadListener {
+    @Override
+    public void onSuccess() {
+
+    }
+
+    @Override
+    public void onProgress(@Nullable String status, @Nullable Integer done, @Nullable Integer total) {
+
+    }
+
+    @Override
+    public void onFailure(Exception cause) {
+
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/JsDevReloadHandler.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/JsDevReloadHandler.java
@@ -29,7 +29,7 @@ public class JsDevReloadHandler {
 		this.reactInstanceManager = reactInstanceManager;
 	}
 
-    public void addReloadListener(ReloadListener listener) {
+    public void setReloadListener(ReloadListener listener) {
         reloadListener = listener;
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/JsDevReloadHandler.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/JsDevReloadHandler.java
@@ -7,27 +7,48 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.view.KeyEvent;
 
-import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
+import com.reactnativenavigation.utils.UiUtils;
 
-public class JsDevReloadHandler {
+import javax.annotation.Nullable;
+
+public class JsDevReloadHandler implements DevBundleDownloadListener {
+    private static final String RELOAD_BROADCAST = "com.reactnativenavigation.broadcast.RELOAD";
+
     public interface ReloadListener {
         void onReload();
     }
 
-	private static final String RELOAD_BROADCAST = "com.reactnativenavigation.broadcast.RELOAD";
 	private final BroadcastReceiver reloadReceiver = new BroadcastReceiver() {
 		@Override
 		public void onReceive(final Context context, final Intent intent) {
 			reloadReactNative();
 		}
 	};
-	private final ReactInstanceManager reactInstanceManager;
-	private long firstRTimestamp = 0;
-    private ReloadListener reloadListener;
+    private final DevSupportManager devSupportManager;
 
-    JsDevReloadHandler(final ReactInstanceManager reactInstanceManager) {
-		this.reactInstanceManager = reactInstanceManager;
-	}
+    private long firstRTimestamp = 0;
+    private ReloadListener reloadListener = () -> {};
+
+    JsDevReloadHandler(DevSupportManager devSupportManager) {
+        this.devSupportManager = devSupportManager;
+    }
+
+    @Override
+    public void onSuccess() {
+        UiUtils.runOnMainThread(reloadListener::onReload);
+    }
+
+    @Override
+    public void onProgress(@Nullable String status, @Nullable Integer done, @Nullable Integer total) {
+
+    }
+
+    @Override
+    public void onFailure(Exception cause) {
+
+    }
 
     public void setReloadListener(ReloadListener listener) {
         reloadListener = listener;
@@ -48,12 +69,12 @@ public class JsDevReloadHandler {
 	}
 
 	public boolean onKeyUp(int keyCode) {
-		if (!reactInstanceManager.getDevSupportManager().getDevSupportEnabled()) {
+		if (!devSupportManager.getDevSupportEnabled()) {
 			return false;
 		}
 
 		if (keyCode == KeyEvent.KEYCODE_MENU) {
-			reactInstanceManager.getDevSupportManager().showDevOptionsDialog();
+			devSupportManager.showDevOptionsDialog();
 			return true;
 		}
 
@@ -73,6 +94,6 @@ public class JsDevReloadHandler {
 
 	private void reloadReactNative() {
         reloadListener.onReload();
-		reactInstanceManager.getDevSupportManager().handleReloadJS();
+		devSupportManager.handleReloadJS();
 	}
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactNativeHost.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactNativeHost.java
@@ -21,50 +21,60 @@ import java.util.List;
  * Default implementation of {@link ReactNativeHost} that includes {@link NavigationPackage}
  * and user-defined additional packages.
  */
-public class NavigationReactNativeHost extends ReactNativeHost {
+public class NavigationReactNativeHost extends ReactNativeHost implements BundleDownloadListenerProvider {
 
-	private final boolean isDebug;
-	private final List<ReactPackage> additionalReactPackages;
+    private final boolean isDebug;
+    private final List<ReactPackage> additionalReactPackages;
     private @Nullable DevBundleDownloadListener bundleListener;
+    private final DevBundleDownloadListener bundleListenerMediator = new DevBundleDownloadListenerAdapter() {
+        @Override
+        public void onSuccess() {
+            if (bundleListener != null) {
+                bundleListener.onSuccess();
+            }
+        }
+    };
+
 
     public NavigationReactNativeHost(NavigationApplication application) {
         this(application, application.isDebug(), application.createAdditionalReactPackages());
     }
 
-	@SuppressWarnings("WeakerAccess")
+    @SuppressWarnings("WeakerAccess")
     public NavigationReactNativeHost(Application application, boolean isDebug, final List<ReactPackage> additionalReactPackages) {
-		super(application);
-		this.isDebug = isDebug;
-		this.additionalReactPackages = additionalReactPackages;
-	}
-
-	@Override
-	public boolean getUseDeveloperSupport() {
-		return isDebug;
-	}
-
-    public void setDevBundleDownloadListener(DevBundleDownloadListener listener) {
-        this.bundleListener = listener;
+        super(application);
+        this.isDebug = isDebug;
+        this.additionalReactPackages = additionalReactPackages;
     }
 
     @Override
-	protected List<ReactPackage> getPackages() {
-		List<ReactPackage> packages = new ArrayList<>();
-		boolean hasMainReactPackage = false;
-		packages.add(new NavigationPackage(this));
-		if (additionalReactPackages != null) {
-			for (ReactPackage p : additionalReactPackages) {
-				if (!(p instanceof NavigationPackage)) {
-					packages.add(p);
-				}
-				if (p instanceof MainReactPackage) hasMainReactPackage = true;
-			}
-		}
+    public void setBundleLoaderListener(DevBundleDownloadListener listener) {
+        bundleListener = listener;
+    }
+
+    @Override
+    public boolean getUseDeveloperSupport() {
+        return isDebug;
+    }
+
+    @Override
+    protected List<ReactPackage> getPackages() {
+        List<ReactPackage> packages = new ArrayList<>();
+        boolean hasMainReactPackage = false;
+        packages.add(new NavigationPackage(this));
+        if (additionalReactPackages != null) {
+            for (ReactPackage p : additionalReactPackages) {
+                if (!(p instanceof NavigationPackage)) {
+                    packages.add(p);
+                }
+                if (p instanceof MainReactPackage) hasMainReactPackage = true;
+            }
+        }
         if (!hasMainReactPackage) {
             packages.add(new MainReactPackage());
         }
-		return packages;
-	}
+        return packages;
+    }
 
     protected ReactInstanceManager createReactInstanceManager() {
         ReactInstanceManagerBuilder builder = ReactInstanceManager.builder()
@@ -93,13 +103,6 @@ public class NavigationReactNativeHost extends ReactNativeHost {
     @SuppressWarnings("WeakerAccess")
     @NonNull
     protected DevBundleDownloadListener getDevBundleDownloadListener() {
-        return new DevBundleDownloadListenerAdapter() {
-            @Override
-            public void onSuccess() {
-                if (bundleListener != null) {
-                    bundleListener.onSuccess();
-                }
-            }
-        };
+        return bundleListenerMediator;
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/ReactGateway.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/ReactGateway.java
@@ -13,27 +13,32 @@ import java.util.List;
 
 public class ReactGateway {
 
-	private final ReactNativeHost reactNativeHost;
+	private final ReactNativeHost host;
 	private final NavigationReactInitializer initializer;
 	private final JsDevReloadHandler jsDevReloadHandler;
 
-	public ReactGateway(final Application application, final boolean isDebug, final List<ReactPackage> additionalReactPackages) {
+    @SuppressWarnings("unused")
+    public ReactGateway(final Application application, final boolean isDebug, final List<ReactPackage> additionalReactPackages) {
 		this(application, isDebug, new NavigationReactNativeHost(application, isDebug, additionalReactPackages));
 	}
 
-	public ReactGateway(final Application application, final boolean isDebug, final ReactNativeHost reactNativeHost) {
-		SoLoader.init(application, false);
-		this.reactNativeHost = reactNativeHost;
-		initializer = new NavigationReactInitializer(reactNativeHost.getReactInstanceManager(), isDebug);
-		jsDevReloadHandler = new JsDevReloadHandler(reactNativeHost.getReactInstanceManager());
+	public ReactGateway(final Application application, final boolean isDebug, final ReactNativeHost host) {
+        SoLoader.init(application, false);
+		this.host = host;
+		initializer = new NavigationReactInitializer(host.getReactInstanceManager(), isDebug);
+		jsDevReloadHandler = new JsDevReloadHandler(host.getReactInstanceManager().getDevSupportManager());
+        if (host instanceof BundleDownloadListenerProvider) {
+            ((BundleDownloadListenerProvider) host).setBundleLoaderListener(jsDevReloadHandler);
+        }
 	}
 
 	public ReactNativeHost getReactNativeHost() {
-		return reactNativeHost;
+		return host;
 	}
 
 	public void onActivityCreated(NavigationActivity activity) {
 		initializer.onActivityCreated(activity);
+        jsDevReloadHandler.setReloadListener(activity);
 	}
 
 	public void onActivityResumed(NavigationActivity activity) {
@@ -47,29 +52,19 @@ public class ReactGateway {
 	}
 
 	public void onActivityDestroyed(NavigationActivity activity) {
+        jsDevReloadHandler.removeReloadListener(activity);
 		initializer.onActivityDestroyed(activity);
 	}
-
-    public void setReloadListener(ReloadListener reloadListener) {
-	    jsDevReloadHandler.setReloadListener(reloadListener);
-        if (reactNativeHost instanceof NavigationReactNativeHost) {
-            ((NavigationReactNativeHost) reactNativeHost).setDevBundleDownloadListener(reloadListener);
-        }
-    }
-
-    public void removeReloadListener(JsDevReloadHandler.ReloadListener reloadListener) {
-	    jsDevReloadHandler.removeReloadListener(reloadListener);
-    }
 
 	public boolean onKeyUp(final int keyCode) {
 		return jsDevReloadHandler.onKeyUp(keyCode);
 	}
 
     public void onBackPressed() {
-	    reactNativeHost.getReactInstanceManager().onBackPressed();
+	    host.getReactInstanceManager().onBackPressed();
     }
 
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
-        reactNativeHost.getReactInstanceManager().onActivityResult(activity, requestCode, resultCode, data);
+        host.getReactInstanceManager().onActivityResult(activity, requestCode, resultCode, data);
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/ReactGateway.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/ReactGateway.java
@@ -50,8 +50,11 @@ public class ReactGateway {
 		initializer.onActivityDestroyed(activity);
 	}
 
-    public void addReloadListener(JsDevReloadHandler.ReloadListener reloadListener) {
-	    jsDevReloadHandler.addReloadListener(reloadListener);
+    public void setReloadListener(ReloadListener reloadListener) {
+	    jsDevReloadHandler.setReloadListener(reloadListener);
+        if (reactNativeHost instanceof NavigationReactNativeHost) {
+            ((NavigationReactNativeHost) reactNativeHost).setDevBundleDownloadListener(reloadListener);
+        }
     }
 
     public void removeReloadListener(JsDevReloadHandler.ReloadListener reloadListener) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/ReloadHandler.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/ReloadHandler.java
@@ -1,16 +1,15 @@
 package com.reactnativenavigation.react;
 
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
-import com.reactnativenavigation.utils.UiUtils;
-import com.reactnativenavigation.viewcontrollers.Navigator;
 
 import javax.annotation.Nullable;
 
-public class ReloadListener implements JsDevReloadHandler.ReloadListener, DevBundleDownloadListener {
-    private Navigator navigator;
+public class ReloadHandler implements JsDevReloadHandler.ReloadListener, DevBundleDownloadListener {
 
-    public ReloadListener(Navigator navigator) {
-        this.navigator = navigator;
+    private Runnable onReloadListener = () -> {};
+
+    public void setOnReloadListener(Runnable onReload) {
+        this.onReloadListener = onReload;
     }
 
     /**
@@ -18,7 +17,7 @@ public class ReloadListener implements JsDevReloadHandler.ReloadListener, DevBun
      */
     @Override
     public void onReload() {
-        navigator.destroyViews();
+        onReloadListener.run();
     }
 
     /**
@@ -26,7 +25,7 @@ public class ReloadListener implements JsDevReloadHandler.ReloadListener, DevBun
      */
     @Override
     public void onSuccess() {
-        UiUtils.runOnMainThread(navigator::destroyViews);
+        onReloadListener.run();
     }
 
     /**
@@ -46,6 +45,6 @@ public class ReloadListener implements JsDevReloadHandler.ReloadListener, DevBun
     }
 
     public void destroy() {
-        navigator = null;
+        onReloadListener = null;
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/ReloadListener.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/ReloadListener.java
@@ -1,0 +1,51 @@
+package com.reactnativenavigation.react;
+
+import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+import com.reactnativenavigation.utils.UiUtils;
+import com.reactnativenavigation.viewcontrollers.Navigator;
+
+import javax.annotation.Nullable;
+
+public class ReloadListener implements JsDevReloadHandler.ReloadListener, DevBundleDownloadListener {
+    private Navigator navigator;
+
+    public ReloadListener(Navigator navigator) {
+        this.navigator = navigator;
+    }
+
+    /**
+     * Called on RR and adb reload events
+     */
+    @Override
+    public void onReload() {
+        navigator.destroyViews();
+    }
+
+    /**
+     * Called when the bundle was successfully reloaded
+     */
+    @Override
+    public void onSuccess() {
+        UiUtils.runOnMainThread(navigator::destroyViews);
+    }
+
+    /**
+     * Bundle progress updates
+     */
+    @Override
+    public void onProgress(@Nullable String status, @Nullable Integer done, @Nullable Integer total) {
+
+    }
+
+    /**
+     * Bundle load failure
+     */
+    @Override
+    public void onFailure(Exception cause) {
+
+    }
+
+    public void destroy() {
+        navigator = null;
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/Navigator.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/Navigator.java
@@ -13,7 +13,6 @@ import com.reactnativenavigation.anim.NavigationAnimator;
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.presentation.OptionsPresenter;
 import com.reactnativenavigation.presentation.OverlayManager;
-import com.reactnativenavigation.react.JsDevReloadHandler;
 import com.reactnativenavigation.utils.CommandListener;
 import com.reactnativenavigation.utils.CommandListenerAdapter;
 import com.reactnativenavigation.utils.CompatUtils;
@@ -24,7 +23,7 @@ import com.reactnativenavigation.viewcontrollers.stack.StackController;
 import java.util.Collection;
 import java.util.Collections;
 
-public class Navigator extends ParentController implements JsDevReloadHandler.ReloadListener {
+public class Navigator extends ParentController {
 
     private final ModalStack modalStack;
     private ViewController root;
@@ -81,17 +80,12 @@ public class Navigator extends ParentController implements JsDevReloadHandler.Re
     }
 
     @Override
-    public void onReload() {
-        destroyViews();
-    }
-
-    @Override
     public void destroy() {
         destroyViews();
         super.destroy();
     }
 
-    private void destroyViews() {
+    public void destroyViews() {
         modalStack.dismissAllModals(new CommandListenerAdapter(), root);
         overlayManager.destroy();
         destroyRoot();

--- a/lib/android/app/src/test/java/com/reactnativenavigation/react/ReloadListenerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/react/ReloadListenerTest.java
@@ -1,0 +1,25 @@
+package com.reactnativenavigation.react;
+
+import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+import com.reactnativenavigation.BaseTest;
+import com.reactnativenavigation.viewcontrollers.Navigator;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ReloadListenerTest extends BaseTest {
+    private DevBundleDownloadListener uut;
+    private Navigator navigator;
+
+    @Override
+    public void beforeEach() {
+        navigator = Mockito.mock(Navigator.class);
+        uut = new ReloadListener(navigator);
+    }
+
+    @Test
+    public void onSuccess_viewsAreDestroyed() {
+        uut.onSuccess();
+        Mockito.verify(navigator).destroyViews();
+    }
+}

--- a/lib/android/app/src/test/java/com/reactnativenavigation/react/ReloadListenerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/react/ReloadListenerTest.java
@@ -1,25 +1,24 @@
 package com.reactnativenavigation.react;
 
-import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
 import com.reactnativenavigation.BaseTest;
-import com.reactnativenavigation.viewcontrollers.Navigator;
 
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public class ReloadListenerTest extends BaseTest {
-    private DevBundleDownloadListener uut;
-    private Navigator navigator;
+    private ReloadHandler uut;
+    private Runnable handler;
 
     @Override
     public void beforeEach() {
-        navigator = Mockito.mock(Navigator.class);
-        uut = new ReloadListener(navigator);
+        handler = Mockito.mock(Runnable.class);
+        uut = new ReloadHandler();
     }
 
     @Test
     public void onSuccess_viewsAreDestroyed() {
+        uut.setOnReloadListener(handler);
         uut.onSuccess();
-        Mockito.verify(navigator).destroyViews();
+        Mockito.verify(handler).run();
     }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/NavigatorTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/NavigatorTest.java
@@ -508,13 +508,4 @@ public class NavigatorTest extends BaseTest {
         uut.destroy();
         assertThat(childRegistry.size()).isZero();
     }
-
-    @Test
-    public void reload_navigatorIsDestroyedOnReload() {
-        StackController spy = spy(parentController);
-        uut.setRoot(spy, new CommandListenerAdapter());
-        uut.onReload();
-        verify(spy, times(1)).destroy();
-        verify(overlayManager, times(1)).destroy();
-    }
 }

--- a/playground/src/screens/PushedScreen.js
+++ b/playground/src/screens/PushedScreen.js
@@ -35,7 +35,7 @@ class PushedScreen extends Component {
 
   listeners = [];
 
-  componentWillMount() {
+  componentDidMount() {
     this.listeners.push(
       Navigation.events().registerNativeEventListener((name, params) => {
         if (name === 'previewContext') {


### PR DESCRIPTION
Until now, RNN unmounted components in `reactContextInitialized` event - which appears to be too late and results in mounted components entering some limbo state for a short time where there are two mounted instances of each mounted component.

This PR adds a listener to bundle load events, when bundle is loaded successfully, we unmount any existing components.
 
Related to #3472