### PR TITLE
Hack to fix when app is stuck on the splash screen.

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -63,12 +63,15 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     @Nullable
     private PermissionListener mPermissionListener;
 
+    boolean killedBySystem = false;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (!NavigationApplication.instance.getReactGateway().hasStartedCreatingContext() ||
                 getIntent() == null ||
                 getIntent().getBundleExtra("ACTIVITY_PARAMS_BUNDLE") == null) {
+            killedBySystem = true;
             SplashActivity.start(this);
             finish();
             return;
@@ -196,6 +199,10 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     }
 
     private void destroyJsIfNeeded() {
+        if ( killedBySystem ) {
+            return;
+        }
+
         if (currentActivity == null || currentActivity.isFinishing()) {
             getReactGateway().onDestroyApp(this);
         }


### PR DESCRIPTION
When the navigation activity is killed/restarted by the system, onCreate launches the SplashActivity and kills itself. The new SplashActivity starts context initialization but that is broken in between by the onDestroy of the NavigationActivity we just killed. This fix adds a boolean to disable destruction of js in this case.