### PR TITLE
Support Android 9.0 Pie and update buildToolsVersion

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply from: '../prepare-robolectric.gradle'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -47,8 +47,8 @@ android {
 dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
 
-	compile 'com.android.support:design:25.3.1'
-    compile "com.android.support:appcompat-v7:25.3.1"
+    compile 'com.android.support:design:27.1.1'
+    compile "com.android.support:appcompat-v7:27.1.1"
 
     // node_modules
     compile "com.facebook.react:react-native:+"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.2'
@@ -19,6 +23,10 @@ allprojects {
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
+        }
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
         }
     }
 }


### PR DESCRIPTION
I know you guys are focusing on v2, but Android 9.0 was released and v2 was not yet ready, so this commit supports latest Android version.

If you try `react-native-navigation` with Android 9.0, it simply doesn't work (white screen, React context not loaded). 

Can you give this PR a chance?