### PR TITLE
Expose layout in NavigationActivity

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -498,4 +498,8 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     public static void setStartAppPromise(Promise promise) {
         NavigationActivity.startAppPromise = promise;
     }
+
+    public Layout getLayout() {
+        return layout;
+    }
 }


### PR DESCRIPTION
Use Case: When exposing the layout, other android code can check what kind of layout it is and react accordingly, fx:
```
if (activity.getLayout() instanceof BottomTabsLayout) {
    // ...
}
```