### PR TITLE
[Fix typescript] Add title alignment to OptionsTopBarTitle

### DIFF
--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -235,7 +235,8 @@ Navigation.mergeOptions(this.props.componentId, {
     elevation: 1.5, // TopBar elevation in dp
     topMargin: 24, // top margin in dp
     title: {
-      height: 70 // TitleBar height in dp
+      height: 70, // TitleBar height in dp
+      alignment: 'center', // Center title
     }
   },
   bottomTabs: {

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -116,10 +116,6 @@ export interface OptionsTopBarTitle {
    */
   fontFamily?: FontFamily;
   /**
-   * Title alignment
-   */
-  alignment?: 'center'
-  /**
    * Custom component as the title view
    */
   component?: {
@@ -145,6 +141,11 @@ export interface OptionsTopBarTitle {
    * #### (Android specific)
    */
   height?: number;
+  /**
+   * Title alignment
+   * #### (Android specific)
+   */
+  alignment?: 'center';
 }
 
 export interface OptionsTopBarSubtitle {

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -116,6 +116,10 @@ export interface OptionsTopBarTitle {
    */
   fontFamily?: FontFamily;
   /**
+   * Title alignment
+   */
+  alignment?: 'center'
+  /**
    * Custom component as the title view
    */
   component?: {

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -145,7 +145,7 @@ export interface OptionsTopBarTitle {
    * Title alignment
    * #### (Android specific)
    */
-  alignment?: 'center';
+  alignment?: 'center' | 'fill';
 }
 
 export interface OptionsTopBarSubtitle {


### PR DESCRIPTION
Title alignment works on Android; however, the OptionsTopBarTitle interface (in Options.ts) is missing the optional alignment field preventing us to use that option.
```
    topBar: {
      title: {
        alignment: "center"
      }
    },
```