### PR TITLE
[V2] Disable gesture capture when sideMenu is disabled #3651

### DIFF
--- a/lib/ios/RNNSideMenuSideOptions.m
+++ b/lib/ios/RNNSideMenuSideOptions.m
@@ -16,6 +16,7 @@
 				default:
 					break;
 			}
+			sideMenuController.sideMenu.openDrawerGestureModeMask = [self.enabled boolValue] ? MMOpenDrawerGestureModeAll : MMOpenDrawerGestureModeNone;
 		}
 		
 		if (self.visible) {


### PR DESCRIPTION
By default, gestures are captures when you layout a sideMenu, regardless of whether you disable the sideMenu. This is problematic when you want to push a screen and have the swipe back gesture pop the newly pushed screen, instead of opening the drawer.

This PR simply disabled gestures when the sideMenu is disabled, and enables when the sideMenu is enabled. It resolves #3651