### PR TITLE
RTL Layout

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutOptions.java
@@ -3,9 +3,12 @@ package com.reactnativenavigation.parse;
 import com.reactnativenavigation.parse.params.Color;
 import com.reactnativenavigation.parse.params.NullColor;
 import com.reactnativenavigation.parse.params.NullNumber;
+import com.reactnativenavigation.parse.params.Text;
 import com.reactnativenavigation.parse.params.Number;
+import com.reactnativenavigation.parse.params.Text;
 import com.reactnativenavigation.parse.parsers.ColorParser;
 import com.reactnativenavigation.parse.parsers.NumberParser;
+import com.reactnativenavigation.parse.parsers.TextParser;
 
 import org.json.JSONObject;
 
@@ -17,6 +20,7 @@ public class LayoutOptions {
         result.backgroundColor = ColorParser.parse(json, "backgroundColor");
         result.topMargin = NumberParser.parse(json, "topMargin");
         result.orientation = OrientationOptions.parse(json);
+        result.direction = TextParser.parse(json, "direction");
 
         return result;
     }
@@ -24,17 +28,19 @@ public class LayoutOptions {
     public Color backgroundColor = new NullColor();
     public Number topMargin = new NullNumber();
     public OrientationOptions orientation = new OrientationOptions();
+    public Text direction = new Text("ltr");
 
     public void mergeWith(LayoutOptions other) {
         if (other.backgroundColor.hasValue()) backgroundColor = other.backgroundColor;
         if (other.topMargin.hasValue()) topMargin = other.topMargin;
         if (other.orientation.hasValue()) orientation = other.orientation;
-
+        if (other.direction.hasValue()) direction = other.direction;
     }
 
     public void mergeWithDefault(LayoutOptions defaultOptions) {
         if (!backgroundColor.hasValue()) backgroundColor = defaultOptions.backgroundColor;
         if (!topMargin.hasValue()) topMargin = defaultOptions.topMargin;
         if (!orientation.hasValue()) orientation = defaultOptions.orientation;
+        if (!direction.hasValue()) direction = defaultOptions.direction;
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutOptions.java
@@ -5,7 +5,6 @@ import com.reactnativenavigation.parse.params.NullColor;
 import com.reactnativenavigation.parse.params.NullNumber;
 import com.reactnativenavigation.parse.params.Text;
 import com.reactnativenavigation.parse.params.Number;
-import com.reactnativenavigation.parse.params.Text;
 import com.reactnativenavigation.parse.parsers.ColorParser;
 import com.reactnativenavigation.parse.parsers.NumberParser;
 import com.reactnativenavigation.parse.parsers.TextParser;

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
@@ -15,6 +15,7 @@ import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.parse.LayoutFactory;
 import com.reactnativenavigation.parse.LayoutNode;
 import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.parse.params.Bool;
 import com.reactnativenavigation.parse.parsers.JSONParser;
 import com.reactnativenavigation.parse.parsers.LayoutNodeParser;
 import com.reactnativenavigation.utils.NativeCommandListener;
@@ -25,6 +26,10 @@ import com.reactnativenavigation.utils.UiUtils;
 import com.reactnativenavigation.viewcontrollers.Navigator;
 import com.reactnativenavigation.viewcontrollers.ViewController;
 import com.reactnativenavigation.viewcontrollers.externalcomponent.ExternalComponentCreator;
+
+import com.facebook.react.modules.i18nmanager.I18nUtil;
+import android.view.View;
+
 
 import java.util.Map;
 
@@ -150,12 +155,25 @@ public class NavigationModule extends ReactContextBaseJavaModule {
 
 	@NonNull
 	private LayoutFactory newLayoutFactory() {
-		return new LayoutFactory(activity(),
+
+		NavigationActivity layoutActivity = activity();
+
+		I18nUtil i18nUtil = I18nUtil.getInstance();
+		ReactApplicationContext reactContext = getReactApplicationContext();
+		Options defaultOptions = navigator().getDefaultOptions();
+		Boolean isRtl = defaultOptions.layout.direction.hasValue() && defaultOptions.layout.direction.get().equals("rtl");
+
+		// set activity layout direction
+		layoutActivity.getWindow().getDecorView().setLayoutDirection(isRtl ? View.LAYOUT_DIRECTION_RTL : View.LAYOUT_DIRECTION_LTR);
+		i18nUtil.allowRTL(reactContext, isRtl);
+		i18nUtil.forceRTL(reactContext, isRtl);
+
+		return new LayoutFactory(layoutActivity,
                 navigator().getChildRegistry(),
                 reactInstanceManager,
                 eventEmitter,
                 externalComponentCreator(),
-                navigator().getDefaultOptions()
+                defaultOptions
         );
 	}
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/TopBarButtonController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/TopBarButtonController.java
@@ -80,7 +80,8 @@ public class TopBarButtonController extends ViewController<TitleBarReactButtonVi
     }
 
     public void applyNavigationIcon(Toolbar toolbar) {
-        navigationIconResolver.resolve(button, icon -> {
+        Integer direction = getActivity().getWindow().getDecorView().getLayoutDirection();
+        navigationIconResolver.resolve(button, direction, icon -> {
             setIconColor(icon);
             toolbar.setNavigationOnClickListener(view -> onPressListener.onPress(button.id));
             toolbar.setNavigationIcon(icon);

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/button/NavigationIconResolver.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/button/NavigationIconResolver.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
+import android.view.View;
 
 import com.reactnativenavigation.R;
 import com.reactnativenavigation.parse.params.Button;
@@ -22,7 +23,7 @@ public class NavigationIconResolver {
         this.imageLoader = imageLoader;
     }
 
-    public void resolve(Button button, Task<Drawable> onSuccess) {
+    public void resolve(Button button, Integer direction, Task<Drawable> onSuccess) {
         if (button.icon.hasValue()) {
             imageLoader.loadIcon(context, button.icon.get(), new ImageLoadingListenerAdapter() {
                 @Override
@@ -36,7 +37,8 @@ public class NavigationIconResolver {
                 }
             });
         } else if (Constants.BACK_BUTTON_ID.equals(button.id)) {
-            onSuccess.run(ContextCompat.getDrawable(context, R.drawable.ic_arrow_back_black_24dp));
+            Boolean isRTL = direction == View.LAYOUT_DIRECTION_RTL;
+            onSuccess.run(ContextCompat.getDrawable(context, isRTL ? R.drawable.ic_arrow_back_black_rtl_24dp : R.drawable.ic_arrow_back_black_24dp));
         } else {
             throw new RuntimeException("Left button needs to have an icon");
         }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBar.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBar.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import android.view.Gravity;
 import android.view.ViewGroup;
 import android.widget.TextView;
+import android.view.View;
 
 import com.reactnativenavigation.parse.Alignment;
 import com.reactnativenavigation.parse.BackButton;
@@ -110,13 +111,16 @@ public class TitleBar extends Toolbar {
     }
 
     private void alignTextView(Alignment alignment, TextView view) {
+        Integer direction = view.getParent().getLayoutDirection();
+        Boolean isRTL = direction == View.LAYOUT_DIRECTION_RTL;
+
         view.post(() -> {
             if (alignment == Alignment.Center) {
                 view.setX((getWidth() - view.getWidth()) / 2);
             } else if (leftButtonController != null) {
-                view.setX(getContentInsetStartWithNavigation());
+                view.setX(isRTL ? (getWidth() - view.getWidth()) - getContentInsetStartWithNavigation() : getContentInsetStartWithNavigation());
             } else {
-                view.setX(UiUtils.dpToPx(getContext(), 16));
+                view.setX(isRTL ? (getWidth() - view.getWidth()) - UiUtils.dpToPx(getContext(), 16) : UiUtils.dpToPx(getContext(), 16));
             }
         });
     }

--- a/lib/android/app/src/main/res/drawable/ic_arrow_back_black_rtl_24dp.xml
+++ b/lib/android/app/src/main/res/drawable/ic_arrow_back_black_rtl_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M4,13H16.15l-5.6,5.6L12,20l8-8L12,4,10.6,5.4,16.15,11H4Z" />
+</vector>

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/button/NavigationIconResolverTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/button/NavigationIconResolverTest.java
@@ -41,7 +41,7 @@ public class NavigationIconResolverTest extends BaseTest {
 
             }
         });
-        uut.resolve(iconButton(), onSuccess);
+        uut.resolve(iconButton(), 0, onSuccess);
         verify(imageLoader).loadIcon(eq(context), eq(ICON_URI), any());
         verify(onSuccess).run(any(Drawable.class));
     }
@@ -54,7 +54,7 @@ public class NavigationIconResolverTest extends BaseTest {
 
             }
         });
-        uut.resolve(backButton(), onSuccess);
+        uut.resolve(backButton(), 0, onSuccess);
         verifyZeroInteractions(imageLoader);
         verify(onSuccess).run(any());
     }

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -7,6 +7,7 @@
 #import "RNNSplitViewController.h"
 #import "RNNElementFinder.h"
 #import "React/RCTUIManager.h"
+#import "React/RCTI18nUtil.h"
 
 
 static NSString* const setRoot	= @"setRoot";
@@ -48,6 +49,20 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 
 -(void) setRoot:(NSDictionary*)layout completion:(RNNTransitionCompletionBlock)completion {
 	[self assertReady];
+
+	if (@available(iOS 9, *)) {
+        if ([_controllerFactory.defaultOptionsDict[@"layout"][@"direction"] isEqualToString:@"rtl"]) {
+            [[RCTI18nUtil sharedInstance] allowRTL:YES];
+            [[RCTI18nUtil sharedInstance] forceRTL:YES];
+            [[UIView appearance] setSemanticContentAttribute:UISemanticContentAttributeForceRightToLeft];
+            [[UINavigationBar appearance] setSemanticContentAttribute:UISemanticContentAttributeForceRightToLeft];
+        } else {
+            [[RCTI18nUtil sharedInstance] allowRTL:NO];
+            [[RCTI18nUtil sharedInstance] forceRTL:NO];
+            [[UIView appearance] setSemanticContentAttribute:UISemanticContentAttributeForceLeftToRight];
+            [[UINavigationBar appearance] setSemanticContentAttribute:UISemanticContentAttributeForceLeftToRight];
+        }
+    }
 	
 	[_modalManager dismissAllModals];
 	[_eventEmitter sendOnNavigationCommand:setRoot params:@{@"layout": layout}];

--- a/lib/ios/RNNNavigationStackManager.m
+++ b/lib/ios/RNNNavigationStackManager.m
@@ -1,5 +1,6 @@
 #import "RNNNavigationStackManager.h"
 #import "RNNErrorHandler.h"
+#import <React/RCTI18nUtil.h>
 
 typedef void (^RNNAnimationBlock)(void);
 
@@ -7,6 +8,14 @@ typedef void (^RNNAnimationBlock)(void);
 
 - (void)push:(UIViewController *)newTop onTop:(UIViewController *)onTopViewController animated:(BOOL)animated animationDelegate:(id)animationDelegate completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection {
 	UINavigationController *nvc = onTopViewController.navigationController;
+
+    if([[RCTI18nUtil sharedInstance] isRTL]) {
+        nvc.view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
+        nvc.navigationBar.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
+    } else {
+        nvc.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        nvc.navigationBar.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    }
 
 	if (animationDelegate) {
 		nvc.delegate = animationDelegate;


### PR DESCRIPTION
Fixes #3485 

```javascript

// Set direction to RTL layout
Navigation.setDefaultOptions({
      layout: {
          direction: 'rtl'
      }
});

Navigation.setRoot({});
```

#### AndroidManifest.xml
> Android requires to set supportsRTL in androidManifest

```xml
<application
      android:name=".MainApplication"
+     android:supportsRtl="true"
      ...
      android:theme="@style/AppTheme">
```