### PR TITLE
search for views in displayed modal in findViewById

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/ModalController.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/ModalController.java
@@ -2,6 +2,7 @@ package com.reactnativenavigation.controllers;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.view.View;
 import android.view.Window;
 
 import com.facebook.react.bridge.Callback;
@@ -191,5 +192,9 @@ class ModalController implements ScreenStackContainer, Modal.OnModalDismissedLis
 
     String getCurrentlyVisibleEventId() {
         return stack.peek().getCurrentlyVisibleEventId();
+    }
+
+    public <T extends View> T findViewById(int id) {
+        return stack.peek().findViewById(id);
     }
 }

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -9,6 +9,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.view.KeyEvent;
+import android.view.View;
 import android.view.Window;
 
 import com.facebook.react.bridge.Callback;
@@ -497,5 +498,17 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
 
     public static void setStartAppPromise(Promise promise) {
         NavigationActivity.startAppPromise = promise;
+    }
+
+    @Override
+    public <T extends View> T findViewById(int id) {
+        T found = null;
+        if(modalController.isShowing()) {
+            found = modalController.findViewById(id);
+        }
+        if(found != null) {
+            return found;
+        }
+        return super.findViewById(id);
     }
 }


### PR DESCRIPTION
When using libraries which depend on findViewById (e.g. https://github.com/prscX/react-native-popover-menu) the function will return null for a view ID from a subview in a modal.
findViewById is not implemented in NavigationActivity and the super implementation only searches through the subviews of the NavigationActivity but not the subviews of Modals.