### PR TITLE
Update Installing.md with proper name for Bundle Root

### DIFF
--- a/docs/docs/Installing.md
+++ b/docs/docs/Installing.md
@@ -34,7 +34,7 @@
 
 	- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 	{
-		NSURL *jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
+		NSURL *jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
 		[ReactNativeNavigation bootstrap:jsCodeLocation launchOptions:launchOptions];
 		
 		return YES;


### PR DESCRIPTION
In React-Native v51+ the bundle roots are no longer platform specific (`index.ios` or `index.android`). In the current versions there is only one `index.js` file for both platforms. Yet in the provided `AppDelegate.m` file the `jsBundleURLForBundleRoot` is still written as `index.ios`. If you try to build from this documentation with `react-native` v56 you will get the following error from MetroBundler: `UnhandledPromiseRejectionWarning: Error: File not found: index.ios.js in any of the project roots (/Users/skingman/projects/niche-mobile-app)`. It should be looking for `index.js`. I assume this would be the case for the other supported versions of `react-native` (51+).