### PR TITLE
[V2] Checking off statusbarhidden for Android

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -203,7 +203,7 @@ Note:  v1 properties with names beginning with 'navBar' are replaced in v2 with 
 | screenBackgroundColor     | ✅    |   ✅     |     [Contribute](/docs/WorkingLocally.md)       |  Wix|
 | orientation     |  ✅   |    ✅     |✅| Wix|
 | statusBarHideWithTopBar        |  ✅   |   ✅     |     [Contribute](/docs/WorkingLocally.md)       | @gtchance|
-| statusBarHidden       |  ✅   |    ✅       |     [Contribute](/docs/WorkingLocally.md)      | WIX |
+| statusBarHidden       |  ✅   |    ✅       |     ✅      | WIX |
 | disabledBackGesture       |   ✅  |   ✅  |    / iOS specific     |
 | screenBackgroundImageName         |   ✅  |   ✅      |    [Contribute](/docs/WorkingLocally.md)        |
 | rootBackgroundImageName            |  ✅   |    ✅     |    [Contribute](/docs/WorkingLocally.md)       |

--- a/docs/docs/options-migration.md
+++ b/docs/docs/options-migration.md
@@ -188,7 +188,7 @@ Navigation.mergeOptions(this.props.componentId, {
 On **iOS**, BottomTab visibility can be changed only when pushing screens. This means that if you'd like to hide BottomTabs when pushing a screen, You'll need to set the property to `false` in the options passed to the `push` command or via the `static options(passProps) {}` api.
 
 ## statusBarHidden
-StatusBar visibility
+StatusBar visibility. For android, also set `drawBehind: true`.
 
 ```js
 statusBar: {


### PR DESCRIPTION
Implemented here https://github.com/wix/react-native-navigation/commit/126f31c2fbf2a59b18ff8cf07f6d6c66fd0834ad

In use by playground: https://github.com/wix/react-native-navigation/blob/v2/playground/src/screens/ModalScreen.js#L15