### PR TITLE
Update Android Instructions to reactNative57

### DIFF
--- a/docs/docs/Installing.md
+++ b/docs/docs/Installing.md
@@ -255,7 +255,7 @@ android {
         applicationId "com.yourproject"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-+        missingDimensionStrategy "RNN.reactNativeVersion", "reactNative56"
++        missingDimensionStrategy "RNN.reactNativeVersion", "reactNative57"
         versionCode 1
         versionName "1.0"
         ...


### PR DESCRIPTION
Updates the instructions to use the latest version of React Native 0.57 'reactNative57' instead of 'reactNative56'.  Using reactNative56 prevented me from creating an Android Build.