### PR TITLE
Clean up last 'enable' properties

### DIFF
--- a/docs/docs/screen-api.md
+++ b/docs/docs/screen-api.md
@@ -62,7 +62,7 @@ Navigation.setStackRoot(this.props.componentId, {
         options: {
           animations: {
             setStackRoot: {
-              enable: true
+              enabled: true
             }
           }
         }

--- a/playground/src/screens/PushedScreen.js
+++ b/playground/src/screens/PushedScreen.js
@@ -111,7 +111,7 @@ class PushedScreen extends Component {
           },
           animations: {
             push: {
-              enable: false
+              enabled: false
             }
           },
           preview: {
@@ -178,7 +178,7 @@ class PushedScreen extends Component {
         options: {
           animations: {
             setStackRoot: {
-              enable: false
+              enabled: false
             }
           },
           topBar: {

--- a/playground/src/screens/WelcomeScreen.js
+++ b/playground/src/screens/WelcomeScreen.js
@@ -359,7 +359,7 @@ class WelcomeScreen extends Component {
         options: {
           animations: {
             push: {
-              enable: false
+              enabled: false
             }
           },
           preview: reactTag ? {
@@ -391,7 +391,7 @@ class WelcomeScreen extends Component {
         options: {
           animations: {
             push: {
-              enable: false
+              enabled: false
             }
           }
         }


### PR DESCRIPTION
Seems like there are still some leftover 'enable' properties that should be 'enabled'.
While Android allows both 'enable' and 'enabled', it seems iOS does not and it's causing some minimal confusion.