### PR TITLE
Fixed: iOS searchBar tintColor utilize buttonColor

### DIFF
--- a/lib/ios/RNNTopBarOptions.m
+++ b/lib/ios/RNNTopBarOptions.m
@@ -43,6 +43,9 @@ extern const NSInteger BLUR_TOPBAR_TAG;
 			if (self.searchBarPlaceholder) {
 				search.searchBar.placeholder = self.searchBarPlaceholder;
 			}
+			if (self.buttonColor) {
+				search.searchBar.tintColor = [RCTConvert UIColor:self.buttonColor];
+			}
 			viewController.navigationItem.searchController = search;
 			// enable it back if needed on componentDidAppear
 			viewController.navigationItem.hidesSearchBarWhenScrolling = NO;


### PR DESCRIPTION
Currently searchBar using default tintColor which in most case didnt match with topBar.buttonColor if defined.