### PR TITLE
update hoist-non-react-statics to 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-native": "*"
   },
   "dependencies": {
-    "hoist-non-react-statics": "2.x.x",
+    "hoist-non-react-statics": "3.x.x",
     "lodash": "4.x.x",
     "prop-types": "15.x.x",
     "react-lifecycles-compat": "2.0.0"


### PR DESCRIPTION
Fix crash when using the new `registerComponentWithRedux` API
https://github.com/wix/react-native-navigation/pull/3675#issuecomment-413923307
