### PR TITLE
Add support to pass any argument to <Provider />

### DIFF
--- a/docs/api/ComponentRegistry.md
+++ b/docs/api/ComponentRegistry.md
@@ -2,9 +2,9 @@
 
 ## registerComponent
 
-`registerComponent(componentName: string, getComponentClassFunc: ComponentProvider, ReduxProvider: any, userStore: any): ComponentType<any>`
+`registerComponent(componentName: string, getComponentClassFunc: ComponentProvider, Provider: any, providerParams: any): ComponentProvider`
 
-[source](https://github.com/wix/react-native-navigation/blob/v2/lib/src/components/ComponentRegistry.ts#L10)
+[source](https://github.com/wix/react-native-navigation/blob/v2/lib/src/components/ComponentRegistry.ts#L9)
 
 ---
 

--- a/docs/api/ComponentWrapper.md
+++ b/docs/api/ComponentWrapper.md
@@ -2,17 +2,17 @@
 
 ## wrap
 
-`wrap(componentName: string, OriginalComponentClass: React.ComponentType<any>, store: any, componentEventsObserver: any, ReduxProvider: any, reduxStore: any): React.ComponentType<any>`
+`wrap(componentName: string, OriginalComponentGenerator: ComponentProvider, store: Store, componentEventsObserver: ComponentEventsObserver, Provider: any, providerParams: any): ComponentClass<any>`
 
-[source](https://github.com/wix/react-native-navigation/blob/v2/lib/src/components/ComponentWrapper.tsx#L7)
+[source](https://github.com/wix/react-native-navigation/blob/v2/lib/src/components/ComponentWrapper.tsx#L12)
 
 ---
 
-## wrapWithRedux
+## wrapWithProvider
 
-`wrapWithRedux(WrappedComponent: any, ReduxProvider: any, reduxStore: any): React.ComponentType<any>`
+`wrapWithProvider(WrappedComponent: ComponentClass<any>, Provider: any, providerParams: any): ComponentClass<any>`
 
-[source](https://github.com/wix/react-native-navigation/blob/v2/lib/src/components/ComponentWrapper.tsx#L64)
+[source](https://github.com/wix/react-native-navigation/blob/v2/lib/src/components/ComponentWrapper.tsx#L69)
 
 ---
 

--- a/docs/api/Navigation.md
+++ b/docs/api/Navigation.md
@@ -22,14 +22,14 @@ The component itself is a traditional React component extending React.Component.
 
 ---
 
-## registerComponentWithRedux
+## registerComponentWithProvider
 
-`registerComponentWithRedux(componentName: string, getComponentClassFunc: ComponentProvider, ReduxProvider: any, reduxStore: any): ComponentType<any>`
+`registerComponentWithProvider(componentName: string, getComponentClassFunc: ComponentProvider, ReduxProvider: any, providerParams: any): ComponentProvider`
 
-[source](https://github.com/wix/react-native-navigation/blob/v2/lib/src/Navigation.ts#L60)
+[source](https://github.com/wix/react-native-navigation/blob/v2/lib/src/Navigation.ts#L67)
 
 Utility helper function like registerComponent,
-wraps the provided component with a react-redux Provider with the passed redux store
+wraps the provided component with a react-redux Provider with the passed params for the provider
 
 ---
 

--- a/docs/docs/third-party.md
+++ b/docs/docs/third-party.md
@@ -2,10 +2,10 @@
 
 ## Redux
 
-### registerComponentWithRedux(screenID, generator, Provider, store)
+### wrapWithProvider(screenID, generator, Provider, providerParams)
 Utility helper function like registerComponent,
-wraps the provided component with a react-redux Provider with the passed redux store
+wraps the provided component with a react-redux Provider or any other type of provider with the passed params for the provider.
 
 ```js
-Navigation.registerComponentWithRedux('navigation.playground.WelcomeScreen', () => WelcomeScreen, Provider, store);
+Navigation.wrapWithProvider('navigation.playground.WelcomeScreen', () => WelcomeScreen, Provider, {store: store});
 ```

--- a/lib/src/Navigation.ts
+++ b/lib/src/Navigation.ts
@@ -63,15 +63,15 @@ export class Navigation {
 
   /**
    * Utility helper function like registerComponent,
-   * wraps the provided component with a react-redux Provider with the passed redux store
+   * wraps the provided component with a react-redux Provider with the passed params for the provider
    */
-  public registerComponentWithRedux(
+  public registerComponentWithProvider(
     componentName: string | number,
     getComponentClassFunc: ComponentProvider,
     ReduxProvider: any,
-    reduxStore: any
+    providerParams: any
   ): ComponentProvider {
-    return this.componentRegistry.registerComponent(componentName, getComponentClassFunc, ReduxProvider, reduxStore);
+    return this.componentRegistry.registerComponent(componentName, getComponentClassFunc, ReduxProvider, providerParams);
   }
 
   /**

--- a/lib/src/components/ComponentRegistry.ts
+++ b/lib/src/components/ComponentRegistry.ts
@@ -6,9 +6,9 @@ import { ComponentEventsObserver } from '../events/ComponentEventsObserver';
 export class ComponentRegistry {
   constructor(private readonly store: Store, private readonly componentEventsObserver: ComponentEventsObserver, private readonly ComponentWrapperClass: typeof ComponentWrapper) { }
 
-  registerComponent(componentName: string | number, getComponentClassFunc: ComponentProvider, ReduxProvider?: any, reduxStore?: any): ComponentProvider {
+  registerComponent(componentName: string | number, getComponentClassFunc: ComponentProvider, Provider?: any, providerParams?: any): ComponentProvider {
     const NavigationComponent = () => {
-      return this.ComponentWrapperClass.wrap(componentName.toString(), getComponentClassFunc, this.store, this.componentEventsObserver, ReduxProvider, reduxStore)
+      return this.ComponentWrapperClass.wrap(componentName.toString(), getComponentClassFunc, this.store, this.componentEventsObserver, Provider, providerParams)
     };
     this.store.setComponentClassForName(componentName.toString(), NavigationComponent);
     AppRegistry.registerComponent(componentName.toString(), NavigationComponent);

--- a/lib/src/components/ComponentWrapper.test.tsx
+++ b/lib/src/components/ComponentWrapper.test.tsx
@@ -162,7 +162,7 @@ describe('ComponentWrapper', () => {
     const reduxStore = require('redux').createStore((state = initialState) => state);
 
     it(`wraps the component with a react-redux provider with passed store`, () => {
-      const NavigationComponent = ComponentWrapper.wrap(componentName, () => ConnectedComp, store, componentEventsObserver, ReduxProvider, reduxStore);
+      const NavigationComponent = ComponentWrapper.wrap(componentName, () => ConnectedComp, store, componentEventsObserver, ReduxProvider, {store: reduxStore});
       const tree = renderer.create(<NavigationComponent componentId={'theCompId'} />);
       expect(tree.toJSON()!.children).toEqual(['it just works']);
       expect((NavigationComponent as any).options).toEqual({ foo: 123 });

--- a/lib/src/components/ComponentWrapper.tsx
+++ b/lib/src/components/ComponentWrapper.tsx
@@ -14,8 +14,8 @@ export class ComponentWrapper {
     OriginalComponentGenerator: ComponentProvider,
     store: Store,
     componentEventsObserver: ComponentEventsObserver,
-    ReduxProvider?: any,
-    reduxStore?: any
+    Provider?: any,
+    providerParams?: any
   ): React.ComponentClass<any> {
     const GeneratedComponentClass = OriginalComponentGenerator();
     class WrappedComponent extends React.Component<HocProps, HocState> {
@@ -59,25 +59,25 @@ export class ComponentWrapper {
     ReactLifecyclesCompat.polyfill(WrappedComponent);
     require('hoist-non-react-statics')(WrappedComponent, GeneratedComponentClass);
 
-    if (reduxStore && ReduxProvider) {
-      return ComponentWrapper.wrapWithRedux(WrappedComponent, ReduxProvider, reduxStore);
+    if (Provider) {
+      return ComponentWrapper.wrapWithProvider(WrappedComponent, Provider, providerParams);
     } else {
       return WrappedComponent;
     }
   }
 
-  static wrapWithRedux(WrappedComponent: React.ComponentClass<any>, ReduxProvider: any, reduxStore: any): React.ComponentClass<any> {
-    const providerProps = reduxStore.dispatch ? {store: reduxStore} : reduxStore
-    class ReduxWrapper extends React.Component<any, any> {
-      render() {
+  static wrapWithProvider(WrappedComponent: React.ComponentClass<any>, Provider: any, providerParams: {}): React.ComponentClass<any> {
+    class ProviderWrapper extends React.Component<any, any> {
+      render () {
         return (
-          <ReduxProvider {...providerProps}>
+          <Provider {...providerParams}>
             <WrappedComponent {...this.props} />
-          </ReduxProvider>
+          </Provider>
         );
       }
     }
-    require('hoist-non-react-statics')(ReduxWrapper, WrappedComponent);
-    return ReduxWrapper;
+
+    require('hoist-non-react-statics')(ProviderWrapper, WrappedComponent);
+    return ProviderWrapper;
   }
 }

--- a/lib/src/components/ComponentWrapper.tsx
+++ b/lib/src/components/ComponentWrapper.tsx
@@ -67,10 +67,11 @@ export class ComponentWrapper {
   }
 
   static wrapWithRedux(WrappedComponent: React.ComponentClass<any>, ReduxProvider: any, reduxStore: any): React.ComponentClass<any> {
+    const providerProps = reduxStore.dispatch ? {store: reduxStore} : reduxStore
     class ReduxWrapper extends React.Component<any, any> {
       render() {
         return (
-          <ReduxProvider store={reduxStore}>
+          <ReduxProvider {...providerProps}>
             <WrappedComponent {...this.props} />
           </ReduxProvider>
         );


### PR DESCRIPTION
I would like to suggest this change for `registerComponentWithRedux` method. For the last argument to accept a set of props that can be passed to `<Provider />`. This is backward compatible, but additionally, it would enable new use cases:

1. Using [unstated](https://github.com/jamiebuilds/unstated) instead of `redux`:

```js
import { Provider, Subscribe, Container } from 'unstated'

class Counter extends Container {
// ...
// <as per https://github.com/jamiebuilds/unstated#example>
// ...
}

Navigation.registerComponentWithRedux('screen.Home', () => HomeScreen, Provider, {inject: [counter]})
```


2. Enable `persistor` for redux


```js
import 'redux-persist'

const persistor = ...

Navigation.registerComponentWithRedux('screen.Home', () => HomeScreen, Provider, {store: store, persistor: persistor})
```