### PR TITLE
Handle back only if root exists

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/Navigator.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/Navigator.java
@@ -72,6 +72,7 @@ public class Navigator extends ParentController {
 
     @Override
     public boolean handleBack(CommandListener listener) {
+        if (modalStack.isEmpty() && root == null) return false;
         if (modalStack.isEmpty()) return root.handleBack(listener);
         return modalStack.handleBack(listener, root);
     }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/NavigatorTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/NavigatorTest.java
@@ -279,6 +279,8 @@ public class NavigatorTest extends BaseTest {
 
     @Test
     public void handleBack_DelegatesToRoot() {
+        assertThat(uut.handleBack(new CommandListenerAdapter())).isFalse();
+
         ViewController root = spy(child1);
         uut.setRoot(root, new CommandListenerAdapter());
         when(root.handleBack(any(CommandListener.class))).thenReturn(true);


### PR DESCRIPTION
This commit fixes a crash when hardware back button was pressed before root was set.