### PR TITLE
Fix setStackRoot crash

### DIFF
--- a/lib/ios/RNNNavigationStackManager.m
+++ b/lib/ios/RNNNavigationStackManager.m
@@ -67,7 +67,7 @@ typedef void (^RNNAnimationBlock)(void);
 	NSArray *newViewControllers = [[newRoot navigationController] viewControllers];
 	
 	[self performAnimationBlock:^{
-		[nvc setViewControllers:newViewControllers animated:animated];
+		[nvc setViewControllers:newViewControllers ? newViewControllers : @[newRoot] animated:animated];
 	} completion:completion];
 }
 

--- a/lib/ios/RNNNavigationStackManager.m
+++ b/lib/ios/RNNNavigationStackManager.m
@@ -67,7 +67,7 @@ typedef void (^RNNAnimationBlock)(void);
 	NSArray *newViewControllers = [[newRoot navigationController] viewControllers];
 	
 	[self performAnimationBlock:^{
-		[nvc setViewControllers:newViewControllers ? newViewControllers : @[newRoot] animated:animated];
+		[nvc setViewControllers:newViewControllers ?: @[newRoot] animated:animated];
 	} completion:completion];
 }
 

--- a/lib/ios/RNNNavigationStackManager.m
+++ b/lib/ios/RNNNavigationStackManager.m
@@ -64,9 +64,10 @@ typedef void (^RNNAnimationBlock)(void);
 
 - (void)setStackRoot:(UIViewController *)newRoot fromViewController:(UIViewController *)fromViewController animated:(BOOL)animated completion:(RNNTransitionCompletionBlock)completion rejection:(RNNTransitionRejectionBlock)rejection {
 	UINavigationController* nvc = fromViewController.navigationController;
+	NSArray *newViewControllers = [[newRoot navigationController] viewControllers];
 	
 	[self performAnimationBlock:^{
-		[nvc setViewControllers:@[newRoot] animated:animated];
+		[nvc setViewControllers:newViewControllers animated:animated];
 	} completion:completion];
 }
 

--- a/lib/ios/ReactNativeNavigationTests/RNNNavigationStackManagerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNNavigationStackManagerTest.m
@@ -66,8 +66,8 @@
 - (void)testStackRoot_shouldUpdateNavigationControllerChildrenViewControllers {
 	XCTestExpectation *expectation = [self expectationWithDescription:@"Testing Async Method"];
 	[_stackManager setStackRoot:self.vc2 fromViewController:self.vc1 animated:NO completion:^{
-		XCTAssertTrue(self.nvc.childViewControllers.count == 1);
-		XCTAssertTrue([self.nvc.topViewController isEqual:self.vc2]);
+		XCTAssertTrue(self.nvc.childViewControllers.count == 3);
+		XCTAssertTrue([self.nvc.topViewController isEqual:self.vc3]);
 		[expectation fulfill];
 	} rejection:nil];
 


### PR DESCRIPTION
Related issue: https://github.com/wix/react-native-navigation/issues/3592

## Background for this issue
Lets say I have two simple tabs where home tab is just plain component and items tab is stack:

```ts
Navigation.setRoot({
  root: {
    bottomTabs: {
      children: [
        {
          component: {
            name: 'home',
            options: {
              bottomTab: {
                text: 'Home',
                icon: require('./home.png'),
              },
            },
          },
        },
        {
          stack: {
            children: [
              {
                component: {
                  name: 'items',
                  options: {
                    bottomTab: {
                      text: 'Items',
                      icon: require('./items.png'),
                    },
                  },
                },
              },
            ],
          },
        },
      ],
    },
  },
});
```

The items component has list of items that can be tapped. When you tap an item is will push individual item to the stack. So far so good.

Now lets assume we have the current situation

![image](https://user-images.githubusercontent.com/12229968/49811548-2f7fcc80-fd6c-11e8-80ca-947f5c410233.png)


So the individual item component is visible. But now we could have for example notification on top of individual item view which when tapped will replace the whole items stack. Here is picture of what I mean

![image](https://user-images.githubusercontent.com/12229968/49811801-addc6e80-fd6c-11e8-8ca3-a5c282ba3a7d.png)


So basically according to Wix docs looks like `setStackRoot` should do the job: https://wix.github.io/react-native-navigation/#/docs/screen-api?id=setstackrootcomponentid-params

But when I used `setStackRoot` like this

```ts
Navigation.setStackRoot(this.props.componentId, {
  stack: {
    children: [
      {
        component: {
          name: 'home',
          options: {
            bottomTab: {
              text: 'Home',
              icon: require('./home.png'),
            },
          },
        },
      },
      {
        stack: {
          children: [
            {
              component: {
                name: 'items',
                options: {
                  bottomTab: {
                    text: 'Items',
                    icon: require('./items.png'),
                  },
                },
              },
            },
          ],
        },
      },
    ],
  },
});
```

It caused a crash

![image](https://user-images.githubusercontent.com/12229968/49811979-0d3a7e80-fd6d-11e8-9756-217ec2b95b6a.png)

Same crash is at: https://github.com/wix/react-native-navigation/issues/3592

## Solution

According to my testing the root cause is that when using `setStackRoot` we should not nest new `UINavigationController`s but replace the  `ViewController`s. At least in my project this works just fine 👌 So please if you know other scenarios where `setStackRoot` should be tested with this :)

