### PR TITLE
Prefer left button custom icon to default icon

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/TitleBar.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/TitleBar.java
@@ -238,13 +238,13 @@ public class TitleBar extends Toolbar {
     }
 
     private void updateLeftButton(TitleBarLeftButtonParams leftButtonParams) {
-        if (leftButtonParams.hasDefaultIcon()) {
-            leftButton.setIconState(leftButtonParams);
-            setNavigationIcon(leftButton);
-        } else if (leftButtonParams.hasCustomIcon()) {
+        if (leftButtonParams.hasCustomIcon()) {
             leftButton.setCustomIcon(leftButtonParams);
             setNavigationIcon(leftButtonParams.icon);
-        }
+        } else if (leftButtonParams.hasDefaultIcon()) {
+            leftButton.setIconState(leftButtonParams);
+            setNavigationIcon(leftButton);
+        } 
     }
 
     private boolean shouldSetLeftButton(TitleBarLeftButtonParams leftButtonParams) {


### PR DESCRIPTION
Aligns with `createAndSetLeftButton` which also prefers a custom icon. Allows overriding the four default icons (back, cancel, accept, sideMenu) with a custom one.