### PR TITLE
Remove undefined rootView

### DIFF
--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -205,8 +205,8 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 }
 
 - (void)sendScreenChangedEvent:(NSString *)eventName {
-    if (self.rootView != nil) {
-        RCTRootView *rootView = self.rootView;
+    if (self.view != nil) {
+        RCTRootView *rootView = self.view;
         
         if (rootView.appProperties && rootView.appProperties[@"navigatorEventID"]) {
             
@@ -220,8 +220,8 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 }
 
 - (void)sendGlobalScreenEvent:(NSString *)eventName endTimestampString:(NSString *)endTimestampStr shouldReset:(BOOL)shouldReset {
-    if (self.rootView != nil){
-        RCTRootView *rootView = self.rootView;
+    if (self.view != nil){
+        RCTRootView *rootView = self.view;
         NSString *screenName = [rootView moduleName];
         
         [[[RCCManager sharedInstance] getBridge].eventDispatcher sendAppEventWithName:eventName body:@


### PR DESCRIPTION
I think this pull request for revert is not sufficient.
https://github.com/wix/react-native-navigation/pull/3441

ver 1.1.475
This error occurred.
```
/react-native-navigation/ios/RCCViewController.m:208:14: error: property 'rootView' not found on object of type 'RCCViewController *'
    if (self.rootView != nil) {
             ^
```

So I remove undefined rootView.
Please confirm my pull request.