### PR TITLE
[v2] Fix migration topBar fontSize example on docs

### DIFF
--- a/docs/docs/options-migration.md
+++ b/docs/docs/options-migration.md
@@ -17,7 +17,7 @@ Title font size
 ```js
 topBar: {
   title: {
-    fontSize: 'red'
+    fontSize: 18
   }
 }
 ```


### PR DESCRIPTION
On *Migration from V1 › Options* the `navBarTextFontSize` to `topBar title fontSize` example was set to `'red'`, this PR changes it to the default value, 18.