### PR TITLE
[v2][Android] Add sideMenu height and width options for consistency with IOS

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/SideMenuOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/SideMenuOptions.java
@@ -2,24 +2,38 @@ package com.reactnativenavigation.parse;
 
 import com.reactnativenavigation.parse.params.Bool;
 import com.reactnativenavigation.parse.params.NullBool;
+import com.reactnativenavigation.parse.params.NullNumber;
+import com.reactnativenavigation.parse.params.Number;
 import com.reactnativenavigation.parse.parsers.BoolParser;
+import com.reactnativenavigation.parse.parsers.NumberParser;
 
 import org.json.JSONObject;
 
 public class SideMenuOptions {
     public Bool visible = new NullBool();
+    public Number height = new NullNumber();
+    public Number width = new NullNumber();
 
     public static SideMenuOptions parse(JSONObject json) {
         SideMenuOptions options = new SideMenuOptions();
         if (json == null) return options;
 
         options.visible = BoolParser.parse(json, "visible");
+        options.height = NumberParser.parse(json, "height");
+        options.width = NumberParser.parse(json, "width");
+
         return options;
     }
 
     public void mergeWith(SideMenuOptions other) {
         if (other.visible.hasValue()) {
             visible = other.visible;
+        }
+        if (other.height.hasValue()) {
+            height = other.height;
+        }
+        if (other.width.hasValue()) {
+            width = other.width;
         }
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/SideMenuController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/SideMenuController.java
@@ -1,13 +1,16 @@
 package com.reactnativenavigation.viewcontrollers;
 
 import android.app.Activity;
+import android.content.res.Resources;
 import android.support.annotation.NonNull;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v4.widget.DrawerLayout.LayoutParams;
+import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 
 import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.parse.SideMenuOptions;
 import com.reactnativenavigation.presentation.OptionsPresenter;
 import com.reactnativenavigation.presentation.SideMenuOptionsPresenter;
 import com.reactnativenavigation.views.Component;
@@ -87,13 +90,33 @@ public class SideMenuController extends ParentController<DrawerLayout> {
 		getView().addView(childView);
 	}
 
-	public void setLeftController(ViewController controller) {
-		this.leftController = controller;
-        getView().addView(controller.getView(), new LayoutParams(MATCH_PARENT, MATCH_PARENT, Gravity.LEFT));
-	}
+    public void setLeftController(ViewController controller) {
+        this.leftController = controller;
+        int height = this.getHeight(options.sideMenuRootOptions.left);
+        int width = this.getWidth(options.sideMenuRootOptions.left);
+        getView().addView(controller.getView(), new LayoutParams(width, height, Gravity.LEFT));
+    }
 
-	public void setRightController(ViewController controller) {
-		this.rightController = controller;
-        getView().addView(controller.getView(), new LayoutParams(MATCH_PARENT, MATCH_PARENT, Gravity.RIGHT));
-	}
+    public void setRightController(ViewController controller) {
+        this.rightController = controller;
+        int height = this.getHeight(options.sideMenuRootOptions.right);
+        int width = this.getWidth(options.sideMenuRootOptions.right);
+        getView().addView(controller.getView(), new LayoutParams(width, height, Gravity.RIGHT));
+    }
+
+    protected int getWidth(SideMenuOptions sideMenuOptions) {
+        int width = MATCH_PARENT;
+        if (sideMenuOptions.width.hasValue()) {
+            width = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, sideMenuOptions.width.get(), Resources.getSystem().getDisplayMetrics());
+        }
+        return width;
+    }
+
+    protected int getHeight(SideMenuOptions sideMenuOptions) {
+        int height = MATCH_PARENT;
+        if (sideMenuOptions.height.hasValue()) {
+            height = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, sideMenuOptions.height.get(), Resources.getSystem().getDisplayMetrics());
+        }
+        return height;
+    }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/SideMenuControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/SideMenuControllerTest.java
@@ -1,16 +1,23 @@
 package com.reactnativenavigation.viewcontrollers;
 
 import android.app.Activity;
+import android.content.res.Resources;
+import android.view.ViewGroup.LayoutParams;
+import android.util.TypedValue;
 import android.view.Gravity;
 
 import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.mocks.SimpleComponentViewController;
 import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.parse.SideMenuOptions;
 import com.reactnativenavigation.parse.params.Bool;
+import com.reactnativenavigation.parse.params.Number;
 import com.reactnativenavigation.presentation.OptionsPresenter;
 
+import org.junit.Assert;
 import org.junit.Test;
 
+import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class SideMenuControllerTest extends BaseTest {
@@ -54,5 +61,68 @@ public class SideMenuControllerTest extends BaseTest {
         Options options = new Options();
         uut.mergeOptions(options);
         assertThat(uut.options.sideMenuRootOptions).isNotEqualTo(initialOptions.sideMenuRootOptions);
+    }
+
+    @Test
+    public void setLeftController_matchesParentByDefault() {
+        SideMenuOptions options = new SideMenuOptions();
+        assertThat(options.width.hasValue()).isFalse();
+        assertThat(options.height.hasValue()).isFalse();
+        uut.options.sideMenuRootOptions.left = options;
+
+        SimpleComponentViewController componentViewController = new SimpleComponentViewController(activity, childRegistry, "left", new Options());
+        uut.setLeftController(componentViewController);
+
+        LayoutParams params = componentViewController.getView().getLayoutParams();
+        assertThat(params.width).isEqualTo(MATCH_PARENT);
+        assertThat(params.height).isEqualTo(MATCH_PARENT);
+    }
+    @Test
+    public void setLeftController_setHeightAndWidthWithOptions() {
+        SideMenuOptions options = new SideMenuOptions();
+        options.height = new Number(100);
+        options.width = new Number(200);
+        uut.options.sideMenuRootOptions.left = options;
+
+        SimpleComponentViewController componentViewController = new SimpleComponentViewController(activity, childRegistry, "left", new Options());
+        uut.setLeftController(componentViewController);
+
+        int heightInDp = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 100, Resources.getSystem().getDisplayMetrics());
+        int widthInDp = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 200, Resources.getSystem().getDisplayMetrics());
+
+        LayoutParams params = componentViewController.getView().getLayoutParams();
+        assertThat(params.width).isEqualTo(widthInDp);
+        assertThat(params.height).isEqualTo(heightInDp);
+    }
+    @Test
+    public void setRightController_matchesParentByDefault() {
+        SideMenuOptions options = new SideMenuOptions();
+        assertThat(options.width.hasValue()).isFalse();
+        assertThat(options.height.hasValue()).isFalse();
+        uut.options.sideMenuRootOptions.left = options;
+
+        SimpleComponentViewController componentViewController = new SimpleComponentViewController(activity, childRegistry, "right", new Options());
+        uut.setRightController(componentViewController);
+
+        LayoutParams params = componentViewController.getView().getLayoutParams();
+        assertThat(params.width).isEqualTo(MATCH_PARENT);
+        assertThat(params.height).isEqualTo(MATCH_PARENT);
+    }
+    @Test
+    public void setRightController_setHeightAndWidthWithOptions() {
+        SideMenuOptions options = new SideMenuOptions();
+        options.height = new Number(100);
+        options.width = new Number(200);
+        uut.options.sideMenuRootOptions.left = options;
+
+        SimpleComponentViewController componentViewController = new SimpleComponentViewController(activity, childRegistry, "left", new Options());
+        uut.setLeftController(componentViewController);
+
+        int heightInDp = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 100, Resources.getSystem().getDisplayMetrics());
+        int widthInDp = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 200, Resources.getSystem().getDisplayMetrics());
+
+        LayoutParams params = componentViewController.getView().getLayoutParams();
+        assertThat(params.width).isEqualTo(widthInDp);
+        assertThat(params.height).isEqualTo(heightInDp);
     }
 }


### PR DESCRIPTION
Dear Maintainers,

Thanks for the awesome library.
Hereby my pull request for adding height and width options for Android. The width option already worked for IOS and this PR makes it consistent.
The options can be set in sideMenu for left and/or right, i.e.: `options { sideMenu: { left: { width: 200 } }.`

It is a minor change in SideMenuOptions and SideMenuController. Nevertheless, I've added unit tests to SideMenuControllerTest. I also ran yarn test-all without any issues.

Please let me know if any changes are necessary.

Cheers, Derk
