### PR TITLE
Call sideMenu.setEnabled, pass side to fix enabling only left or right menu

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/layouts/BottomTabsLayout.java
+++ b/android/app/src/main/java/com/reactnativenavigation/layouts/BottomTabsLayout.java
@@ -270,7 +270,7 @@ public class BottomTabsLayout extends BaseLayout implements AHBottomNavigation.O
     @Override
     public void setSideMenuEnabled(boolean enabled, Side side) {
         if (sideMenu != null) {
-            sideMenu.setDrawerLockMode(enabled ? DrawerLayout.LOCK_MODE_UNLOCKED : DrawerLayout.LOCK_MODE_LOCKED_CLOSED, side.gravity);
+            sideMenu.setEnabled(enabled, side);
         }
     }
 

--- a/android/app/src/main/java/com/reactnativenavigation/layouts/BottomTabsLayout.java
+++ b/android/app/src/main/java/com/reactnativenavigation/layouts/BottomTabsLayout.java
@@ -270,7 +270,7 @@ public class BottomTabsLayout extends BaseLayout implements AHBottomNavigation.O
     @Override
     public void setSideMenuEnabled(boolean enabled, Side side) {
         if (sideMenu != null) {
-            sideMenu.setDrawerLockMode(enabled ? DrawerLayout.LOCK_MODE_UNLOCKED : DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
+            sideMenu.setDrawerLockMode(enabled ? DrawerLayout.LOCK_MODE_UNLOCKED : DrawerLayout.LOCK_MODE_LOCKED_CLOSED, side.gravity);
         }
     }
 


### PR DESCRIPTION
Call sideMenu.setEnabled (in setSideMenuEnabled) instead of sideMenu.setDrawerLockMode and pass side parameter to only enable/disable left or right side menu.