### PR TITLE
Document options for Peek & Pop

### DIFF
--- a/docs/docs/animations.md
+++ b/docs/docs/animations.md
@@ -69,5 +69,5 @@ const Button = (
   </Navigation.TouchablePreview>
 );
 ```
-All options except for reactTag are optional. Actions trigger the same event as [navigation button presses](https://wix.github.io/react-native-navigation/#/docs/topBar-buttons?id=handling-button-press-events). You can listen to a few navigation events to react to the Peek and Pop lifecycle:  `previewContext` when the preview starts, `previewCommit` when the previewed screen is opened (`commit: true`) and `previewDismissed` when the preview is closed without opening the screen (`commit: false`).
+All options except for reactTag are optional. Actions trigger the same event as [navigation button presses](https://wix.github.io/react-native-navigation/#/docs/topBar-buttons?id=handling-button-press-events). To react when a preview is commited, listen to the (previewcompleted)[https://wix.github.io/react-native-navigation/#/docs/events?id=previewcompleted-ios-114-only] event.
 ```

--- a/docs/docs/animations.md
+++ b/docs/docs/animations.md
@@ -49,6 +49,10 @@ const handlePress ({ reactTag }) => {
       options: {
         preview: {
           reactTag,
+          height: 300,
+          width: 300,
+          commit: true,
+          actions: [{title: "Displayed Name", id: "actionId"}],
         },
       },
     },
@@ -64,4 +68,6 @@ const Button = (
     <Text>My button</Text>
   </Navigation.TouchablePreview>
 );
+```
+All options except for reactTag are optional. Actions trigger the same event as [navigation button presses](https://wix.github.io/react-native-navigation/#/docs/topBar-buttons?id=handling-button-press-events). You can listen to a few navigation events to react to the Peek and Pop lifecycle:  `previewContext` when the preview starts, `previewCommit` when the previewed screen is opened (`commit: true`) and `previewDismissed` when the preview is closed without opening the screen (`commit: false`).
 ```

--- a/docs/docs/animations.md
+++ b/docs/docs/animations.md
@@ -69,5 +69,5 @@ const Button = (
   </Navigation.TouchablePreview>
 );
 ```
-All options except for reactTag are optional. Actions trigger the same event as [navigation button presses](https://wix.github.io/react-native-navigation/#/docs/topBar-buttons?id=handling-button-press-events). To react when a preview is commited, listen to the (previewcompleted)[https://wix.github.io/react-native-navigation/#/docs/events?id=previewcompleted-ios-114-only] event.
-```
+
+All options except for reactTag are optional. Actions trigger the same event as [navigation button presses](https://wix.github.io/react-native-navigation/#/docs/topBar-buttons?id=handling-button-press-events). To react when a preview is committed, listen to the [previewCompleted](https://wix.github.io/react-native-navigation/#/docs/events?id=previewcompleted-ios-114-only) event.

--- a/docs/docs/animations.md
+++ b/docs/docs/animations.md
@@ -52,7 +52,12 @@ const handlePress ({ reactTag }) => {
           height: 300,
           width: 300,
           commit: true,
-          actions: [{title: "Displayed Name", id: "actionId"}],
+          actions: [{
+            title: "Displayed Name",
+            id: "actionId",
+            style: 'default', /* or 'selected', 'destructive'*/
+            actions: [/*define a submenu of actions with the same options*/]
+          }]
         },
       },
     },


### PR DESCRIPTION
This is the Information I needed to figure out how to implement Peek and Pop previews. Since the rest of the documentation is fairly concise I was wondering wether it would be appropriate to include "recipe" type things, like disabling scroll during preview, reacting to preview state in the previewed screen etc here or maybe in some other section?