### PR TITLE
[v2] Forward modalPresentationStyle to top UIViewController

### DIFF
--- a/lib/ios/RNNModalManager.m
+++ b/lib/ios/RNNModalManager.m
@@ -27,6 +27,9 @@
 	UIViewController* topVC = [self topPresentedVC];
 	topVC.definesPresentationContext = YES;
 	
+	UIViewController* topUIVC = [self topUIViewController:viewController];
+	topUIVC.modalPresentationStyle = topVC.modalPresentationStyle;
+	
 	if (hasCustomAnimation) {
 		viewController.transitioningDelegate = (UIViewController<UIViewControllerTransitioningDelegate>*)topVC;
 	}
@@ -115,5 +118,19 @@
 	return [root topViewController] ? [root topViewController] : root;
 }
 
+- (UIViewController *)topUIViewController:(UIViewController *)viewController {
+	if ([viewController isKindOfClass:[UINavigationController class]]) {
+		UINavigationController *navigationController = (UINavigationController *)viewController;
+		return [self topUIViewController:[navigationController.viewControllers lastObject]];
+	}
+	if ([viewController isKindOfClass:[UITabBarController class]]) {
+		UITabBarController *tabController = (UITabBarController *)viewController;
+		return [self topUIViewController:tabController.selectedViewController];
+	}
+	if (viewController.presentedViewController) {
+		return [self topUIViewController:viewController.presentedViewController];
+	}
+	return viewController;
+}
 
 @end


### PR DESCRIPTION
Modals were never transparent due `modalPresentationStyle` being ignored. 

This PR fixes the problem for both stacked and non-stacked navigation by finding the closes UIViewController and applying the `modalPresentationStyle` property from the top `presentedViewController`.

Fixes #4134, #3413 and #3272
