### PR TITLE
[v2][ios] Do not set largeTitleDisplayMode to prevent largeTitle jumping

### DIFF
--- a/lib/ios/RNNLargeTitleOptions.m
+++ b/lib/ios/RNNLargeTitleOptions.m
@@ -8,12 +8,20 @@
 
 	if (@available(iOS 11.0, *)) {
 		
+		BOOL prefersLargeTitles = viewController.navigationController.navigationBar.prefersLargeTitles;
+		BOOL previousValue = prefersLargeTitles;
+		long displayMode = viewController.navigationItem.largeTitleDisplayMode;
 		if ([self.visible boolValue]){
-			viewController.navigationController.navigationBar.prefersLargeTitles = YES;
-			viewController.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeAlways;
+			prefersLargeTitles = YES;
+			displayMode = UINavigationItemLargeTitleDisplayModeAlways;
 		} else {
-			viewController.navigationController.navigationBar.prefersLargeTitles = NO;
-			viewController.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+			prefersLargeTitles = NO;
+			displayMode = UINavigationItemLargeTitleDisplayModeNever;
+		}
+                // only call setters for largeTitles if it's really changed
+		if (prefersLargeTitles != previousValue) {
+			viewController.navigationItem.largeTitleDisplayMode = displayMode;
+			viewController.navigationController.navigationBar.prefersLargeTitles = prefersLargeTitles;
 		}
 		
 		NSDictionary* fontAttributes = [self fontAttributes];

--- a/lib/ios/RNNLargeTitleOptions.m
+++ b/lib/ios/RNNLargeTitleOptions.m
@@ -8,13 +8,12 @@
 
 	if (@available(iOS 11.0, *)) {
 		
-		viewController.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-	
 		if ([self.visible boolValue]){
 			viewController.navigationController.navigationBar.prefersLargeTitles = YES;
 			viewController.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeAlways;
 		} else {
 			viewController.navigationController.navigationBar.prefersLargeTitles = NO;
+			viewController.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
 		}
 		
 		NSDictionary* fontAttributes = [self fontAttributes];


### PR DESCRIPTION
It's probably a temporary workaround, until we figure out why it gets re-rendered incorrectly. 
Use case: Two tabs with scrollviews and large titles inside. After switching tabs, a large title gets rendered as a small title. 
Seems like a minor change with the much better and consistent UX as an outcome, but maybe I'm missing something. 