### PR TITLE
Added missing types

### DIFF
--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -82,6 +82,13 @@ export enum OptionsModalPresentationStyle {
   none = 'none'
 }
 
+export enum OptionsModalTransitionStyle {
+  coverVertical = 'coverVertical',
+  crossDissolve = 'crossDissolve',
+  flipHorizontal = 'flipHorizontal',
+  partialCurl = 'partialCurl'
+}
+
 export interface OptionsTopBarLargeTitle {
   /**
    * Enable large titles
@@ -254,7 +261,7 @@ export interface OptionsTopBarButton {
    */
   text?: string;
   /**
-   * Set subtitle font family
+   * Set the button font family
    */
   fontFamily?: string;
   /**
@@ -728,6 +735,10 @@ export interface Options {
    * Configure the presentation style of the modal
    */
   modalPresentationStyle?: OptionsModalPresentationStyle;
+  /**
+   * Configure the transition style of the modal
+   */
+  modalTransitionStyle?: OptionsModalTransitionStyle;
   /**
    * Configure the top bar
    */

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -737,6 +737,8 @@ export interface Options {
   modalPresentationStyle?: OptionsModalPresentationStyle;
   /**
    * Configure the transition style of the modal
+   *
+   * #### (Android specific)
    */
   modalTransitionStyle?: OptionsModalTransitionStyle;
   /**

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -254,6 +254,10 @@ export interface OptionsTopBarButton {
    */
   text?: string;
   /**
+   * Set subtitle font family
+   */
+  fontFamily?: string;
+  /**
    * Set the button enabled or disabled
    * @default true
    */


### PR DESCRIPTION
Some styling options are missing on https://github.com/wix/react-native-navigation/blob/master/lib/src/interfaces/Options.ts.
So I got warnings when I use them from typescript.

### What to do

I added some types what existed on the Objective-C source and  possible to use.