### PR TITLE
[v1][Android] react-native v.0.57 compatibility / remove deprecated UIImplementationProvider

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
+++ b/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
@@ -12,7 +12,6 @@ import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.uimanager.UIImplementationProvider;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.reactnativenavigation.bridge.EventEmitter;
 import com.reactnativenavigation.controllers.ActivityCallbacks;
@@ -35,7 +34,7 @@ public abstract class NavigationApplication extends Application implements React
         super.onCreate();
         instance = this;
         handler = new Handler(getMainLooper());
-        reactGateway = new NavigationReactGateway(getUIImplementationProvider());
+        reactGateway = new NavigationReactGateway();
         eventEmitter = new EventEmitter(reactGateway);
         activityCallbacks = new ActivityCallbacks();
     }
@@ -52,11 +51,6 @@ public abstract class NavigationApplication extends Application implements React
         } else {
             super.startActivity(intent);
         }
-    }
-
-    // here in case someone wants to override this
-    protected UIImplementationProvider getUIImplementationProvider() {
-        return null; // if null the default UIImplementationProvider will be used
     }
 
     public void startReactContextOnceInBackgroundAndExecuteJS() {

--- a/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactGateway.java
+++ b/android/app/src/main/java/com/reactnativenavigation/react/NavigationReactGateway.java
@@ -10,7 +10,6 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.shell.MainReactPackage;
-import com.facebook.react.uimanager.UIImplementationProvider;
 import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.bridge.NavigationReactEventEmitter;
 import com.reactnativenavigation.bridge.NavigationReactPackage;
@@ -29,28 +28,7 @@ public class NavigationReactGateway implements ReactGateway {
 	private JsDevReloadHandler jsDevReloadHandler;
 
 	public NavigationReactGateway() {
-		this(null);
-	}
-
-	public NavigationReactGateway(final UIImplementationProvider customImplProvider) {
-
-		if (customImplProvider != null) {
-			host = new ReactNativeHostImpl() {
-				/**
-				 * This was added in case someone needs to provide a different UIImplementationProvider
-				 * @param {UIImplementationProvider} defaultProvider
-				 * @return {UIImplementationProvider}
-				 */
-				@Override
-				protected UIImplementationProvider getUIImplementationProvider() {
-					return customImplProvider;
-				}
-			};
-		} else {
-			host = new ReactNativeHostImpl();
-		}
-
-
+		host = new ReactNativeHostImpl();
 		jsDevReloadHandler = new JsDevReloadHandler();
 	}
 


### PR DESCRIPTION
`com.facebook.react.uimanager.UIImplementationProvider` has been removed as of react-native@0.57 ([commit](https://github.com/facebook/react-native/commit/506f92083806e91a90d9a213bcdd05ab3b2ba888)), breaking react-native-navigation v1 on android.

Hence removing the usage of UIImplementationProvider in react-native-navigation.

I know, all your efforts are on v2 already, but it would be great not to see v1 compatibility with react-native break too soon. :) 

