### PR TITLE
[V2][IOS][Bug fixed] topBar title image Fixes #4165

### DIFF
--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -164,10 +164,10 @@
 
 - (void)setCustomNavigationTitleView {
 	if (!_customTitleView && _isBeingPresented) {
-		if (self.options.topBar.title.component.name.hasValue) {
-			_customTitleView = (RNNReactView*)[_creator createRootViewFromComponentOptions:self.options.topBar.title.component];
+		if (self.optionsWithDefault.topBar.title.component.name.hasValue) {
+			_customTitleView = (RNNReactView*)[_creator createRootViewFromComponentOptions:self.optionsWithDefault.topBar.title.component];
 			_customTitleView.backgroundColor = UIColor.clearColor;
-			NSString* alignment = [self.options.topBar.title.component.alignment getWithDefaultValue:@""];
+			NSString* alignment = [self.optionsWithDefault.topBar.title.component.alignment getWithDefaultValue:@""];
 			[_customTitleView setAlignment:alignment];
 			BOOL isCenter = [alignment isEqualToString:@"center"];
 			__weak RNNReactView *weakTitleView = _customTitleView;


### PR DESCRIPTION
Hey my knowledge of Objective-C is very limited, but after some digging around in the code I stumbled on what seems to be a fix for this issue ``` https://github.com/wix/react-native-navigation/issues/4165 ``` 

The issue is that values set by 

```js 
Navigation.setDefaultOptions({});
```

is ignored when calling the  ``` self.options ``` in the ``` RNNRootViewController.m ```

my initial testing also revealed a lot of other bugs getting fixed by this issue, so if this is the correct way to handle the bug then this fix could possibly fix some more bugs

Hope this PR helps thin the vast amount of issues