### PR TITLE
[v2] making topbar icon configuration compatible on Android and iOS

### DIFF
--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -75,7 +75,6 @@ Navigation.mergeOptions(this.props.componentId, {
     buttonColor: 'black',
     drawBehind: false,
     testID: 'topBar',
-    largeTitle: true, // iOS 11+ Large Title
     searchBar: true, // iOS 11+ native UISearchBar inside topBar
     searchBarHiddenWhenScrolling: true,
     searchBarPlaceholder: 'Search', // iOS 11+ SearchBar placeholder
@@ -104,7 +103,8 @@ Navigation.mergeOptions(this.props.componentId, {
     },
     backButton: {
       icon: require('icon.png'),
-      visible: true
+      visible: true,
+      color: 'green'
     },
     background: {
       color: '#00ff00',

--- a/lib/ios/RNNBackButtonOptions.h
+++ b/lib/ios/RNNBackButtonOptions.h
@@ -7,5 +7,5 @@
 @property (nonatomic, strong) NSString* title;
 @property (nonatomic, strong) NSString* transition;
 @property (nonatomic, strong) NSNumber* showTitle;
-
+@property (nonatomic, strong) NSNumber* color;
 @end

--- a/lib/ios/RNNBackButtonOptions.m
+++ b/lib/ios/RNNBackButtonOptions.m
@@ -25,6 +25,13 @@
 		
 		viewController.navigationItem.backBarButtonItem = backItem;
 	}
+	
+	if (self.color) {
+		UIColor* buttonColor = [RCTConvert UIColor:self.color];
+		viewController.navigationController.navigationBar.tintColor = buttonColor;
+	} else {
+		viewController.navigationController.navigationBar.tintColor = nil;
+	}
 }
 
 @end

--- a/lib/ios/RNNNavigationButtons.m
+++ b/lib/ios/RNNNavigationButtons.m
@@ -105,6 +105,8 @@
 	if (color) {
 		[textAttributes setObject:color forKey:NSForegroundColorAttributeName];
 	}
+
+	[barButtonItem setTintColor: color];
 	
 	UIColor* disabledColor = [self color:dictionary[@"disabledColor"] defaultColor:_defaultButtonStyle.disabledColor];;
 	if (disabledColor) {

--- a/lib/ios/RNNTopBarOptions.h
+++ b/lib/ios/RNNTopBarOptions.h
@@ -13,7 +13,6 @@
 @property (nonatomic, strong) NSArray* rightButtons;
 @property (nonatomic, strong) NSNumber* visible;
 @property (nonatomic, strong) NSNumber* hideOnScroll;
-@property (nonatomic, strong) NSNumber* buttonColor;
 @property (nonatomic, strong) NSNumber* translucent;
 @property (nonatomic, strong) NSNumber* transparent;
 @property (nonatomic, strong) NSNumber* drawBehind;

--- a/lib/ios/RNNTopBarOptions.m
+++ b/lib/ios/RNNTopBarOptions.m
@@ -61,12 +61,6 @@ extern const NSInteger BLUR_TOPBAR_TAG;
 		viewController.navigationController.hidesBarsOnSwipe = NO;
 	}
 	
-	if (self.buttonColor) {
-		UIColor* buttonColor = [RCTConvert UIColor:self.buttonColor];
-		viewController.navigationController.navigationBar.tintColor = buttonColor;
-	} else {
-		viewController.navigationController.navigationBar.tintColor = nil;
-	}
 	
 	if ([self.blur boolValue]) {
 		if (![viewController.navigationController.navigationBar viewWithTag:BLUR_TOPBAR_TAG]) {

--- a/lib/ios/ReactNativeNavigationTests/RNNRootViewControllerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNRootViewControllerTest.m
@@ -169,15 +169,6 @@
 	XCTAssertTrue(self.uut.navigationController.hidesBarsOnSwipe);
 }
 
--(void)testTopBarButtonColor {
-	NSNumber* inputColor = @(0xFFFF0000);
-	__unused RNNNavigationController* nav = [[RNNNavigationController alloc] initWithRootViewController:self.uut];
-	self.options.topBar.buttonColor = inputColor;
-	[self.uut viewWillAppear:false];
-	UIColor* expectedColor = [UIColor colorWithRed:1 green:0 blue:0 alpha:1];
-	XCTAssertTrue([self.uut.navigationController.navigationBar.tintColor isEqual:expectedColor]);
-}
-
 -(void)testTopBarTranslucent {
 	NSNumber* topBarTranslucentInput = @(0);
 	self.options.topBar.translucent = topBarTranslucentInput;
@@ -456,7 +447,7 @@
 -(void)testRightButtonsWithTitle_withStyle {
 	NSNumber* inputColor = @(0xFFFF0000);
 
-	self.options.topBar.rightButtons = @[@{@"id": @"testId", @"title": @"test", @"enabled": @false, @"buttonColor": inputColor, @"buttonFontSize": @22, @"buttonFontWeight": @"800"}];
+	self.options.topBar.rightButtons = @[@{@"id": @"testId", @"title": @"test", @"enabled": @false, @"color": inputColor, @"fontSize": @22, @"fontFamily": @"HelveticaNeue"}];
 	__unused UINavigationController* nav = [[UINavigationController alloc] initWithRootViewController:self.uut];
 	[self.uut viewWillAppear:false];
 
@@ -467,7 +458,7 @@
 	XCTAssertTrue([button.title isEqualToString:expectedTitle]);
 	XCTAssertFalse(button.enabled);
 
-	//TODO: Determine how to tests buttonColor,buttonFontSize and buttonFontWeight?
+	//TODO: Determine how to tests buttonColor,fontSize and fontFamily?
 }
 
 
@@ -487,7 +478,7 @@
 -(void)testLeftButtonsWithTitle_withStyle {
 	NSNumber* inputColor = @(0xFFFF0000);
 
-	self.options.topBar.leftButtons = @[@{@"id": @"testId", @"title": @"test", @"enabled": @false, @"buttonColor": inputColor, @"buttonFontSize": @22, @"buttonFontWeight": @"800"}];
+	self.options.topBar.leftButtons = @[@{@"id": @"testId", @"title": @"test", @"enabled": @false, @"color": inputColor, @"fontSize": @22, @"fontFamily": @"HelveticaNeue"}];
 	__unused UINavigationController* nav = [[UINavigationController alloc] initWithRootViewController:self.uut];
 	[self.uut viewWillAppear:false];
 
@@ -498,7 +489,7 @@
 	XCTAssertTrue([button.title isEqualToString:expectedTitle]);
 	XCTAssertFalse(button.enabled);
 
-	//TODO: Determine how to tests buttonColor,buttonFontSize and buttonFontWeight?
+	//TODO: Determine how to tests color,fontSize and fontFamily?
 }
 
 -(void)testTopBarNoBorderOn {

--- a/playground/src/screens/SearchScreen.js
+++ b/playground/src/screens/SearchScreen.js
@@ -25,6 +25,9 @@ class SearchControllerScreen extends Component {
         largeTitle: {
           visible: true
         },
+        backButton: {
+          color: 'green',
+        },
         searchBar: true,
         searchBarHiddenWhenScrolling: true,
         translucent: true,


### PR DESCRIPTION
Top bar's icon color configuration were different between iOS and Android.

On iOS
`{topBar: { backButton: {color: 'red' } } }` wasn't working.
`{topBar: { leftButtons: [{color: 'red'}] }` wasn't working either.


On the other hand: 
`{ topBar: { buttonColor: 'red'} }` was ignored on Android.

It works on both platforms now.
