### PR TITLE
Initialize and pass mainWindow to commandsHandler

### DIFF
--- a/lib/ios/RNNBridgeManager.h
+++ b/lib/ios/RNNBridgeManager.h
@@ -7,7 +7,7 @@ typedef UIViewController * (^RNNExternalViewCreator)(NSDictionary* props, RCTBri
 
 @interface RNNBridgeManager : NSObject <RCTBridgeDelegate>
 
-- (instancetype)initWithJsCodeLocation:(NSURL *)jsCodeLocation launchOptions:(NSDictionary *)launchOptions bridgeManagerDelegate:(id<RNNBridgeManagerDelegate>)delegate;
+- (instancetype)initWithJsCodeLocation:(NSURL *)jsCodeLocation launchOptions:(NSDictionary *)launchOptions bridgeManagerDelegate:(id<RNNBridgeManagerDelegate>)delegate mainWindow:(UIWindow *)mainWindow;
 
 - (void)registerExternalComponent:(NSString *)name callback:(RNNExternalViewCreator)callback;
 

--- a/lib/ios/RNNBridgeManager.m
+++ b/lib/ios/RNNBridgeManager.m
@@ -30,13 +30,14 @@
 
 - (instancetype)initWithJsCodeLocation:(NSURL *)jsCodeLocation launchOptions:(NSDictionary *)launchOptions bridgeManagerDelegate:(id<RNNBridgeManagerDelegate>)delegate mainWindow:(UIWindow *)mainWindow {
 	if (self = [super init]) {
+		_mainWindow = mainWindow;
 		_jsCodeLocation = jsCodeLocation;
 		_launchOptions = launchOptions;
 		_delegate = delegate;
 		
 		_store = [RNNStore new];
 		_bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:_launchOptions];
-		_mainWindow = mainWindow;
+		
 		
 		[[NSNotificationCenter defaultCenter] addObserver:self
 												 selector:@selector(onJavaScriptLoaded)

--- a/lib/ios/RNNBridgeManager.m
+++ b/lib/ios/RNNBridgeManager.m
@@ -21,13 +21,14 @@
 	NSDictionary* _launchOptions;
 	id<RNNBridgeManagerDelegate> _delegate;
 	RCTBridge* _bridge;
-
+	UIWindow* _mainWindow;
+	
 	RNNStore* _store;
 
 	RNNCommandsHandler* _commandsHandler;
 }
 
-- (instancetype)initWithJsCodeLocation:(NSURL *)jsCodeLocation launchOptions:(NSDictionary *)launchOptions bridgeManagerDelegate:(id<RNNBridgeManagerDelegate>)delegate {
+- (instancetype)initWithJsCodeLocation:(NSURL *)jsCodeLocation launchOptions:(NSDictionary *)launchOptions bridgeManagerDelegate:(id<RNNBridgeManagerDelegate>)delegate mainWindow:(UIWindow *)mainWindow {
 	if (self = [super init]) {
 		_jsCodeLocation = jsCodeLocation;
 		_launchOptions = launchOptions;
@@ -35,7 +36,8 @@
 		
 		_store = [RNNStore new];
 		_bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:_launchOptions];
-
+		_mainWindow = mainWindow;
+		
 		[[NSNotificationCenter defaultCenter] addObserver:self
 												 selector:@selector(onJavaScriptLoaded)
 													 name:RCTJavaScriptDidLoadNotification
@@ -76,7 +78,7 @@
 	id<RNNRootViewCreator> rootViewCreator = [[RNNReactRootViewCreator alloc] initWithBridge:bridge];
 	RNNControllerFactory *controllerFactory = [[RNNControllerFactory alloc] initWithRootViewCreator:rootViewCreator eventEmitter:eventEmitter andBridge:bridge];
 	
-	_commandsHandler = [[RNNCommandsHandler alloc] initWithStore:_store controllerFactory:controllerFactory eventEmitter:eventEmitter stackManager:[RNNNavigationStackManager new] modalManager:[RNNModalManager new] overlayManager:[RNNOverlayManager new] sharedApplication:[UIApplication sharedApplication]];
+	_commandsHandler = [[RNNCommandsHandler alloc] initWithStore:_store controllerFactory:controllerFactory eventEmitter:eventEmitter stackManager:[RNNNavigationStackManager new] modalManager:[RNNModalManager new] overlayManager:[RNNOverlayManager new] mainWindow:_mainWindow];
 	RNNBridgeModule *bridgeModule = [[RNNBridgeModule alloc] initWithCommandsHandler:_commandsHandler];
 
 	return [@[bridgeModule,eventEmitter] arrayByAddingObjectsFromArray:[self extraModulesFromDelegate]];

--- a/lib/ios/RNNCommandsHandler.h
+++ b/lib/ios/RNNCommandsHandler.h
@@ -9,7 +9,7 @@
 
 @interface RNNCommandsHandler : NSObject
 
-- (instancetype)initWithStore:(RNNStore*)store controllerFactory:(RNNControllerFactory*)controllerFactory eventEmitter:(RNNEventEmitter *)eventEmitter stackManager:(RNNNavigationStackManager *)stackManager modalManager:(RNNModalManager *)modalManager overlayManager:(RNNOverlayManager *)overlayManager sharedApplication:(UIApplication *)sharedApplication;
+- (instancetype)initWithStore:(RNNStore*)store controllerFactory:(RNNControllerFactory*)controllerFactory eventEmitter:(RNNEventEmitter *)eventEmitter stackManager:(RNNNavigationStackManager *)stackManager modalManager:(RNNModalManager *)modalManager overlayManager:(RNNOverlayManager *)overlayManager mainWindow:(UIWindow *)mainWindow;
 
 - (void)setRoot:(NSDictionary*)layout completion:(RNNTransitionCompletionBlock)completion;
 

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -34,11 +34,10 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	RNNOverlayManager* _overlayManager;
 	RNNNavigationStackManager* _stackManager;
 	RNNEventEmitter* _eventEmitter;
-	UIApplication* _sharedApplication;
 	UIWindow* _mainWindow;
 }
 
-- (instancetype)initWithStore:(RNNStore*)store controllerFactory:(RNNControllerFactory*)controllerFactory eventEmitter:(RNNEventEmitter *)eventEmitter stackManager:(RNNNavigationStackManager *)stackManager modalManager:(RNNModalManager *)modalManager overlayManager:(RNNOverlayManager *)overlayManager sharedApplication:(UIApplication *)sharedApplication {
+- (instancetype)initWithStore:(RNNStore*)store controllerFactory:(RNNControllerFactory*)controllerFactory eventEmitter:(RNNEventEmitter *)eventEmitter stackManager:(RNNNavigationStackManager *)stackManager modalManager:(RNNModalManager *)modalManager overlayManager:(RNNOverlayManager *)overlayManager mainWindow:(UIWindow *)mainWindow {
 	self = [super init];
 	_store = store;
 	_controllerFactory = controllerFactory;
@@ -47,7 +46,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	_modalManager.delegate = self;
 	_stackManager = stackManager;
 	_overlayManager = overlayManager;
-	_sharedApplication = sharedApplication;
+	_mainWindow = mainWindow;
 	return self;
 }
 
@@ -55,10 +54,6 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 
 - (void)setRoot:(NSDictionary*)layout completion:(RNNTransitionCompletionBlock)completion {
 	[self assertReady];
-	
-	if (!_mainWindow) {
-		_mainWindow = _sharedApplication.keyWindow;
-	}
 	
 	[_modalManager dismissAllModalsAnimated:NO];
 	[_store removeAllComponentsFromWindow:_mainWindow];

--- a/lib/ios/RNNSplashScreen.h
+++ b/lib/ios/RNNSplashScreen.h
@@ -3,6 +3,6 @@
 
 @interface RNNSplashScreen : UIViewController
 
-+(void)show;
++(void)showOnWindow:(UIWindow *)window;
 
 @end

--- a/lib/ios/RNNSplashScreen.m
+++ b/lib/ios/RNNSplashScreen.m
@@ -5,9 +5,6 @@
 @implementation RNNSplashScreen
 
 + (void)showOnWindow:(UIWindow *)window {
-	
-	UIApplication.sharedApplication.delegate.window = window;
-	
 	CGRect screenBounds = [UIScreen mainScreen].bounds;
 	UIViewController *viewController = nil;
 	

--- a/lib/ios/RNNSplashScreen.m
+++ b/lib/ios/RNNSplashScreen.m
@@ -4,10 +4,9 @@
 
 @implementation RNNSplashScreen
 
-+(void)show {
++ (void)showOnWindow:(UIWindow *)window {
 	
-	UIApplication.sharedApplication.delegate.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-	UIApplication.sharedApplication.delegate.window.backgroundColor = [UIColor whiteColor];
+	UIApplication.sharedApplication.delegate.window = window;
 	
 	CGRect screenBounds = [UIScreen mainScreen].bounds;
 	UIViewController *viewController = nil;

--- a/lib/ios/ReactNativeNavigation.m
+++ b/lib/ios/ReactNativeNavigation.m
@@ -55,8 +55,11 @@
 }
 
 -(void)bootstrap:(NSURL *)jsCodeLocation launchOptions:(NSDictionary *)launchOptions bridgeManagerDelegate:(id<RNNBridgeManagerDelegate>)delegate {
-	self.bridgeManager = [[RNNBridgeManager alloc] initWithJsCodeLocation:jsCodeLocation launchOptions:launchOptions bridgeManagerDelegate:delegate];
-	[RNNSplashScreen show];
+	UIWindow* mainWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+	mainWindow.backgroundColor = [UIColor whiteColor];
+	
+	self.bridgeManager = [[RNNBridgeManager alloc] initWithJsCodeLocation:jsCodeLocation launchOptions:launchOptions bridgeManagerDelegate:delegate mainWindow:mainWindow];
+	[RNNSplashScreen showOnWindow:mainWindow];
 }
 
 @end

--- a/lib/ios/ReactNativeNavigation.m
+++ b/lib/ios/ReactNativeNavigation.m
@@ -55,11 +55,18 @@
 }
 
 -(void)bootstrap:(NSURL *)jsCodeLocation launchOptions:(NSDictionary *)launchOptions bridgeManagerDelegate:(id<RNNBridgeManagerDelegate>)delegate {
-	UIWindow* mainWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-	mainWindow.backgroundColor = [UIColor whiteColor];
+	UIWindow* mainWindow = [self initializeKeyWindow];
 	
 	self.bridgeManager = [[RNNBridgeManager alloc] initWithJsCodeLocation:jsCodeLocation launchOptions:launchOptions bridgeManagerDelegate:delegate mainWindow:mainWindow];
 	[RNNSplashScreen showOnWindow:mainWindow];
+}
+
+- (UIWindow *)initializeKeyWindow {
+	UIWindow* keyWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+	keyWindow.backgroundColor = [UIColor whiteColor];
+	UIApplication.sharedApplication.delegate.window = keyWindow;
+	
+	return keyWindow;
 }
 
 @end

--- a/lib/ios/ReactNativeNavigationTests/RNNCommandsHandlerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNCommandsHandlerTest.m
@@ -58,13 +58,12 @@
 
 - (void)setUp {
 	[super setUp];
-	self.sharedApplication = [OCMockObject mockForClass:[UIApplication class]];
 	self.mainWindow = [OCMockObject partialMockForObject:[UIWindow new]];
 	self.store = [OCMockObject partialMockForObject:[[RNNStore alloc] init]];
 	self.eventEmmiter = [OCMockObject partialMockForObject:[RNNEventEmitter new]];
 	self.overlayManager = [OCMockObject partialMockForObject:[RNNOverlayManager new]];
 	self.controllerFactory = [OCMockObject partialMockForObject:[[RNNControllerFactory alloc] initWithRootViewCreator:nil eventEmitter:self.eventEmmiter andBridge:nil]];
-	self.uut = [[RNNCommandsHandler alloc] initWithStore:self.store controllerFactory:self.controllerFactory eventEmitter:self.eventEmmiter stackManager:[RNNNavigationStackManager new] modalManager:[RNNModalManager new] overlayManager:self.overlayManager sharedApplication:_sharedApplication];
+	self.uut = [[RNNCommandsHandler alloc] initWithStore:self.store controllerFactory:self.controllerFactory eventEmitter:self.eventEmmiter stackManager:[RNNNavigationStackManager new] modalManager:[RNNModalManager new] overlayManager:self.overlayManager mainWindow:_mainWindow];
 	self.vc1 = [RNNRootViewController new];
 	self.vc2 = [RNNRootViewController new];
 	self.vc3 = [RNNRootViewController new];
@@ -92,7 +91,7 @@
 -(NSArray*) getPublicMethodNamesForObject:(NSObject*)obj{
 	NSMutableArray* skipMethods = [NSMutableArray new];
 	
-	[skipMethods addObject:@"initWithStore:controllerFactory:eventEmitter:stackManager:modalManager:overlayManager:sharedApplication:"];
+	[skipMethods addObject:@"initWithStore:controllerFactory:eventEmitter:stackManager:modalManager:overlayManager:mainWindow:"];
 	[skipMethods addObject:@"assertReady"];
 	[skipMethods addObject:@"removePopedViewControllers:"];
 	[skipMethods addObject:@".cxx_destruct"];


### PR DESCRIPTION
Change the way main window application is created in order to initialize commandsHandler with this window instance in order to avoid inconsistency in overlays window management and separate between those two components.