### PR TITLE
[V2] Fix order of `registerComponentWithRedux` arguments in Third Party documentation

### DIFF
--- a/docs/docs/third-party.md
+++ b/docs/docs/third-party.md
@@ -2,10 +2,10 @@
 
 ## Redux
 
-### registerComponentWithRedux(screenID, generator, store, provider)
+### registerComponentWithRedux(screenID, generator, Provider, store)
 Utility helper function like registerComponent,
 wraps the provided component with a react-redux Provider with the passed redux store
 
 ```js
-Navigation.registerComponentWithRedux('navigation.playground.WelcomeScreen', () => WelcomeScreen, store, provider);
+Navigation.registerComponentWithRedux('navigation.playground.WelcomeScreen', () => WelcomeScreen, Provider, store);
 ```


### PR DESCRIPTION
The actual `registerComponentWithRedux` function definition is the following:
```
    registerComponentWithRedux(componentName, getComponentClassFunc, ReduxProvider, reduxStore) {
        return this.componentRegistry.registerComponent(componentName, getComponentClassFunc, ReduxProvider, reduxStore);
    }
```

Note the order of `store` and `provider` are the opposite as shown in the original documentation.  This will fix it, but it's worth mentioning that v1 has the order shown in the original documentation, so it would be nice to keep the parameter order the same in v2.

I also capitalized Provider as it is a React Component.