### PR TITLE
[v2] [ios] Don't touch navigationController if this viewController is not a top one

### DIFF
--- a/lib/ios/RNNTopBarOptions.m
+++ b/lib/ios/RNNTopBarOptions.m
@@ -27,6 +27,9 @@ extern const NSInteger BLUR_TOPBAR_TAG;
 }
 
 - (void)applyOn:(UIViewController*)viewController {
+	if (viewController.navigationController.topViewController != viewController) {
+		return;
+	}
 	[self.title applyOn:viewController];
 	[self.largeTitle applyOn:viewController];
 	[self.background applyOn:viewController];


### PR DESCRIPTION
Probable fix for https://github.com/wix/react-native-navigation/issues/3570 and similar issues. Not well-tested, fixes my use-case. 

When we have several view controllers in stack: 
```
navigationController 
  --- viewController1
  --- viewController2
  --- viewController3
```
and update some options for `viewController2` via `mergeOptions(componentId, { } )` (for example updating bottomtab badge after getting a push notification) we also apply all these options for navigationController, which might lead to undoing some work