### PR TITLE
Added callback handle for when a modal is open

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/ActivityCallbacks.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/ActivityCallbacks.java
@@ -1,6 +1,7 @@
 package com.reactnativenavigation.controllers;
 
 import android.app.Activity;
+import android.app.Dialog;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
@@ -8,6 +9,10 @@ import android.view.KeyEvent;
 
 public class ActivityCallbacks {
     public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+
+    }
+
+    public void onModalOpen(Dialog modal) {
 
     }
 

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/ModalController.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/ModalController.java
@@ -6,6 +6,7 @@ import android.view.Window;
 
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
+import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.events.EventBus;
 import com.reactnativenavigation.events.ModalDismissedEvent;
 import com.reactnativenavigation.layouts.ScreenStackContainer;
@@ -38,6 +39,7 @@ class ModalController implements ScreenStackContainer, Modal.OnModalDismissedLis
 
     void showModal(ScreenParams screenParams) {
         Modal modal = new Modal(activity, this, screenParams);
+        NavigationApplication.instance.getActivityCallbacks().onModalOpen(modal);
         modal.show();
         stack.add(modal);
     }


### PR DESCRIPTION
This should allow people to do stuff like what was reported on https://github.com/wix/react-native-navigation/issues/2841 by just overriding the method `public void onModalOpen(Dialog modal)`.

Tested with the call to `modal.setVolumeControlStream(AudioManager.STREAM_MUSIC);` on a real App