### PR TITLE
Missing 'color' property

### DIFF
--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -170,6 +170,7 @@ Navigation.mergeOptions(this.props.componentId, {
   topBar: {
     barStyle: 'default' | 'black',
     background: {
+      color: 'white',
       translucent: true,
       blur: false
     }


### PR DESCRIPTION
Missing `color` property in the styling docs for the topBar background color.