### PR TITLE
Fixes AppBarLayout delayed init of elevation (issue #3582)

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/StackOptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/StackOptionsPresenter.java
@@ -73,7 +73,7 @@ public class StackOptionsPresenter {
 
     private void applyTopBarOptions(TopBarOptions options, AnimationsOptions animationOptions, Component component, Options componentOptions) {
         topBar.setHeight(options.height.get(LayoutParams.WRAP_CONTENT));
-        topBar.setElevation(options.elevation);
+        topBar.setElevation(options.elevation.get(4d));
 
         topBar.setTitleHeight(options.title.height.get(LayoutParams.WRAP_CONTENT));
         topBar.setTitle(options.title.text.get(""));
@@ -172,7 +172,7 @@ public class StackOptionsPresenter {
 
     private void mergeTopBarOptions(TopBarOptions options, AnimationsOptions animationsOptions, Component component) {
         if (options.height.hasValue()) topBar.setHeight(options.height.get());
-        if (options.elevation.hasValue()) topBar.setElevation(options.elevation);
+        if (options.elevation.hasValue()) topBar.setElevation(options.elevation.get());
 
         if (options.title.height.hasValue()) topBar.setTitleHeight(options.title.height.get());
         if (options.title.text.hasValue()) topBar.setTitle(options.title.text.get());

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/topbar/TopBar.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/topbar/TopBar.java
@@ -20,6 +20,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.reactnativenavigation.BuildConfig;
+import com.reactnativenavigation.R;
 import com.reactnativenavigation.anim.TopBarAnimator;
 import com.reactnativenavigation.anim.TopBarCollapseBehavior;
 import com.reactnativenavigation.interfaces.ScrollEventListener;
@@ -29,7 +30,6 @@ import com.reactnativenavigation.parse.BackButton;
 import com.reactnativenavigation.parse.Component;
 import com.reactnativenavigation.parse.params.Button;
 import com.reactnativenavigation.parse.params.Color;
-import com.reactnativenavigation.parse.params.Fraction;
 import com.reactnativenavigation.parse.params.Number;
 import com.reactnativenavigation.utils.CompatUtils;
 import com.reactnativenavigation.utils.ImageLoader;
@@ -63,6 +63,7 @@ public class TopBar extends AppBarLayout implements ScrollEventListener.ScrollAw
 
     public TopBar(final Context context, ReactViewCreator buttonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener onClickListener, StackLayout parentView, ImageLoader imageLoader) {
         super(context);
+        context.setTheme(R.style.TopBar);
         this.imageLoader = imageLoader;
         collapsingBehavior = new TopBarCollapseBehavior(this);
         this.topBarBackgroundViewController = topBarBackgroundViewController;
@@ -225,11 +226,10 @@ public class TopBar extends AppBarLayout implements ScrollEventListener.ScrollAw
         titleBar.setRightButtons(rightButtons);
     }
 
-    public void setElevation(Fraction elevation) {
-        if (elevation.hasValue() &&
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
-            getElevation() != elevation.get().floatValue()) {
-            setElevation(UiUtils.dpToPx(getContext(), elevation.get().floatValue()));
+    public void setElevation(Double elevation) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
+                getElevation() != elevation.floatValue()) {
+            setElevation(UiUtils.dpToPx(getContext(), elevation.floatValue()));
         }
     }
 

--- a/lib/android/app/src/main/res/values/styles.xml
+++ b/lib/android/app/src/main/res/values/styles.xml
@@ -10,4 +10,9 @@
         <item name="android:windowEnterAnimation">@null</item>
         <item name="android:windowExitAnimation">@null</item>
     </style>
+
+    <style name="TopBar" parent="ThemeOverlay.AppCompat.ActionBar">
+        <item name="elevation">0dp</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
When no theme is provided, AppBarLayout styles itself programmatically. What happens is that because these tasks are done asynchronously based on events, its call for "setElevation" equivalent can run after RNN calls!

I'm proposing a fix for #3582 that create a style for TopBar where elevation=0 and make RNN responsible to set that 4dp elevation value which is default to Android.