### PR TITLE
Document default left/right button colours

### DIFF
--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -101,7 +101,9 @@ Navigation.mergeOptions(this.props.componentId, {
       component: {
         name: 'example.CustomTopBarBackground'
       }
-    }
+    },
+    rightButtonColor: '#ffffff',
+    leftButtonColor: '#ff00ff',
   },
   bottomTabs: {
     visible: true,


### PR DESCRIPTION
I noticed these properties in (eg) https://github.com/wix/react-native-navigation/blob/b0c8113243de2043b98442dd485c04b0422aa213/lib/android/app/src/main/java/com/reactnativenavigation/parse/TopBarOptions.java#L48 – they don't seem to be documented so I've added them.