### PR TITLE
[V2] added passProps in component in OptionsTopBarButton interface

### DIFF
--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -234,6 +234,7 @@ export interface OptionsTopBarButton {
    */
   component?: {
     name: string;
+    passProps?: object;
   };
   /**
    * Set the button text


### PR DESCRIPTION
Hi,
passProps is working good on rightButtons or leftButtons, but in typescript throw error that passProps does not exist on rightButtons or leftButtons in **custom component**.
example: 
```
 Navigation.mergeOptions(this.props.componentId, {
            topBar: {
                rightButtons: [
                    {
                        id: "sendCommentBtn",
                        component: {
                            name: Screens.PostButton,
                            passProps: {
                                onPress: () => this._sendComment(),
                                isLoading: this.state.isLoading,
                            },
                        },
                    },
                ],
            },
        });
```
the **onPress** works perfect if you ignore typescript error. 
this pull request remove the error.