### PR TITLE
Fix name collision so auto import works correctly

### DIFF
--- a/lib/src/Navigation.ts
+++ b/lib/src/Navigation.ts
@@ -17,7 +17,7 @@ import { LayoutRoot, Layout } from './interfaces/Layout';
 import { Options } from './interfaces/Options';
 import { ComponentWrapper } from './components/ComponentWrapper';
 
-export class Navigation {
+export class NavigationRoot {
   public readonly Element: React.ComponentType<{ elementId: any; resizeMode?: any; }>;
   public readonly TouchablePreview: React.ComponentType<any>;
   public readonly store: Store;

--- a/lib/src/components/Store.ts
+++ b/lib/src/components/Store.ts
@@ -12,7 +12,6 @@ export class Store {
     return _.get(this.propsById, componentId, {});
   }
 
-
   setComponentClassForName(componentName: string | number, ComponentClass) {
     _.set(this.componentsByName, componentName.toString(), ComponentClass);
   }
@@ -20,7 +19,7 @@ export class Store {
   getComponentClassForName(componentName: string | number) {
     return _.get(this.componentsByName, componentName.toString());
   }
-  
+
   cleanId(id: string) {
     _.unset(this.propsById, id);
   }

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,8 +1,8 @@
-import { Navigation as NavigationClass } from './Navigation';
+import { NavigationRoot } from './Navigation';
 
-const singleton = new NavigationClass();
+const navigationSingleton = new NavigationRoot();
 
-export const Navigation = singleton;
+export const Navigation = navigationSingleton;
 export * from './adapters/Constants';
 export * from './interfaces/ComponentEvents';
 export * from './interfaces/Events';


### PR DESCRIPTION
Before this PR if I wrote `Navigation` to my code and pressed `ctrl` + `space` I will get suggested place to auto import `Navigation`

But as you can see from the picture it is suggesting import from wrong place
![image](https://user-images.githubusercontent.com/12229968/49648850-04297480-fa30-11e8-9253-6e697d40541b.png)

With this PR the import will come from right place when using auto import
![image](https://user-images.githubusercontent.com/12229968/49648888-26bb8d80-fa30-11e8-8d5f-f7c650dcd4a7.png)


The reason for wrong place was that two files were exporting `Navigation` so auto complete was confused. Tell me what you guys think @yogevbd @guyca :)