### PR TITLE
Only remove the launch screen when the initial root view is ready

### DIFF
--- a/lib/ios/RNNBridgeManager.m
+++ b/lib/ios/RNNBridgeManager.m
@@ -97,7 +97,8 @@
 }
 
 - (void)onBridgeWillReload {
-	UIApplication.sharedApplication.delegate.window.rootViewController =  nil;
+	// This will only remove the root if it's not the launch screen
+	[_commandsHandler removeRootIfNotLaunchScreen];
 }
 
 @end

--- a/lib/ios/RNNCommandsHandler.h
+++ b/lib/ios/RNNCommandsHandler.h
@@ -13,6 +13,8 @@
 
 - (void)setRoot:(NSDictionary*)layout completion:(RNNTransitionCompletionBlock)completion;
 
+- (void)removeRootIfNotLaunchScreen;
+
 - (void)mergeOptions:(NSString*)componentId options:(NSDictionary*)options completion:(RNNTransitionCompletionBlock)completion;
 
 - (void)setDefaultOptions:(NSDictionary*)options completion:(RNNTransitionCompletionBlock)completion;

--- a/lib/ios/RNNLeafProtocol.h
+++ b/lib/ios/RNNLeafProtocol.h
@@ -4,7 +4,7 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 @protocol RNNLeafProtocol <NSObject>
 
-- (void)waitForReactViewRender:(BOOL)wait perform:(RNNReactViewReadyCompletionBlock)readyBlock;
+- (void)waitForReactViewReady:(BOOL)wait waitForUIEvent:(BOOL)waitForUIEvent perform:(RNNReactViewReadyCompletionBlock)readyBlock;
 
 - (void)bindViewController:(UIViewController *)viewController;
 

--- a/lib/ios/RNNSplashScreen.h
+++ b/lib/ios/RNNSplashScreen.h
@@ -3,6 +3,6 @@
 
 @interface RNNSplashScreen : UIViewController
 
-+(void)showOnWindow:(UIWindow *)window;
++ (void)showOnWindow:(UIWindow *)window;
 
 @end

--- a/lib/ios/RNNSplashScreen.m
+++ b/lib/ios/RNNSplashScreen.m
@@ -73,4 +73,17 @@
 	}
 }
 
+- (UIStatusBarStyle)preferredStatusBarStyle {
+	NSString *styleString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIStatusBarStyle"];
+	
+	if ([styleString isEqualToString:@"UIStatusBarStyleLightContent"])
+		return UIStatusBarStyleLightContent;
+	
+	return UIStatusBarStyleDefault;
+}
+
+- (BOOL)prefersStatusBarHidden {
+	return [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIStatusBarHidden"] boolValue];
+}
+
 @end

--- a/lib/ios/RNNTransitionsOptions.h
+++ b/lib/ios/RNNTransitionsOptions.h
@@ -9,5 +9,6 @@
 @property (nonatomic, strong) RNNScreenTransition* showModal;
 @property (nonatomic, strong) RNNScreenTransition* dismissModal;
 @property (nonatomic, strong) RNNScreenTransition* setStackRoot;
+@property (nonatomic, strong) RNNScreenTransition* setRoot;
 
 @end

--- a/lib/ios/RNNTransitionsOptions.m
+++ b/lib/ios/RNNTransitionsOptions.m
@@ -10,6 +10,7 @@
 	self.showModal = [[RNNScreenTransition alloc] initWithDict:dict[@"showModal"]];
 	self.dismissModal = [[RNNScreenTransition alloc] initWithDict:dict[@"dismissModal"]];
 	self.setStackRoot = [[RNNScreenTransition alloc] initWithDict:dict[@"setStackRoot"]];
+	self.setRoot = [[RNNScreenTransition alloc] initWithDict:dict[@"setRoot"]];
 
 	return self;
 }

--- a/lib/ios/ReactNativeNavigation.h
+++ b/lib/ios/ReactNativeNavigation.h
@@ -4,6 +4,8 @@
 #import <React/RCTUIManager.h>
 #import "RNNBridgeManagerDelegate.h"
 
+@class RNNBridgeManager;
+
 typedef UIViewController * (^RNNExternalViewCreator)(NSDictionary* props, RCTBridge* bridge);
 
 @interface ReactNativeNavigation : NSObject

--- a/lib/ios/ReactNativeNavigationTests/RNNCommandsHandlerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNCommandsHandlerTest.m
@@ -97,6 +97,7 @@
 	[skipMethods addObject:@".cxx_destruct"];
 	[skipMethods addObject:@"dismissedModal:"];
 	[skipMethods addObject:@"dismissedMultipleModals:"];
+	[skipMethods addObject:@"removeRootIfNotLaunchScreen"];
 	
 	NSMutableArray* result = [NSMutableArray new];
 	
@@ -292,7 +293,7 @@
 	[self.eventEmmiter verify];
 }
 
-- (void)testSetRoot_setRootViewControllerOnMainWindow {
+/*- (void)testSetRoot_setRootViewControllerOnMainWindow {
 	[self.store setReadyToReceiveCommands:true];
 	OCMStub([self.controllerFactory createLayout:[OCMArg any] saveToStore:self.store]).andReturn(self.vc1);
 	
@@ -308,7 +309,7 @@
 	[[self.store expect] removeAllComponentsFromWindow:self.mainWindow];
 	[self.uut setRoot:@{} completion:^{}];
 	[self.store verify];
-}
+}*/
 
 - (void)testSetStackRoot_resetStackWithSingleComponent {
 	OCMStub([self.controllerFactory createChildrenLayout:[OCMArg any] saveToStore:self.store]).andReturn(@[self.vc2]);

--- a/lib/ios/ReactNativeNavigationTests/RNNCommandsHandlerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNCommandsHandlerTest.m
@@ -293,7 +293,7 @@
 	[self.eventEmmiter verify];
 }
 
-/*- (void)testSetRoot_setRootViewControllerOnMainWindow {
+- (void)testSetRoot_setRootViewControllerOnMainWindow {
 	[self.store setReadyToReceiveCommands:true];
 	OCMStub([self.controllerFactory createLayout:[OCMArg any] saveToStore:self.store]).andReturn(self.vc1);
 	
@@ -309,7 +309,7 @@
 	[[self.store expect] removeAllComponentsFromWindow:self.mainWindow];
 	[self.uut setRoot:@{} completion:^{}];
 	[self.store verify];
-}*/
+}
 
 - (void)testSetStackRoot_resetStackWithSingleComponent {
 	OCMStub([self.controllerFactory createChildrenLayout:[OCMArg any] saveToStore:self.store]).andReturn(@[self.vc2]);


### PR DESCRIPTION
This will avoid the flashing white screen on app launch (Fixes #3661)

Currently RNN creates a mock of the Launch Screen (`RNNSplashImage`), and removes it on two opportunities:
1. `onBridgeWillReload` - when someone is doing a Command+R to reload - or *on the first load*. At this stage it is `null`ified, leaving the `UIWindow` empty.
2. `setRoot` - so we avoided the `= nil` in the bridge load, but still when the react code was loaded, executed and the user's code call `Navigation.setRoot(...`, the `UIWindow`'s `rootViewController` with the new root, which starts up as blank, white screen. This is because the first layout/render cycle did not happen yet.

This PR fixes this in two stages:
1. The very first `onBridgeWillReload`, when the `rootViewController` is still the `RNNSplashImage` - it will *not* set it to null anymore. It will still do this on subsequent reloads in debug mode.
2. The `setRoot` will wait for the first react ui event, and only then it will set the root view controller.
3. Fixes to `RNNSplashImage` to take default status bar style/hidden from the bundle's plist file.