### PR TITLE
Unmount title view when corresponding child component is unmounted

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutFactory.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutFactory.java
@@ -162,13 +162,11 @@ public class LayoutFactory {
                 .setChildren(createChildren(node.children))
                 .setChildRegistry(childRegistry)
                 .setTopBarButtonCreator(new TitleBarButtonCreator(reactInstanceManager))
-                .setTitleBarReactViewCreator(new TitleBarReactViewCreator(reactInstanceManager))
                 .setTopBarBackgroundViewController(new TopBarBackgroundViewController(activity, new TopBarBackgroundViewCreator(reactInstanceManager)))
                 .setTopBarController(new TopBarController())
                 .setId(node.id)
                 .setInitialOptions(parse(typefaceManager, node.getOptions()))
-                .setOptionsPresenter(new OptionsPresenter(activity, defaultOptions))
-                .setStackPresenter(new StackOptionsPresenter(activity, defaultOptions))
+                .setStackPresenter(new StackOptionsPresenter(activity, new TitleBarReactViewCreator(reactInstanceManager), defaultOptions))
                 .build();
 	}
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/StackOptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/StackOptionsPresenter.java
@@ -1,12 +1,15 @@
 package com.reactnativenavigation.presentation;
 
 import android.app.Activity;
-import android.content.Context;
 import android.graphics.Color;
 import android.support.annotation.Nullable;
+import android.support.annotation.RestrictTo;
+import android.support.v7.widget.Toolbar;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 
+import com.reactnativenavigation.parse.Alignment;
 import com.reactnativenavigation.parse.AnimationsOptions;
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.parse.OrientationOptions;
@@ -17,11 +20,15 @@ import com.reactnativenavigation.parse.TopTabsOptions;
 import com.reactnativenavigation.parse.params.Button;
 import com.reactnativenavigation.utils.UiUtils;
 import com.reactnativenavigation.viewcontrollers.IReactView;
+import com.reactnativenavigation.viewcontrollers.TitleBarReactViewController;
 import com.reactnativenavigation.views.Component;
+import com.reactnativenavigation.views.titlebar.TitleBarReactViewCreator;
 import com.reactnativenavigation.views.topbar.TopBar;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class StackOptionsPresenter {
     private static final int DEFAULT_TITLE_COLOR = Color.BLACK;
@@ -30,14 +37,19 @@ public class StackOptionsPresenter {
     private static final double DEFAULT_ELEVATION = 4d;
     private final double defaultTitleFontSize;
     private final double defaultSubtitleFontSize;
+    private final Activity activity;
 
     private TopBar topBar;
+    private TitleBarReactViewCreator titleViewCreator;
     private Options defaultOptions;
+    private Map<Component, TitleBarReactViewController> titleComponentViewControllers = new HashMap<>();
 
-    public StackOptionsPresenter(Context context, Options defaultOptions) {
-        defaultTitleFontSize = UiUtils.dpToSp(context, 18);
-        defaultSubtitleFontSize = UiUtils.dpToSp(context, 14);
+    public StackOptionsPresenter(Activity activity, TitleBarReactViewCreator titleViewCreator, Options defaultOptions) {
+        this.activity = activity;
+        this.titleViewCreator = titleViewCreator;
         this.defaultOptions = defaultOptions;
+        defaultTitleFontSize = UiUtils.dpToSp(activity, 18);
+        defaultSubtitleFontSize = UiUtils.dpToSp(activity, 14);
     }
 
     public void setDefaultOptions(Options defaultOptions) {
@@ -78,13 +90,32 @@ public class StackOptionsPresenter {
         ((Activity) topBar.getContext()).setRequestedOrientation(withDefaultOptions.getValue());
     }
 
+    public void onChildDestroyed(Component child) {
+        TitleBarReactViewController removed = titleComponentViewControllers.remove(child);
+        if (removed != null) {
+            removed.destroy();
+        }
+    }
+
     private void applyTopBarOptions(TopBarOptions options, AnimationsOptions animationOptions, Component component, Options componentOptions) {
         topBar.setHeight(options.height.get(LayoutParams.WRAP_CONTENT));
         topBar.setElevation(options.elevation.get(DEFAULT_ELEVATION));
 
         topBar.setTitleHeight(options.title.height.get(LayoutParams.WRAP_CONTENT));
         topBar.setTitle(options.title.text.get(""));
-        if (options.title.component.hasValue()) topBar.setTitleComponent(options.title.component);
+
+        if (options.title.component.hasValue()) {
+            if (titleComponentViewControllers.containsKey(component)) {
+                topBar.setTitleComponent(titleComponentViewControllers.get(component).getView());
+            } else {
+                TitleBarReactViewController controller = new TitleBarReactViewController(activity, titleViewCreator);
+                titleComponentViewControllers.put(component, controller);
+                controller.setComponent(options.title.component);
+                controller.getView().setLayoutParams(getComponentLayoutParams(options.title.component));
+                topBar.setTitleComponent(controller.getView());
+            }
+        }
+
         topBar.setTitleFontSize(options.title.fontSize.get(defaultTitleFontSize));
         topBar.setTitleTextColor(options.title.color.get(DEFAULT_TITLE_COLOR));
         topBar.setTitleTypeface(options.title.fontFamily);
@@ -210,7 +241,19 @@ public class StackOptionsPresenter {
 
         if (options.title.height.hasValue()) topBar.setTitleHeight(options.title.height.get());
         if (options.title.text.hasValue()) topBar.setTitle(options.title.text.get());
-        if (options.title.component.hasValue()) topBar.setTitleComponent(options.title.component);
+
+        if (options.title.component.hasValue()) {
+            if (titleComponentViewControllers.containsKey(component)) {
+                topBar.setTitleComponent(titleComponentViewControllers.get(component).getView());
+            } else {
+                TitleBarReactViewController controller = new TitleBarReactViewController(activity, titleViewCreator);
+                titleComponentViewControllers.put(component, controller);
+                controller.setComponent(options.title.component);
+                controller.getView().setLayoutParams(getComponentLayoutParams(options.title.component));
+                topBar.setTitleComponent(controller.getView());
+            }
+        }
+
         if (options.title.color.hasValue()) topBar.setTitleTextColor(options.title.color.get());
         if (options.title.fontSize.hasValue()) topBar.setTitleFontSize(options.title.fontSize.get());
         if (options.title.fontFamily != null) topBar.setTitleTypeface(options.title.fontFamily);
@@ -261,5 +304,14 @@ public class StackOptionsPresenter {
 
     private void mergeTopTabOptions(TopTabOptions topTabOptions) {
         if (topTabOptions.fontFamily != null) topBar.setTopTabFontFamily(topTabOptions.tabIndex, topTabOptions.fontFamily);
+    }
+
+    private LayoutParams getComponentLayoutParams(com.reactnativenavigation.parse.Component component) {
+        return new Toolbar.LayoutParams(component.alignment == Alignment.Center ? Gravity.CENTER : Gravity.START);
+    }
+
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    public Map<Component, TitleBarReactViewController> getTitleComponents() {
+        return titleComponentViewControllers;
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ComponentViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ComponentViewController.java
@@ -63,8 +63,14 @@ public class ComponentViewController extends ChildController<ComponentLayout> {
 
     @Override
     public void mergeOptions(Options options) {
-        applyOnParentController(parentController -> parentController.mergeChildOptions(options, getView()));
+        performOnParentController(parentController -> parentController.mergeChildOptions(options, getView()));
         super.mergeOptions(options);
+    }
+
+    @Override
+    public void destroy() {
+        if (!isDestroyed()) performOnParentController(parent -> parent.onChildDestroyed(getView()));
+        super.destroy();
     }
 
     ReactComponent getComponent() {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ParentController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ParentController.java
@@ -117,7 +117,7 @@ public abstract class ParentController<T extends ViewGroup> extends ChildControl
 
 	@CallSuper
     protected void clearOptions() {
-	    applyOnParentController(parent -> ((ParentController) parent).clearOptions());
+	    performOnParentController(parent -> ((ParentController) parent).clearOptions());
         options = initialOptions.copy().clearOneTimeOptions();
     }
 
@@ -132,5 +132,9 @@ public abstract class ParentController<T extends ViewGroup> extends ChildControl
     @Override
     public boolean isRendered() {
         return getCurrentChild() != null && getCurrentChild().isRendered();
+    }
+
+    public void onChildDestroyed(Component child) {
+
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/SideMenuController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/SideMenuController.java
@@ -64,7 +64,7 @@ public class SideMenuController extends ParentController<DrawerLayout> {
     @Override
     public void applyChildOptions(Options options, Component child) {
         super.applyChildOptions(options, child);
-        applyOnParentController(parentController ->
+        performOnParentController(parentController ->
                 ((ParentController) parentController).applyChildOptions(this.options, child)
         );
     }
@@ -73,7 +73,7 @@ public class SideMenuController extends ParentController<DrawerLayout> {
     public void mergeChildOptions(Options options, Component child) {
         super.mergeChildOptions(options, child);
         new SideMenuOptionsPresenter(getView()).present(options.sideMenuRootOptions);
-        applyOnParentController(parentController ->
+        performOnParentController(parentController ->
                 ((ParentController) parentController).mergeChildOptions(options.copy().clearSideMenuOptions(), child)
         );
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ViewController.java
@@ -118,7 +118,7 @@ public abstract class ViewController<T extends ViewGroup> implements ViewTreeObs
         return activity;
     }
 
-    protected void applyOnParentController(Task<ParentController> task) {
+    protected void performOnParentController(Task<ParentController> task) {
         if (parentController != null) task.run(parentController);
     }
 
@@ -193,7 +193,7 @@ public abstract class ViewController<T extends ViewGroup> implements ViewTreeObs
     public void onViewAppeared() {
         isShown = true;
         applyOptions(options);
-        applyOnParentController(parentController -> {
+        performOnParentController(parentController -> {
             parentController.clearOptions();
             if (getView() instanceof Component) parentController.applyChildOptions(options, (Component) getView());
         });
@@ -232,6 +232,10 @@ public abstract class ViewController<T extends ViewGroup> implements ViewTreeObs
             view = null;
             isDestroyed = true;
         }
+    }
+
+    protected boolean isDestroyed() {
+        return isDestroyed;
     }
 
     @Override

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -84,7 +84,7 @@ public class BottomTabsController extends ParentController implements AHBottomNa
     public void applyChildOptions(Options options, Component child) {
         super.applyChildOptions(options, child);
         presenter.applyChildOptions(this.options, child);
-        applyOnParentController(parentController ->
+        performOnParentController(parentController ->
                 ((ParentController) parentController).applyChildOptions(this.options.copy().clearBottomTabsOptions().clearBottomTabOptions(), child)
         );
     }
@@ -94,7 +94,7 @@ public class BottomTabsController extends ParentController implements AHBottomNa
         super.mergeChildOptions(options, child);
         presenter.mergeChildOptions(options, child);
         tabPresenter.mergeChildOptions(options, child);
-        applyOnParentController(parentController ->
+        performOnParentController(parentController ->
                 ((ParentController) parentController).mergeChildOptions(options.copy().clearBottomTabsOptions(), child)
         );
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
@@ -26,7 +26,6 @@ import com.reactnativenavigation.viewcontrollers.topbar.TopBarController;
 import com.reactnativenavigation.views.Component;
 import com.reactnativenavigation.views.ReactComponent;
 import com.reactnativenavigation.views.StackLayout;
-import com.reactnativenavigation.views.titlebar.TitleBarReactViewCreator;
 import com.reactnativenavigation.views.topbar.TopBar;
 
 import java.util.Collection;
@@ -40,17 +39,15 @@ public class StackController extends ParentController<StackLayout> {
     private final IdStack<ViewController> stack = new IdStack<>();
     private final NavigationAnimator animator;
     private final ReactViewCreator topBarButtonCreator;
-    private final TitleBarReactViewCreator titleBarReactViewCreator;
     private TopBarBackgroundViewController topBarBackgroundViewController;
     private TopBarController topBarController;
     private BackButtonHelper backButtonHelper;
     private final StackOptionsPresenter presenter;
 
-    public StackController(Activity activity, List<ViewController> children, ChildControllersRegistry childRegistry, ReactViewCreator topBarButtonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarController topBarController, NavigationAnimator animator, String id, Options initialOptions, BackButtonHelper backButtonHelper, StackOptionsPresenter stackPresenter, OptionsPresenter presenter) {
+    public StackController(Activity activity, List<ViewController> children, ChildControllersRegistry childRegistry, ReactViewCreator topBarButtonCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarController topBarController, NavigationAnimator animator, String id, Options initialOptions, BackButtonHelper backButtonHelper, StackOptionsPresenter stackPresenter, OptionsPresenter presenter) {
         super(activity, childRegistry, id, presenter, initialOptions);
         this.topBarController = topBarController;
         this.topBarButtonCreator = topBarButtonCreator;
-        this.titleBarReactViewCreator = titleBarReactViewCreator;
         this.topBarBackgroundViewController = topBarBackgroundViewController;
         this.animator = animator;
         this.backButtonHelper = backButtonHelper;
@@ -79,7 +76,7 @@ public class StackController extends ParentController<StackLayout> {
         if (child instanceof ReactComponent) {
             fabOptionsPresenter.applyOptions(this.options.fabOptions, (ReactComponent) child, getView());
         }
-        applyOnParentController(parentController ->
+        performOnParentController(parentController ->
                 ((ParentController) parentController).applyChildOptions(
                         this.options.copy()
                                 .clearTopBarOptions()
@@ -99,7 +96,7 @@ public class StackController extends ParentController<StackLayout> {
         if (options.fabOptions.hasValue() && child instanceof ReactComponent) {
             fabOptionsPresenter.mergeOptions(options.fabOptions, (ReactComponent) child, getView());
         }
-        applyOnParentController(parentController ->
+        performOnParentController(parentController ->
                 ((ParentController) parentController).mergeChildOptions(
                         options.copy()
                                 .clearTopBarOptions()
@@ -122,6 +119,12 @@ public class StackController extends ParentController<StackLayout> {
     public void clearOptions() {
         super.clearOptions();
         topBarController.clear();
+    }
+
+    @Override
+    public void onChildDestroyed(Component child) {
+        super.onChildDestroyed(child);
+        presenter.onChildDestroyed(child);
     }
 
     public void push(ViewController child, CommandListener listener) {
@@ -296,7 +299,6 @@ public class StackController extends ParentController<StackLayout> {
     protected StackLayout createView() {
         StackLayout stackLayout = new StackLayout(getActivity(),
                 topBarButtonCreator,
-                titleBarReactViewCreator,
                 topBarBackgroundViewController,
                 topBarController,
                 this::onNavigationButtonPressed,

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerBuilder.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerBuilder.java
@@ -12,7 +12,6 @@ import com.reactnativenavigation.viewcontrollers.ViewController;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarBackgroundViewController;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarController;
 import com.reactnativenavigation.views.element.ElementTransitionManager;
-import com.reactnativenavigation.views.titlebar.TitleBarReactViewCreator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +20,6 @@ public class StackControllerBuilder {
     private Activity activity;
     private ChildControllersRegistry childRegistry;
     private ReactViewCreator topBarButtonCreator;
-    private TitleBarReactViewCreator titleBarReactViewCreator;
     private TopBarBackgroundViewController topBarBackgroundViewController;
     private TopBarController topBarController;
     private String id;
@@ -43,11 +41,6 @@ public class StackControllerBuilder {
         return this;
     }
 
-    public StackControllerBuilder setOptionsPresenter(OptionsPresenter presenter) {
-        this.presenter = presenter;
-        return this;
-    }
-
     public StackControllerBuilder setStackPresenter(StackOptionsPresenter stackPresenter) {
         this.stackPresenter = stackPresenter;
         return this;
@@ -60,11 +53,6 @@ public class StackControllerBuilder {
 
     public StackControllerBuilder setTopBarButtonCreator(ReactViewCreator topBarButtonCreator) {
         this.topBarButtonCreator = topBarButtonCreator;
-        return this;
-    }
-
-    public StackControllerBuilder setTitleBarReactViewCreator(TitleBarReactViewCreator titleBarReactViewCreator) {
-        this.titleBarReactViewCreator = titleBarReactViewCreator;
         return this;
     }
 
@@ -103,7 +91,6 @@ public class StackControllerBuilder {
                 children,
                 childRegistry,
                 topBarButtonCreator,
-                titleBarReactViewCreator,
                 topBarBackgroundViewController,
                 topBarController,
                 animator,

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/topbar/TopBarController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/topbar/TopBarController.java
@@ -9,23 +9,22 @@ import com.reactnativenavigation.utils.ImageLoader;
 import com.reactnativenavigation.viewcontrollers.ReactViewCreator;
 import com.reactnativenavigation.viewcontrollers.TopBarButtonController;
 import com.reactnativenavigation.views.StackLayout;
-import com.reactnativenavigation.views.titlebar.TitleBarReactViewCreator;
 import com.reactnativenavigation.views.topbar.TopBar;
 
 
 public class TopBarController {
     private TopBar topBar;
 
-    public View createView(Context context, ReactViewCreator buttonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener topBarButtonClickListener, StackLayout stackLayout) {
+    public View createView(Context context, ReactViewCreator buttonCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener topBarButtonClickListener, StackLayout stackLayout) {
         if (topBar == null) {
-            topBar = createTopBar(context, buttonCreator, titleBarReactViewCreator, topBarBackgroundViewController, topBarButtonClickListener, stackLayout, new ImageLoader());
+            topBar = createTopBar(context, buttonCreator, topBarBackgroundViewController, topBarButtonClickListener, stackLayout, new ImageLoader());
             topBar.setId(CompatUtils.generateViewId());
         }
         return topBar;
     }
 
-    protected TopBar createTopBar(Context context, ReactViewCreator buttonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener topBarButtonClickListener, StackLayout stackLayout, ImageLoader imageLoader) {
-        return new TopBar(context, buttonCreator, titleBarReactViewCreator, topBarBackgroundViewController, topBarButtonClickListener, stackLayout, imageLoader);
+    protected TopBar createTopBar(Context context, ReactViewCreator buttonCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener topBarButtonClickListener, StackLayout stackLayout, ImageLoader imageLoader) {
+        return new TopBar(context, buttonCreator, topBarBackgroundViewController, topBarButtonClickListener, stackLayout, imageLoader);
     }
 
     public void clear() {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/toptabs/TopTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/toptabs/TopTabsController.java
@@ -60,7 +60,7 @@ public class TopTabsController extends ParentController<TopTabsViewPager> {
     @Override
     public void onViewAppeared() {
         super.onViewAppeared();
-        applyOnParentController(parentController -> ((ParentController) parentController).setupTopTabsWithViewPager(getView()));
+        performOnParentController(parentController -> ((ParentController) parentController).setupTopTabsWithViewPager(getView()));
         performOnCurrentTab(ViewController::onViewAppeared);
     }
 
@@ -73,7 +73,7 @@ public class TopTabsController extends ParentController<TopTabsViewPager> {
     public void onViewDisappear() {
         super.onViewDisappear();
         performOnCurrentTab(ViewController::onViewDisappear);
-        applyOnParentController(parentController -> ((ParentController) parentController).clearTopTabs());
+        performOnParentController(parentController -> ((ParentController) parentController).clearTopTabs());
     }
 
     @Override
@@ -90,13 +90,13 @@ public class TopTabsController extends ParentController<TopTabsViewPager> {
     @Override
     public void applyChildOptions(Options options, Component child) {
         super.applyChildOptions(options, child);
-        applyOnParentController(parentController -> ((ParentController) parentController).applyChildOptions(this.options.copy(), child));
+        performOnParentController(parentController -> ((ParentController) parentController).applyChildOptions(this.options.copy(), child));
     }
 
     @CallSuper
     public void mergeChildOptions(Options options, Component child) {
         super.mergeChildOptions(options, child);
-        applyOnParentController(parentController -> ((ParentController) parentController).applyChildOptions(options.copy(), child));
+        performOnParentController(parentController -> ((ParentController) parentController).applyChildOptions(options.copy(), child));
     }
 
     public void switchToTab(int index) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/StackLayout.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/StackLayout.java
@@ -8,7 +8,6 @@ import com.reactnativenavigation.viewcontrollers.ReactViewCreator;
 import com.reactnativenavigation.viewcontrollers.TopBarButtonController;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarBackgroundViewController;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarController;
-import com.reactnativenavigation.views.titlebar.TitleBarReactViewCreator;
 import com.reactnativenavigation.views.topbar.TopBar;
 
 import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
@@ -18,15 +17,15 @@ import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 public class StackLayout extends RelativeLayout implements Component {
     private String stackId;
 
-    public StackLayout(Context context, ReactViewCreator topBarButtonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarController topBarController, TopBarButtonController.OnClickListener topBarButtonClickListener, String stackId) {
+    public StackLayout(Context context, ReactViewCreator topBarButtonCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarController topBarController, TopBarButtonController.OnClickListener topBarButtonClickListener, String stackId) {
         super(context);
         this.stackId = stackId;
-        createLayout(topBarButtonCreator, titleBarReactViewCreator, topBarBackgroundViewController, topBarController, topBarButtonClickListener);
+        createLayout(topBarButtonCreator, topBarBackgroundViewController, topBarController, topBarButtonClickListener);
         setContentDescription("StackLayout");
     }
 
-    private void createLayout(ReactViewCreator buttonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarController topBarController, TopBarButtonController.OnClickListener topBarButtonClickListener) {
-        addView(topBarController.createView(getContext(), buttonCreator, titleBarReactViewCreator, topBarBackgroundViewController, topBarButtonClickListener, this), MATCH_PARENT, WRAP_CONTENT);
+    private void createLayout(ReactViewCreator buttonCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarController topBarController, TopBarButtonController.OnClickListener topBarButtonClickListener) {
+        addView(topBarController.createView(getContext(), buttonCreator, topBarBackgroundViewController, topBarButtonClickListener, this), MATCH_PARENT, WRAP_CONTENT);
     }
 
     public String getStackId() {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBar.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBar.java
@@ -6,13 +6,12 @@ import android.content.Context;
 import android.graphics.Typeface;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
-import android.view.Gravity;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.reactnativenavigation.parse.Alignment;
 import com.reactnativenavigation.parse.BackButton;
-import com.reactnativenavigation.parse.Component;
 import com.reactnativenavigation.parse.params.Button;
 import com.reactnativenavigation.parse.params.Color;
 import com.reactnativenavigation.utils.ButtonOptionsPresenter;
@@ -20,7 +19,6 @@ import com.reactnativenavigation.utils.ImageLoader;
 import com.reactnativenavigation.utils.UiUtils;
 import com.reactnativenavigation.utils.ViewUtils;
 import com.reactnativenavigation.viewcontrollers.ReactViewCreator;
-import com.reactnativenavigation.viewcontrollers.TitleBarReactViewController;
 import com.reactnativenavigation.viewcontrollers.TopBarButtonController;
 import com.reactnativenavigation.viewcontrollers.button.NavigationIconResolver;
 
@@ -29,24 +27,21 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
-
 @SuppressLint("ViewConstructor")
 public class TitleBar extends Toolbar {
+    public static final int DEFAULT_LEFT_MARGIN = 16;
+
     private final ReactViewCreator buttonCreator;
-    private TitleBarReactViewController reactViewController;
-    private final TitleBarReactViewCreator reactViewCreator;
     private final TopBarButtonController.OnClickListener onClickListener;
     private final List<TopBarButtonController> rightButtonControllers = new ArrayList<>();
     private TopBarButtonController leftButtonController;
     private ImageLoader imageLoader;
+    private View component;
 
-    public TitleBar(Context context, ReactViewCreator buttonCreator, TitleBarReactViewCreator reactViewCreator, TopBarButtonController.OnClickListener onClickListener, ImageLoader imageLoader) {
+    public TitleBar(Context context, ReactViewCreator buttonCreator, TopBarButtonController.OnClickListener onClickListener, ImageLoader imageLoader) {
         super(context);
         this.buttonCreator = buttonCreator;
-        this.reactViewCreator = reactViewCreator;
         this.imageLoader = imageLoader;
-        reactViewController = new TitleBarReactViewController((Activity) context, reactViewCreator);
         this.onClickListener = onClickListener;
         getMenu();
         setContentDescription("titleBar");
@@ -66,11 +61,11 @@ public class TitleBar extends Toolbar {
         if (color.hasValue()) setTitleTextColor(color.get());
     }
 
-    public void setComponent(Component component) {
+    public void setComponent(View component) {
         clearTitle();
         clearSubtitle();
-        reactViewController.setComponent(component);
-        addView(reactViewController.getView(), getComponentLayoutParams(component));
+        this.component = component;
+        addView(component);
     }
 
     public void setBackgroundColor(Color color) {
@@ -116,7 +111,7 @@ public class TitleBar extends Toolbar {
             } else if (leftButtonController != null) {
                 view.setX(getContentInsetStartWithNavigation());
             } else {
-                view.setX(UiUtils.dpToPx(getContext(), 16));
+                view.setX(UiUtils.dpToPx(getContext(), DEFAULT_LEFT_MARGIN));
             }
         });
     }
@@ -150,8 +145,10 @@ public class TitleBar extends Toolbar {
     }
 
     private void clearComponent() {
-        reactViewController.destroy();
-        reactViewController = new TitleBarReactViewController((Activity) getContext(), reactViewCreator);
+        if (component != null) {
+            removeView(component);
+            component = null;
+        }
     }
 
     private void clearLeftButton() {
@@ -211,14 +208,6 @@ public class TitleBar extends Toolbar {
                 buttonCreator,
                 onClickListener
         );
-    }
-
-    public Toolbar.LayoutParams getComponentLayoutParams(Component component) {
-        LayoutParams lp = new LayoutParams(MATCH_PARENT, getHeight());
-        if (component.alignment == Alignment.Center) {
-            lp.gravity = Gravity.CENTER;
-        }
-        return lp;
     }
 
     public void setHeight(int height) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/topbar/TopBar.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/topbar/TopBar.java
@@ -39,7 +39,6 @@ import com.reactnativenavigation.viewcontrollers.TopBarButtonController;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarBackgroundViewController;
 import com.reactnativenavigation.views.StackLayout;
 import com.reactnativenavigation.views.titlebar.TitleBar;
-import com.reactnativenavigation.views.titlebar.TitleBarReactViewCreator;
 import com.reactnativenavigation.views.toptabs.TopTabs;
 
 import java.util.List;
@@ -58,7 +57,7 @@ public class TopBar extends AppBarLayout implements ScrollEventListener.ScrollAw
     private View border;
     private ImageLoader imageLoader;
 
-    public TopBar(final Context context, ReactViewCreator buttonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener onClickListener, StackLayout parentView, ImageLoader imageLoader) {
+    public TopBar(final Context context, ReactViewCreator buttonCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener onClickListener, StackLayout parentView, ImageLoader imageLoader) {
         super(context);
         context.setTheme(R.style.TopBar);
         this.imageLoader = imageLoader;
@@ -66,12 +65,12 @@ public class TopBar extends AppBarLayout implements ScrollEventListener.ScrollAw
         this.topBarBackgroundViewController = topBarBackgroundViewController;
         topTabs = new TopTabs(getContext());
         animator = new TopBarAnimator(this, parentView.getStackId());
-        createLayout(buttonCreator, titleBarReactViewCreator, onClickListener);
+        createLayout(buttonCreator, onClickListener);
     }
 
-    private void createLayout(ReactViewCreator buttonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarButtonController.OnClickListener onClickListener) {
+    private void createLayout(ReactViewCreator buttonCreator, TopBarButtonController.OnClickListener onClickListener) {
         setId(CompatUtils.generateViewId());
-        titleBar = createTitleBar(getContext(), buttonCreator, titleBarReactViewCreator, onClickListener, imageLoader);
+        titleBar = createTitleBar(getContext(), buttonCreator, onClickListener, imageLoader);
         topTabs = createTopTabs();
         border = createBorder();
         LinearLayout content = createContentLayout();
@@ -111,8 +110,8 @@ public class TopBar extends AppBarLayout implements ScrollEventListener.ScrollAw
         return border;
     }
 
-    protected TitleBar createTitleBar(Context context, ReactViewCreator buttonCreator, TitleBarReactViewCreator reactViewCreator, TopBarButtonController.OnClickListener onClickListener, ImageLoader imageLoader) {
-        TitleBar titleBar = new TitleBar(context, buttonCreator, reactViewCreator, onClickListener, imageLoader);
+    protected TitleBar createTitleBar(Context context, ReactViewCreator buttonCreator, TopBarButtonController.OnClickListener onClickListener, ImageLoader imageLoader) {
+        TitleBar titleBar = new TitleBar(context, buttonCreator, onClickListener, imageLoader);
         titleBar.setId(CompatUtils.generateViewId());
         return titleBar;
     }
@@ -176,7 +175,7 @@ public class TopBar extends AppBarLayout implements ScrollEventListener.ScrollAw
         titleBar.setTitleAlignment(alignment);
     }
 
-    public void setTitleComponent(Component component) {
+    public void setTitleComponent(View component) {
         titleBar.setComponent(component);
     }
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/BaseTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/BaseTest.java
@@ -60,6 +60,12 @@ public abstract class BaseTest {
         }
     }
 
+    protected void disablePopAnimation(ViewController... controllers) {
+        for (ViewController controller : controllers) {
+            controller.options.animations.pop.enable = new Bool(false);
+        }
+    }
+
     protected void disableShowModalAnimation(ViewController... modals) {
         for (ViewController modal : modals) {
             modal.options.animations.showModal.enable = new Bool(false);

--- a/lib/android/app/src/test/java/com/reactnativenavigation/TestUtils.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/TestUtils.java
@@ -16,7 +16,6 @@ import com.reactnativenavigation.viewcontrollers.stack.StackControllerBuilder;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarBackgroundViewController;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarController;
 import com.reactnativenavigation.views.StackLayout;
-import com.reactnativenavigation.views.titlebar.TitleBarReactViewCreator;
 import com.reactnativenavigation.views.topbar.TopBar;
 
 public class TestUtils {
@@ -25,17 +24,16 @@ public class TestUtils {
                 .setId("stack")
                 .setChildRegistry(new ChildControllersRegistry())
                 .setTopBarButtonCreator(new TopBarButtonCreatorMock())
-                .setTitleBarReactViewCreator(new TitleBarReactViewCreatorMock())
                 .setTopBarBackgroundViewController(new TopBarBackgroundViewController(activity, new TopBarBackgroundViewCreatorMock()))
                 .setTopBarController(new TopBarController() {
                     @Override
-                    protected TopBar createTopBar(Context context, ReactViewCreator buttonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener topBarButtonClickListener, StackLayout stackLayout, ImageLoader imageLoader) {
-                        TopBar topBar = super.createTopBar(context, buttonCreator, titleBarReactViewCreator, topBarBackgroundViewController, topBarButtonClickListener, stackLayout, imageLoader);
+                    protected TopBar createTopBar(Context context, ReactViewCreator buttonCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener topBarButtonClickListener, StackLayout stackLayout, ImageLoader imageLoader) {
+                        TopBar topBar = super.createTopBar(context, buttonCreator, topBarBackgroundViewController, topBarButtonClickListener, stackLayout, imageLoader);
                         topBar.layout(0, 0, 1000, 100);
                         return topBar;
                     }
                 })
-                .setStackPresenter(new StackOptionsPresenter(activity, new Options()))
+                .setStackPresenter(new StackOptionsPresenter(activity, new TitleBarReactViewCreatorMock(), new Options()))
                 .setInitialOptions(new Options());
     }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/mocks/SimpleViewController.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/mocks/SimpleViewController.java
@@ -41,13 +41,19 @@ public class SimpleViewController extends ChildController<SimpleViewController.S
     }
 
     @Override
+    public void destroy() {
+        if (!isDestroyed()) performOnParentController(parent -> parent.onChildDestroyed(getView()));
+        super.destroy();
+    }
+
+    @Override
     public String toString() {
         return "SimpleViewController " + getId();
     }
 
     @Override
     public void mergeOptions(Options options) {
-        applyOnParentController(parentController -> parentController.mergeChildOptions(options, getView()));
+        performOnParentController(parentController -> parentController.mergeChildOptions(options, getView()));
         super.mergeOptions(options);
     }
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabsControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabsControllerTest.java
@@ -10,6 +10,7 @@ import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.TestUtils;
 import com.reactnativenavigation.mocks.ImageLoaderMock;
 import com.reactnativenavigation.mocks.SimpleViewController;
+import com.reactnativenavigation.mocks.TitleBarReactViewCreatorMock;
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.parse.params.Bool;
 import com.reactnativenavigation.parse.params.Color;
@@ -282,7 +283,7 @@ public class BottomTabsControllerTest extends BaseTest {
         return TestUtils.newStackController(activity)
                 .setId(id)
                 .setInitialOptions(tabOptions)
-                .setStackPresenter(new StackOptionsPresenter(activity, new Options()))
+                .setStackPresenter(new StackOptionsPresenter(activity, new TitleBarReactViewCreatorMock(), new Options()))
                 .build();
     }
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/OptionsApplyingTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/OptionsApplyingTest.java
@@ -30,7 +30,6 @@ import com.reactnativenavigation.viewcontrollers.stack.StackControllerBuilder;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarBackgroundViewController;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarController;
 import com.reactnativenavigation.views.StackLayout;
-import com.reactnativenavigation.views.titlebar.TitleBarReactViewCreator;
 import com.reactnativenavigation.views.topbar.TopBar;
 
 import org.json.JSONObject;
@@ -69,9 +68,9 @@ public class OptionsApplyingTest extends BaseTest {
         );
         TopBarController topBarController = new TopBarController() {
             @Override
-            protected TopBar createTopBar(Context context, ReactViewCreator buttonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener topBarButtonClickListener, StackLayout stackLayout, ImageLoader imageLoader) {
+            protected TopBar createTopBar(Context context, ReactViewCreator buttonCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener topBarButtonClickListener, StackLayout stackLayout, ImageLoader imageLoader) {
                 topBar =
-                        spy(super.createTopBar(context, buttonCreator, titleBarReactViewCreator, topBarBackgroundViewController, topBarButtonClickListener, stackLayout, imageLoader));
+                        spy(super.createTopBar(context, buttonCreator, topBarBackgroundViewController, topBarButtonClickListener, stackLayout, imageLoader));
                 return topBar;
             }
         };
@@ -100,12 +99,11 @@ public class OptionsApplyingTest extends BaseTest {
         StackController stackController =
                 new StackControllerBuilder(activity)
                         .setTopBarButtonCreator(new TopBarButtonCreatorMock())
-                        .setTitleBarReactViewCreator(new TitleBarReactViewCreatorMock())
                         .setTopBarBackgroundViewController(new TopBarBackgroundViewController(activity, new TopBarBackgroundViewCreatorMock()))
                         .setTopBarController(new TopBarController())
                         .setId("stackId")
                         .setInitialOptions(new Options())
-                        .setStackPresenter(new StackOptionsPresenter(activity, new Options()))
+                        .setStackPresenter(new StackOptionsPresenter(activity, new TitleBarReactViewCreatorMock(), new Options()))
                         .build();
         stackController.ensureViewIsCreated();
         stackController.push(uut, new CommandListenerAdapter());

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/StackOptionsPresenterTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/StackOptionsPresenterTest.java
@@ -2,11 +2,16 @@ package com.reactnativenavigation.viewcontrollers;
 
 import android.app.Activity;
 import android.graphics.Typeface;
+import android.support.v7.widget.Toolbar;
+import android.view.Gravity;
 import android.view.View;
 
 import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.mocks.TestComponentLayout;
 import com.reactnativenavigation.mocks.TestReactView;
+import com.reactnativenavigation.mocks.TitleBarReactViewCreatorMock;
+import com.reactnativenavigation.parse.Alignment;
+import com.reactnativenavigation.parse.Component;
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.parse.OrientationOptions;
 import com.reactnativenavigation.parse.SubtitleOptions;
@@ -18,7 +23,7 @@ import com.reactnativenavigation.parse.params.Fraction;
 import com.reactnativenavigation.parse.params.Number;
 import com.reactnativenavigation.parse.params.Text;
 import com.reactnativenavigation.presentation.StackOptionsPresenter;
-import com.reactnativenavigation.views.Component;
+import com.reactnativenavigation.views.titlebar.TitleBarReactView;
 import com.reactnativenavigation.views.topbar.TopBar;
 
 import org.json.JSONObject;
@@ -45,16 +50,70 @@ public class StackOptionsPresenterTest extends BaseTest {
     private static final Options EMPTY_OPTIONS = new Options();
     private StackOptionsPresenter uut;
     private TestComponentLayout child;
+    private TestComponentLayout otherChild;
     private Activity activity;
     private TopBar topBar;
 
     @Override
     public void beforeEach() {
         activity = spy(newActivity());
-        uut = spy(new StackOptionsPresenter(activity, new Options()));
+
+        TitleBarReactViewCreatorMock titleViewCreator = new TitleBarReactViewCreatorMock() {
+            @Override
+            public TitleBarReactView create(Activity activity, String componentId, String componentName) {
+                return spy(super.create(activity, componentId, componentName));
+            }
+        };
+        uut = spy(new StackOptionsPresenter(activity, titleViewCreator, new Options()));
         topBar = mockTopBar();
         uut.bindView(topBar);
         child = spy(new TestComponentLayout(activity, new TestReactView(activity)));
+        otherChild = new TestComponentLayout(activity, new TestReactView(activity));
+    }
+
+    @Test
+    public void applyChildOptions_setTitleComponent() {
+        Options options = new Options();
+        options.topBar.title.component = component(Alignment.Default);
+        uut.applyChildOptions(options, child);
+        verify(topBar).setTitleComponent(uut.getTitleComponents().get(child).getView());
+    }
+
+    @Test
+    public void applyChildOptions_setTitleComponentCreatesOnce() {
+        Options options = new Options();
+        options.topBar.title.component = component(Alignment.Default);
+        uut.applyChildOptions(options, child);
+
+        uut.applyChildOptions(new Options(), otherChild);
+
+        TitleBarReactViewController titleController = uut.getTitleComponents().get(child);
+        uut.applyChildOptions(options, child);
+        assertThat(uut.getTitleComponents().size()).isOne();
+        assertThat(uut.getTitleComponents().get(child)).isEqualTo(titleController);
+    }
+
+    @Test
+    public void applyChildOptions_setTitleComponentAlignment() {
+        Options options = new Options();
+        options.topBar.title.component = component(Alignment.Center);
+        uut.applyChildOptions(options, child);
+        ArgumentCaptor<View> captor = ArgumentCaptor.forClass(View.class);
+        verify(topBar).setTitleComponent(captor.capture());
+
+        Toolbar.LayoutParams lp = (Toolbar.LayoutParams) captor.getValue().getLayoutParams();
+        assertThat(lp.gravity).isEqualTo(Gravity.CENTER);
+    }
+
+    @Test
+    public void onChildDestroyed_destroyTitleComponent() {
+        Options options = new Options();
+        options.topBar.title.component = component(Alignment.Default);
+        uut.applyChildOptions(options, child);
+
+        TitleBarReactView titleView = uut.getTitleComponents().get(child).getView();
+        uut.onChildDestroyed(child);
+        verify(titleView).destroy();
     }
 
     @Test
@@ -157,7 +216,7 @@ public class StackOptionsPresenterTest extends BaseTest {
         Options options = new Options();
         options.topBar.visible = new Bool(false);
         options.topBar.animate = new Bool(false);
-        View view = Mockito.mock(View.class, Mockito.withSettings().extraInterfaces(Component.class));
+        View view = Mockito.mock(View.class, Mockito.withSettings().extraInterfaces(com.reactnativenavigation.views.Component.class));
 
         uut.applyLayoutParamsOptions(options, view);
         verify(topBar).hide();
@@ -295,5 +354,13 @@ public class StackOptionsPresenterTest extends BaseTest {
         TopBar topBar = mock(TopBar.class);
         when(topBar.getContext()).then(invocation -> activity);
         return topBar;
+    }
+
+    private Component component(Alignment alignment) {
+        Component component = new Component();
+        component.name = new Text("myComp");
+        component.alignment = alignment;
+        component.componentId = new Text("compId");
+        return component;
     }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/StackOptionsPresenterTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/StackOptionsPresenterTest.java
@@ -176,6 +176,7 @@ public class StackOptionsPresenterTest extends BaseTest {
         verify(topBar, times(0)).setBackgroundColor(anyInt());
     }
 
+    @Test
     public void applyButtons_buttonColorIsMergedToButtons() {
         Options options = new Options();
         Button rightButton1 = new Button();

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TitleBarTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TitleBarTest.java
@@ -1,26 +1,18 @@
 package com.reactnativenavigation.viewcontrollers;
 
 import android.app.Activity;
-import android.support.v7.widget.Toolbar;
-import android.view.Gravity;
-import android.view.ViewGroup;
+import android.view.View;
 
 import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.mocks.ImageLoaderMock;
-import com.reactnativenavigation.mocks.TitleBarReactViewCreatorMock;
 import com.reactnativenavigation.mocks.TopBarButtonCreatorMock;
-import com.reactnativenavigation.parse.Alignment;
-import com.reactnativenavigation.parse.Component;
 import com.reactnativenavigation.parse.params.Button;
 import com.reactnativenavigation.parse.params.Text;
 import com.reactnativenavigation.react.Constants;
 import com.reactnativenavigation.react.ReactView;
-import com.reactnativenavigation.utils.ViewUtils;
 import com.reactnativenavigation.views.titlebar.TitleBar;
-import com.reactnativenavigation.views.titlebar.TitleBarReactView;
 
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -42,15 +33,15 @@ public class TitleBarTest extends BaseTest {
     private Button textButton;
     private Button customButton;
     private Map<String, TopBarButtonController> buttonControllers;
+    private Activity activity;
 
     @Override
     public void beforeEach() {
         final TopBarButtonCreatorMock buttonCreator = new TopBarButtonCreatorMock();
-        final Activity activity = newActivity();
+        activity = newActivity();
         createButtons();
         buttonControllers = new HashMap<>();
-        TitleBarReactViewCreatorMock reactViewCreator = new TitleBarReactViewCreatorMock();
-        uut = spy(new TitleBar(activity, buttonCreator, reactViewCreator, (buttonId -> {}), ImageLoaderMock.mock()) {
+        uut = spy(new TitleBar(activity, buttonCreator, buttonId -> {}, ImageLoaderMock.mock()) {
             @Override
             public TopBarButtonController createButtonController(Button button) {
                 TopBarButtonController controller = spy(super.createButtonController(button));
@@ -146,47 +137,22 @@ public class TitleBarTest extends BaseTest {
 
     @Test
     public void setComponent_addsComponentToTitleBar() {
-        uut.setComponent(component("com.rnn.CustomView", Alignment.Center));
-        verify(uut, times(1)).addView(any(TitleBarReactView.class), any(Toolbar.LayoutParams.class));
-    }
-
-    private Component component(String name, Alignment alignment) {
-        Component component = new Component();
-        component.name = new Text(name);
-        component.alignment = alignment;
-        component.componentId = new Text("compId");
-        return component;
-    }
-
-    @Test
-    public void setComponent_alignFill() {
-        Component component = component("com.rnn.CustomView", Alignment.Fill);
+        View component = new View(activity);
         uut.setComponent(component);
-        verify(uut, times(1)).getComponentLayoutParams(component);
-        ArgumentCaptor<Toolbar.LayoutParams> lpCaptor = ArgumentCaptor.forClass(Toolbar.LayoutParams.class);
-        verify(uut, times(1)).addView(any(TitleBarReactView.class), lpCaptor.capture());
-        assertThat(lpCaptor.getValue().width == ViewGroup.LayoutParams.MATCH_PARENT);
-    }
-
-    @Test
-    public void setComponent_alignCenter() {
-        Component component = component("com.rnn.CustomView", Alignment.Center);
-        uut.setComponent(component);
-        verify(uut, times(1)).getComponentLayoutParams(component);
-        ArgumentCaptor<Toolbar.LayoutParams> lpCaptor = ArgumentCaptor.forClass(Toolbar.LayoutParams.class);
-        verify(uut, times(1)).addView(any(TitleBarReactView.class), lpCaptor.capture());
-        assertThat(lpCaptor.getValue().width == ViewGroup.LayoutParams.WRAP_CONTENT);
-        assertThat(lpCaptor.getValue().gravity == Gravity.CENTER);
+        verify(uut).addView(component);
     }
 
     @Test
     public void clear() {
-        uut.setComponent(component("someComponent", Alignment.Center));
+        View title = new View(activity);
+        uut.setComponent(title);
+        verify(uut).addView(title);
+
         uut.clear();
         assertThat(uut.getTitle()).isNullOrEmpty();
         assertThat(uut.getMenu().size()).isZero();
         assertThat(uut.getNavigationIcon()).isNull();
-        assertThat(ViewUtils.findChildrenByClassRecursive(uut, TitleBarReactView.class).size()).isZero();
+        verify(uut).removeView(title);
     }
 
     private List<Button> leftButton(Button leftButton) {

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TopBarControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TopBarControllerTest.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 
 import com.reactnativenavigation.BaseTest;
-import com.reactnativenavigation.mocks.TitleBarReactViewCreatorMock;
 import com.reactnativenavigation.mocks.TopBarBackgroundViewCreatorMock;
 import com.reactnativenavigation.mocks.TopBarButtonCreatorMock;
 import com.reactnativenavigation.utils.ImageLoader;
@@ -13,7 +12,6 @@ import com.reactnativenavigation.viewcontrollers.topbar.TopBarBackgroundViewCont
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarController;
 import com.reactnativenavigation.views.StackLayout;
 import com.reactnativenavigation.views.titlebar.TitleBar;
-import com.reactnativenavigation.views.titlebar.TitleBarReactViewCreator;
 import com.reactnativenavigation.views.topbar.TopBar;
 
 import org.junit.Test;
@@ -38,18 +36,18 @@ public class TopBarControllerTest extends BaseTest {
         uut = new TopBarController() {
             @NonNull
             @Override
-            protected TopBar createTopBar(Context context, ReactViewCreator buttonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener topBarButtonClickListener, StackLayout stackLayout, ImageLoader imageLoader) {
-                return new TopBar(context, buttonCreator, titleBarReactViewCreator, topBarBackgroundViewController, topBarButtonClickListener, stackLayout, imageLoader) {
+            protected TopBar createTopBar(Context context, ReactViewCreator buttonCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener topBarButtonClickListener, StackLayout stackLayout, ImageLoader imageLoader) {
+                return new TopBar(context, buttonCreator, topBarBackgroundViewController, topBarButtonClickListener, stackLayout, imageLoader) {
                     @Override
-                    protected TitleBar createTitleBar(Context context, ReactViewCreator buttonCreator, TitleBarReactViewCreator reactViewCreator, TopBarButtonController.OnClickListener onClickListener, ImageLoader imageLoader) {
-                        titleBar[0] = spy(super.createTitleBar(context, buttonCreator, reactViewCreator, onClickListener, imageLoader));
+                    protected TitleBar createTitleBar(Context context, ReactViewCreator buttonCreator, TopBarButtonController.OnClickListener onClickListener, ImageLoader imageLoader) {
+                        titleBar[0] = spy(super.createTitleBar(context, buttonCreator, onClickListener, imageLoader));
                         return titleBar[0];
                     }
                 };
             }
         };
         Activity activity = newActivity();
-        uut.createView(activity, new TopBarButtonCreatorMock(), new TitleBarReactViewCreatorMock(), new TopBarBackgroundViewController(activity, new TopBarBackgroundViewCreatorMock()), buttonId -> { }, Mockito.mock(StackLayout.class));
+        uut.createView(activity, new TopBarButtonCreatorMock(), new TopBarBackgroundViewController(activity, new TopBarBackgroundViewCreatorMock()), buttonId -> {}, Mockito.mock(StackLayout.class));
         uut.clear();
         verify(titleBar[0], times(1)).clear();
     }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
@@ -32,7 +32,6 @@ import com.reactnativenavigation.viewcontrollers.topbar.TopBarController;
 import com.reactnativenavigation.views.Component;
 import com.reactnativenavigation.views.ReactComponent;
 import com.reactnativenavigation.views.StackLayout;
-import com.reactnativenavigation.views.titlebar.TitleBarReactViewCreator;
 import com.reactnativenavigation.views.topbar.TopBar;
 
 import org.assertj.core.api.iterable.Extractor;
@@ -73,7 +72,7 @@ public class StackControllerTest extends BaseTest {
         animator = Mockito.mock(NavigationAnimator.class);
         activity = newActivity();
         childRegistry = new ChildControllersRegistry();
-        presenter = new StackOptionsPresenter(activity, new Options());
+        presenter = spy(new StackOptionsPresenter(activity, new TitleBarReactViewCreatorMock(), new Options()));
         child1 = spy(new SimpleViewController(activity, childRegistry, "child1", new Options()));
         child2 = spy(new SimpleViewController(activity, childRegistry, "child2", new Options()));
         child3 = spy(new SimpleViewController(activity, childRegistry, "child3", new Options()));
@@ -231,12 +230,11 @@ public class StackControllerTest extends BaseTest {
     public void pop_layoutHandlesChildWillDisappear() {
         uut = new StackControllerBuilder(activity)
                         .setTopBarButtonCreator(new TopBarButtonCreatorMock())
-                        .setTitleBarReactViewCreator(new TitleBarReactViewCreatorMock())
                         .setTopBarBackgroundViewController(new TopBarBackgroundViewController(activity, new TopBarBackgroundViewCreatorMock()))
                         .setTopBarController(new TopBarController())
                         .setId("uut")
                         .setInitialOptions(new Options())
-                        .setStackPresenter(new StackOptionsPresenter(activity, new Options()))
+                        .setStackPresenter(new StackOptionsPresenter(activity, new TitleBarReactViewCreatorMock(), new Options()))
                         .build();
         uut.ensureViewIsCreated();
         uut.push(child1, new CommandListenerAdapter());
@@ -262,6 +260,13 @@ public class StackControllerTest extends BaseTest {
         assertThat(uut.peek()).isEqualTo(child1);
         assertThat(uut.size()).isEqualTo(1);
         assertThat(uut.isEmpty()).isFalse();
+    }
+
+    @Test
+    public void onChildDestroyed() {
+        Component childView = (Component) child2.getView();
+        uut.onChildDestroyed(childView);
+        verify(presenter).onChildDestroyed(childView);
     }
 
     @Test
@@ -750,12 +755,11 @@ public class StackControllerTest extends BaseTest {
     public void mergeChildOptions_updatesViewWithNewOptions() {
         StackController uut = spy(new StackControllerBuilder(activity)
                         .setTopBarButtonCreator(new TopBarButtonCreatorMock())
-                        .setTitleBarReactViewCreator(new TitleBarReactViewCreatorMock())
                         .setTopBarBackgroundViewController(new TopBarBackgroundViewController(activity, new TopBarBackgroundViewCreatorMock()))
                         .setTopBarController(new TopBarController())
                         .setId("stack")
                         .setInitialOptions(new Options())
-                        .setStackPresenter(new StackOptionsPresenter(activity, new Options()))
+                        .setStackPresenter(new StackOptionsPresenter(activity, new TitleBarReactViewCreatorMock(), new Options()))
                         .build());
         Options optionsToMerge = new Options();
         Component component = mock(Component.class);
@@ -767,12 +771,11 @@ public class StackControllerTest extends BaseTest {
     public void mergeChildOptions_updatesParentControllerWithNewOptions() {
         StackController uut = new StackControllerBuilder(activity)
                         .setTopBarButtonCreator(new TopBarButtonCreatorMock())
-                        .setTitleBarReactViewCreator(new TitleBarReactViewCreatorMock())
                         .setTopBarBackgroundViewController(new TopBarBackgroundViewController(activity, new TopBarBackgroundViewCreatorMock()))
                         .setTopBarController(new TopBarController())
                         .setId("stack")
                         .setInitialOptions(new Options())
-                        .setStackPresenter(new StackOptionsPresenter(activity, new Options()))
+                        .setStackPresenter(new StackOptionsPresenter(activity, new TitleBarReactViewCreatorMock(), new Options()))
                         .build();
         ParentController parentController = Mockito.mock(ParentController.class);
         uut.setParentController(parentController);
@@ -848,8 +851,8 @@ public class StackControllerTest extends BaseTest {
     private void createTopBarController() {
         topBarController = spy(new TopBarController() {
             @Override
-            protected TopBar createTopBar(Context context, ReactViewCreator buttonCreator, TitleBarReactViewCreator titleBarReactViewCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener topBarButtonClickListener, StackLayout stackLayout, ImageLoader imageLoader) {
-                TopBar spy = spy(super.createTopBar(context, buttonCreator, titleBarReactViewCreator, topBarBackgroundViewController, topBarButtonClickListener, stackLayout, ImageLoaderMock.mock()));
+            protected TopBar createTopBar(Context context, ReactViewCreator buttonCreator, TopBarBackgroundViewController topBarBackgroundViewController, TopBarButtonController.OnClickListener topBarButtonClickListener, StackLayout stackLayout, ImageLoader imageLoader) {
+                TopBar spy = spy(super.createTopBar(context, buttonCreator, topBarBackgroundViewController, topBarButtonClickListener, stackLayout, ImageLoaderMock.mock()));
                 spy.layout(0, 0, 1000, 100);
                 return spy;
             }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/views/TopBarBackgroundComponentTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/views/TopBarBackgroundComponentTest.java
@@ -8,7 +8,6 @@ import android.view.ViewGroup;
 import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.R;
 import com.reactnativenavigation.mocks.ImageLoaderMock;
-import com.reactnativenavigation.mocks.TitleBarReactViewCreatorMock;
 import com.reactnativenavigation.mocks.TopBarBackgroundViewCreatorMock;
 import com.reactnativenavigation.mocks.TopBarButtonCreatorMock;
 import com.reactnativenavigation.parse.Component;
@@ -42,8 +41,8 @@ public class TopBarBackgroundComponentTest extends BaseTest {
         });
         Activity activity = newActivity();
         topBarBackgroundViewController = spy(new TopBarBackgroundViewController(activity, new TopBarBackgroundViewCreatorMock()));
-        StackLayout parent = new StackLayout(activity, new TopBarButtonCreatorMock(), new TitleBarReactViewCreatorMock(), topBarBackgroundViewController, new TopBarController(), onClickListener, null);
-        uut = new TopBar(activity, new TopBarButtonCreatorMock(), new TitleBarReactViewCreatorMock(), topBarBackgroundViewController, onClickListener, parent, ImageLoaderMock.mock());
+        StackLayout parent = new StackLayout(activity, new TopBarButtonCreatorMock(), topBarBackgroundViewController, new TopBarController(), onClickListener, null);
+        uut = new TopBar(activity, new TopBarButtonCreatorMock(), topBarBackgroundViewController, onClickListener, parent, ImageLoaderMock.mock());
         parent.addView(uut);
     }
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/views/TopBarTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/views/TopBarTest.java
@@ -7,7 +7,6 @@ import android.view.MenuItem;
 import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.anim.TopBarAnimator;
 import com.reactnativenavigation.mocks.ImageLoaderMock;
-import com.reactnativenavigation.mocks.TitleBarReactViewCreatorMock;
 import com.reactnativenavigation.mocks.TopBarBackgroundViewCreatorMock;
 import com.reactnativenavigation.mocks.TopBarButtonCreatorMock;
 import com.reactnativenavigation.parse.AnimationOptions;
@@ -35,7 +34,6 @@ public class TopBarTest extends BaseTest {
 
     private TopBar uut;
     private TopBarAnimator animator;
-    private ArrayList<Button> leftButton;
     private ArrayList<Button> rightButtons;
     private TopBarButtonController.OnClickListener onClickListener;
 
@@ -50,22 +48,12 @@ public class TopBarTest extends BaseTest {
         });
         Activity activity = newActivity();
         TopBarBackgroundViewController topBarBackgroundViewController = new TopBarBackgroundViewController(activity, new TopBarBackgroundViewCreatorMock());
-        StackLayout parent = new StackLayout(activity, new TopBarButtonCreatorMock(), new TitleBarReactViewCreatorMock(), topBarBackgroundViewController, new TopBarController(), this.onClickListener, null);
-        uut = new TopBar(activity, new TopBarButtonCreatorMock(), new TitleBarReactViewCreatorMock(), topBarBackgroundViewController, this.onClickListener, parent, ImageLoaderMock.mock());
+        StackLayout parent = new StackLayout(activity, new TopBarButtonCreatorMock(), topBarBackgroundViewController, new TopBarController(), this.onClickListener, null);
+        uut = new TopBar(activity, new TopBarButtonCreatorMock(), topBarBackgroundViewController, this.onClickListener, parent, ImageLoaderMock.mock());
         animator = spy(new TopBarAnimator(uut));
         uut.setAnimator(animator);
-        leftButton = createLeftButton();
         rightButtons = createRightButtons();
         parent.addView(uut);
-    }
-
-    private ArrayList<Button> createLeftButton() {
-        ArrayList<Button> result = new ArrayList<>();
-        Button leftButton = new Button();
-        leftButton.id = "leftButton";
-        leftButton.text = new Text("");
-        result.add(spy(leftButton));
-        return result;
     }
 
     private ArrayList<Button> createRightButtons() {


### PR DESCRIPTION
Currently TopBar title component, background and buttons are unmounted when a new screen is pushed to the stack.
This causes a bug when props are passed to these components as props are cleared when child components unmount. When navigating back to a screen which passed props to the component, the are missing as the component is recreated in native but props were already cleared in Js.

This commit fixes this bug only for title components.