### PR TITLE
Initialize splashscreen viewController anyway

### DIFF
--- a/lib/ios/RNNSplashScreen.m
+++ b/lib/ios/RNNSplashScreen.m
@@ -66,11 +66,13 @@
 		}
 	}
 	
-	if (viewController != nil) {
-		id<UIApplicationDelegate> appDelegate = [UIApplication sharedApplication].delegate;
-		appDelegate.window.rootViewController = viewController;
-		[appDelegate.window makeKeyAndVisible];
+	if (viewController == nil) {
+		viewController = [[RNNSplashScreen alloc] init];
 	}
+	
+	id<UIApplicationDelegate> appDelegate = [UIApplication sharedApplication].delegate;
+	appDelegate.window.rootViewController = viewController;
+	[appDelegate.window makeKeyAndVisible];
 }
 
 @end


### PR DESCRIPTION
Resolve #4459.

We need to initialize the `viewController` and remove the `viewController != nil` condition.
If the image is not found, the window will remain invisible because of the `viewController` is not initialized and `makeKeyAndVisible` is not called.

Note this would be the right step also if the developer needs to implement the splash screen in a different way.

P.S. If this pull request is approved, I will implement a default splash screen in `viewController == nil ` section where the name of the application will be displayed.

Thanks.