### PR TITLE
[ios][v2] SplashScreen: Support LaunchScreen.xib with navigation controllers

### DIFF
--- a/lib/ios/RNNSplashScreen.m
+++ b/lib/ios/RNNSplashScreen.m
@@ -21,12 +21,19 @@
 		}
 		@catch(NSException *e)
 		{
-			UIView *splashView = [[NSBundle mainBundle] loadNibNamed:launchStoryBoard owner:self options:nil][0];
-			if (splashView != nil)
-			{
-				splashView.frame = CGRectMake(0, 0, screenBounds.size.width, screenBounds.size.height);
-				viewController = [[RNNSplashScreen alloc] init];
-				viewController.view = splashView;
+			id splash = [[NSBundle mainBundle] loadNibNamed:launchStoryBoard owner:self options:nil][0];
+			
+			if (splash != nil) {
+				if ([splash isKindOfClass:UIView.class]) {
+					UIView *splashView = (UIView*)splashView;
+					splashView.frame = CGRectMake(0, 0, screenBounds.size.width, screenBounds.size.height);
+					viewController = [[RNNSplashScreen alloc] init];
+					viewController.view = splashView;
+				}
+				if ([splash isKindOfClass:UINavigationController.class]) {
+					UINavigationController *splashNavController = (UINavigationController*)splash;
+					viewController = splashNavController.topViewController;
+				}
 			}
 		}
 	}

--- a/lib/ios/RNNSplashScreen.m
+++ b/lib/ios/RNNSplashScreen.m
@@ -32,7 +32,7 @@
 				}
 				if ([splash isKindOfClass:UINavigationController.class]) {
 					UINavigationController *splashNavController = (UINavigationController*)splash;
-					viewController = splashNavController.topViewController;
+					viewController = splashNavController;
 				}
 			}
 		}


### PR DESCRIPTION
Useful when you want to mimic your real app screen and for some reason don't want to use Storyboards

![image](https://user-images.githubusercontent.com/1004115/48786015-f3ba8f80-ecf6-11e8-9d54-b688a991e3ec.png)
