### PR TITLE
Allow also number to be passed

### DIFF
--- a/lib/src/interfaces/Layout.ts
+++ b/lib/src/interfaces/Layout.ts
@@ -8,7 +8,7 @@ export interface LayoutComponent {
   /**
    * Name of your component
    */
-  name: string;
+  name: string | number;
   /**
    * Styling options
    */


### PR DESCRIPTION
I have added number to be valid screen name too because then you can easily use enums to define your screen. Like this
```
export enum Screen {
  Login = 1,
  Home,
  Settings,
}
```

This way I just add new enum name and it will generate new id (number) for it. This reduces boilerplate when defining screen names