### PR TITLE
Fix app crash bug when reload [cmd + r]

### DIFF
--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -205,8 +205,8 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 }
 
 - (void)sendScreenChangedEvent:(NSString *)eventName {
-    if (self.view != nil) {
-        RCTRootView *rootView = self.view;
+    if ([self.view isKindOfClass:[RCTRootView class]]) {
+        RCTRootView *rootView = (RCTRootView *)self.view;
         
         if (rootView.appProperties && rootView.appProperties[@"navigatorEventID"]) {
             
@@ -220,10 +220,9 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 }
 
 - (void)sendGlobalScreenEvent:(NSString *)eventName endTimestampString:(NSString *)endTimestampStr shouldReset:(BOOL)shouldReset {
-    if (self.view != nil){
-        RCTRootView *rootView = self.view;
-        NSString *screenName = [rootView moduleName];
-        
+    if ([self.view isKindOfClass:[RCTRootView class]]){
+        NSString *screenName = [((RCTRootView *)self.view) moduleName];
+
         [[[RCCManager sharedInstance] getBridge].eventDispatcher sendAppEventWithName:eventName body:@
          {
              @"commandType": self.commandType ? self.commandType : @"",


### PR DESCRIPTION
Sorry, this pull request I created yesterday and merged same day is not sufficient...
https://github.com/wix/react-native-navigation/pull/3441

```
if (self.view != nil){
-        RCTRootView *rootView = self.view;
-        NSString *screenName = [rootView moduleName];
```
This condition is always true. So, when we reload simulator (cmd + r) app reset and back to home of simulator.

I modify my commit, so please check.  