### PR TITLE
[V2] [Android] Add onNewIntent to NavigationActivity.java

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
@@ -105,4 +105,9 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     public void onReload() {
         navigator.destroyViews();
     }
+
+    @Override
+    public void onNewIntent(Intent intent) {
+        getReactGateway().onNewIntent(intent);
+    }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/ReactGateway.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/ReactGateway.java
@@ -67,4 +67,8 @@ public class ReactGateway {
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
         host.getReactInstanceManager().onActivityResult(activity, requestCode, resultCode, data);
     }
+
+	public void onNewIntent(Intent intent) {
+	    host.getReactInstanceManager().onNewIntent(intent);
+    }
 }


### PR DESCRIPTION
I tested on android and found [Deep-link](https://developer.android.com/training/app-links/deep-linking) in Android is not working when user wait to listen event `url` that come from `onNewIntent`.

By add these two method, when user receive `onNewIntent` then we can pass it back to React Native library and let them handle normally.

This commit like `onNewIntent` that you have on `master` branch.

https://github.com/wix/react-native-navigation/blob/664a701fe805dd4d72e319fbeac0fd16c4b71fe5/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactGateway.java#L109-L111