### PR TITLE
[V2][IOS] Resolve 'push'-command with next componentId for ios

### DIFF
--- a/lib/ios/RNNBridgeModule.m
+++ b/lib/ios/RNNBridgeModule.m
@@ -50,8 +50,8 @@ RCT_EXPORT_METHOD(pop:(NSString*)commandId componentId:(NSString*)componentId me
 }
 
 RCT_EXPORT_METHOD(setStackRoot:(NSString*)commandId componentId:(NSString*)componentId children:(NSArray*)children resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-	[_commandsHandler setStackRoot:componentId children:children completion:^{
-		resolve(componentId);
+	[_commandsHandler setStackRoot:componentId children:children completion:^(NSString *newComponentId){
+		resolve(newComponentId);
 	} rejection:reject];
 }
 

--- a/lib/ios/RNNBridgeModule.m
+++ b/lib/ios/RNNBridgeModule.m
@@ -38,8 +38,8 @@ RCT_EXPORT_METHOD(setDefaultOptions:(NSDictionary*)options resolver:(RCTPromiseR
 }
 
 RCT_EXPORT_METHOD(push:(NSString*)commandId componentId:(NSString*)componentId layout:(NSDictionary*)layout resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-	[_commandsHandler push:componentId layout:layout completion:^{
-		resolve(componentId);
+	[_commandsHandler push:componentId layout:layout completion:^(NSString *newComponentId){
+		resolve(newComponentId);
 	} rejection:reject];
 }
 

--- a/lib/ios/RNNCommandsHandler.h
+++ b/lib/ios/RNNCommandsHandler.h
@@ -25,7 +25,7 @@
 
 - (void)popToRoot:(NSString*)componentId mergeOptions:(NSDictionary*)options completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;
 
-- (void)setStackRoot:(NSString*)componentId children:(NSArray*)children completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;
+- (void)setStackRoot:(NSString*)componentId children:(NSArray*)children completion:(RNNTransitionWithComponentIdCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;
 
 - (void)showModal:(NSDictionary*)layout completion:(RNNTransitionWithComponentIdCompletionBlock)completion;
 

--- a/lib/ios/RNNCommandsHandler.h
+++ b/lib/ios/RNNCommandsHandler.h
@@ -17,7 +17,7 @@
 
 - (void)setDefaultOptions:(NSDictionary*)options completion:(RNNTransitionCompletionBlock)completion;
 
-- (void)push:(NSString*)componentId layout:(NSDictionary*)layout completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;
+- (void)push:(NSString*)componentId layout:(NSDictionary*)layout completion:(RNNTransitionWithComponentIdCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;
 
 - (void)pop:(NSString*)componentId mergeOptions:(NSDictionary*)options completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;
 

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -111,7 +111,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	completion();
 }
 
-- (void)push:(NSString*)componentId layout:(NSDictionary*)layout completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection {
+- (void)push:(NSString*)componentId layout:(NSDictionary*)layout completion:(RNNTransitionWithComponentIdCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection {
 	[self assertReady];
 	
 	UIViewController<RNNLayoutProtocol> *newVc = [_controllerFactory createLayout:layout];
@@ -132,7 +132,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 					[CATransaction begin];
 					[CATransaction setCompletionBlock:^{
 						[self->_eventEmitter sendOnNavigationCommandCompletion:push params:@{@"componentId": componentId}];
-						completion();
+						completion(newVc.componentId);
 					}];
 					[rvc.navigationController pushViewController:newVc animated:YES];
 					[CATransaction commit];
@@ -163,7 +163,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 		[newVc renderTreeAndWait:([newVc.resolveOptions.animations.push.waitForRender getWithDefaultValue:NO] || animationDelegate) perform:^{
 			[_stackManager push:newVc onTop:fromVC animated:[newVc.resolveOptions.animations.push.enable getWithDefaultValue:YES] animationDelegate:animationDelegate completion:^{
 				[_eventEmitter sendOnNavigationCommandCompletion:push params:@{@"componentId": componentId}];
-				completion();
+				completion(newVc.componentId);
 			} rejection:rejection];
 		}];
 	}

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -169,7 +169,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	}
 }
 
-- (void)setStackRoot:(NSString*)componentId children:(NSArray*)children completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection {
+- (void)setStackRoot:(NSString*)componentId children:(NSArray*)children completion:(RNNTransitionWithComponentIdCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection {
 	[self assertReady];
 	
  	NSArray<RNNLayoutProtocol> *childViewControllers = [_controllerFactory createChildrenLayout:children];
@@ -181,7 +181,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	__weak typeof(RNNEventEmitter*) weakEventEmitter = _eventEmitter;
 	[_stackManager setStackChildren:childViewControllers fromViewController:fromVC animated:[options.animations.setStackRoot.enable getWithDefaultValue:YES] completion:^{
 		[weakEventEmitter sendOnNavigationCommandCompletion:setStackRoot params:@{@"componentId": componentId}];
-		completion();
+		completion(newVC.getLeafViewController.componentId);
 	} rejection:rejection];
 }
 

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -132,7 +132,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 					[CATransaction begin];
 					[CATransaction setCompletionBlock:^{
 						[self->_eventEmitter sendOnNavigationCommandCompletion:push params:@{@"componentId": componentId}];
-						completion(newVc.componentId);
+						completion(newVc.layoutInfo.componentId);
 					}];
 					[rvc.navigationController pushViewController:newVc animated:YES];
 					[CATransaction commit];
@@ -163,7 +163,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 		[newVc renderTreeAndWait:([newVc.resolveOptions.animations.push.waitForRender getWithDefaultValue:NO] || animationDelegate) perform:^{
 			[_stackManager push:newVc onTop:fromVC animated:[newVc.resolveOptions.animations.push.enable getWithDefaultValue:YES] animationDelegate:animationDelegate completion:^{
 				[_eventEmitter sendOnNavigationCommandCompletion:push params:@{@"componentId": componentId}];
-				completion(newVc.componentId);
+				completion(newVc.layoutInfo.componentId);
 			} rejection:rejection];
 		}];
 	}
@@ -181,7 +181,8 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	__weak typeof(RNNEventEmitter*) weakEventEmitter = _eventEmitter;
 	[_stackManager setStackChildren:childViewControllers fromViewController:fromVC animated:[options.animations.setStackRoot.enable getWithDefaultValue:YES] completion:^{
 		[weakEventEmitter sendOnNavigationCommandCompletion:setStackRoot params:@{@"componentId": componentId}];
-		completion(newVC.getLeafViewController.componentId);
+    NSString* newComponentId = [childViewControllers.lastObject getCurrentChild].layoutInfo.componentId;
+		completion(newComponentId);
 	} rejection:rejection];
 }
 

--- a/lib/ios/ReactNativeNavigationTests/RNNCommandsHandlerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNCommandsHandlerTest.m
@@ -314,7 +314,7 @@
 - (void)testSetStackRoot_resetStackWithSingleComponent {
 	OCMStub([self.controllerFactory createChildrenLayout:[OCMArg any]]).andReturn(@[self.vc2]);
 	[self.store setReadyToReceiveCommands:true];
-	[self.uut setStackRoot:@"vc1" children:nil completion:^{
+	[self.uut setStackRoot:@"vc1" children:nil completion:^(NSString *newComponentId) {
 		
 	} rejection:^(NSString *code, NSString *message, NSError *error) {
 		
@@ -327,7 +327,7 @@
 	NSArray* newViewControllers = @[_vc1, _vc3];
 	OCMStub([self.controllerFactory createChildrenLayout:[OCMArg any]]).andReturn(newViewControllers);
 	[self.store setReadyToReceiveCommands:true];
-	[self.uut setStackRoot:@"vc1" children:nil completion:^{
+	[self.uut setStackRoot:@"vc1" children:nil completion:^(NSString *newComponentId){
 		
 	} rejection:^(NSString *code, NSString *message, NSError *error) {
 		


### PR DESCRIPTION
Behavior of `Navigation.push(someComponentId, layout)` between android and ios is different.
In android promise resolves with next componentId (id of component that was pushed), but on ios - componentId on which we pushed.
Android: [https://github.com/wix/react-native-navigation/blob/v2/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java#L145](url)
Motivation of this PR - keep api behavior more consistent.