### PR TITLE
[v2] [iOS] Remove OCMock files from being compiled into pod

### DIFF
--- a/ReactNativeNavigation.podspec
+++ b/ReactNativeNavigation.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/wix/react-native-navigation.git", :tag => "#{s.version}" }
   s.source_files  = "lib/ios/**/*.{h,m}"
-  s.exclude_files  = "lib/ios/ReactNativeNavigationTests/**/*.*"
+  s.exclude_files  = "lib/ios/ReactNativeNavigationTests/**/*.*", "lib/ios/OCMock/**/*.*"
 
   s.dependency 'React'
   s.frameworks = 'UIKit'

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "typings": "lib/dist/index.d.ts",
   "scripts": {
     "build": "rm -rf ./lib/dist && tsc",
-    "prepare": "npm run build",
     "xcode": "open playground/ios/playground.xcodeproj",
     "install-android": "node ./scripts/install-android",
     "uninstall-android": "cd playground/android && ./gradlew uninstallAll",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "typings": "lib/dist/index.d.ts",
   "scripts": {
     "build": "rm -rf ./lib/dist && tsc",
+    "prepare": "npm run build",
     "xcode": "open playground/ios/playground.xcodeproj",
     "install-android": "node ./scripts/install-android",
     "uninstall-android": "cd playground/android && ./gradlew uninstallAll",


### PR DESCRIPTION
I am assuming that OCMock is a test only dependency and should not be included into the compiled pod which fails to compile.