### PR TITLE
Fixed the bug that number will be passed to modalPresentationStyle when using OptionsModalPresentationStyle

### DIFF
--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -72,14 +72,14 @@ export interface OptionsLayout {
 }
 
 export enum OptionsModalPresentationStyle {
-  'formSheet',
-  'pageSheet',
-  'overFullScreen',
-  'overCurrentContext',
-  'currentContext',
-  'popOver',
-  'fullScreen',
-  'none',
+  formSheet = 'formSheet',
+  pageSheet = 'pageSheet',
+  overFullScreen = 'overFullScreen',
+  overCurrentContext = 'overCurrentContext',
+  currentContext = 'currentContext',
+  popOver = 'popOver',
+  fullScreen = 'fullScreen',
+  none = 'none'
 }
 
 export interface OptionsTopBarLargeTitle {


### PR DESCRIPTION
## Problem

 using OptionsModalPresentationStyle would pass a number instead of string to modalPresentationStyle.

The reason is OptionsModalPresentationStyle is defined as a numeric enumeration.

## Fixed

I fixed OptionsModalPresentationStyle as a string enum
