### PR TITLE
Overlay iOS key window management

### DIFF
--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -281,7 +281,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	UIViewController<RNNParentProtocol>* overlayVC = [_controllerFactory createLayout:layout saveToStore:_store];
 	UIWindow* overlayWindow = [[RNNOverlayWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
 	overlayWindow.rootViewController = overlayVC;
-	[_overlayManager showOverlayWindow:overlayWindow];
+	[_overlayManager showOverlayWindow:overlayWindow withOptions:layout[@"data"][@"options"][@"overlay"]];
 	[_eventEmitter sendOnNavigationCommandCompletion:showOverlay params:@{@"layout": layout}];
 	completion();
 }

--- a/lib/ios/RNNOverlayManager.h
+++ b/lib/ios/RNNOverlayManager.h
@@ -5,9 +5,10 @@
 
 @interface RNNOverlayManager : NSObject
 
-- (void)showOverlayWindow:(UIWindow*)viewController;
+- (void)showOverlay:(UIViewController*)viewController withOptions:(NSDictionary *)options;
 - (void)dismissOverlay:(UIViewController*)viewController;
 
 @property (nonatomic, retain) NSMutableArray* overlayWindows;
+@property (nonatomic, retain) NSMutableArray* keyOverlayWindows;
 
 @end

--- a/lib/ios/RNNOverlayManager.h
+++ b/lib/ios/RNNOverlayManager.h
@@ -5,7 +5,7 @@
 
 @interface RNNOverlayManager : NSObject
 
-- (void)showOverlay:(UIViewController*)viewController withOptions:(NSDictionary *)options;
+- (void)showOverlayWindow:(UIWindow*)window withOptions:(NSDictionary *)options;
 - (void)dismissOverlay:(UIViewController*)viewController;
 
 @property (nonatomic, retain) NSMutableArray* overlayWindows;

--- a/lib/ios/RNNOverlayManager.m
+++ b/lib/ios/RNNOverlayManager.m
@@ -6,23 +6,28 @@
 - (instancetype)init {
 	self = [super init];
 	_overlayWindows = [[NSMutableArray alloc] init];
+	_keyOverlayWindows = [[NSMutableArray alloc] init];
 	return self;
 }
 
 #pragma mark - public
 
-- (void)showOverlayWindow:(RNNOverlayWindow *)overlayWindow {
-	overlayWindow.previousWindow = [UIApplication sharedApplication].keyWindow;
+- (void)showOverlayWindow:(RNNOverlayWindow *)overlayWindow withOptions:(NSDictionary *)options {
 	[_overlayWindows addObject:overlayWindow];
 	overlayWindow.rootViewController.view.backgroundColor = [UIColor clearColor];
 	[overlayWindow setWindowLevel:UIWindowLevelNormal];
-	[overlayWindow makeKeyAndVisible];
+    if (options[@"becomeKeyWindow"]) {
+        [overlayWindow makeKeyAndVisible];
+		[_keyOverlayWindows addObject: overlayWindow];
+    } else {
+        [overlayWindow setHidden:NO];
+    }
 }
 
 - (void)dismissOverlay:(UIViewController*)viewController {
 	RNNOverlayWindow* overlayWindow = [self findWindowByRootViewController:viewController];
-	[overlayWindow.previousWindow makeKeyWindow];
 	[self detachOverlayWindow:overlayWindow];
+	[self assignKeyWindow];
 }
 
 #pragma mark - private
@@ -31,6 +36,15 @@
 	[overlayWindow setHidden:YES];
 	[overlayWindow setRootViewController:nil];
 	[_overlayWindows removeObject:overlayWindow];
+	[_keyOverlayWindows removeObject:overlayWindow];
+}
+
+- (void)assignKeyWindow {
+	UIWindow *nextKeyWindow = [_keyOverlayWindows firstObject];
+    if (!nextKeyWindow) {
+		nextKeyWindow =[[[UIApplication sharedApplication] delegate] window];
+    }
+	[nextKeyWindow makeKeyWindow];
 }
 
 - (RNNOverlayWindow *)findWindowByRootViewController:(UIViewController *)viewController {

--- a/lib/ios/RNNOverlayManager.m
+++ b/lib/ios/RNNOverlayManager.m
@@ -4,57 +4,57 @@
 @implementation RNNOverlayManager
 
 - (instancetype)init {
-	self = [super init];
-	_overlayWindows = [[NSMutableArray alloc] init];
-	_keyOverlayWindows = [[NSMutableArray alloc] init];
-	return self;
+    self = [super init];
+    _overlayWindows = [[NSMutableArray alloc] init];
+    _keyOverlayWindows = [[NSMutableArray alloc] init];
+    return self;
 }
 
 #pragma mark - public
 
 - (void)showOverlayWindow:(RNNOverlayWindow *)overlayWindow withOptions:(NSDictionary *)options {
-	[_overlayWindows addObject:overlayWindow];
-	overlayWindow.rootViewController.view.backgroundColor = [UIColor clearColor];
-	[overlayWindow setWindowLevel:UIWindowLevelNormal];
+    [_overlayWindows addObject:overlayWindow];
+    overlayWindow.rootViewController.view.backgroundColor = [UIColor clearColor];
+    [overlayWindow setWindowLevel:UIWindowLevelNormal];
     if (options[@"becomeKeyWindow"]) {
         [overlayWindow makeKeyAndVisible];
-		[_keyOverlayWindows addObject: overlayWindow];
+        [_keyOverlayWindows addObject: overlayWindow];
     } else {
         [overlayWindow setHidden:NO];
     }
 }
 
 - (void)dismissOverlay:(UIViewController*)viewController {
-	RNNOverlayWindow* overlayWindow = [self findWindowByRootViewController:viewController];
-	[self detachOverlayWindow:overlayWindow];
-	[self assignKeyWindow];
+    RNNOverlayWindow* overlayWindow = [self findWindowByRootViewController:viewController];
+    [self detachOverlayWindow:overlayWindow];
+    [self assignKeyWindow];
 }
 
 #pragma mark - private
 
 - (void)detachOverlayWindow:(UIWindow *)overlayWindow {
-	[overlayWindow setHidden:YES];
-	[overlayWindow setRootViewController:nil];
-	[_overlayWindows removeObject:overlayWindow];
-	[_keyOverlayWindows removeObject:overlayWindow];
+    [overlayWindow setHidden:YES];
+    [overlayWindow setRootViewController:nil];
+    [_overlayWindows removeObject:overlayWindow];
+    [_keyOverlayWindows removeObject:overlayWindow];
 }
 
 - (void)assignKeyWindow {
-	UIWindow *nextKeyWindow = [_keyOverlayWindows firstObject];
+    UIWindow *nextKeyWindow = [_keyOverlayWindows firstObject];
     if (!nextKeyWindow) {
-		nextKeyWindow =[[[UIApplication sharedApplication] delegate] window];
+        nextKeyWindow =[[[UIApplication sharedApplication] delegate] window];
     }
-	[nextKeyWindow makeKeyWindow];
+    [nextKeyWindow makeKeyWindow];
 }
 
 - (RNNOverlayWindow *)findWindowByRootViewController:(UIViewController *)viewController {
-	for (RNNOverlayWindow* window in _overlayWindows) {
-		if ([window.rootViewController isEqual:viewController]) {
-			return window;
-		}
-	}
-	
-	return nil;
+    for (RNNOverlayWindow* window in _overlayWindows) {
+        if ([window.rootViewController isEqual:viewController]) {
+            return window;
+        }
+    }
+    
+    return nil;
 }
 
 @end


### PR DESCRIPTION
In our application we make extensive use of overlays and sometimes need to show more than one at the same time. Currently each overlay that is displayed automatically becomes the key window. This creates a problem if you need to display an overlay at the same time as a view that may need the keyboard. One example of this is using an overlay for notifications. With the current implementation the keyboard would dismiss if a notification were to display. 

This is a breaking PR. It adds a flag called `becomeKeyWindow` that can be passed when showing an overlay. If an overlay has this flag, that window will become the key window. If not, the window will not become the key window. Additionally it stores windows that include this flag allowing for the display of multiple overlays and will focus the next window upon dismissal. 

An alternate solution would be an `avoidKeyWindow` option that would implement the opposite behavior. I'm also open to this solution, however I'm assuming the main use case would be for overlays that do NOT require the keyboard.

Tests likely need to be updated and I'm happy to do so once I receive feedback.

