### PR TITLE
Fix sideMenu intuitive side width - #4527

### DIFF
--- a/lib/ios/RNNSideMenuChildVC.h
+++ b/lib/ios/RNNSideMenuChildVC.h
@@ -20,4 +20,6 @@ typedef NS_ENUM(NSInteger, RNNSideMenuChildType) {
 
 - (instancetype)initWithLayoutInfo:(RNNLayoutInfo *)layoutInfo childViewControllers:(NSArray *)childViewControllers options:(RNNNavigationOptions *)options defaultOptions:(RNNNavigationOptions *)defaultOptions presenter:(RNNViewControllerPresenter *)presenter type:(RNNSideMenuChildType)type;
 
+- (void)setWidth:(CGFloat)width;
+
 @end

--- a/lib/ios/RNNSideMenuChildVC.m
+++ b/lib/ios/RNNSideMenuChildVC.m
@@ -60,6 +60,12 @@
 	[self.view bringSubviewToFront:self.child.view];
 }
 
+- (void)setWidth:(CGFloat)width {
+	CGRect frame = self.child.view.frame;
+	frame.size.width = width;
+	self.child.view.frame = frame;
+}
+
 - (UIViewController *)getCurrentChild {
 	return self.child;
 }

--- a/lib/ios/RNNSideMenuController.m
+++ b/lib/ios/RNNSideMenuController.m
@@ -76,9 +76,11 @@
 	switch (side) {
 		case MMDrawerSideRight:
 			self.maximumRightDrawerWidth = width;
+			[self.right setWidth:width];
 			break;
 		case MMDrawerSideLeft:
 			self.maximumLeftDrawerWidth = width;
+			[self.left setWidth:width];
 		default:
 			break;
 	}

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		507F43F81FF525B500D9425B /* RNNSegmentedControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 507F43F61FF525B500D9425B /* RNNSegmentedControl.h */; };
 		507F43F91FF525B500D9425B /* RNNSegmentedControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 507F43F71FF525B500D9425B /* RNNSegmentedControl.m */; };
 		507F44201FFA8A8800D9425B /* RNNParentProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 507F441F1FFA8A8800D9425B /* RNNParentProtocol.h */; };
+		5085DD2D21DCF75A0032E64B /* RNNSideMenuControllerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5085DD2C21DCF75A0032E64B /* RNNSideMenuControllerTest.m */; };
 		50887C1520ECC5C200D06111 /* RNNButtonOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 50887C1320ECC5C200D06111 /* RNNButtonOptions.h */; };
 		50887C1620ECC5C200D06111 /* RNNButtonOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 50887C1420ECC5C200D06111 /* RNNButtonOptions.m */; };
 		50887CA920F26BFE00D06111 /* RNNOverlayWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = 50887CA720F26BFD00D06111 /* RNNOverlayWindow.m */; };
@@ -526,6 +527,7 @@
 		507F43F61FF525B500D9425B /* RNNSegmentedControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNSegmentedControl.h; sourceTree = "<group>"; };
 		507F43F71FF525B500D9425B /* RNNSegmentedControl.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNSegmentedControl.m; sourceTree = "<group>"; };
 		507F441F1FFA8A8800D9425B /* RNNParentProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNParentProtocol.h; sourceTree = "<group>"; };
+		5085DD2C21DCF75A0032E64B /* RNNSideMenuControllerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNSideMenuControllerTest.m; sourceTree = "<group>"; };
 		50887C1320ECC5C200D06111 /* RNNButtonOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNButtonOptions.h; sourceTree = "<group>"; };
 		50887C1420ECC5C200D06111 /* RNNButtonOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNButtonOptions.m; sourceTree = "<group>"; };
 		50887CA720F26BFD00D06111 /* RNNOverlayWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNOverlayWindow.m; sourceTree = "<group>"; };
@@ -1017,6 +1019,7 @@
 				509B258E2178BE7A00C83C23 /* RNNNavigationControllerPresenterTest.m */,
 				502F0E172179C39900367CC3 /* RNNTabBarPresenterTest.m */,
 				50CE8502217C6C9B00084EBF /* RNNSideMenuPresenterTest.m */,
+				5085DD2C21DCF75A0032E64B /* RNNSideMenuControllerTest.m */,
 				50206A6C21AFE75400B7BB1A /* RNNSideMenuParserTest.m */,
 				502F0E152178D09600367CC3 /* RNNBasePresenterTest.m */,
 				5038A378216D01F6009280BC /* RNNBottomTabOptionsTest.m */,
@@ -1398,6 +1401,7 @@
 				50206A6D21AFE75400B7BB1A /* RNNSideMenuParserTest.m in Sources */,
 				509B258F2178BE7A00C83C23 /* RNNNavigationControllerPresenterTest.m in Sources */,
 				7B49FECD1E95098500DEB3EA /* RNNModalManagerTest.m in Sources */,
+				5085DD2D21DCF75A0032E64B /* RNNSideMenuControllerTest.m in Sources */,
 				E83BAD791F27416B00A9F3DD /* RNNRootViewControllerTest.m in Sources */,
 				50CE8503217C6C9B00084EBF /* RNNSideMenuPresenterTest.m in Sources */,
 				E8DA243D1F973C1900CD552B /* RNNTransitionStateHolderTest.m in Sources */,

--- a/lib/ios/ReactNativeNavigationTests/RNNSideMenuControllerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNSideMenuControllerTest.m
@@ -1,0 +1,32 @@
+#import <XCTest/XCTest.h>
+#import "RNNSideMenuController.h"
+#import "RNNRootViewController.h"
+
+@interface RNNSideMenuControllerTest : XCTestCase
+@property (nonatomic, strong) RNNSideMenuController *uut;
+@property (nonatomic, strong) RNNSideMenuChildVC *centerVC;
+@property (nonatomic, strong) RNNSideMenuChildVC *leftVC;
+@property (nonatomic, strong) RNNSideMenuChildVC *rightVC;
+@end
+
+@implementation RNNSideMenuControllerTest
+
+- (void)setUp {
+    [super setUp];
+	_leftVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil childViewControllers:@[[RNNRootViewController new]] options:nil defaultOptions:nil presenter:nil type:RNNSideMenuChildTypeLeft];
+	_rightVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil childViewControllers:@[[RNNRootViewController new]] options:nil defaultOptions:nil presenter:nil type:RNNSideMenuChildTypeRight];
+	_centerVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil childViewControllers:@[[RNNRootViewController new]] options:nil defaultOptions:nil presenter:nil type:RNNSideMenuChildTypeCenter];
+	self.uut = [[RNNSideMenuController alloc] initWithLayoutInfo:nil childViewControllers:@[_leftVC, _centerVC, _rightVC] options:[[RNNNavigationOptions alloc] initEmptyOptions] defaultOptions:nil presenter:nil];
+}
+
+- (void)testSetSideMenuWidthShouldUpdateLeftReactViewFrameWidth {
+	[self.uut side:MMDrawerSideLeft width:100];
+	XCTAssertEqual(self.uut.left.child.view.frame.size.width, 100.f);
+}
+
+- (void)testSetSideMenuWidthShouldUpdateRightReactViewFrameWidth {
+	[self.uut side:MMDrawerSideRight width:150];
+	XCTAssertEqual(self.uut.right.child.view.frame.size.width, 150.f);
+}
+
+@end

--- a/lib/ios/ReactNativeNavigationTests/RNNSideMenuPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNSideMenuPresenterTest.m
@@ -82,7 +82,4 @@
 	[self.bindedViewController verify];
 }
 
-
-
-
 @end


### PR DESCRIPTION
Setting react view according to the provided `sideMenu.{side}.width`.
When `sideMenu.{side}.width` isn't supplied, the react view will fill the screen.