### PR TITLE
[V2] Fix disableIconTint not being respected on iOS

### DIFF
--- a/lib/ios/RNNNavigationButtons.m
+++ b/lib/ios/RNNNavigationButtons.m
@@ -114,7 +114,12 @@
 	
 	if (color) {
 		[textAttributes setObject:color forKey:NSForegroundColorAttributeName];
-		[barButtonItem setImage:[[iconImage withTintColor:color] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal]];
+		bool disableIconTint = [RCTConvert BOOL:dictionary[@"disableIconTint"]];
+		
+		if (disableIconTint == false) {
+			iconImage = [iconImage withTintColor:color];
+		}
+		[barButtonItem setImage:[iconImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal]];
 	}
 	
 	NSNumber* fontSize = [self fontSize:dictionary[@"fontSize"] defaultFontSize:[defaultStyle.fontSize getWithDefaultValue:nil]];


### PR DESCRIPTION
Setting `disableIconTint: true` on a nav bar button is not being respected on iOS – this PR should fix it. Thanks very much!