### PR TITLE
Documentation website maintenance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,5 +9,5 @@ React Native Navigation provides 100% native platform navigation on both iOS and
 - [Documentation](https://wix.github.io/react-native-navigation/)
 - [Stack Overflow](http://stackoverflow.com/questions/tagged/react-native-navigation)
 - [Chat with us](https://discord.gg/DhkZjq2)
-- [Contributing](/docs/docs/WorkingLocally.md)
+- [Contributing](/docs/WorkingLocally.md)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="shortcut icon" href="_images/favicon.ico" type="image/x-icon">
   <link rel="icon" href="_images/favicon.ico" type="image/x-icon">
-  <link rel="stylesheet" href="//unpkg.com/docsify/themes/vue.css">
+  <link rel="stylesheet" href="https://unpkg.com/docsify@4.7.1/themes/vue.css">
 
   <style>
     /* diff syntax highlighting */
@@ -29,7 +29,7 @@
 
 <body>
   <div id="app">Please wait...</div>
-  <script src="//unpkg.com/docsify-copy-code"></script>
+  <script src="https://unpkg.com/docsify-copy-code@2"></script>
   <script>
     window.$docsify = {
       name: 'React Native Navigation',
@@ -45,14 +45,14 @@
       auto2top: true,
     }
   </script>
-  <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
-  <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
-  <script src="//unpkg.com/prismjs/components/prism-typescript.min.js"></script>
-  <script src="//unpkg.com/prismjs/components/prism-jsx.min.js"></script>
-  <script src="//unpkg.com/prismjs/components/prism-java.min.js"></script>
-  <script src="//unpkg.com/prismjs/components/prism-c.min.js"></script>
-  <script src="//unpkg.com/prismjs/components/prism-objectivec.min.js"></script>
-  <script src="//unpkg.com/prismjs/components/prism-diff.min.js"></script>
+  <script src="https://unpkg.com/docsify@4.7.1/lib/docsify.min.js"></script>
+  <script src="https://unpkg.com/docsify@4.7.1/lib/plugins/search.min.js"></script>
+  <script src="https://unpkg.com/prismjs/components/prism-typescript.min.js"></script>
+  <script src="https://unpkg.com/prismjs/components/prism-jsx.min.js"></script>
+  <script src="https://unpkg.com/prismjs/components/prism-java.min.js"></script>
+  <script src="https://unpkg.com/prismjs/components/prism-c.min.js"></script>
+  <script src="https://unpkg.com/prismjs/components/prism-objectivec.min.js"></script>
+  <script src="https://unpkg.com/prismjs/components/prism-diff.min.js"></script>
 
   <!-- this allows us to re-run docs even when offline -->
   <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,6 @@
   <link rel="shortcut icon" href="_images/favicon.ico" type="image/x-icon">
   <link rel="icon" href="_images/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="//unpkg.com/docsify/themes/vue.css">
-  <link rel="stylesheet" href="//unpkg.com/docsify-copy-code/styles.css">
 
   <style>
     /* diff syntax highlighting */

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,9 +44,6 @@
       },
       subMaxLevel: 2,
       auto2top: true,
-      plugins: [
-        window.DocsifyCopyCodePlugin.init()
-      ]
     }
   </script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>


### PR DESCRIPTION
There has been a couple of complaints on Discord and issue #4473  about the documentation website not rendering properly.

This PR does the following:
- Anchored Docsify versions to 4.7.1 ( Docsify Github issues show there might be some rendering problems with 4.8.3)
- Anchor docsify-copy-plugin to 2
- Remove deprecated docsify-copy-code stylesheet
- Remove deprecated docsify-copy-code init function 
- Use HTTPS for all script loading
- Fix path for Working Locally
