### PR TITLE
Instructions for create-react-native-app

### DIFF
--- a/docs/docs/Installing.md
+++ b/docs/docs/Installing.md
@@ -42,6 +42,8 @@
 
 	@end
 	```
+	
+For apps created with `create-react-native-app`, change `jsBundleURLForBundleRoot:@"index.ios"` to `jsBundleURLForBundleRoot:@"index"`.
 
 ## Android
 


### PR DESCRIPTION
Apps created with create-react-native-app will have a single index.js entry point. References to index.ios.js will throw an error.