### PR TITLE
Add addtional common problem for cache reset

### DIFF
--- a/docs/docs/WorkingLocally.md
+++ b/docs/docs/WorkingLocally.md
@@ -80,4 +80,8 @@ No PR will be accepted without adequate test coverage.
 	```
 		
 	You probably have an old node version which doesn't support async functions. Update your nodejs to 8+.
+* If the bundling fails with an error like `bundling failed: ambiguous resolution`, reset the `rn-packager` cache manually.
+	```
+	node ./node_modules/react-native/local-cli/cli.js start --reset-cache
+	```
 


### PR DESCRIPTION
When fresh installing `v2` branch some time getting issues with bundling. Due to `rn-packager` cache. Normal `npm start -- --reset-cache` was not working properly. So had to reset the cache manually. Maybe its because of the start script is different from regular react native app setup.

## Error Description

```
Metro Bundler ready.

Loading dependency graph, done.
Bundling `index.js`  [development, non-minified]  0.0% (0/2), failed.
error: bundling failed: ambiguous resolution: module `/Users/mac/react-native-navigation/playground/src/app.js` tries to require `react-native`, but there are several files providing this module. You can delete or fix them: 

  * `/Users/mac/react-native-navigation/example/node_modules/react-native/package.json`
  * `/Users/mac/react-native-navigation/node_modules/react-native/package.json`
```

As submitted in other closed issues, resetting the cache fixed it. So adding it into common problems section.