### PR TITLE
Road to noImplicitAny part 6 (FINAL part)

### DIFF
--- a/lib/src/Navigation.ts
+++ b/lib/src/Navigation.ts
@@ -53,9 +53,9 @@ export class NavigationRoot {
       this.componentWrapper,
       appRegistryService
     );
-    this.layoutTreeParser = new LayoutTreeParser();
+    this.layoutTreeParser = new LayoutTreeParser(this.uniqueIdProvider);
     const optionsProcessor = new OptionsProcessor(this.store, this.uniqueIdProvider, new ColorService(), new AssetService());
-    this.layoutTreeCrawler = new LayoutTreeCrawler(this.uniqueIdProvider, this.store, optionsProcessor);
+    this.layoutTreeCrawler = new LayoutTreeCrawler(this.store, optionsProcessor);
     this.nativeCommandsSender = new NativeCommandsSender();
     this.commandsObserver = new CommandsObserver(this.uniqueIdProvider);
     this.commands = new Commands(

--- a/lib/src/Navigation.ts
+++ b/lib/src/Navigation.ts
@@ -23,7 +23,7 @@ import { AssetService } from './adapters/AssetResolver';
 import { AppRegistryService } from './adapters/AppRegistryService';
 
 export class NavigationRoot {
-  public readonly Element: React.ComponentType<{ elementId: any; resizeMode?: any; }>;
+  public readonly Element: React.ComponentType<{ elementId: string; resizeMode?: string; }>;
   public readonly TouchablePreview: React.ComponentType<any>;
   public readonly store: Store;
   private readonly nativeEventsReceiver: NativeEventsReceiver;

--- a/lib/src/Navigation.ts
+++ b/lib/src/Navigation.ts
@@ -9,7 +9,7 @@ import { LayoutTreeParser } from './commands/LayoutTreeParser';
 import { LayoutTreeCrawler } from './commands/LayoutTreeCrawler';
 import { EventsRegistry } from './events/EventsRegistry';
 import { ComponentProvider } from 'react-native';
-import { Element } from './adapters/Element';
+import { SharedElement } from './adapters/SharedElement';
 import { CommandsObserver } from './events/CommandsObserver';
 import { Constants } from './adapters/Constants';
 import { ComponentEventsObserver } from './events/ComponentEventsObserver';
@@ -23,7 +23,7 @@ import { AssetService } from './adapters/AssetResolver';
 import { AppRegistryService } from './adapters/AppRegistryService';
 
 export class NavigationRoot {
-  public readonly Element: React.ComponentType<{ elementId: string; resizeMode?: string; }>;
+  public readonly Element: typeof SharedElement;
   public readonly TouchablePreview: React.ComponentType<any>;
   public readonly store: Store;
   private readonly nativeEventsReceiver: NativeEventsReceiver;
@@ -39,7 +39,7 @@ export class NavigationRoot {
   private readonly componentWrapper: ComponentWrapper;
 
   constructor() {
-    this.Element = Element;
+    this.Element = SharedElement;
     this.TouchablePreview = TouchablePreview;
     this.componentWrapper = new ComponentWrapper();
     this.store = new Store();

--- a/lib/src/Navigation.ts
+++ b/lib/src/Navigation.ts
@@ -23,9 +23,10 @@ import { AssetService } from './adapters/AssetResolver';
 import { AppRegistryService } from './adapters/AppRegistryService';
 
 export class NavigationRoot {
-  public readonly Element: typeof SharedElement;
-  public readonly TouchablePreview: React.ComponentType<any>;
-  public readonly store: Store;
+  public readonly Element = SharedElement;
+  public readonly TouchablePreview = TouchablePreview;
+
+  private readonly store: Store;
   private readonly nativeEventsReceiver: NativeEventsReceiver;
   private readonly uniqueIdProvider: UniqueIdProvider;
   private readonly componentRegistry: ComponentRegistry;
@@ -39,8 +40,6 @@ export class NavigationRoot {
   private readonly componentWrapper: ComponentWrapper;
 
   constructor() {
-    this.Element = SharedElement;
-    this.TouchablePreview = TouchablePreview;
     this.componentWrapper = new ComponentWrapper();
     this.store = new Store();
     this.nativeEventsReceiver = new NativeEventsReceiver();

--- a/lib/src/adapters/SharedElement.tsx
+++ b/lib/src/adapters/SharedElement.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { requireNativeComponent } from 'react-native';
 
-export class Element extends React.Component<{ elementId: string; resizeMode?: string }> {
+export interface SharedElementProps {
+  elementId: string;
+  resizeMode: string;
+}
+
+export class SharedElement extends React.Component<SharedElementProps> {
   static propTypes = {
     elementId: PropTypes.string.isRequired,
     resizeMode: PropTypes.string
@@ -13,10 +18,10 @@ export class Element extends React.Component<{ elementId: string; resizeMode?: s
   };
 
   render() {
-    return <RNNElement {...this.props} />;
+    return <RnnSharedElement {...this.props} />;
   }
 }
 
-const RNNElement = requireNativeComponent('RNNElement', Element, {
+const RnnSharedElement = requireNativeComponent('RNNElement', SharedElement, {
   nativeOnly: { nativeID: true }
 });

--- a/lib/src/adapters/UniqueIdProvider.mock.ts
+++ b/lib/src/adapters/UniqueIdProvider.mock.ts
@@ -1,5 +1,0 @@
-export class UniqueIdProvider {
-  generate(prefix: string): string {
-    return `${prefix}+UNIQUE_ID`;
-  }
-}

--- a/lib/src/commands/Commands.test.ts
+++ b/lib/src/commands/Commands.test.ts
@@ -389,29 +389,6 @@ describe('Commands', () => {
       return methods;
     }
 
-    // function getAllMethodsOfNativeCommandsSender() {
-    //   const nativeCommandsSenderFns = _.functions(mockedNativeCommandsSender);
-    //   expect(nativeCommandsSenderFns.length).toBeGreaterThan(1);
-    //   return nativeCommandsSenderFns;
-    // }
-
-    // it('always call last, when nativeCommand fails, dont notify listeners', () => {
-    //   // expect(getAllMethodsOfUut().sort()).toEqual(getAllMethodsOfNativeCommandsSender().sort());
-
-    //   // call all commands on uut, all should throw, no commandObservers called
-    //   _.forEach(getAllMethodsOfUut(), (m) => {
-    //     expect(() => uut[m]()).toThrow();
-    //     expect(cb).not.toHaveBeenCalled();
-    //   });
-    // });
-
-    // it('notify on all commands', () => {
-    //   _.forEach(getAllMethodsOfUut(), (m) => {
-    //     uut[m]({});
-    //   });
-    //   expect(cb).toHaveBeenCalledTimes(getAllMethodsOfUut().length);
-    // });
-
     describe('passes correct params', () => {
       const argsForMethodName: Record<string, any[]> = {
         setRoot: [{}],

--- a/lib/src/commands/Commands.test.ts
+++ b/lib/src/commands/Commands.test.ts
@@ -28,8 +28,8 @@ describe('Commands', () => {
 
     uut = new Commands(
       nativeCommandsSender,
-      new LayoutTreeParser(),
-      new LayoutTreeCrawler(new UniqueIdProvider(), store, optionsProcessor),
+      new LayoutTreeParser(new UniqueIdProvider()),
+      new LayoutTreeCrawler(store, optionsProcessor),
       commandsObserver,
       new UniqueIdProvider(),
       optionsProcessor

--- a/lib/src/commands/Commands.test.ts
+++ b/lib/src/commands/Commands.test.ts
@@ -21,7 +21,7 @@ describe('Commands', () => {
   beforeEach(() => {
     mockedNativeCommandsSender = mock(NativeCommandsSender);
     mockedUniqueIdProvider = mock(UniqueIdProvider);
-    when(mockedUniqueIdProvider.generate(anything())).thenCall(prefix => `${prefix}+UNIQUE_ID`);
+    when(mockedUniqueIdProvider.generate(anything())).thenCall((prefix) => `${prefix}+UNIQUE_ID`);
     const uniqueIdProvider = instance(mockedUniqueIdProvider);
     mockedStore = mock(Store);
     commandsObserver = new CommandsObserver(uniqueIdProvider);
@@ -71,25 +71,9 @@ describe('Commands', () => {
 
     it('inputs modals and overlays', () => {
       uut.setRoot({
-        root: {
-          component: {
-            name: 'com.example.MyScreen'
-          }
-        },
-        modals: [
-          {
-            component: {
-              name: 'com.example.MyModal'
-            }
-          }
-        ],
-        overlays: [
-          {
-            component: {
-              name: 'com.example.MyOverlay'
-            }
-          }
-        ]
+        root: { component: { name: 'com.example.MyScreen' } },
+        modals: [{ component: { name: 'com.example.MyModal' } }],
+        overlays: [{ component: { name: 'com.example.MyOverlay' } }]
       });
       verify(
         mockedNativeCommandsSender.setRoot(
@@ -139,18 +123,17 @@ describe('Commands', () => {
     it('passes options for component', () => {
       uut.mergeOptions('theComponentId', { blurOnUnmount: true });
       verify(
-        mockedNativeCommandsSender.mergeOptions('theComponentId', deepEqual({ blurOnUnmount: true }))
+        mockedNativeCommandsSender.mergeOptions(
+          'theComponentId',
+          deepEqual({ blurOnUnmount: true })
+        )
       ).called();
     });
   });
 
   describe('showModal', () => {
     it('sends command to native after parsing into a correct layout tree', () => {
-      uut.showModal({
-        component: {
-          name: 'com.example.MyScreen'
-        }
-      });
+      uut.showModal({ component: { name: 'com.example.MyScreen' } });
       verify(
         mockedNativeCommandsSender.showModal(
           'showModal+UNIQUE_ID',
@@ -169,7 +152,9 @@ describe('Commands', () => {
     });
 
     it('returns a promise with the resolved layout', async () => {
-      when(mockedNativeCommandsSender.showModal(anything(), anything())).thenResolve('the resolved layout');
+      when(mockedNativeCommandsSender.showModal(anything(), anything())).thenResolve(
+        'the resolved layout'
+      );
       const result = await uut.showModal({ component: { name: 'com.example.MyScreen' } });
       expect(result).toEqual('the resolved layout');
     });
@@ -205,7 +190,9 @@ describe('Commands', () => {
     });
 
     it('returns a promise with the id', async () => {
-      when(mockedNativeCommandsSender.dismissAllModals(anyString(), anything())).thenResolve('the id');
+      when(mockedNativeCommandsSender.dismissAllModals(anyString(), anything())).thenResolve(
+        'the id'
+      );
       const result = await uut.dismissAllModals();
       expect(result).toEqual('the id');
     });
@@ -213,7 +200,9 @@ describe('Commands', () => {
 
   describe('push', () => {
     it('resolves with the parsed layout', async () => {
-      when(mockedNativeCommandsSender.push(anyString(), anyString(), anything())).thenResolve('the resolved layout');
+      when(mockedNativeCommandsSender.push(anyString(), anyString(), anything())).thenResolve(
+        'the resolved layout'
+      );
       const result = await uut.push('theComponentId', {
         component: { name: 'com.example.MyScreen' }
       });
@@ -249,13 +238,15 @@ describe('Commands', () => {
       ).called();
     });
     it('pops a component, passing componentId and options', () => {
-      const options: Options = {popGesture: true};
+      const options: Options = { popGesture: true };
       uut.pop('theComponentId', options);
       verify(mockedNativeCommandsSender.pop('pop+UNIQUE_ID', 'theComponentId', options)).called();
     });
 
     it('pop returns a promise that resolves to componentId', async () => {
-      when(mockedNativeCommandsSender.pop(anyString(), anyString(), anything())).thenResolve('theComponentId');
+      when(mockedNativeCommandsSender.pop(anyString(), anyString(), anything())).thenResolve(
+        'theComponentId'
+      );
       const result = await uut.pop('theComponentId', {});
       expect(result).toEqual('theComponentId');
     });
@@ -270,7 +261,9 @@ describe('Commands', () => {
     });
 
     it('returns a promise that resolves to targetId', async () => {
-      when(mockedNativeCommandsSender.popTo(anyString(), anyString(), anything())).thenResolve('theComponentId');
+      when(mockedNativeCommandsSender.popTo(anyString(), anyString(), anything())).thenResolve(
+        'theComponentId'
+      );
       const result = await uut.popTo('theComponentId');
       expect(result).toEqual('theComponentId');
     });
@@ -285,7 +278,9 @@ describe('Commands', () => {
     });
 
     it('returns a promise that resolves to targetId', async () => {
-      when(mockedNativeCommandsSender.popToRoot(anyString(), anyString(), anything())).thenResolve('theComponentId');
+      when(mockedNativeCommandsSender.popToRoot(anyString(), anyString(), anything())).thenResolve(
+        'theComponentId'
+      );
       const result = await uut.popToRoot('theComponentId');
       expect(result).toEqual('theComponentId');
     });
@@ -317,11 +312,7 @@ describe('Commands', () => {
 
   describe('showOverlay', () => {
     it('sends command to native after parsing into a correct layout tree', () => {
-      uut.showOverlay({
-        component: {
-          name: 'com.example.MyScreen'
-        }
-      });
+      uut.showOverlay({ component: { name: 'com.example.MyScreen' } });
       verify(
         mockedNativeCommandsSender.showOverlay(
           'showOverlay+UNIQUE_ID',
@@ -340,7 +331,9 @@ describe('Commands', () => {
     });
 
     it('resolves with the component id', async () => {
-      when(mockedNativeCommandsSender.showOverlay(anyString(), anything())).thenResolve('Component1');
+      when(mockedNativeCommandsSender.showOverlay(anyString(), anything())).thenResolve(
+        'Component1'
+      );
       const result = await uut.showOverlay({ component: { name: 'com.example.MyScreen' } });
       expect(result).toEqual('Component1');
     });

--- a/lib/src/commands/Commands.test.ts
+++ b/lib/src/commands/Commands.test.ts
@@ -9,6 +9,7 @@ import { CommandsObserver } from '../events/CommandsObserver';
 import { NativeCommandsSender } from '../adapters/NativeCommandsSender';
 import { OptionsProcessor } from './OptionsProcessor';
 import { UniqueIdProvider } from '../adapters/UniqueIdProvider';
+import { Options } from '../interfaces/Options';
 
 describe('Commands', () => {
   let uut: Commands;
@@ -20,7 +21,7 @@ describe('Commands', () => {
   beforeEach(() => {
     mockedNativeCommandsSender = mock(NativeCommandsSender);
     mockedUniqueIdProvider = mock(UniqueIdProvider);
-    when(mockedUniqueIdProvider.generate(anything())).thenCall((prefix) => `${prefix}+UNIQUE_ID`);
+    when(mockedUniqueIdProvider.generate(anything())).thenCall(prefix => `${prefix}+UNIQUE_ID`);
     const uniqueIdProvider = instance(mockedUniqueIdProvider);
     mockedStore = mock(Store);
     commandsObserver = new CommandsObserver(uniqueIdProvider);
@@ -41,11 +42,7 @@ describe('Commands', () => {
   describe('setRoot', () => {
     it('sends setRoot to native after parsing into a correct layout tree', () => {
       uut.setRoot({
-        root: {
-          component: {
-            name: 'com.example.MyScreen'
-          }
-        }
+        root: { component: { name: 'com.example.MyScreen' } }
       });
       verify(
         mockedNativeCommandsSender.setRoot(
@@ -55,11 +52,7 @@ describe('Commands', () => {
               type: 'Component',
               id: 'Component+UNIQUE_ID',
               children: [],
-              data: {
-                name: 'com.example.MyScreen',
-                options: {},
-                passProps: undefined
-              }
+              data: { name: 'com.example.MyScreen', options: {}, passProps: undefined }
             },
             modals: [],
             overlays: []
@@ -144,9 +137,9 @@ describe('Commands', () => {
 
   describe('mergeOptions', () => {
     it('passes options for component', () => {
-      uut.mergeOptions('theComponentId', { title: '1' } as any);
+      uut.mergeOptions('theComponentId', { blurOnUnmount: true });
       verify(
-        mockedNativeCommandsSender.mergeOptions('theComponentId', deepEqual({ title: '1' }))
+        mockedNativeCommandsSender.mergeOptions('theComponentId', deepEqual({ blurOnUnmount: true }))
       ).called();
     });
   });
@@ -176,9 +169,7 @@ describe('Commands', () => {
     });
 
     it('returns a promise with the resolved layout', async () => {
-      when(mockedNativeCommandsSender.showModal(anything(), anything())).thenResolve(
-        'the resolved layout' as any
-      );
+      when(mockedNativeCommandsSender.showModal(anything(), anything())).thenResolve('the resolved layout');
       const result = await uut.showModal({ component: { name: 'com.example.MyScreen' } });
       expect(result).toEqual('the resolved layout');
     });
@@ -199,7 +190,7 @@ describe('Commands', () => {
     it('returns a promise with the id', async () => {
       when(
         mockedNativeCommandsSender.dismissModal(anyString(), anything(), anything())
-      ).thenResolve('the id' as any);
+      ).thenResolve('the id');
       const result = await uut.dismissModal('myUniqueId');
       expect(result).toEqual('the id');
     });
@@ -214,9 +205,7 @@ describe('Commands', () => {
     });
 
     it('returns a promise with the id', async () => {
-      when(mockedNativeCommandsSender.dismissAllModals(anyString(), anything())).thenResolve(
-        'the id' as any
-      );
+      when(mockedNativeCommandsSender.dismissAllModals(anyString(), anything())).thenResolve('the id');
       const result = await uut.dismissAllModals();
       expect(result).toEqual('the id');
     });
@@ -224,9 +213,7 @@ describe('Commands', () => {
 
   describe('push', () => {
     it('resolves with the parsed layout', async () => {
-      when(mockedNativeCommandsSender.push(anyString(), anyString(), anything())).thenResolve(
-        'the resolved layout' as any
-      );
+      when(mockedNativeCommandsSender.push(anyString(), anyString(), anything())).thenResolve('the resolved layout');
       const result = await uut.push('theComponentId', {
         component: { name: 'com.example.MyScreen' }
       });
@@ -262,29 +249,13 @@ describe('Commands', () => {
       ).called();
     });
     it('pops a component, passing componentId and options', () => {
-      const options = {
-        customTransition: {
-          animations: [
-            {
-              type: 'sharedElement',
-              fromId: 'title2',
-              toId: 'title1',
-              startDelay: 0,
-              springVelocity: 0.2,
-              duration: 0.5
-            }
-          ],
-          duration: 0.8
-        }
-      };
-      uut.pop('theComponentId', options as any);
+      const options: Options = {popGesture: true};
+      uut.pop('theComponentId', options);
       verify(mockedNativeCommandsSender.pop('pop+UNIQUE_ID', 'theComponentId', options)).called();
     });
 
     it('pop returns a promise that resolves to componentId', async () => {
-      when(mockedNativeCommandsSender.pop(anyString(), anyString(), anything())).thenResolve(
-        'theComponentId' as any
-      );
+      when(mockedNativeCommandsSender.pop(anyString(), anyString(), anything())).thenResolve('theComponentId');
       const result = await uut.pop('theComponentId', {});
       expect(result).toEqual('theComponentId');
     });
@@ -299,9 +270,7 @@ describe('Commands', () => {
     });
 
     it('returns a promise that resolves to targetId', async () => {
-      when(mockedNativeCommandsSender.popTo(anyString(), anyString(), anything())).thenResolve(
-        'theComponentId' as any
-      );
+      when(mockedNativeCommandsSender.popTo(anyString(), anyString(), anything())).thenResolve('theComponentId');
       const result = await uut.popTo('theComponentId');
       expect(result).toEqual('theComponentId');
     });
@@ -316,9 +285,7 @@ describe('Commands', () => {
     });
 
     it('returns a promise that resolves to targetId', async () => {
-      when(mockedNativeCommandsSender.popToRoot(anyString(), anyString(), anything())).thenResolve(
-        'theComponentId' as any
-      );
+      when(mockedNativeCommandsSender.popToRoot(anyString(), anyString(), anything())).thenResolve('theComponentId');
       const result = await uut.popToRoot('theComponentId');
       expect(result).toEqual('theComponentId');
     });
@@ -373,9 +340,7 @@ describe('Commands', () => {
     });
 
     it('resolves with the component id', async () => {
-      when(mockedNativeCommandsSender.showOverlay(anyString(), anything())).thenResolve(
-        'Component1' as any
-      );
+      when(mockedNativeCommandsSender.showOverlay(anyString(), anything())).thenResolve('Component1');
       const result = await uut.showOverlay({ component: { name: 'com.example.MyScreen' } });
       expect(result).toEqual('Component1');
     });
@@ -383,9 +348,7 @@ describe('Commands', () => {
 
   describe('dismissOverlay', () => {
     it('check promise returns true', async () => {
-      when(mockedNativeCommandsSender.dismissOverlay(anyString(), anyString())).thenResolve(
-        true as any
-      );
+      when(mockedNativeCommandsSender.dismissOverlay(anyString(), anyString())).thenResolve(true);
       const result = await uut.dismissOverlay('Component1');
       verify(mockedNativeCommandsSender.dismissOverlay(anyString(), anyString())).called();
       expect(result).toEqual(true);
@@ -401,25 +364,28 @@ describe('Commands', () => {
 
   describe('notifies commandsObserver', () => {
     let cb: any;
+    let mockedLayoutTreeParser: LayoutTreeParser;
+    let mockedLayoutTreeCrawler: LayoutTreeCrawler;
     let anotherMockedUniqueIdProvider: UniqueIdProvider;
 
     beforeEach(() => {
       cb = jest.fn();
-      const mockParser = { parse: () => 'parsed' };
-      const mockCrawler = { crawl: (x: any) => x, processOptions: (x: any) => x };
+      mockedLayoutTreeParser = mock(LayoutTreeParser);
+      mockedLayoutTreeCrawler = mock(LayoutTreeCrawler);
       commandsObserver.register(cb);
       const mockedOptionsProcessor = mock(OptionsProcessor);
-      const optionsProcessor = instance(mockedOptionsProcessor);
       anotherMockedUniqueIdProvider = mock(UniqueIdProvider);
-      when(anotherMockedUniqueIdProvider.generate(anything())).thenCall((prefix) => `${prefix}+UNIQUE_ID`);
+      when(anotherMockedUniqueIdProvider.generate(anything())).thenCall(
+        (prefix) => `${prefix}+UNIQUE_ID`
+      );
 
       uut = new Commands(
         mockedNativeCommandsSender,
-        mockParser as any,
-        mockCrawler as any,
+        instance(mockedLayoutTreeParser),
+        instance(mockedLayoutTreeCrawler),
         commandsObserver,
         instance(anotherMockedUniqueIdProvider),
-        optionsProcessor
+        instance(mockedOptionsProcessor)
       );
     });
 
@@ -473,23 +439,23 @@ describe('Commands', () => {
       const paramsForMethodName: Record<string, object> = {
         setRoot: {
           commandId: 'setRoot+UNIQUE_ID',
-          layout: { root: 'parsed', modals: [], overlays: [] }
+          layout: { root: null, modals: [], overlays: [] }
         },
         setDefaultOptions: { options: {} },
         mergeOptions: { componentId: 'id', options: {} },
-        showModal: { commandId: 'showModal+UNIQUE_ID', layout: 'parsed' },
+        showModal: { commandId: 'showModal+UNIQUE_ID', layout: null },
         dismissModal: { commandId: 'dismissModal+UNIQUE_ID', componentId: 'id', mergeOptions: {} },
         dismissAllModals: { commandId: 'dismissAllModals+UNIQUE_ID', mergeOptions: {} },
-        push: { commandId: 'push+UNIQUE_ID', componentId: 'id', layout: 'parsed' },
+        push: { commandId: 'push+UNIQUE_ID', componentId: 'id', layout: null },
         pop: { commandId: 'pop+UNIQUE_ID', componentId: 'id', mergeOptions: {} },
         popTo: { commandId: 'popTo+UNIQUE_ID', componentId: 'id', mergeOptions: {} },
         popToRoot: { commandId: 'popToRoot+UNIQUE_ID', componentId: 'id', mergeOptions: {} },
         setStackRoot: {
           commandId: 'setStackRoot+UNIQUE_ID',
           componentId: 'id',
-          layout: ['parsed']
+          layout: [null]
         },
-        showOverlay: { commandId: 'showOverlay+UNIQUE_ID', layout: 'parsed' },
+        showOverlay: { commandId: 'showOverlay+UNIQUE_ID', layout: null },
         dismissOverlay: { commandId: 'dismissOverlay+UNIQUE_ID', componentId: 'id' },
         getLaunchArgs: { commandId: 'getLaunchArgs+UNIQUE_ID' }
       };

--- a/lib/src/commands/Commands.test.ts
+++ b/lib/src/commands/Commands.test.ts
@@ -13,7 +13,7 @@ import { UniqueIdProvider } from '../adapters/UniqueIdProvider';
 describe('Commands', () => {
   let uut: Commands;
   let mockedNativeCommandsSender: NativeCommandsSender;
-  let store: Store;
+  let mockedStore: Store;
   let commandsObserver: CommandsObserver;
   let mockedUniqueIdProvider: UniqueIdProvider;
 
@@ -22,7 +22,7 @@ describe('Commands', () => {
     mockedUniqueIdProvider = mock(UniqueIdProvider);
     when(mockedUniqueIdProvider.generate(anything())).thenCall((prefix) => `${prefix}+UNIQUE_ID`);
     const uniqueIdProvider = instance(mockedUniqueIdProvider);
-    store = new Store();
+    mockedStore = mock(Store);
     commandsObserver = new CommandsObserver(uniqueIdProvider);
 
     const mockedOptionsProcessor = mock(OptionsProcessor);
@@ -31,7 +31,7 @@ describe('Commands', () => {
     uut = new Commands(
       instance(mockedNativeCommandsSender),
       new LayoutTreeParser(uniqueIdProvider),
-      new LayoutTreeCrawler(store, optionsProcessor),
+      new LayoutTreeCrawler(instance(mockedStore), optionsProcessor),
       commandsObserver,
       uniqueIdProvider,
       optionsProcessor
@@ -66,16 +66,6 @@ describe('Commands', () => {
           })
         )
       ).called();
-    });
-
-    it('passProps into components', () => {
-      const passProps = {
-        fn: () => 'Hello'
-      };
-      expect(store.getPropsForId('Component+UNIQUE_ID')).toEqual({});
-      uut.setRoot({ root: { component: { name: 'asd', passProps } } });
-      expect(store.getPropsForId('Component+UNIQUE_ID')).toEqual(passProps);
-      expect(store.getPropsForId('Component+UNIQUE_ID').fn()).toEqual('Hello');
     });
 
     it('returns a promise with the resolved layout', async () => {
@@ -185,18 +175,6 @@ describe('Commands', () => {
       ).called();
     });
 
-    it('passProps into components', () => {
-      const passProps = {};
-      expect(store.getPropsForId('Component+UNIQUE_ID')).toEqual({});
-      uut.showModal({
-        component: {
-          name: 'com.example.MyScreen',
-          passProps
-        }
-      });
-      expect(store.getPropsForId('Component+UNIQUE_ID')).toEqual(passProps);
-    });
-
     it('returns a promise with the resolved layout', async () => {
       when(mockedNativeCommandsSender.showModal(anything(), anything())).thenResolve(
         'the resolved layout' as any
@@ -273,15 +251,6 @@ describe('Commands', () => {
           })
         )
       ).called();
-    });
-
-    it('calls component generator once', async () => {
-      const generator = jest.fn(() => {
-        return {};
-      });
-      store.setComponentClassForName('theComponentName', generator);
-      await uut.push('theComponentId', { component: { name: 'theComponentName' } });
-      expect(generator).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/lib/src/commands/Commands.test.ts
+++ b/lib/src/commands/Commands.test.ts
@@ -13,7 +13,6 @@ import { OptionsProcessor } from './OptionsProcessor';
 describe('Commands', () => {
   let uut: Commands;
   let mockedNativeCommandsSender: NativeCommandsSender;
-  let nativeCommandsSender: NativeCommandsSender;
   let store: Store;
   let commandsObserver: CommandsObserver;
 
@@ -21,13 +20,12 @@ describe('Commands', () => {
     store = new Store();
     commandsObserver = new CommandsObserver(new UniqueIdProvider());
     mockedNativeCommandsSender = mock(NativeCommandsSender);
-    nativeCommandsSender = instance(mockedNativeCommandsSender);
 
     const mockedOptionsProcessor = mock(OptionsProcessor);
     const optionsProcessor = instance(mockedOptionsProcessor);
 
     uut = new Commands(
-      nativeCommandsSender,
+      instance(mockedNativeCommandsSender),
       new LayoutTreeParser(new UniqueIdProvider()),
       new LayoutTreeCrawler(store, optionsProcessor),
       commandsObserver,
@@ -45,20 +43,25 @@ describe('Commands', () => {
           }
         }
       });
-      verify(mockedNativeCommandsSender.setRoot('setRoot+UNIQUE_ID', deepEqual({
-        root: {
-          type: 'Component',
-          id: 'Component+UNIQUE_ID',
-          children: [],
-          data: {
-            name: 'com.example.MyScreen',
-            options: {},
-            passProps: undefined
-          }
-        },
-        modals: [],
-        overlays: []
-      }))).called();
+      verify(
+        mockedNativeCommandsSender.setRoot(
+          'setRoot+UNIQUE_ID',
+          deepEqual({
+            root: {
+              type: 'Component',
+              id: 'Component+UNIQUE_ID',
+              children: [],
+              data: {
+                name: 'com.example.MyScreen',
+                options: {},
+                passProps: undefined
+              }
+            },
+            modals: [],
+            overlays: []
+          })
+        )
+      ).called();
     });
 
     it('passProps into components', () => {
@@ -72,7 +75,9 @@ describe('Commands', () => {
     });
 
     it('returns a promise with the resolved layout', async () => {
-      when(mockedNativeCommandsSender.setRoot(anything(), anything())).thenResolve('the resolved layout' as any);
+      when(mockedNativeCommandsSender.setRoot(anything(), anything())).thenResolve(
+        'the resolved layout' as any
+      );
       const result = await uut.setRoot({ root: { component: { name: 'com.example.MyScreen' } } });
       expect(result).toEqual('the resolved layout');
     });
@@ -99,50 +104,56 @@ describe('Commands', () => {
           }
         ]
       });
-      verify(mockedNativeCommandsSender.setRoot('setRoot+UNIQUE_ID', deepEqual({
-        root:
-          {
-            type: 'Component',
-            id: 'Component+UNIQUE_ID',
-            children: [],
-            data: {
-              name: 'com.example.MyScreen',
-              options: {},
-              passProps: undefined
-            }
-          },
-        modals: [
-          {
-            type: 'Component',
-            id: 'Component+UNIQUE_ID',
-            children: [],
-            data: {
-              name: 'com.example.MyModal',
-              options: {},
-              passProps: undefined
-            }
-          }
-        ],
-        overlays: [
-          {
-            type: 'Component',
-            id: 'Component+UNIQUE_ID',
-            children: [],
-            data: {
-              name: 'com.example.MyOverlay',
-              options: {},
-              passProps: undefined
-            }
-          }
-        ]
-      }))).called();
+      verify(
+        mockedNativeCommandsSender.setRoot(
+          'setRoot+UNIQUE_ID',
+          deepEqual({
+            root: {
+              type: 'Component',
+              id: 'Component+UNIQUE_ID',
+              children: [],
+              data: {
+                name: 'com.example.MyScreen',
+                options: {},
+                passProps: undefined
+              }
+            },
+            modals: [
+              {
+                type: 'Component',
+                id: 'Component+UNIQUE_ID',
+                children: [],
+                data: {
+                  name: 'com.example.MyModal',
+                  options: {},
+                  passProps: undefined
+                }
+              }
+            ],
+            overlays: [
+              {
+                type: 'Component',
+                id: 'Component+UNIQUE_ID',
+                children: [],
+                data: {
+                  name: 'com.example.MyOverlay',
+                  options: {},
+                  passProps: undefined
+                }
+              }
+            ]
+          })
+        )
+      ).called();
     });
   });
 
   describe('mergeOptions', () => {
     it('passes options for component', () => {
       uut.mergeOptions('theComponentId', { title: '1' } as any);
-      verify(mockedNativeCommandsSender.mergeOptions('theComponentId', deepEqual({title: '1'}))).called();
+      verify(
+        mockedNativeCommandsSender.mergeOptions('theComponentId', deepEqual({ title: '1' }))
+      ).called();
     });
   });
 
@@ -153,16 +164,21 @@ describe('Commands', () => {
           name: 'com.example.MyScreen'
         }
       });
-      verify(mockedNativeCommandsSender.showModal('showModal+UNIQUE_ID', deepEqual({
-        type: 'Component',
-        id: 'Component+UNIQUE_ID',
-        data: {
-          name: 'com.example.MyScreen',
-          options: {},
-          passProps: undefined
-        },
-        children: []
-      }))).called();
+      verify(
+        mockedNativeCommandsSender.showModal(
+          'showModal+UNIQUE_ID',
+          deepEqual({
+            type: 'Component',
+            id: 'Component+UNIQUE_ID',
+            data: {
+              name: 'com.example.MyScreen',
+              options: {},
+              passProps: undefined
+            },
+            children: []
+          })
+        )
+      ).called();
     });
 
     it('passProps into components', () => {
@@ -178,7 +194,9 @@ describe('Commands', () => {
     });
 
     it('returns a promise with the resolved layout', async () => {
-      when(mockedNativeCommandsSender.showModal(anything(), anything())).thenResolve('the resolved layout' as any);
+      when(mockedNativeCommandsSender.showModal(anything(), anything())).thenResolve(
+        'the resolved layout' as any
+      );
       const result = await uut.showModal({ component: { name: 'com.example.MyScreen' } });
       expect(result).toEqual('the resolved layout');
     });
@@ -187,11 +205,19 @@ describe('Commands', () => {
   describe('dismissModal', () => {
     it('sends command to native', () => {
       uut.dismissModal('myUniqueId', {});
-      verify(mockedNativeCommandsSender.dismissModal('dismissModal+UNIQUE_ID', 'myUniqueId', deepEqual({}))).called();
+      verify(
+        mockedNativeCommandsSender.dismissModal(
+          'dismissModal+UNIQUE_ID',
+          'myUniqueId',
+          deepEqual({})
+        )
+      ).called();
     });
 
     it('returns a promise with the id', async () => {
-      when(mockedNativeCommandsSender.dismissModal(anyString(), anything(), anything())).thenResolve('the id' as any);
+      when(
+        mockedNativeCommandsSender.dismissModal(anyString(), anything(), anything())
+      ).thenResolve('the id' as any);
       const result = await uut.dismissModal('myUniqueId');
       expect(result).toEqual('the id');
     });
@@ -200,11 +226,15 @@ describe('Commands', () => {
   describe('dismissAllModals', () => {
     it('sends command to native', () => {
       uut.dismissAllModals({});
-      verify(mockedNativeCommandsSender.dismissAllModals('dismissAllModals+UNIQUE_ID', deepEqual({}))).called();
+      verify(
+        mockedNativeCommandsSender.dismissAllModals('dismissAllModals+UNIQUE_ID', deepEqual({}))
+      ).called();
     });
 
     it('returns a promise with the id', async () => {
-      when(mockedNativeCommandsSender.dismissAllModals(anyString(), anything())).thenResolve('the id' as any);
+      when(mockedNativeCommandsSender.dismissAllModals(anyString(), anything())).thenResolve(
+        'the id' as any
+      );
       const result = await uut.dismissAllModals();
       expect(result).toEqual('the id');
     });
@@ -212,23 +242,33 @@ describe('Commands', () => {
 
   describe('push', () => {
     it('resolves with the parsed layout', async () => {
-      when(mockedNativeCommandsSender.push(anyString(), anyString(), anything())).thenResolve('the resolved layout' as any);
-      const result = await uut.push('theComponentId', { component: { name: 'com.example.MyScreen' } });
+      when(mockedNativeCommandsSender.push(anyString(), anyString(), anything())).thenResolve(
+        'the resolved layout' as any
+      );
+      const result = await uut.push('theComponentId', {
+        component: { name: 'com.example.MyScreen' }
+      });
       expect(result).toEqual('the resolved layout');
     });
 
     it('parses into correct layout node and sends to native', () => {
       uut.push('theComponentId', { component: { name: 'com.example.MyScreen' } });
-      verify(mockedNativeCommandsSender.push('push+UNIQUE_ID', 'theComponentId', deepEqual({
-        type: 'Component',
-        id: 'Component+UNIQUE_ID',
-        data: {
-          name: 'com.example.MyScreen',
-          options: {},
-          passProps: undefined
-        },
-        children: []
-      }))).called();
+      verify(
+        mockedNativeCommandsSender.push(
+          'push+UNIQUE_ID',
+          'theComponentId',
+          deepEqual({
+            type: 'Component',
+            id: 'Component+UNIQUE_ID',
+            data: {
+              name: 'com.example.MyScreen',
+              options: {},
+              passProps: undefined
+            },
+            children: []
+          })
+        )
+      ).called();
     });
 
     it('calls component generator once', async () => {
@@ -244,13 +284,22 @@ describe('Commands', () => {
   describe('pop', () => {
     it('pops a component, passing componentId', () => {
       uut.pop('theComponentId', {});
-      verify(mockedNativeCommandsSender.pop('pop+UNIQUE_ID', 'theComponentId', deepEqual({}))).called();
+      verify(
+        mockedNativeCommandsSender.pop('pop+UNIQUE_ID', 'theComponentId', deepEqual({}))
+      ).called();
     });
     it('pops a component, passing componentId and options', () => {
       const options = {
         customTransition: {
           animations: [
-            { type: 'sharedElement', fromId: 'title2', toId: 'title1', startDelay: 0, springVelocity: 0.2, duration: 0.5 }
+            {
+              type: 'sharedElement',
+              fromId: 'title2',
+              toId: 'title1',
+              startDelay: 0,
+              springVelocity: 0.2,
+              duration: 0.5
+            }
           ],
           duration: 0.8
         }
@@ -260,7 +309,9 @@ describe('Commands', () => {
     });
 
     it('pop returns a promise that resolves to componentId', async () => {
-      when(mockedNativeCommandsSender.pop(anyString(), anyString(), anything())).thenResolve('theComponentId' as any);
+      when(mockedNativeCommandsSender.pop(anyString(), anyString(), anything())).thenResolve(
+        'theComponentId' as any
+      );
       const result = await uut.pop('theComponentId', {});
       expect(result).toEqual('theComponentId');
     });
@@ -269,11 +320,15 @@ describe('Commands', () => {
   describe('popTo', () => {
     it('pops all components until the passed Id is top', () => {
       uut.popTo('theComponentId', {});
-      verify(mockedNativeCommandsSender.popTo('popTo+UNIQUE_ID', 'theComponentId', deepEqual({}))).called();
+      verify(
+        mockedNativeCommandsSender.popTo('popTo+UNIQUE_ID', 'theComponentId', deepEqual({}))
+      ).called();
     });
 
     it('returns a promise that resolves to targetId', async () => {
-      when(mockedNativeCommandsSender.popTo(anyString(), anyString(), anything())).thenResolve('theComponentId' as any);
+      when(mockedNativeCommandsSender.popTo(anyString(), anyString(), anything())).thenResolve(
+        'theComponentId' as any
+      );
       const result = await uut.popTo('theComponentId');
       expect(result).toEqual('theComponentId');
     });
@@ -282,11 +337,15 @@ describe('Commands', () => {
   describe('popToRoot', () => {
     it('pops all components to root', () => {
       uut.popToRoot('theComponentId', {});
-      verify(mockedNativeCommandsSender.popToRoot('popToRoot+UNIQUE_ID', 'theComponentId', deepEqual({}))).called();
+      verify(
+        mockedNativeCommandsSender.popToRoot('popToRoot+UNIQUE_ID', 'theComponentId', deepEqual({}))
+      ).called();
     });
 
     it('returns a promise that resolves to targetId', async () => {
-      when(mockedNativeCommandsSender.popToRoot(anyString(), anyString(), anything())).thenResolve('theComponentId' as any);
+      when(mockedNativeCommandsSender.popToRoot(anyString(), anyString(), anything())).thenResolve(
+        'theComponentId' as any
+      );
       const result = await uut.popToRoot('theComponentId');
       expect(result).toEqual('theComponentId');
     });
@@ -295,18 +354,24 @@ describe('Commands', () => {
   describe('setStackRoot', () => {
     it('parses into correct layout node and sends to native', () => {
       uut.setStackRoot('theComponentId', [{ component: { name: 'com.example.MyScreen' } }]);
-      verify(mockedNativeCommandsSender.setStackRoot('setStackRoot+UNIQUE_ID', 'theComponentId', deepEqual([
-        {
-          type: 'Component',
-          id: 'Component+UNIQUE_ID',
-          data: {
-            name: 'com.example.MyScreen',
-            options: {},
-            passProps: undefined
-          },
-          children: []
-        }
-      ]))).called();
+      verify(
+        mockedNativeCommandsSender.setStackRoot(
+          'setStackRoot+UNIQUE_ID',
+          'theComponentId',
+          deepEqual([
+            {
+              type: 'Component',
+              id: 'Component+UNIQUE_ID',
+              data: {
+                name: 'com.example.MyScreen',
+                options: {},
+                passProps: undefined
+              },
+              children: []
+            }
+          ])
+        )
+      ).called();
     });
   });
 
@@ -317,20 +382,27 @@ describe('Commands', () => {
           name: 'com.example.MyScreen'
         }
       });
-      verify(mockedNativeCommandsSender.showOverlay('showOverlay+UNIQUE_ID', deepEqual({
-        type: 'Component',
-        id: 'Component+UNIQUE_ID',
-        data: {
-          name: 'com.example.MyScreen',
-          options: {},
-          passProps: undefined
-        },
-        children: []
-      }))).called();
+      verify(
+        mockedNativeCommandsSender.showOverlay(
+          'showOverlay+UNIQUE_ID',
+          deepEqual({
+            type: 'Component',
+            id: 'Component+UNIQUE_ID',
+            data: {
+              name: 'com.example.MyScreen',
+              options: {},
+              passProps: undefined
+            },
+            children: []
+          })
+        )
+      ).called();
     });
 
     it('resolves with the component id', async () => {
-      when(mockedNativeCommandsSender.showOverlay(anyString(), anything())).thenResolve('Component1' as any);
+      when(mockedNativeCommandsSender.showOverlay(anyString(), anything())).thenResolve(
+        'Component1' as any
+      );
       const result = await uut.showOverlay({ component: { name: 'com.example.MyScreen' } });
       expect(result).toEqual('Component1');
     });
@@ -338,7 +410,9 @@ describe('Commands', () => {
 
   describe('dismissOverlay', () => {
     it('check promise returns true', async () => {
-      when(mockedNativeCommandsSender.dismissOverlay(anyString(), anyString())).thenResolve(true as any);
+      when(mockedNativeCommandsSender.dismissOverlay(anyString(), anyString())).thenResolve(
+        true as any
+      );
       const result = await uut.dismissOverlay('Component1');
       verify(mockedNativeCommandsSender.dismissOverlay(anyString(), anyString())).called();
       expect(result).toEqual(true);
@@ -346,7 +420,9 @@ describe('Commands', () => {
 
     it('send command to native with componentId', () => {
       uut.dismissOverlay('Component1');
-      verify(mockedNativeCommandsSender.dismissOverlay('dismissOverlay+UNIQUE_ID', 'Component1')).called();
+      verify(
+        mockedNativeCommandsSender.dismissOverlay('dismissOverlay+UNIQUE_ID', 'Component1')
+      ).called();
     });
   });
 
@@ -418,7 +494,10 @@ describe('Commands', () => {
         getLaunchArgs: ['id']
       };
       const paramsForMethodName: Record<string, object> = {
-        setRoot: { commandId: 'setRoot+UNIQUE_ID', layout: { root: 'parsed', modals: [], overlays: [] } },
+        setRoot: {
+          commandId: 'setRoot+UNIQUE_ID',
+          layout: { root: 'parsed', modals: [], overlays: [] }
+        },
         setDefaultOptions: { options: {} },
         mergeOptions: { componentId: 'id', options: {} },
         showModal: { commandId: 'showModal+UNIQUE_ID', layout: 'parsed' },
@@ -428,10 +507,14 @@ describe('Commands', () => {
         pop: { commandId: 'pop+UNIQUE_ID', componentId: 'id', mergeOptions: {} },
         popTo: { commandId: 'popTo+UNIQUE_ID', componentId: 'id', mergeOptions: {} },
         popToRoot: { commandId: 'popToRoot+UNIQUE_ID', componentId: 'id', mergeOptions: {} },
-        setStackRoot: { commandId: 'setStackRoot+UNIQUE_ID', componentId: 'id', layout: ['parsed'] },
+        setStackRoot: {
+          commandId: 'setStackRoot+UNIQUE_ID',
+          componentId: 'id',
+          layout: ['parsed']
+        },
         showOverlay: { commandId: 'showOverlay+UNIQUE_ID', layout: 'parsed' },
         dismissOverlay: { commandId: 'dismissOverlay+UNIQUE_ID', componentId: 'id' },
-        getLaunchArgs: { commandId: 'getLaunchArgs+UNIQUE_ID' },
+        getLaunchArgs: { commandId: 'getLaunchArgs+UNIQUE_ID' }
       };
       _.forEach(getAllMethodsOfUut(), (m) => {
         it(`for ${m}`, () => {

--- a/lib/src/commands/LayoutTreeCrawler.test.ts
+++ b/lib/src/commands/LayoutTreeCrawler.test.ts
@@ -19,12 +19,9 @@ describe('LayoutTreeCrawler', () => {
   });
 
   it('crawls a layout tree and adds unique id to each node', () => {
-    const node = {
+    const node: LayoutNode = {
       type: LayoutType.Stack,
-      id: 'Stack+UNIQUE_ID',
-      children: [
-        { id: 'BottomTabs+UNIQUE_ID', type: LayoutType.BottomTabs, data: {}, children: [] }
-      ],
+      children: [{ type: LayoutType.BottomTabs, data: {}, children: [] }],
       data: {}
     };
     uut.crawl(node);
@@ -33,9 +30,15 @@ describe('LayoutTreeCrawler', () => {
   });
 
   it('does not generate unique id when already provided', () => {
-    const node = { id: 'user defined id', type: LayoutType.Stack, data: {}, children: [] };
+    const node: LayoutNode = {
+      id: 'user defined id',
+      type: LayoutType.Stack,
+      children: [{ id: 'user defined id for child', type: LayoutType.BottomTabs, data: {}, children: [] }],
+      data: {}
+    };
     uut.crawl(node);
     expect(node.id).toEqual('user defined id');
+    expect(node.children[0].id).toEqual('user defined id for child');
   });
 
   it('crawls a layout tree and ensures data exists', () => {

--- a/lib/src/commands/LayoutTreeCrawler.test.ts
+++ b/lib/src/commands/LayoutTreeCrawler.test.ts
@@ -168,24 +168,6 @@ describe('LayoutTreeCrawler', () => {
     });
   });
 
-  // it('Component: deepClones options', () => {
-  //   const theStyle = {};
-  //   const MyComponent = class CoolComponent extends React.Component {
-  //     static options() {
-  //       return theStyle;
-  //     }
-  //   };
-
-  //   const node = {
-  //     type: LayoutType.Component,
-  //     data: { name: 'theComponentName', options: {} },
-  //     children: []
-  //   };
-  //   store.setComponentClassForName('theComponentName', () => MyComponent);
-  //   uut.crawl(node);
-  //   expect(node.data.options).not.toBe(theStyle);
-  // });
-
   it('Components: must contain data name', () => {
     const node = { type: LayoutType.Component, data: {}, children: [] };
     expect(() => uut.crawl(node)).toThrowError('Missing component data.name');

--- a/lib/src/commands/LayoutTreeCrawler.test.ts
+++ b/lib/src/commands/LayoutTreeCrawler.test.ts
@@ -1,21 +1,25 @@
-import * as React from 'react';
+// import * as React from 'react';
 
 import { LayoutType } from './LayoutType';
 import { LayoutTreeCrawler, LayoutNode } from './LayoutTreeCrawler';
 import { UniqueIdProvider } from '../adapters/UniqueIdProvider.mock';
 import { Store } from '../components/Store';
-import { mock, instance } from 'ts-mockito';
+import { mock, instance, verify, deepEqual } from 'ts-mockito';
 import { OptionsProcessor } from './OptionsProcessor';
 
 describe('LayoutTreeCrawler', () => {
   let uut: LayoutTreeCrawler;
-  let store: Store;
+  let mockedStore: Store;
   let mockedOptionsProcessor: OptionsProcessor;
 
   beforeEach(() => {
-    store = new Store();
+    mockedStore = mock(Store);
     mockedOptionsProcessor = mock(OptionsProcessor);
-    uut = new LayoutTreeCrawler(new UniqueIdProvider(), store, instance(mockedOptionsProcessor));
+    uut = new LayoutTreeCrawler(
+      new UniqueIdProvider(),
+      instance(mockedStore),
+      instance(mockedOptionsProcessor)
+    );
   });
 
   it('crawls a layout tree and adds unique id to each node', () => {
@@ -33,7 +37,9 @@ describe('LayoutTreeCrawler', () => {
     const node: LayoutNode = {
       id: 'user defined id',
       type: LayoutType.Stack,
-      children: [{ id: 'user defined id for child', type: LayoutType.BottomTabs, data: {}, children: [] }],
+      children: [
+        { id: 'user defined id for child', type: LayoutType.BottomTabs, data: {}, children: [] }
+      ],
       data: {}
     };
     uut.crawl(node);
@@ -41,32 +47,12 @@ describe('LayoutTreeCrawler', () => {
     expect(node.children[0].id).toEqual('user defined id for child');
   });
 
-  it('crawls a layout tree and ensures data exists', () => {
-    const node = {
-      type: LayoutType.Stack,
-      children: [{ type: LayoutType.BottomTabs, data: {}, children: [] }],
-      data: {}
-    };
-    uut.crawl(node);
-    expect(node.data).toEqual({});
-    expect(node.children[0].data).toEqual({});
-  });
-
-  it('crawls a layout tree and ensures children exists', () => {
-    const node = {
-      type: LayoutType.Stack,
-      children: [{ type: LayoutType.BottomTabs, data: {}, children: [] }],
-      data: {}
-    };
-    uut.crawl(node);
-    expect(node.children[0].children).toEqual([]);
-  });
-
   it('saves passProps into store for Component nodes', () => {
     const node = {
       type: LayoutType.BottomTabs,
       children: [
         {
+          id: 'testId',
           type: LayoutType.Component,
           data: { name: 'the name', passProps: { myProp: 123 } },
           children: []
@@ -74,214 +60,194 @@ describe('LayoutTreeCrawler', () => {
       ],
       data: {}
     };
-    expect(store.getPropsForId('Component+UNIQUE_ID')).toEqual({});
     uut.crawl(node);
-    expect(store.getPropsForId('Component+UNIQUE_ID')).toEqual({ myProp: 123 });
+    verify(mockedStore.setPropsForId('testId', deepEqual({ myProp: 123 }))).called();
   });
 
-  it('Components: injects options from original component class static property', () => {
-    const theStyle = {};
-    const MyComponent = class CoolComponent extends React.Component {
-      static get options() {
-        return theStyle;
-      }
-    };
+  // it('Components: injects options from original component class static property', () => {
+  //   const theStyle = {};
+  //   const MyComponent = class CoolComponent extends React.Component {
+  //     static get options() {
+  //       return theStyle;
+  //     }
+  //   };
 
-    const node = {
-      type: LayoutType.Component,
-      data: { name: 'theComponentName', options: {} },
-      children: []
-    };
-    store.setComponentClassForName('theComponentName', () => MyComponent);
-    uut.crawl(node);
-    expect(node.data.options).toEqual(theStyle);
-  });
+  //   const node = {
+  //     type: LayoutType.Component,
+  //     data: { name: 'theComponentName', options: {} },
+  //     children: []
+  //   };
+  //   store.setComponentClassForName('theComponentName', () => MyComponent);
+  //   uut.crawl(node);
+  //   expect(node.data.options).toEqual(theStyle);
+  // });
 
-  it('Components: crawl does not cache options', () => {
-    const optionsWithTitle = (title?: string) => {
-      return {
-        topBar: {
-          title: {
-            text: title
-          }
-        }
-      };
-    };
+  // it('Components: crawl does not cache options', () => {
+  //   const optionsWithTitle = (title?: string) => {
+  //     return {
+  //       topBar: {
+  //         title: {
+  //           text: title
+  //         }
+  //       }
+  //     };
+  //   };
 
-    const MyComponent = class CoolComponent extends React.Component {
-      static options(props: { title: string }) {
-        return {
-          topBar: {
-            title: {
-              text: props.title
-            }
-          }
-        };
-      }
-    };
+  //   const MyComponent = class CoolComponent extends React.Component {
+  //     static options(props: { title: string }) {
+  //       return {
+  //         topBar: {
+  //           title: {
+  //             text: props.title
+  //           }
+  //         }
+  //       };
+  //     }
+  //   };
 
-    const node = {
-      type: LayoutType.Component,
-      data: { name: 'theComponentName', options: {}, passProps: { title: 'title' } },
-      children: []
-    };
-    store.setComponentClassForName('theComponentName', () => MyComponent);
-    uut.crawl(node);
-    expect(node.data.options).toEqual(optionsWithTitle('title'));
+  //   const node = {
+  //     type: LayoutType.Component,
+  //     data: { name: 'theComponentName', options: {}, passProps: { title: 'title' } },
+  //     children: []
+  //   };
+  //   store.setComponentClassForName('theComponentName', () => MyComponent);
+  //   uut.crawl(node);
+  //   expect(node.data.options).toEqual(optionsWithTitle('title'));
 
-    const node2 = {
-      type: LayoutType.Component,
-      data: { name: 'theComponentName', options: {} },
-      children: []
-    };
-    uut.crawl(node2);
-    expect(node2.data.options).toEqual(optionsWithTitle(undefined));
-  });
+  //   const node2 = {
+  //     type: LayoutType.Component,
+  //     data: { name: 'theComponentName', options: {} },
+  //     children: []
+  //   };
+  //   uut.crawl(node2);
+  //   expect(node2.data.options).toEqual(optionsWithTitle(undefined));
+  // });
 
-  it('Components: passes passProps to the static options function to be used by the user', () => {
-    const MyComponent = class CoolComponent extends React.Component {
-      static options(passProps: { bar: { baz: { value: string } } }) {
-        return { foo: passProps.bar.baz.value };
-      }
-    };
+  // it('Components: passes passProps to the static options function to be used by the user', () => {
+  //   const MyComponent = class CoolComponent extends React.Component {
+  //     static options(passProps: { bar: { baz: { value: string } } }) {
+  //       return { foo: passProps.bar.baz.value };
+  //     }
+  //   };
 
-    const node = {
-      type: LayoutType.Component,
-      data: {
-        name: 'theComponentName',
-        passProps: { bar: { baz: { value: 'hello' } } },
-        options: {}
-      },
-      children: []
-    };
-    store.setComponentClassForName('theComponentName', () => MyComponent);
-    uut.crawl(node);
-    expect(node.data.options).toEqual({ foo: 'hello' });
-  });
+  //   const node = {
+  //     type: LayoutType.Component,
+  //     data: {
+  //       name: 'theComponentName',
+  //       passProps: { bar: { baz: { value: 'hello' } } },
+  //       options: {}
+  //     },
+  //     children: []
+  //   };
+  //   store.setComponentClassForName('theComponentName', () => MyComponent);
+  //   uut.crawl(node);
+  //   expect(node.data.options).toEqual({ foo: 'hello' });
+  // });
 
-  it('Components: passProps in the static options is optional', () => {
-    const MyComponent = class CoolComponent extends React.Component {
-      static options(passProps: string) {
-        return { foo: passProps };
-      }
-    };
+  // it('Components: passProps in the static options is optional', () => {
+  //   const MyComponent = class CoolComponent extends React.Component {
+  //     static options(passProps: string) {
+  //       return { foo: passProps };
+  //     }
+  //   };
 
-    const node = {
-      type: LayoutType.Component,
-      data: { name: 'theComponentName', options: {} },
-      children: []
-    };
-    store.setComponentClassForName('theComponentName', () => MyComponent);
-    uut.crawl(node);
-    expect(node.data.options).toEqual({ foo: {} });
-  });
+  //   const node = {
+  //     type: LayoutType.Component,
+  //     data: { name: 'theComponentName', options: {} },
+  //     children: []
+  //   };
+  //   store.setComponentClassForName('theComponentName', () => MyComponent);
+  //   uut.crawl(node);
+  //   expect(node.data.options).toEqual({ foo: {} });
+  // });
 
-  it('Components: merges options from component class static property with passed options, favoring passed options', () => {
-    const theStyle = {
-      bazz: 123,
-      inner: {
-        foo: 'bar'
-      },
-      opt: 'exists only in static'
-    };
-    const MyComponent = class CoolComponent extends React.Component {
-      static get options() {
-        return theStyle;
-      }
-    };
+  // it('Components: merges options from component class static property with passed options, favoring passed options', () => {
+  //   const theStyle = {
+  //     bazz: 123,
+  //     inner: {
+  //       foo: 'bar'
+  //     },
+  //     opt: 'exists only in static'
+  //   };
+  //   const MyComponent = class CoolComponent extends React.Component {
+  //     static get options() {
+  //       return theStyle;
+  //     }
+  //   };
 
-    const passedOptions = {
-      aaa: 'exists only in passed',
-      bazz: 789,
-      inner: {
-        foo: 'this is overriden'
-      }
-    };
+  //   const passedOptions = {
+  //     aaa: 'exists only in passed',
+  //     bazz: 789,
+  //     inner: {
+  //       foo: 'this is overriden'
+  //     }
+  //   };
 
-    const node = {
-      type: LayoutType.Component,
-      data: { name: 'theComponentName', options: passedOptions },
-      children: []
-    };
-    store.setComponentClassForName('theComponentName', () => MyComponent);
+  //   const node = {
+  //     type: LayoutType.Component,
+  //     data: { name: 'theComponentName', options: passedOptions },
+  //     children: []
+  //   };
+  //   store.setComponentClassForName('theComponentName', () => MyComponent);
 
-    uut.crawl(node);
+  //   uut.crawl(node);
 
-    expect(node.data.options).toEqual({
-      aaa: 'exists only in passed',
-      bazz: 789,
-      inner: {
-        foo: 'this is overriden'
-      },
-      opt: 'exists only in static'
-    });
-  });
+  //   expect(node.data.options).toEqual({
+  //     aaa: 'exists only in passed',
+  //     bazz: 789,
+  //     inner: {
+  //       foo: 'this is overriden'
+  //     },
+  //     opt: 'exists only in static'
+  //   });
+  // });
 
-  it('Component: deepClones options', () => {
-    const theStyle = {};
-    const MyComponent = class CoolComponent extends React.Component {
-      static get options() {
-        return theStyle;
-      }
-    };
+  // it('Component: deepClones options', () => {
+  //   const theStyle = {};
+  //   const MyComponent = class CoolComponent extends React.Component {
+  //     static get options() {
+  //       return theStyle;
+  //     }
+  //   };
 
-    const node = {
-      type: LayoutType.Component,
-      data: { name: 'theComponentName', options: {} },
-      children: []
-    };
-    store.setComponentClassForName('theComponentName', () => MyComponent);
-    uut.crawl(node);
-    expect(node.data.options).not.toBe(theStyle);
-  });
+  //   const node = {
+  //     type: LayoutType.Component,
+  //     data: { name: 'theComponentName', options: {} },
+  //     children: []
+  //   };
+  //   store.setComponentClassForName('theComponentName', () => MyComponent);
+  //   uut.crawl(node);
+  //   expect(node.data.options).not.toBe(theStyle);
+  // });
 
   it('Components: must contain data name', () => {
     const node = { type: LayoutType.Component, data: {}, children: [] };
     expect(() => uut.crawl(node)).toThrowError('Missing component data.name');
   });
 
-  it('Components: options default obj', () => {
-    const MyComponent = class extends React.Component {};
+  // it('Components: options default obj', () => {
+  //   const MyComponent = class extends React.Component {};
 
-    const node = {
-      type: LayoutType.Component,
-      data: { name: 'theComponentName', options: {} },
-      children: []
-    };
-    store.setComponentClassForName('theComponentName', () => MyComponent);
-    uut.crawl(node);
-    expect(node.data.options).toEqual({});
-  });
+  //   const node = {
+  //     type: LayoutType.Component,
+  //     data: { name: 'theComponentName', options: {} },
+  //     children: []
+  //   };
+  //   store.setComponentClassForName('theComponentName', () => MyComponent);
+  //   uut.crawl(node);
+  //   expect(node.data.options).toEqual({});
+  // });
 
   it('Components: omits passProps after processing so they are not passed over the bridge', () => {
     const node = {
       type: LayoutType.Component,
       data: {
         name: 'compName',
-        passProps: {}
+        passProps: { someProp: 'here' }
       },
       children: []
     };
     uut.crawl(node);
     expect(node.data.passProps).toBeUndefined();
-  });
-
-  describe('LayoutNode', () => {
-    it('convertable from same data structure', () => {
-      const x = {
-        id: 'theId',
-        type: LayoutType.Component,
-        data: {},
-        children: []
-      };
-
-      let got;
-      function expectingLayoutNode(param: LayoutNode) {
-        got = param;
-      }
-      expectingLayoutNode(x);
-
-      expect(got).toBe(x);
-    });
   });
 });

--- a/lib/src/commands/LayoutTreeCrawler.test.ts
+++ b/lib/src/commands/LayoutTreeCrawler.test.ts
@@ -74,7 +74,7 @@ describe('LayoutTreeCrawler', () => {
     when(mockedStore.getComponentClassForName('theComponentName')).thenReturn(
       () =>
         class extends React.Component {
-          static get options(): Options {
+          static options(): Options {
             return { popGesture: true };
           }
         }
@@ -135,7 +135,7 @@ describe('LayoutTreeCrawler', () => {
     when(mockedStore.getComponentClassForName('theComponentName')).thenReturn(
       () =>
         class extends React.Component {
-          static get options() {
+          static options() {
             return {
               bazz: 123,
               inner: { foo: 'this gets overriden' },
@@ -171,7 +171,7 @@ describe('LayoutTreeCrawler', () => {
   // it('Component: deepClones options', () => {
   //   const theStyle = {};
   //   const MyComponent = class CoolComponent extends React.Component {
-  //     static get options() {
+  //     static options() {
   //       return theStyle;
   //     }
   //   };

--- a/lib/src/commands/LayoutTreeCrawler.test.ts
+++ b/lib/src/commands/LayoutTreeCrawler.test.ts
@@ -1,60 +1,27 @@
 import * as React from 'react';
 
 import { LayoutType } from './LayoutType';
-import { LayoutTreeCrawler, LayoutNode } from './LayoutTreeCrawler';
-import { UniqueIdProvider } from '../adapters/UniqueIdProvider';
+import { LayoutTreeCrawler } from './LayoutTreeCrawler';
 import { Store } from '../components/Store';
-import { mock, instance, verify, deepEqual, when, anyString } from 'ts-mockito';
+import { mock, instance, verify, deepEqual, when } from 'ts-mockito';
 import { OptionsProcessor } from './OptionsProcessor';
 import { Options } from '../interfaces/Options';
 
 describe('LayoutTreeCrawler', () => {
   let uut: LayoutTreeCrawler;
-  let mockedUniqueIdProvider: UniqueIdProvider;
   let mockedStore: Store;
   let mockedOptionsProcessor: OptionsProcessor;
 
   beforeEach(() => {
-    mockedUniqueIdProvider = mock(UniqueIdProvider);
     mockedStore = mock(Store);
     mockedOptionsProcessor = mock(OptionsProcessor);
 
-    when(mockedUniqueIdProvider.generate(anyString())).thenCall((prefix) => `${prefix}+UNIQUE_ID`);
-
-    uut = new LayoutTreeCrawler(
-      instance(mockedUniqueIdProvider),
-      instance(mockedStore),
-      instance(mockedOptionsProcessor)
-    );
-  });
-
-  it('crawls a layout tree and adds unique id to each node', () => {
-    const node: LayoutNode = {
-      type: LayoutType.Stack,
-      children: [{ type: LayoutType.BottomTabs, data: {}, children: [] }],
-      data: {}
-    };
-    uut.crawl(node);
-    expect(node.id).toEqual('Stack+UNIQUE_ID');
-    expect(node.children[0].id).toEqual('BottomTabs+UNIQUE_ID');
-  });
-
-  it('does not generate unique id when already provided', () => {
-    const node: LayoutNode = {
-      id: 'user defined id',
-      type: LayoutType.Stack,
-      children: [
-        { id: 'user defined id for child', type: LayoutType.BottomTabs, data: {}, children: [] }
-      ],
-      data: {}
-    };
-    uut.crawl(node);
-    expect(node.id).toEqual('user defined id');
-    expect(node.children[0].id).toEqual('user defined id for child');
+    uut = new LayoutTreeCrawler(instance(mockedStore), instance(mockedOptionsProcessor));
   });
 
   it('saves passProps into store for Component nodes', () => {
     const node = {
+      id: 'testId',
       type: LayoutType.BottomTabs,
       children: [
         {
@@ -80,6 +47,7 @@ describe('LayoutTreeCrawler', () => {
         }
     );
     const node = {
+      id: 'testId',
       type: LayoutType.Component,
       data: { name: 'theComponentName', options: {} },
       children: []
@@ -98,6 +66,7 @@ describe('LayoutTreeCrawler', () => {
         }
     );
     const node = {
+      id: 'testId',
       type: LayoutType.Component,
       data: { name: 'theComponentName', options: {}, passProps: { title: 'title' } },
       children: []
@@ -106,6 +75,7 @@ describe('LayoutTreeCrawler', () => {
     expect(node.data.options).toEqual({ topBar: { title: { text: 'title' } } });
 
     const node2 = {
+      id: 'testId',
       type: LayoutType.Component,
       data: { name: 'theComponentName', options: {} },
       children: []
@@ -146,6 +116,7 @@ describe('LayoutTreeCrawler', () => {
     );
 
     const node = {
+      id: 'testId',
       type: LayoutType.Component,
       data: {
         name: 'theComponentName',
@@ -169,7 +140,7 @@ describe('LayoutTreeCrawler', () => {
   });
 
   it('Components: must contain data name', () => {
-    const node = { type: LayoutType.Component, data: {}, children: [] };
+    const node = { type: LayoutType.Component, data: {}, children: [], id: 'testId' };
     expect(() => uut.crawl(node)).toThrowError('Missing component data.name');
   });
 
@@ -179,6 +150,7 @@ describe('LayoutTreeCrawler', () => {
     );
 
     const node = {
+      id: 'testId',
       type: LayoutType.Component,
       data: { name: 'theComponentName', options: {} },
       children: []
@@ -189,6 +161,7 @@ describe('LayoutTreeCrawler', () => {
 
   it('Components: omits passProps after processing so they are not passed over the bridge', () => {
     const node = {
+      id: 'testId',
       type: LayoutType.Component,
       data: {
         name: 'compName',

--- a/lib/src/commands/LayoutTreeCrawler.test.ts
+++ b/lib/src/commands/LayoutTreeCrawler.test.ts
@@ -84,23 +84,6 @@ describe('LayoutTreeCrawler', () => {
     expect(node2.data.options).toEqual({ topBar: { title: {} } });
   });
 
-  // it('Components: passProps in the static options is optional', () => {
-  //   const MyComponent = class CoolComponent extends React.Component {
-  //     static options(passProps: string) {
-  //       return { foo: passProps };
-  //     }
-  //   };
-
-  //   const node = {
-  //     type: LayoutType.Component,
-  //     data: { name: 'theComponentName', options: {} },
-  //     children: []
-  //   };
-  //   store.setComponentClassForName('theComponentName', () => MyComponent);
-  //   uut.crawl(node);
-  //   expect(node.data.options).toEqual({ foo: {} });
-  // });
-
   it('Components: merges options from component class static property with passed options, favoring passed options', () => {
     when(mockedStore.getComponentClassForName('theComponentName')).thenReturn(
       () =>

--- a/lib/src/commands/LayoutTreeCrawler.test.ts
+++ b/lib/src/commands/LayoutTreeCrawler.test.ts
@@ -2,21 +2,26 @@
 
 import { LayoutType } from './LayoutType';
 import { LayoutTreeCrawler, LayoutNode } from './LayoutTreeCrawler';
-import { UniqueIdProvider } from '../adapters/UniqueIdProvider.mock';
+import { UniqueIdProvider } from '../adapters/UniqueIdProvider';
 import { Store } from '../components/Store';
-import { mock, instance, verify, deepEqual } from 'ts-mockito';
+import { mock, instance, verify, deepEqual, when, anyString } from 'ts-mockito';
 import { OptionsProcessor } from './OptionsProcessor';
 
 describe('LayoutTreeCrawler', () => {
   let uut: LayoutTreeCrawler;
+  let mockedUniqueIdProvider: UniqueIdProvider;
   let mockedStore: Store;
   let mockedOptionsProcessor: OptionsProcessor;
 
   beforeEach(() => {
+    mockedUniqueIdProvider = mock(UniqueIdProvider);
     mockedStore = mock(Store);
     mockedOptionsProcessor = mock(OptionsProcessor);
+
+    when(mockedUniqueIdProvider.generate(anyString())).thenCall((prefix) => `${prefix}+UNIQUE_ID`);
+
     uut = new LayoutTreeCrawler(
-      new UniqueIdProvider(),
+      instance(mockedUniqueIdProvider),
       instance(mockedStore),
       instance(mockedOptionsProcessor)
     );

--- a/lib/src/commands/LayoutTreeCrawler.test.ts
+++ b/lib/src/commands/LayoutTreeCrawler.test.ts
@@ -10,16 +10,23 @@ import { OptionsProcessor } from './OptionsProcessor';
 describe('LayoutTreeCrawler', () => {
   let uut: LayoutTreeCrawler;
   let store: Store;
+  let mockedOptionsProcessor: OptionsProcessor;
 
   beforeEach(() => {
     store = new Store();
-    const mockedOptionsProcessor = mock(OptionsProcessor);
-    const optionsProcessor = instance(mockedOptionsProcessor);
-    uut = new LayoutTreeCrawler(new UniqueIdProvider(), store, optionsProcessor);
+    mockedOptionsProcessor = mock(OptionsProcessor);
+    uut = new LayoutTreeCrawler(new UniqueIdProvider(), store, instance(mockedOptionsProcessor));
   });
 
   it('crawls a layout tree and adds unique id to each node', () => {
-    const node = { type: LayoutType.Stack, id: 'Stack+UNIQUE_ID', children: [{ id: 'BottomTabs+UNIQUE_ID', type: LayoutType.BottomTabs, data: {}, children: [] }], data: {} };
+    const node = {
+      type: LayoutType.Stack,
+      id: 'Stack+UNIQUE_ID',
+      children: [
+        { id: 'BottomTabs+UNIQUE_ID', type: LayoutType.BottomTabs, data: {}, children: [] }
+      ],
+      data: {}
+    };
     uut.crawl(node);
     expect(node.id).toEqual('Stack+UNIQUE_ID');
     expect(node.children[0].id).toEqual('BottomTabs+UNIQUE_ID');
@@ -32,14 +39,22 @@ describe('LayoutTreeCrawler', () => {
   });
 
   it('crawls a layout tree and ensures data exists', () => {
-    const node = { type: LayoutType.Stack, children: [{ type: LayoutType.BottomTabs, data: {}, children: [] }], data: {} };
+    const node = {
+      type: LayoutType.Stack,
+      children: [{ type: LayoutType.BottomTabs, data: {}, children: [] }],
+      data: {}
+    };
     uut.crawl(node);
     expect(node.data).toEqual({});
     expect(node.children[0].data).toEqual({});
   });
 
   it('crawls a layout tree and ensures children exists', () => {
-    const node = { type: LayoutType.Stack, children: [{ type: LayoutType.BottomTabs, data: {}, children: [] }], data: {} };
+    const node = {
+      type: LayoutType.Stack,
+      children: [{ type: LayoutType.BottomTabs, data: {}, children: [] }],
+      data: {}
+    };
     uut.crawl(node);
     expect(node.children[0].children).toEqual([]);
   });
@@ -47,7 +62,13 @@ describe('LayoutTreeCrawler', () => {
   it('saves passProps into store for Component nodes', () => {
     const node = {
       type: LayoutType.BottomTabs,
-      children: [{ type: LayoutType.Component, data: { name: 'the name', passProps: { myProp: 123 } }, children: [] }],
+      children: [
+        {
+          type: LayoutType.Component,
+          data: { name: 'the name', passProps: { myProp: 123 } },
+          children: []
+        }
+      ],
       data: {}
     };
     expect(store.getPropsForId('Component+UNIQUE_ID')).toEqual({});
@@ -63,7 +84,11 @@ describe('LayoutTreeCrawler', () => {
       }
     };
 
-    const node = { type: LayoutType.Component, data: { name: 'theComponentName', options: {} }, children: [] };
+    const node = {
+      type: LayoutType.Component,
+      data: { name: 'theComponentName', options: {} },
+      children: []
+    };
     store.setComponentClassForName('theComponentName', () => MyComponent);
     uut.crawl(node);
     expect(node.data.options).toEqual(theStyle);
@@ -81,7 +106,7 @@ describe('LayoutTreeCrawler', () => {
     };
 
     const MyComponent = class CoolComponent extends React.Component {
-      static options(props: {title: string}) {
+      static options(props: { title: string }) {
         return {
           topBar: {
             title: {
@@ -92,24 +117,40 @@ describe('LayoutTreeCrawler', () => {
       }
     };
 
-    const node = { type: LayoutType.Component, data: { name: 'theComponentName', options: {}, passProps: { title: 'title' } }, children: [] };
+    const node = {
+      type: LayoutType.Component,
+      data: { name: 'theComponentName', options: {}, passProps: { title: 'title' } },
+      children: []
+    };
     store.setComponentClassForName('theComponentName', () => MyComponent);
     uut.crawl(node);
     expect(node.data.options).toEqual(optionsWithTitle('title'));
 
-    const node2 = { type: LayoutType.Component, data: { name: 'theComponentName', options: {} }, children: [] };
+    const node2 = {
+      type: LayoutType.Component,
+      data: { name: 'theComponentName', options: {} },
+      children: []
+    };
     uut.crawl(node2);
     expect(node2.data.options).toEqual(optionsWithTitle(undefined));
   });
 
   it('Components: passes passProps to the static options function to be used by the user', () => {
     const MyComponent = class CoolComponent extends React.Component {
-      static options(passProps: {bar: {baz: {value: string}}}) {
+      static options(passProps: { bar: { baz: { value: string } } }) {
         return { foo: passProps.bar.baz.value };
       }
     };
 
-    const node = { type: LayoutType.Component, data: { name: 'theComponentName', passProps: { bar: { baz: { value: 'hello' } } }, options: {} }, children: [] };
+    const node = {
+      type: LayoutType.Component,
+      data: {
+        name: 'theComponentName',
+        passProps: { bar: { baz: { value: 'hello' } } },
+        options: {}
+      },
+      children: []
+    };
     store.setComponentClassForName('theComponentName', () => MyComponent);
     uut.crawl(node);
     expect(node.data.options).toEqual({ foo: 'hello' });
@@ -122,7 +163,11 @@ describe('LayoutTreeCrawler', () => {
       }
     };
 
-    const node = { type: LayoutType.Component, data: { name: 'theComponentName', options: {} }, children: [] };
+    const node = {
+      type: LayoutType.Component,
+      data: { name: 'theComponentName', options: {} },
+      children: []
+    };
     store.setComponentClassForName('theComponentName', () => MyComponent);
     uut.crawl(node);
     expect(node.data.options).toEqual({ foo: {} });
@@ -150,7 +195,11 @@ describe('LayoutTreeCrawler', () => {
       }
     };
 
-    const node = { type: LayoutType.Component, data: { name: 'theComponentName', options: passedOptions }, children: [] };
+    const node = {
+      type: LayoutType.Component,
+      data: { name: 'theComponentName', options: passedOptions },
+      children: []
+    };
     store.setComponentClassForName('theComponentName', () => MyComponent);
 
     uut.crawl(node);
@@ -173,7 +222,11 @@ describe('LayoutTreeCrawler', () => {
       }
     };
 
-    const node = { type: LayoutType.Component, data: { name: 'theComponentName', options: {} }, children: [] };
+    const node = {
+      type: LayoutType.Component,
+      data: { name: 'theComponentName', options: {} },
+      children: []
+    };
     store.setComponentClassForName('theComponentName', () => MyComponent);
     uut.crawl(node);
     expect(node.data.options).not.toBe(theStyle);
@@ -185,9 +238,13 @@ describe('LayoutTreeCrawler', () => {
   });
 
   it('Components: options default obj', () => {
-    const MyComponent = class extends React.Component { };
+    const MyComponent = class extends React.Component {};
 
-    const node = { type: LayoutType.Component, data: { name: 'theComponentName', options: {} }, children: [] };
+    const node = {
+      type: LayoutType.Component,
+      data: { name: 'theComponentName', options: {} },
+      children: []
+    };
     store.setComponentClassForName('theComponentName', () => MyComponent);
     uut.crawl(node);
     expect(node.data.options).toEqual({});

--- a/lib/src/commands/LayoutTreeCrawler.ts
+++ b/lib/src/commands/LayoutTreeCrawler.ts
@@ -1,7 +1,6 @@
 import * as _ from 'lodash';
 import { LayoutType } from './LayoutType';
 import { OptionsProcessor } from './OptionsProcessor';
-import { UniqueIdProvider } from '../adapters/UniqueIdProvider';
 import { Store } from '../components/Store';
 
 export interface Data {
@@ -10,7 +9,7 @@ export interface Data {
   passProps?: any;
 }
 export interface LayoutNode {
-  id?: string;
+  id: string;
   type: LayoutType;
   data: Data;
   children: LayoutNode[];
@@ -18,7 +17,6 @@ export interface LayoutNode {
 
 export class LayoutTreeCrawler {
   constructor(
-    private readonly uniqueIdProvider: UniqueIdProvider,
     public readonly store: Store,
     private readonly optionsProcessor: OptionsProcessor
   ) {
@@ -26,7 +24,6 @@ export class LayoutTreeCrawler {
   }
 
   crawl(node: LayoutNode): void {
-    node.id = node.id || this.uniqueIdProvider.generate(node.type);
     if (node.type === LayoutType.Component) {
       this.handleComponent(node);
     }
@@ -42,7 +39,7 @@ export class LayoutTreeCrawler {
   }
 
   private savePropsToStore(node: LayoutNode) {
-    this.store.setPropsForId(node.id!, node.data.passProps);
+    this.store.setPropsForId(node.id, node.data.passProps);
   }
 
   private staticOptionsIfPossible(node: LayoutNode) {

--- a/lib/src/commands/LayoutTreeCrawler.ts
+++ b/lib/src/commands/LayoutTreeCrawler.ts
@@ -50,7 +50,7 @@ export class LayoutTreeCrawler {
       : {};
     const staticOptions = _.isFunction(clazz.options)
       ? clazz.options(node.data.passProps || {})
-      : _.cloneDeep(clazz.options) || {};
+      : {};
     const passedOptions = node.data.options || {};
     node.data.options = _.merge({}, staticOptions, passedOptions);
   }

--- a/lib/src/commands/LayoutTreeCrawler.ts
+++ b/lib/src/commands/LayoutTreeCrawler.ts
@@ -27,31 +27,31 @@ export class LayoutTreeCrawler {
   crawl(node: LayoutNode): void {
     node.id = node.id || this.uniqueIdProvider.generate(node.type);
     if (node.type === LayoutType.Component) {
-      this._handleComponent(node);
+      this.handleComponent(node);
     }
     this.optionsProcessor.processOptions(node.data.options);
-    _.forEach(node.children, this.crawl);
+    node.children.forEach(this.crawl);
   }
 
-  _handleComponent(node) {
-    this._assertComponentDataName(node);
-    this._savePropsToStore(node);
-    this._applyStaticOptions(node);
+  private handleComponent(node) {
+    this.assertComponentDataName(node);
+    this.savePropsToStore(node);
+    this.applyStaticOptions(node);
     node.data.passProps = undefined;
   }
 
-  _savePropsToStore(node) {
+  private savePropsToStore(node) {
     this.store.setPropsForId(node.id, node.data.passProps);
   }
 
-  _applyStaticOptions(node) {
+  private applyStaticOptions(node) {
     const clazz = this.store.getComponentClassForName(node.data.name) ? this.store.getComponentClassForName(node.data.name)() : {};
     const staticOptions = _.isFunction(clazz.options) ? clazz.options(node.data.passProps || {}) : (_.cloneDeep(clazz.options) || {});
     const passedOptions = node.data.options || {};
     node.data.options = _.merge({}, staticOptions, passedOptions);
   }
 
-  _assertComponentDataName(component) {
+  private assertComponentDataName(component) {
     if (!component.data.name) {
       throw new Error('Missing component data.name');
     }

--- a/lib/src/commands/LayoutTreeCrawler.ts
+++ b/lib/src/commands/LayoutTreeCrawler.ts
@@ -45,8 +45,12 @@ export class LayoutTreeCrawler {
   }
 
   private applyStaticOptions(node) {
-    const clazz = this.store.getComponentClassForName(node.data.name) ? this.store.getComponentClassForName(node.data.name)() : {};
-    const staticOptions = _.isFunction(clazz.options) ? clazz.options(node.data.passProps || {}) : (_.cloneDeep(clazz.options) || {});
+    const clazz = this.store.getComponentClassForName(node.data.name)
+      ? this.store.getComponentClassForName(node.data.name)()
+      : {};
+    const staticOptions = _.isFunction(clazz.options)
+      ? clazz.options(node.data.passProps || {})
+      : _.cloneDeep(clazz.options) || {};
     const passedOptions = node.data.options || {};
     node.data.options = _.merge({}, staticOptions, passedOptions);
   }

--- a/lib/src/commands/LayoutTreeCrawler.ts
+++ b/lib/src/commands/LayoutTreeCrawler.ts
@@ -51,11 +51,11 @@ export class LayoutTreeCrawler {
     const reactComponent = foundReactGenerator ? foundReactGenerator() : undefined;
     return reactComponent && this.isComponentWithOptions(reactComponent)
       ? reactComponent.options(node.data.passProps || {})
-      : undefined;
+      : {};
   }
 
   private applyStaticOptions(node: LayoutNode) {
-    node.data.options = { ...this.staticOptionsIfPossible(node), ...node.data.options };
+    node.data.options = _.merge({}, this.staticOptionsIfPossible(node), node.data.options);
   }
 
   private assertComponentDataName(component: LayoutNode) {

--- a/lib/src/commands/LayoutTreeParser.ts
+++ b/lib/src/commands/LayoutTreeParser.ts
@@ -33,7 +33,7 @@ export class LayoutTreeParser {
     } else if (api.splitView) {
       return this.splitView(api.splitView);
     }
-    throw new Error(`unknown LayoutType "${Object.keys(api)}"`); // käytä object.keys?
+    throw new Error(`unknown LayoutType "${Object.keys(api)}"`);
   }
 
   private topTabs(api: TopTabs): LayoutNode {

--- a/lib/src/commands/LayoutTreeParser.ts
+++ b/lib/src/commands/LayoutTreeParser.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import { LayoutType } from './LayoutType';
 import { LayoutNode } from './LayoutTreeCrawler';
 import {
@@ -34,7 +33,7 @@ export class LayoutTreeParser {
     } else if (api.splitView) {
       return this.splitView(api.splitView);
     }
-    throw new Error(`unknown LayoutType "${_.keys(api)}"`);
+    throw new Error(`unknown LayoutType "${Object.keys(api)}"`); // käytä object.keys?
   }
 
   private topTabs(api: TopTabs): LayoutNode {

--- a/lib/src/commands/LayoutTreeParser.ts
+++ b/lib/src/commands/LayoutTreeParser.ts
@@ -11,9 +11,10 @@ import {
   LayoutSplitView,
   ExternalComponent
 } from '../interfaces/Layout';
+import { UniqueIdProvider } from '../adapters/UniqueIdProvider';
 
 export class LayoutTreeParser {
-  constructor() {
+  constructor(private uniqueIdProvider: UniqueIdProvider) {
     this.parse = this.parse.bind(this);
   }
 
@@ -38,7 +39,7 @@ export class LayoutTreeParser {
 
   private topTabs(api: TopTabs): LayoutNode {
     return {
-      id: api.id,
+      id: api.id || this.uniqueIdProvider.generate(LayoutType.TopTabs),
       type: LayoutType.TopTabs,
       data: { options: api.options },
       children: api.children ? api.children.map(this.parse) : []
@@ -47,7 +48,7 @@ export class LayoutTreeParser {
 
   private sideMenu(api: LayoutSideMenu): LayoutNode {
     return {
-      id: api.id,
+      id: api.id || this.uniqueIdProvider.generate(LayoutType.SideMenuRoot),
       type: LayoutType.SideMenuRoot,
       data: { options: api.options },
       children: this.sideMenuChildren(api)
@@ -57,15 +58,22 @@ export class LayoutTreeParser {
   private sideMenuChildren(api: LayoutSideMenu): LayoutNode[] {
     const children: LayoutNode[] = [];
     if (api.left) {
-      children.push({ type: LayoutType.SideMenuLeft, data: {}, children: [this.parse(api.left)] });
+      children.push({
+        id: this.uniqueIdProvider.generate(LayoutType.SideMenuLeft),
+        type: LayoutType.SideMenuLeft,
+        data: {},
+        children: [this.parse(api.left)]
+      });
     }
     children.push({
+      id: this.uniqueIdProvider.generate(LayoutType.SideMenuCenter),
       type: LayoutType.SideMenuCenter,
       data: {},
       children: [this.parse(api.center)]
     });
     if (api.right) {
       children.push({
+        id: this.uniqueIdProvider.generate(LayoutType.SideMenuRight),
         type: LayoutType.SideMenuRight,
         data: {},
         children: [this.parse(api.right)]
@@ -76,7 +84,7 @@ export class LayoutTreeParser {
 
   private bottomTabs(api: LayoutBottomTabs): LayoutNode {
     return {
-      id: api.id,
+      id: api.id || this.uniqueIdProvider.generate(LayoutType.BottomTabs),
       type: LayoutType.BottomTabs,
       data: { options: api.options },
       children: api.children ? api.children.map(this.parse) : []
@@ -85,7 +93,7 @@ export class LayoutTreeParser {
 
   private stack(api: LayoutStack): LayoutNode {
     return {
-      id: api.id,
+      id: api.id || this.uniqueIdProvider.generate(LayoutType.Stack),
       type: LayoutType.Stack,
       data: { options: api.options },
       children: api.children ? api.children.map(this.parse) : []
@@ -94,7 +102,7 @@ export class LayoutTreeParser {
 
   private component(api: LayoutComponent): LayoutNode {
     return {
-      id: api.id,
+      id: api.id || this.uniqueIdProvider.generate(LayoutType.Component),
       type: LayoutType.Component,
       data: { name: api.name.toString(), options: api.options, passProps: api.passProps },
       children: []
@@ -103,7 +111,7 @@ export class LayoutTreeParser {
 
   private externalComponent(api: ExternalComponent): LayoutNode {
     return {
-      id: api.id,
+      id: api.id || this.uniqueIdProvider.generate(LayoutType.ExternalComponent),
       type: LayoutType.ExternalComponent,
       data: { name: api.name.toString(), options: api.options, passProps: api.passProps },
       children: []
@@ -115,7 +123,7 @@ export class LayoutTreeParser {
     const detail = api.detail ? this.parse(api.detail) : undefined;
 
     return {
-      id: api.id,
+      id: api.id || this.uniqueIdProvider.generate(LayoutType.SplitView),
       type: LayoutType.SplitView,
       data: { options: api.options },
       children: master && detail ? [master, detail] : []

--- a/lib/src/commands/OptionsProcessor.test.ts
+++ b/lib/src/commands/OptionsProcessor.test.ts
@@ -1,7 +1,6 @@
 import { OptionsProcessor } from './OptionsProcessor';
 import { UniqueIdProvider } from '../adapters/UniqueIdProvider';
 import { Store } from '../components/Store';
-import * as _ from 'lodash';
 import { Options, OptionsModalPresentationStyle } from '../interfaces/Options';
 import { mock, when, anyString, instance, anyNumber, verify } from 'ts-mockito';
 import { ColorService } from '../adapters/ColorService';

--- a/lib/src/components/ComponentWrapper.test.tsx
+++ b/lib/src/components/ComponentWrapper.test.tsx
@@ -159,7 +159,7 @@ describe('ComponentWrapper', () => {
 
   describe(`register with redux store`, () => {
     class MyReduxComp extends React.Component<any> {
-      static get options() {
+      static options() {
         return { foo: 123 };
       }
       render() {
@@ -185,7 +185,7 @@ describe('ComponentWrapper', () => {
       const NavigationComponent = uut.wrap(componentName, () => ConnectedComp, store, componentEventsObserver, undefined, ReduxProvider, reduxStore);
       const tree = renderer.create(<NavigationComponent componentId={'theCompId'} />);
       expect(tree.toJSON()!.children).toEqual(['it just works']);
-      expect((NavigationComponent as any).options).toEqual({ foo: 123 });
+      expect((NavigationComponent as any).options()).toEqual({ foo: 123 });
     });
   });
 

--- a/lib/src/components/Store.ts
+++ b/lib/src/components/Store.ts
@@ -1,8 +1,8 @@
-import * as React from 'react';
 import * as _ from 'lodash';
+import { ComponentProvider } from 'react-native';
 
 export class Store {
-  private componentsByName: Record<string, () => React.ComponentClass<any, any>> = {};
+  private componentsByName: Record<string, ComponentProvider> = {};
   private propsById: Record<string, any> = {};
 
   setPropsForId(componentId: string, props: any) {
@@ -13,11 +13,11 @@ export class Store {
     return _.get(this.propsById, componentId, {});
   }
 
-  setComponentClassForName(componentName: string | number, ComponentClass: () => React.ComponentClass<any, any>) {
+  setComponentClassForName(componentName: string | number, ComponentClass: ComponentProvider) {
     _.set(this.componentsByName, componentName.toString(), ComponentClass);
   }
 
-  getComponentClassForName(componentName: string | number) {
+  getComponentClassForName(componentName: string | number): ComponentProvider | undefined {
     return _.get(this.componentsByName, componentName.toString());
   }
 

--- a/lib/src/components/Store.ts
+++ b/lib/src/components/Store.ts
@@ -13,15 +13,15 @@ export class Store {
     return _.get(this.propsById, componentId, {});
   }
 
+  cleanId(componentId: string) {
+    _.unset(this.propsById, componentId);
+  }
+
   setComponentClassForName(componentName: string | number, ComponentClass: ComponentProvider) {
     _.set(this.componentsByName, componentName.toString(), ComponentClass);
   }
 
   getComponentClassForName(componentName: string | number): ComponentProvider | undefined {
     return _.get(this.componentsByName, componentName.toString());
-  }
-
-  cleanId(componentId: string) {
-    _.unset(this.propsById, componentId);
   }
 }

--- a/lib/src/events/CommandsObserver.ts
+++ b/lib/src/events/CommandsObserver.ts
@@ -1,7 +1,7 @@
 import { EventSubscription } from '../interfaces/EventSubscription';
 import { UniqueIdProvider } from '../adapters/UniqueIdProvider';
 
-export type CommandsListener = (name: string, params: any) => void;
+export type CommandsListener = (name: string, params: Record<string, any>) => void;
 
 export class CommandsObserver {
   private listeners: Record<string, CommandsListener> = {};
@@ -15,7 +15,7 @@ export class CommandsObserver {
     };
   }
 
-  public notify(commandName: string, params: any): void {
+  public notify(commandName: string, params: Record<string, any>): void {
     Object.values(this.listeners).forEach((listener) => listener(commandName, params));
   }
 }

--- a/lib/src/events/ComponentEventsObserver.ts
+++ b/lib/src/events/ComponentEventsObserver.ts
@@ -12,8 +12,10 @@ import {
 } from '../interfaces/ComponentEvents';
 import { NativeEventsReceiver } from '../adapters/NativeEventsReceiver';
 
+type ReactComponentWithIndexing = React.Component<any> & Record<string, any>;
+
 export class ComponentEventsObserver {
-  private readonly listeners = {};
+  private listeners: Record<string, Record<string, ReactComponentWithIndexing>> = {};
   private alreadyRegistered = false;
 
   constructor(private readonly nativeEventsReceiver: NativeEventsReceiver) {
@@ -87,7 +89,7 @@ export class ComponentEventsObserver {
 
   private triggerOnAllListenersByComponentId(event: ComponentEvent, method: string) {
     _.forEach(this.listeners[event.componentId], (component) => {
-      if (_.isObject(component) && _.isFunction(component[method])) {
+      if (component[method]) {
         component[method](event);
       }
     });

--- a/lib/src/events/EventsRegistry.test.tsx
+++ b/lib/src/events/EventsRegistry.test.tsx
@@ -1,7 +1,7 @@
 import { EventsRegistry } from './EventsRegistry';
 import { NativeEventsReceiver } from '../adapters/NativeEventsReceiver.mock';
 import { CommandsObserver } from './CommandsObserver';
-import { UniqueIdProvider } from '../adapters/UniqueIdProvider.mock';
+import { UniqueIdProvider } from '../adapters/UniqueIdProvider';
 
 describe('EventsRegistry', () => {
   let uut: EventsRegistry;

--- a/playground/src/screens/BackHandlerModalScreen.js
+++ b/playground/src/screens/BackHandlerModalScreen.js
@@ -4,7 +4,7 @@ const { Component } = require('react');
 const { View, Text, Button, BackHandler } = require('react-native');
 
 class BackHandlerModalScreen extends Component {
-  static get options() {
+  static options() {
     return {
       topBar: {
         title: {

--- a/playground/src/screens/BackHandlerScreen.js
+++ b/playground/src/screens/BackHandlerScreen.js
@@ -4,7 +4,7 @@ const { Navigation } = require('react-native-navigation');
 const { View, Text, Button, BackHandler } = require('react-native');
 
 class BackHandlerScreen extends Component {
-  static get options() {
+  static options() {
     return {
       topBar: {
         title: {

--- a/playground/src/screens/CustomDialog.js
+++ b/playground/src/screens/CustomDialog.js
@@ -7,7 +7,7 @@ const { Navigation } = require('react-native-navigation');
 const testIDs = require('../testIDs');
 
 class CustomDialog extends PureComponent {
-  static get options() {
+  static options() {
     return {
       statusBarBackgroundColor: 'green'
     };

--- a/playground/src/screens/CustomTransitionDestination.js
+++ b/playground/src/screens/CustomTransitionDestination.js
@@ -11,7 +11,7 @@ class CustomTransitionDestination extends Component {
     this.push = this.push.bind(this);
   }
 
-  static get options() {
+  static options() {
     return {
       topBar: {
         title: {

--- a/playground/src/screens/CustomTransitionOrigin.js
+++ b/playground/src/screens/CustomTransitionOrigin.js
@@ -8,7 +8,7 @@ class CustomTransitionOrigin extends Component {
     super(props);
     this.onClickNavigationIcon = this.onClickNavigationIcon.bind(this);
   }
-  static get options() {
+  static options() {
     return {
       topBar: {
         title: {

--- a/playground/src/screens/KeyboardScreen.js
+++ b/playground/src/screens/KeyboardScreen.js
@@ -22,7 +22,7 @@ const LOREM_IPSUM = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, se
                     'dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
 
 class KeyboardScreen extends Component {
-  static get options() {
+  static options() {
     return {
       bottomTabs: {
         drawBehind: true,

--- a/playground/src/screens/ModalScreen.js
+++ b/playground/src/screens/ModalScreen.js
@@ -9,7 +9,7 @@ const { Navigation } = require('react-native-navigation');
 const testIDs = require('../testIDs');
 
 class ModalScreen extends Component {
-  static get options() {
+  static options() {
     return {
       statusBar: {
         visible: false,

--- a/playground/src/screens/OptionsScreen.js
+++ b/playground/src/screens/OptionsScreen.js
@@ -20,7 +20,7 @@ class OptionsScreen extends Component {
     Navigation.events().bindComponent(this);
   }
 
-  static get options() {
+  static options() {
     return {
       statusBar: {
         style: 'dark',

--- a/playground/src/screens/PushedScreen.js
+++ b/playground/src/screens/PushedScreen.js
@@ -7,7 +7,7 @@ const Button = require('./Button');
 const testIDs = require('../testIDs');
 
 class PushedScreen extends Component {
-  static get options() {
+  static options() {
     return {
       _statusBar: {
         visible: false,

--- a/playground/src/screens/ScrollViewScreen.js
+++ b/playground/src/screens/ScrollViewScreen.js
@@ -9,7 +9,7 @@ const testIDs = require('../testIDs');
 const FAB = 'fab';
 
 class ScrollViewScreen extends Component {
-  static get options() {
+  static options() {
     return {
       topBar: {
         title: {

--- a/playground/src/screens/SearchScreen.js
+++ b/playground/src/screens/SearchScreen.js
@@ -20,7 +20,7 @@ for(let i = 0; i < 200; i++) {
 }
 
 class SearchControllerScreen extends Component {
-  static get options() {
+  static options() {
     return {
       topBar: {
         title: {

--- a/playground/src/screens/TextScreen.js
+++ b/playground/src/screens/TextScreen.js
@@ -7,7 +7,7 @@ const { Navigation } = require('react-native-navigation');
 const testIDs = require('../testIDs');
 const Bounds = require('../components/Bounds');
 class TextScreen extends Component {
-  static get options() {
+  static options() {
     return {
       bottomTabs: {
         drawBehind: true,

--- a/playground/src/screens/TopTabOptionsScreen.js
+++ b/playground/src/screens/TopTabOptionsScreen.js
@@ -5,7 +5,7 @@ const { View, Text, Button } = require('react-native');
 const { Navigation } = require('react-native-navigation');
 
 class TopTabOptionsScreen extends PureComponent {
-  static get options() {
+  static options() {
     return {
       topBar: {
         title: {

--- a/playground/src/screens/TopTabScreen.js
+++ b/playground/src/screens/TopTabScreen.js
@@ -5,7 +5,7 @@ const { View, Text } = require('react-native');
 const FAB = 'fab';
 
 class TopTabScreen extends PureComponent {
-  static get options() {
+  static options() {
     return {
       topBar: {
         title: {

--- a/playground/src/screens/WelcomeScreen.js
+++ b/playground/src/screens/WelcomeScreen.js
@@ -8,7 +8,7 @@ const Button = require('./Button');
 const { Navigation } = require('react-native-navigation');
 
 class WelcomeScreen extends Component {
-  static get options() {
+  static options() {
     return {
       _statusBar: {
         backgroundColor: 'transparent',

--- a/playground/src/screens/complexlayouts/BottomTabSideMenuScreen.js
+++ b/playground/src/screens/complexlayouts/BottomTabSideMenuScreen.js
@@ -5,7 +5,7 @@ const { Navigation } = require('react-native-navigation');
 const testIDs = require('../../testIDs');
 
 class BottomTabSideMenuScreen extends Component {
-  static get options() {
+  static options() {
     return {
       topBar: {
         title: {

--- a/tsconfig-strict.json
+++ b/tsconfig-strict.json
@@ -4,20 +4,15 @@
     "allowSyntheticDefaultImports": false,
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
-    "alwaysStrict": true,
     "diagnostics": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "pretty": true,
-    "strictFunctionTypes": true,
-    "strictNullChecks": true,
-    "strict": true,
-    "noImplicitAny": false
+    "strict": true
   }
 }


### PR DESCRIPTION
## What this PR is about?
Finally all strict rules are enables for TypeScript compiler! 🎉 Basically previously `noImplicitAny` was turned off but now it plus all strict rules are turned ON! 💋 

## Some highlights of the changes
- `Element` renamed internally to `SharedElement` to make more sense what is it
- `LayoutTreeParser`'s responsibility is now to do all `id` related stuff. Previously it was spread between `LayoutTreeCrawler` and `LayoutTreeParse` so it is more simple now
- clean up a lot of tests because they were testing duplicate stuff that was covered by other tests already
- removed all usages of `static get options` and replaces them with `static options`. This is how it is in the docs plus you cannot have `static get options(passProps)` because it is impossible to have getter with parameters.

## Tell me what do you think!
Now we have all benefits of strict TypeScript! After all what is the point of using TypeScript is strict types are not on! That is like doing normal JavaScript! :D