### PR TITLE
Fixed a bug that making navigationBar transparent makes it impossible…

### DIFF
--- a/lib/ios/RNNNavigationController.m
+++ b/lib/ios/RNNNavigationController.m
@@ -121,6 +121,7 @@ const NSInteger TOP_BAR_TRANSPARENT_TAG = 78264803;
 			self.navigationBar.barTintColor = backgroundColor;
 			UIView *transparentView = [self.navigationBar viewWithTag:TOP_BAR_TRANSPARENT_TAG];
 			if (transparentView){
+				self.navigationBar.translucent = NO;
 				[transparentView removeFromSuperview];
 				[self.navigationBar setBackgroundImage:self.originalTopBarImages[@"backgroundImage"] forBarMetrics:UIBarMetricsDefault];
 				self.navigationBar.shadowImage = self.originalTopBarImages[@"shadowImage"];
@@ -130,6 +131,7 @@ const NSInteger TOP_BAR_TRANSPARENT_TAG = 78264803;
 	} else {
 		UIView *transparentView = [self.navigationBar viewWithTag:TOP_BAR_TRANSPARENT_TAG];
 		if (transparentView){
+			self.navigationBar.translucent = NO;
 			[transparentView removeFromSuperview];
 			[self.navigationBar setBackgroundImage:self.originalTopBarImages[@"backgroundImage"] ? self.originalTopBarImages[@"backgroundImage"] : [self.navigationBar backgroundImageForBarMetrics:UIBarMetricsDefault] forBarMetrics:UIBarMetricsDefault];
 			self.navigationBar.shadowImage = self.originalTopBarImages[@"shadowImage"] ? self.originalTopBarImages[@"shadowImage"] : self.navigationBar.shadowImage;


### PR DESCRIPTION
### Issue

When making the navigation bar transparent with the following options (with noBorder: true), mergeOptions make it impossible to return to opaque.

```

{
      topBar: {
        background: {
          color: "transparent"
        },
        title: {
          text: "NavigationBar Color"
        },
        noBorder: true
      }
    };
}
```

Here is a demo code.

https://gist.github.com/masarusanjp/05727caf5a1dc9f693bfc884125dd8cb

### Screenshofts

before | after
--- | ---
![before](https://user-images.githubusercontent.com/158416/50501037-8093fe00-0a98-11e9-8f43-c91b2297dd63.gif) | ![after](https://user-images.githubusercontent.com/158416/50501044-8689df00-0a98-11e9-9f5f-ff35ff8f27eb.gif)

