### PR TITLE
[v1] Android tab icons support from drawable resource

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/ScreenParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/ScreenParamsParser.java
@@ -54,7 +54,7 @@ public class ScreenParamsParser extends Parser {
         result.fabParams = ButtonParser.parseFab(params, result.navigationParams.navigatorEventId, result.navigationParams.screenInstanceId);
 
         result.tabLabel = getTabLabel(params);
-        result.tabIcon = new TabIconParser(params).parse();
+        result.tabIcon = getTabIcon(params);
 
         result.animateScreenTransitions = new AnimationParser(params).parse();
         result.sharedElementsTransitions = getSharedElementsTransitions(params);
@@ -77,11 +77,7 @@ public class ScreenParamsParser extends Parser {
     }
 
     private static Drawable getTabIcon(Bundle params) {
-        Drawable tabIcon = null;
-        if (hasKey(params, "icon")) {
-            tabIcon = ImageLoader.loadImage(params.getString("icon"));
-        }
-        return tabIcon;
+        return new TabIconParser(params).parse();
     }
 
     private static String getTabLabel(Bundle params) {

--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/TabIconParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/TabIconParser.java
@@ -3,7 +3,9 @@ package com.reactnativenavigation.params.parsers;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 
+import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.react.ImageLoader;
+import com.reactnativenavigation.react.ResourceDrawableIdHelper;
 
 class TabIconParser extends Parser {
 
@@ -16,7 +18,12 @@ class TabIconParser extends Parser {
     public Drawable parse() {
         Drawable tabIcon = null;
         if (hasKey(params, "icon")) {
-            tabIcon = ImageLoader.loadImage(params.getString("icon"));
+            String uri = params.getString("icon");
+            if (uri.startsWith("http://") || uri.startsWith("https://") || uri.startsWith("file://")) {
+                tabIcon = ImageLoader.loadImage(uri);
+            } else {
+                tabIcon = ResourceDrawableIdHelper.instance.getResourceDrawable(NavigationApplication.instance, uri);
+            }
         }
         return tabIcon;
     }


### PR DESCRIPTION
This fix add possibilities to use tab icons from drawable resource on Android platform. 

Example:
```
...
{
  label: 'Feed',
  screen: 'app.FeedScreen',
  icon: { uri: 'icon_feed' },
  selectedIcon: { uri: 'icon_feed_selected },
  title: 'My Feed',
},
...
```