### PR TITLE
Include missing backButton prop for android

### DIFF
--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -230,6 +230,9 @@ Navigation.mergeOptions(this.props.componentId, {
   },
   topBar: {
     height: 70, // TopBar height in dp
+    backButton: {
+      color: 'red'
+    },
     borderColor: 'red',
     borderHeight: 1.3,
     elevation: 1.5, // TopBar elevation in dp


### PR DESCRIPTION
the generic buttonColor doesn't work for android. Backbutton color is not documented, see [#3454](https://github.com/wix/react-native-navigation/issues/3454)