### PR TITLE
Added animationType to sideMenu demo

### DIFF
--- a/playground/src/screens/WelcomeScreen.js
+++ b/playground/src/screens/WelcomeScreen.js
@@ -265,7 +265,15 @@ class WelcomeScreen extends Component {
                 side: 'right'
               }
             }
-          }
+          },
+          options: {
+            sideMenu: {
+              left: {
+                width: 325,
+              },
+              animationType: 'parallax',
+            },
+          },
         }
       }
     });


### PR DESCRIPTION
This commit adds `animationType` *and* `width` to the `sideMenu` screen in the playground app.  It demonstrates the current issue with animationType.

![oct-28-2018 12-00-11](https://user-images.githubusercontent.com/10797610/47619129-419df800-daa9-11e8-8f92-9d3b7b740c4a.gif)
