### PR TITLE
Remove less-than-correct v2 readiness claim from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
 
 ## Important
 We are currently in late stages of development of [v2](https://github.com/wix/react-native-navigation/tree/v2), which is published to npm under `alpha` tag.
-* New to RNN? We recommend you start with [v2](https://github.com/wix/react-native-navigation/tree/v2).
-* Already using v1? now is the time to migrate your code base to [v2](https://github.com/wix/react-native-navigation/tree/v2), and you can easily do so with a single line of code using the [v1-v2 adapter](https://github.com/wix-playground/react-native-navigation-v1-v2-adapter).
+* ~~New to RNN? We recommend you start with [v2](https://github.com/wix/react-native-navigation/tree/v2).~~
+* ~~Already using v1? now is the time to migrate your code base to [v2](https://github.com/wix/react-native-navigation/tree/v2), and you can easily do so with a single line of code using the [v1-v2 adapter](https://github.com/wix-playground/react-native-navigation-v1-v2-adapter).~~
+* Do not use v2 yet since it is not close to ready yet and doesn't work for many use cases.
 * [v2 Documentation](https://wix.github.io/react-native-navigation/v2/#/)
 <br><br>Have any questions regarding v2? Join us in [Discord](https://discord.gg/DhkZjq2) #v2 channel.
 


### PR DESCRIPTION
After sinking a ton of time into trying to get v2 working for a few different apps, I ran into [many known issues](https://github.com/wix/react-native-navigation/issues?q=is%3Aissue+is%3Aopen+label%3Av2+sort%3Acreated-desc).

I think it's fair to say we shouldn't recommend new users start with v2 quite yet, so this PR removes that suggestion for now.