### PR TITLE
Add link to V2 Documentation

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,3 +1,6 @@
+#### V 1.1.X  
+For [V2 docs click here](https://github.com/wix/react-native-navigation/tree/v2)
+
 - Getting started
  - [Installation - iOS](/installation-ios)
  - [Installation - Android](/installation-android)


### PR DESCRIPTION
Added a header to the sidebar to indicate that this is the V1.1.X documentation and added a link to the V2 docs.

I know of at least one other person who waisted a few hours because they didn't realize they were looking at the wrong docs, so I thought that this header and link might be of some use. 