### PR TITLE
[v2] Typescript: Adds `id` and `passProps` to OptionsTopBarTitle.component

### DIFF
--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -119,8 +119,22 @@ export interface OptionsTopBarTitle {
    * Custom component as the title view
    */
   component?: {
+    /**
+     * Component reference id, Auto generated if empty
+     */
+    id?: string;
+    /**
+     * Name of your component
+     */
     name: string;
+    /**
+     * Set component alignment
+     */
     alignment?: 'center' | 'fill';
+    /**
+     * Properties to pass down to the component
+     */
+    passProps?: object;
   };
   /**
    * Top Bar title height in densitiy pixels


### PR DESCRIPTION
Useful when using custom component with `id` and `passProps` properties in OptionsTopBarTitle.

Fix typescript error TS2345: Argument of type '{ topBar: { title: { component: { name: any; alignment: "center"; passProps: { ... }; }; }; }; }' is not assignable to parameter of type 'Options'.
