### PR TITLE
Prevent user interaction until animation stopped on Android's left button

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/LeftButton.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/LeftButton.java
@@ -52,6 +52,9 @@ class LeftButton extends MaterialMenuDrawable implements View.OnClickListener {
 
     @Override
     public void onClick(View v) {
+        if (isRunning()) {
+            return;
+        }
         if (isBackButton()) {
             handleBackButtonClick();
         } else if (isSideMenuButton()) {


### PR DESCRIPTION
When change a left button's id from `back` to `cancel`, the event for click is still `back` in the animation duration. That is to say, click the button that seems to have became a `x` will still pop the screen.

So I think it's necessary to prevent user interaction in the duration to prevent unexpected interactions.
