### PR TITLE
Update compileSdkVersion version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply from: '../prepare-robolectric.gradle'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
 
     defaultConfig {


### PR DESCRIPTION
when compileSdkVersion is 25, below error was occured in react native 0.56.0.
"No resource found that matches the given name: attr 'android:keyboardNavigationCluster'"
so i have to change compileSdkVersion to 26.
Please add this push on your repository.
Thanks