### PR TITLE
[v1][Android] Title bar icons support for drawable res

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/TitleBarButtonParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/TitleBarButtonParamsParser.java
@@ -2,10 +2,12 @@ package com.reactnativenavigation.params.parsers;
 
 import android.os.Bundle;
 
+import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.params.AppStyle;
 import com.reactnativenavigation.params.BaseTitleBarButtonParams;
 import com.reactnativenavigation.params.TitleBarButtonParams;
 import com.reactnativenavigation.react.ImageLoader;
+import com.reactnativenavigation.react.ResourceDrawableIdHelper;
 
 import java.util.List;
 
@@ -23,7 +25,12 @@ public class TitleBarButtonParamsParser extends Parser {
         TitleBarButtonParams result = new TitleBarButtonParams();
         result.label = bundle.getString("title");
         if (hasKey(bundle, "icon")) {
-            result.icon = ImageLoader.loadImage(bundle.getString("icon"));
+            String uri = bundle.getString("icon");
+            if (uri.startsWith("http://") || uri.startsWith("https://") || uri.startsWith("file://")) {
+                result.icon = ImageLoader.loadImage(uri);
+            } else {
+                result.icon = ResourceDrawableIdHelper.instance.getResourceDrawable(NavigationApplication.instance, uri);
+            }
         }
         result.color = getColor(bundle, "color", AppStyle.appStyle.titleBarButtonColor);
         result.disabledColor = getColor(bundle, "titleBarDisabledButtonColor", AppStyle.appStyle.titleBarDisabledButtonColor);


### PR DESCRIPTION
Similar to #3520, this PR enables support to drawable res to be used in title bar buttons.
Here is an example of our project using this PR side-by-side Android and iOS:

![image](https://user-images.githubusercontent.com/804994/44118222-c7b02aa6-9feb-11e8-8881-d073c52c678f.png)

Code (simplified):
```jsx
navigator.setButtons({
	leftButtons: [{
		id: 'sideMenu',
		icon: { uri: 'settings', scale: Dimensions.get('window').scale },
		testID: 'rooms-list-view-sidebar'
	}],
	rightButtons: [{
		id: 'createChannel',
		icon: { uri: 'new_channel', scale: Dimensions.get('window').scale },
		testID: 'rooms-list-view-create-channel'
	}]
});
```