### PR TITLE
[v2] LargeTitle: Fix scroll position after `mergeOptions` is called

### DIFF
--- a/lib/ios/RNNLargeTitleOptions.m
+++ b/lib/ios/RNNLargeTitleOptions.m
@@ -8,13 +8,13 @@
 
 	if (@available(iOS 11.0, *)) {
 		
-		viewController.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-	
+		
 		if ([self.visible boolValue]){
 			viewController.navigationController.navigationBar.prefersLargeTitles = YES;
 			viewController.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeAlways;
 		} else {
 			viewController.navigationController.navigationBar.prefersLargeTitles = NO;
+			viewController.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
 		}
 		
 		NSDictionary* fontAttributes = [self fontAttributes];


### PR DESCRIPTION
Before this fix each `mergeOptions` call messes with a scroll position which leads to smaller titles (you can scroll LargeTitle back but it's not convenient). 

```js
class App extends Component<Props> {
  static get options() {
    return {
      topBar: {
        title: {
          text: 'My Screen'
        },
        largeTitle: {
          visible: true
        },
        searchBar: true,
        translucent: true,
      },
    };
  }
  
  componentDidMount() {
    setTimeout(() => {
      Navigation.mergeOptions(this.props.componentId, {
        topBar: {
          title: {
            text: "My Screen"
          }
        }
      })
    })
  }
  render() {
    return (
          <FlatList
            data={ITEMS}
            contentContainerStyle={styles.container}
            renderItem={({ item }) => (
              <View style={styles.row}>
                <Text style={styles.rowText}>
                  <Text>{item.key}</Text>
                </Text>
              </View>
            )}
          />
    );
  }
}
```
<img width="492" alt="screen shot 2018-07-05 at 16 51 34" src="https://user-images.githubusercontent.com/1004115/42327257-fd1c5db4-8073-11e8-915f-6e9aacb1dcc7.png">

after fix:

<img width="492" alt="screen shot 2018-07-05 at 16 54 46" src="https://user-images.githubusercontent.com/1004115/42327330-222beb6a-8074-11e8-9d6d-1add75090605.png">
