### PR TITLE
[iOS] Set selected tab if index is given

### DIFF
--- a/lib/ios/RNNTabBarController.m
+++ b/lib/ios/RNNTabBarController.m
@@ -33,7 +33,7 @@
 	[self setViewControllers:childViewControllers];
 	
 	IntNumber *currentTabIndex = [self.options valueForKeyPath:@"bottomTabs.currentTabIndex"];
-	if ([currentTabIndex valueForKey:@"value"] != nil) {
+	if ([[currentTabIndex valueForKey:@"value"] isKindOfClass:[NSNumber class]]) {
 		[self setSelectedIndex:[currentTabIndex get]];
 	}
 	

--- a/lib/ios/RNNTabBarController.m
+++ b/lib/ios/RNNTabBarController.m
@@ -32,6 +32,11 @@
 	[self.presenter bindViewController:self];
 	[self setViewControllers:childViewControllers];
 	
+	IntNumber *currentTabIndex = [self.options valueForKeyPath:@"bottomTabs.currentTabIndex"];
+	if ([currentTabIndex valueForKey:@"value"] != nil) {
+		[self setSelectedIndex:[currentTabIndex get]];
+	}
+	
 	return self;
 }
 


### PR DESCRIPTION
Fixes https://github.com/wix/react-native-navigation/issues/4426
Fixes https://github.com/wix/react-native-navigation/issues/4433

## Scenario
You have app with two bottom tabs but you want the second tab to be preselected when your app is started. To achieve this you will set root like this:
```ts
Navigation.setRoot({
  root: {
    bottomTabs: {
      options: { bottomTabs: { currentTabIndex: 1 } }, // add this
      children: [
        {
          component: {
            name: 'screen1',
            options: {
              bottomTab: {
                // stuff
              }
            },
          },
        },
        {
          component: {
            name: 'screen2',
            options: {
              bottomTab: {
                // stuff
              }
            },
          },
        },
      ],
    },
  },
});
```

## Problem
Currently when using the configuration above it will only select correct bottom on 
- Android ✅ 
- but not in iOS 🔴 

## Previous workaround
Using `mergeOptions` when first component mounts etc is possible but it will have some flashing because the screen can be already mounted before it can set the desired bottom tab.

## Solution
Now when `TabBarController` is created it checks if `options` of `bottomTabs` have any value for `currentTabIndex`. If there is some value it will set selected tab according to that! Now desired bottom tab is preselected before rendering any views on Android and iOS! 🎉 

Comments and change suggestions are welcome! <3