### PR TITLE
Stop override tabBarItem by parent layouts

### DIFF
--- a/lib/ios/RNNNavigationController.m
+++ b/lib/ios/RNNNavigationController.m
@@ -53,10 +53,6 @@ const NSInteger TOP_BAR_TRANSPARENT_TAG = 78264803;
 	[self.options overrideOptions:options];
 }
 
-- (UITabBarItem *)tabBarItem {
-	return self.viewControllers.firstObject.tabBarItem;
-}
-
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
 	return self.getCurrentChild.supportedInterfaceOrientations;
 }

--- a/lib/ios/RNNSideMenuChildVC.m
+++ b/lib/ios/RNNSideMenuChildVC.m
@@ -52,10 +52,6 @@
 	[self.options overrideOptions:options];
 }
 
-- (UITabBarItem *)tabBarItem {
-	return self.child.tabBarItem;
-}
-
 - (void)bindChildViewController:(UIViewController<RNNLayoutProtocol>*)child {
 	self.child = child;
 	[self addChildViewController:self.child];

--- a/lib/ios/RNNSideMenuController.m
+++ b/lib/ios/RNNSideMenuController.m
@@ -42,10 +42,6 @@
 	}
 }
 
-- (UITabBarItem *)tabBarItem {
-	return self.center.tabBarItem;
-}
-
 - (void)onChildWillAppear {
 	[_presenter applyOptions:self.resolveOptions];
 	[((UIViewController<RNNParentProtocol> *)self.parentViewController) onChildWillAppear];

--- a/lib/ios/ReactNativeNavigationTests/RNNNavigationControllerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNNavigationControllerTest.m
@@ -112,10 +112,6 @@
 	XCTAssertFalse(self.uut.navigationController.navigationBar.clipsToBounds);
 }
 
-- (void)testTabBarItemShouldReturnFirstChildTabBarItem {
-	XCTAssertEqual(self.uut.tabBarItem, self.uut.childViewControllers.firstObject.tabBarItem);
-}
-
 - (void)testSupportedOrientationsShouldReturnCurrentChildSupportedOrientations {
 	XCTAssertEqual(self.uut.supportedInterfaceOrientations, self.uut.getCurrentChild.supportedInterfaceOrientations);
 }


### PR DESCRIPTION
Stop override tabBarItem by parent layouts as options are now propagated to all tree and handled by each layout presenter