### PR TITLE
Android: Use proper key for bottom tab height

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
@@ -53,7 +53,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
         ReactApplicationContext ctx = getReactApplicationContext();
         WritableMap constants = Arguments.createMap();
         constants.putString(Constants.BACK_BUTTON_JS_KEY,    Constants.BACK_BUTTON_ID);
-        constants.putDouble(Constants.TOP_BAR_HEIGHT_KEY,    Constants.BOTTOM_TABS_HEIGHT);
+        constants.putDouble(Constants.BOTTOM_TABS_HEIGHT_KEY,    Constants.BOTTOM_TABS_HEIGHT);
         constants.putDouble(Constants.STATUS_BAR_HEIGHT_KEY, UiUtils.pxToDp(ctx, UiUtils.getStatusBarHeight(ctx)));
         constants.putDouble(Constants.TOP_BAR_HEIGHT_KEY,    UiUtils.pxToDp(ctx, UiUtils.getTopBarHeight(ctx)));
         promise.resolve(constants);


### PR DESCRIPTION
Hey,

Noticed wrong key was used for Bottom tabs height, so created a quick patch for it.