### PR TITLE
[V2] Add props to TopBarButton type

### DIFF
--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -239,6 +239,10 @@ export interface OptionsTopBarButton {
    */
   component?: {
     name: string;
+    /**
+     * Properties to pass down to the component
+     */
+    passProps?: object;
   };
   /**
    * Set the button text


### PR DESCRIPTION
Based on my investigation, it looks like props can be passed to top bar buttons. If so, we should expose that in the types.

I modeled this off of other top bar options, but should this actually just be `LayoutComponent`?