### PR TITLE
Add BottomTabs elevation option

### DIFF
--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -237,6 +237,7 @@ Navigation.mergeOptions(this.props.componentId, {
     }
   },
   bottomTabs: {
+    elevation: 8, // BottomTabs elevation in dp
     titleDisplayMode: 'alwaysShow' | 'showWhenActive' | 'alwaysHide' // Sets the title state for each tab.
   },
   bottomTab: {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabsOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabsOptions.java
@@ -2,8 +2,10 @@ package com.reactnativenavigation.parse;
 
 import com.reactnativenavigation.parse.params.Bool;
 import com.reactnativenavigation.parse.params.Colour;
+import com.reactnativenavigation.parse.params.Fraction;
 import com.reactnativenavigation.parse.params.NullBool;
 import com.reactnativenavigation.parse.params.NullColor;
+import com.reactnativenavigation.parse.params.NullFraction;
 import com.reactnativenavigation.parse.params.NullNumber;
 import com.reactnativenavigation.parse.params.NullText;
 import com.reactnativenavigation.parse.params.Number;
@@ -11,6 +13,7 @@ import com.reactnativenavigation.parse.params.Text;
 import com.reactnativenavigation.parse.params.TitleDisplayMode;
 import com.reactnativenavigation.parse.parsers.BoolParser;
 import com.reactnativenavigation.parse.parsers.ColorParser;
+import com.reactnativenavigation.parse.parsers.FractionParser;
 import com.reactnativenavigation.parse.parsers.NumberParser;
 import com.reactnativenavigation.parse.parsers.TextParser;
 
@@ -28,6 +31,7 @@ public class BottomTabsOptions {
 		options.visible = BoolParser.parse(json,"visible");
         options.drawBehind = BoolParser.parse(json, "drawBehind");
 		options.animate = BoolParser.parse(json,"animate");
+        options.elevation = FractionParser.parse(json, "elevation");
         options.testId = TextParser.parse(json, "testID");
         options.titleDisplayMode = TitleDisplayMode.fromString(json.optString("titleDisplayMode"));
 
@@ -39,6 +43,7 @@ public class BottomTabsOptions {
     public Bool drawBehind = new NullBool();
 	public Bool animate = new NullBool();
 	public Number currentTabIndex = new NullNumber();
+	public Fraction elevation = new NullFraction();
 	public Text currentTabId = new NullText();
     public Text testId = new NullText();
     public TitleDisplayMode titleDisplayMode = TitleDisplayMode.UNDEFINED;
@@ -49,6 +54,7 @@ public class BottomTabsOptions {
 		if (other.visible.hasValue()) visible = other.visible;
         if (other.drawBehind.hasValue()) drawBehind = other.drawBehind;
 		if (other.animate.hasValue()) animate = other.animate;
+        if (other.elevation.hasValue()) elevation = other.elevation;
         if (other.backgroundColor.hasValue()) backgroundColor = other.backgroundColor;
         if (other.testId.hasValue()) testId = other.testId;
         if (other.titleDisplayMode.hasValue()) titleDisplayMode = other.titleDisplayMode;
@@ -60,6 +66,7 @@ public class BottomTabsOptions {
         if (!visible.hasValue()) visible = defaultOptions.visible;
         if (!drawBehind.hasValue()) drawBehind = defaultOptions.drawBehind;
         if (!animate.hasValue()) animate = defaultOptions.animate;
+        if (!elevation.hasValue()) elevation = defaultOptions.elevation;
         if (!backgroundColor.hasValue()) backgroundColor = defaultOptions.backgroundColor;
         if (!titleDisplayMode.hasValue()) titleDisplayMode = defaultOptions.titleDisplayMode;
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsOptionsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsOptionsPresenter.java
@@ -158,5 +158,8 @@ public class BottomTabsOptionsPresenter {
                 bottomTabs.hideBottomNavigation(false);
             }
         }
+        if (options.elevation.hasValue()) {
+            bottomTabs.setUseElevation(true, options.elevation.get().floatValue());
+        }
     }
 }

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -411,6 +411,11 @@ export interface OptionsBottomTabs {
    * #### (Android specific)
    */
   titleDisplayMode?: 'alwaysShow' | 'showWhenActive' | 'alwaysHide';
+  /**
+   * Set the elevation of the Bottom Tabs in dp
+   * #### (Android specific)
+   */
+  elevation?: AndroidDensityNumber;
 }
 
 export interface OptionsBottomTab {


### PR DESCRIPTION
## Overview

- Add Android specific options elevation in BottomTabs
- Update docs with new styling option (ahbottomnavigation use by default 8dp elevation)
