### PR TITLE
[v2][iOS] Fixes #4193 - Custom animations for Navigation.push not working

### DIFF
--- a/lib/ios/RNNOptions.m
+++ b/lib/ios/RNNOptions.m
@@ -13,6 +13,10 @@
 	for (id prop in [self objectProperties:otherOptions]) {
 		id value = [otherOptions valueForKey:prop];
 		if ([value isKindOfClass:[RNNOptions class]]) {
+            if( [self valueForKey:prop] == nil ) {
+                RNNOptions* propOptions = [[[value class] alloc] initWithDict:@{}];
+                [self setValue:propOptions forKey:prop];
+            }
 			[[self valueForKey:prop] mergeOptions:value overrideOptions:override];
 		} else if ([value isKindOfClass:[Param class]]) {
 			if ((((Param *)value).hasValue) && (override || !((Param *)[self valueForKey:prop]).hasValue)) {


### PR DESCRIPTION
Fixes animation options for "topBar", "bottomTabs", "content" when using Navigation.push with:
```
options: {
  animations: {
    push: {
      ...
    }
  }
}
```

As commented before, https://github.com/wix/react-native-navigation/issues/4193#issuecomment-435428683, the animation properties have to be set using:
```
content: {
  startAlpha: 0,
  endAlpha: 1,
  duration: 3,
  interpolation: "accelerate"
}
```
and NOT the documented attributes of:
```
content: {
  alpha: {
    from: 0,
    to: 1,
    duration: 3000,
    interpolation: "accelerate"
  }
}
```