### PR TITLE
[V2][iOS] Apply bottom tabs visibility

### DIFF
--- a/lib/ios/RNNBottomTabsOptions.m
+++ b/lib/ios/RNNBottomTabsOptions.m
@@ -49,6 +49,10 @@ extern const NSInteger BLUR_TOPBAR_TAG;
 		viewController.tabBarController.tabBar.clipsToBounds = [self.hideShadow boolValue];
 	}
 
+  if (self.visible) {
+    [viewController.tabBarController.tabBar setHidden:[self.visible boolValue]];
+  }
+
 	[self resetOptions];
 }
 


### PR DESCRIPTION
This PR fixes an issue when using the `bottomTabs` layout with `options.bottomTabs.visible` set to `false` on iOS. It initially renders a visible `UITabBar`, which only disappears after navigating to another screen and going back. It should fix https://github.com/wix/react-native-navigation/issues/4076
