### PR TITLE
[V2][iOS] fix: Apply initial bottomTabs options

### DIFF
--- a/lib/ios/RNNTabBarPresenter.m
+++ b/lib/ios/RNNTabBarPresenter.m
@@ -5,12 +5,10 @@
 
 - (void)applyOptions:(RNNNavigationOptions *)initialOptions {
 	[super applyOptions:initialOptions];
-	
+
 	RNNNavigationOptions* options = [initialOptions withDefault:self.defaultOptions];
-	
-	UITabBarController* tabBarController = self.bindedViewController;
-	
-	[tabBarController rnn_setTabBarTestID:[options.bottomTabs.testID getWithDefaultValue:nil]];
+	RNNNavigationOptions* withDefault = (RNNNavigationOptions *)[options withDefault:self.defaultOptions];
+    [self mergeOptions:options resolvedOptions:withDefault];
 }
 
 - (void)mergeOptions:(RNNNavigationOptions *)options resolvedOptions:(RNNNavigationOptions *)resolvedOptions {


### PR DESCRIPTION
I had the same issue as the other user in #4148  -  `bottomTabs.backgroundColor` not working on iOS. At least not if set through `Navigation.setDefaultOptions()`.

The issue seems to be the fact that we never set values on the tab bar in `applyOptions` which I think is called when initialising.

Conveniently enough mergeOptions does exactly what we want and it seems to fix the issue for me.