### PR TITLE
[V2][iOS] Add back button text styling options

### DIFF
--- a/lib/ios/RNNBackButtonOptions.h
+++ b/lib/ios/RNNBackButtonOptions.h
@@ -9,4 +9,8 @@
 @property (nonatomic, strong) Bool* showTitle;
 @property (nonatomic, strong) Bool* visible;
 
+@property (nonatomic, strong) Color* textColor;
+@property (nonatomic, strong) Text* fontFamily;
+@property (nonatomic, strong) Number* fontSize;
+
 @end

--- a/lib/ios/RNNBackButtonOptions.m
+++ b/lib/ios/RNNBackButtonOptions.m
@@ -11,7 +11,11 @@
 	self.color = [ColorParser parse:dict key:@"color"];
 	self.showTitle = [BoolParser parse:dict key:@"showTitle"];
 	self.visible = [BoolParser parse:dict key:@"visible"];
-	
+
+    self.textColor = [ColorParser parse:dict key:@"textColor"];
+    self.fontSize = [NumberParser parse:dict key:@"fontSize"];
+    self.fontFamily = [TextParser parse:dict key:@"fontFamily"];
+
 	return self;
 }
 

--- a/lib/ios/RNNNavigationControllerPresenter.m
+++ b/lib/ios/RNNNavigationControllerPresenter.m
@@ -25,14 +25,14 @@
 	[navigationController rnn_setNavigationBarLargeTitleFontFamily:[options.topBar.largeTitle.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.largeTitle.fontSize getWithDefaultValue:nil] color:[options.topBar.largeTitle.color getWithDefaultValue:nil]];
 	[navigationController rnn_setNavigationBarFontFamily:[options.topBar.title.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.title.fontSize getWithDefaultValue:nil] color:[options.topBar.title.color getWithDefaultValue:nil]];
 	[navigationController rnn_setBackButtonColor:[options.topBar.backButton.color getWithDefaultValue:nil]];
-	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @""];
+	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[options.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.backButton.fontSize getWithDefaultValue:@(14)] textColor:[options.topBar.backButton.textColor getWithDefaultValue:nil]];
 }
 
 - (void)applyOptionsOnWillMoveToParentViewController:(RNNNavigationOptions *)options {
 	[super applyOptionsOnWillMoveToParentViewController:options];
 	
 	RNNNavigationController* navigationController = self.bindedViewController;
-	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @""];
+	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[options.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.backButton.fontSize getWithDefaultValue:@(14)] textColor: [options.topBar.backButton.textColor getWithDefaultValue:nil]];
 }
 
 - (void)applyOptionsBeforePopping:(RNNNavigationOptions *)options {
@@ -96,7 +96,7 @@
 	}
 	
 	if (newOptions.topBar.backButton.icon.hasValue || newOptions.topBar.backButton.showTitle.hasValue || newOptions.topBar.backButton.color.hasValue || newOptions.topBar.backButton.title.hasValue) {
-		[navigationController rnn_setBackButtonIcon:[newOptions.topBar.backButton.icon getWithDefaultValue:nil] withColor:[newOptions.topBar.backButton.color getWithDefaultValue:nil] title:[newOptions.topBar.backButton.showTitle getWithDefaultValue:YES] ? [newOptions.topBar.backButton.title getWithDefaultValue:nil] : @""];
+		[navigationController rnn_setBackButtonIcon:[newOptions.topBar.backButton.icon getWithDefaultValue:nil] withColor:[newOptions.topBar.backButton.color getWithDefaultValue:nil] title:[newOptions.topBar.backButton.showTitle getWithDefaultValue:YES] ? [newOptions.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[newOptions.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[newOptions.topBar.backButton.fontSize getWithDefaultValue:@(14)] textColor: [newOptions.topBar.backButton.textColor getWithDefaultValue:nil]];
 		
 	}
 	

--- a/lib/ios/RNNNavigationControllerPresenter.m
+++ b/lib/ios/RNNNavigationControllerPresenter.m
@@ -25,14 +25,14 @@
 	[navigationController rnn_setNavigationBarLargeTitleFontFamily:[options.topBar.largeTitle.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.largeTitle.fontSize getWithDefaultValue:nil] color:[options.topBar.largeTitle.color getWithDefaultValue:nil]];
 	[navigationController rnn_setNavigationBarFontFamily:[options.topBar.title.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.title.fontSize getWithDefaultValue:nil] color:[options.topBar.title.color getWithDefaultValue:nil]];
 	[navigationController rnn_setBackButtonColor:[options.topBar.backButton.color getWithDefaultValue:nil]];
-	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[options.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.backButton.fontSize getWithDefaultValue:@(14)] textColor:[options.topBar.backButton.textColor getWithDefaultValue:nil]];
+	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[options.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.backButton.fontSize getWithDefaultValue:@(17)] textColor:[options.topBar.backButton.textColor getWithDefaultValue:nil]];
 }
 
 - (void)applyOptionsOnWillMoveToParentViewController:(RNNNavigationOptions *)options {
 	[super applyOptionsOnWillMoveToParentViewController:options];
 	
 	RNNNavigationController* navigationController = self.bindedViewController;
-	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[options.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.backButton.fontSize getWithDefaultValue:@(14)] textColor: [options.topBar.backButton.textColor getWithDefaultValue:nil]];
+	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[options.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.backButton.fontSize getWithDefaultValue:@(17)] textColor: [options.topBar.backButton.textColor getWithDefaultValue:nil]];
 }
 
 - (void)applyOptionsBeforePopping:(RNNNavigationOptions *)options {
@@ -96,7 +96,7 @@
 	}
 	
 	if (newOptions.topBar.backButton.icon.hasValue || newOptions.topBar.backButton.showTitle.hasValue || newOptions.topBar.backButton.color.hasValue || newOptions.topBar.backButton.title.hasValue) {
-		[navigationController rnn_setBackButtonIcon:[newOptions.topBar.backButton.icon getWithDefaultValue:nil] withColor:[newOptions.topBar.backButton.color getWithDefaultValue:nil] title:[newOptions.topBar.backButton.showTitle getWithDefaultValue:YES] ? [newOptions.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[newOptions.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[newOptions.topBar.backButton.fontSize getWithDefaultValue:@(14)] textColor: [newOptions.topBar.backButton.textColor getWithDefaultValue:nil]];
+		[navigationController rnn_setBackButtonIcon:[newOptions.topBar.backButton.icon getWithDefaultValue:nil] withColor:[newOptions.topBar.backButton.color getWithDefaultValue:nil] title:[newOptions.topBar.backButton.showTitle getWithDefaultValue:YES] ? [newOptions.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[newOptions.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[newOptions.topBar.backButton.fontSize getWithDefaultValue:@(17)] textColor: [newOptions.topBar.backButton.textColor getWithDefaultValue:nil]];
 		
 	}
 	

--- a/lib/ios/ReactNativeNavigationTests/RNNNavigationControllerPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNNavigationControllerPresenterTest.m
@@ -40,7 +40,7 @@
 	Text* title = [[Text alloc] initWithValue:@"Title"];
 	NSNumber* backButtonFontSize = @(17);
 	self.options.topBar.backButton.title = title;
-	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:title.get fontFamily:nil fontSize:backButtonFontSize textColor:nil fontFamily:nil fontSize:backButtonFontSize textColor:nil];
+	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:title.get fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptions:self.options];
 	[_bindedViewController verify];
 }

--- a/lib/ios/ReactNativeNavigationTests/RNNNavigationControllerPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNNavigationControllerPresenterTest.m
@@ -38,56 +38,63 @@
 
 - (void)testApplyOptions_shouldSetBackButtonOnBindedViewController_withTitle {
 	Text* title = [[Text alloc] initWithValue:@"Title"];
+	NSNumber* backButtonFontSize = @(17);
 	self.options.topBar.backButton.title = title;
-	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:title.get];
+	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:title.get fontFamily:nil fontSize:backButtonFontSize textColor:nil fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptions:self.options];
 	[_bindedViewController verify];
 }
 
 - (void)testApplyOptions_shouldSetBackButtonOnBindedViewController_withHideTitle {
 	Text* title = [[Text alloc] initWithValue:@"Title"];
+	NSNumber* backButtonFontSize = @(17);
 	self.options.topBar.backButton.title = title;
 	self.options.topBar.backButton.showTitle = [[Bool alloc] initWithValue:@(0)];
-	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:@""];
+	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:@"" fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptions:self.options];
 	[_bindedViewController verify];
 }
 
 - (void)testApplyOptions_shouldSetBackButtonOnBindedViewController_withIcon {
 	Image* image = [[Image alloc] initWithValue:[UIImage new]];
+	NSNumber* backButtonFontSize = @(17);
 	self.options.topBar.backButton.icon = image;
-	[[_bindedViewController expect] rnn_setBackButtonIcon:image.get withColor:nil title:nil];
+	[[_bindedViewController expect] rnn_setBackButtonIcon:image.get withColor:nil title:nil fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptions:self.options];
 	[_bindedViewController verify];
 }
 
 - (void)testApplyOptionsOnWillMoveToParent_shouldSetBackButtonOnBindedViewController_withTitle {
 	Text* title = [[Text alloc] initWithValue:@"Title"];
+	NSNumber* backButtonFontSize = @(17);
 	self.options.topBar.backButton.title = title;
-	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:title.get];
+	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:title.get fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptionsOnWillMoveToParentViewController:self.options];
 	[_bindedViewController verify];
 }
 
 - (void)testApplyOptionsOnWillMoveToParent_shouldSetBackButtonOnBindedViewController_withHideTitle {
 	Text* title = [[Text alloc] initWithValue:@"Title"];
+	NSNumber* backButtonFontSize = @(17);
 	self.options.topBar.backButton.title = title;
 	self.options.topBar.backButton.showTitle = [[Bool alloc] initWithValue:@(0)];
-	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:@""];
+	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:@"" fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptionsOnWillMoveToParentViewController:self.options];
 	[_bindedViewController verify];
 }
 
 - (void)testApplyOptionsOnWillMoveToParent_shouldSetBackButtonOnBindedViewController_withIcon {
 	Image* image = [[Image alloc] initWithValue:[UIImage new]];
+	NSNumber* backButtonFontSize = @(17);
 	self.options.topBar.backButton.icon = image;
-	[[_bindedViewController expect] rnn_setBackButtonIcon:image.get withColor:nil title:nil];
+	[[_bindedViewController expect] rnn_setBackButtonIcon:image.get withColor:nil title:nil fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptionsOnWillMoveToParentViewController:self.options];
 	[_bindedViewController verify];
 }
 
 - (void)testApplyOptionsOnWillMoveToParent_shouldSetBackButtonOnBindedViewController_withDefaultValues {
-	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:nil];
+    NSNumber* backButtonFontSize = @(17);
+	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:nil fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptionsOnWillMoveToParentViewController:self.options];
 	[_bindedViewController verify];
 }

--- a/lib/ios/ReactNativeNavigationTests/UINavigationController+RNNOptionsTest.m
+++ b/lib/ios/ReactNativeNavigationTests/UINavigationController+RNNOptionsTest.m
@@ -15,8 +15,9 @@
 	UIViewController* viewController = [UIViewController new];
 	UINavigationController* nav = [[UINavigationController alloc] initWithRootViewController:viewController];
 	UIColor* color = [UIColor blackColor];
-	
-	[nav rnn_setBackButtonIcon:nil withColor:color title:nil];
+	NSNumber* backButtonFontSize = @(17);
+
+	[nav rnn_setBackButtonIcon:nil withColor:color title:nil fontFamily:nil fontSize:backButtonFontSize textColor: nil];
 	XCTAssertEqual(color, viewController.navigationItem.backBarButtonItem.tintColor);
 }
 
@@ -24,8 +25,9 @@
 	UIViewController* viewController = [UIViewController new];
 	UINavigationController* nav = [[UINavigationController alloc] initWithRootViewController:viewController];
 	NSString* title = @"Title";
-	
-	[nav rnn_setBackButtonIcon:nil withColor:nil title:title];
+	NSNumber* backButtonFontSize = @(17);
+
+	[nav rnn_setBackButtonIcon:nil withColor:nil title:title fontFamily:nil fontSize:backButtonFontSize textColor: nil];
 	XCTAssertEqual(title, viewController.navigationItem.backBarButtonItem.title);
 }
 
@@ -33,8 +35,9 @@
 	UIViewController* viewController = [UIViewController new];
 	UINavigationController* nav = [[UINavigationController alloc] initWithRootViewController:viewController];
 	UIImage* icon = [UIImage new];
-	
-	[nav rnn_setBackButtonIcon:icon withColor:nil title:nil];
+
+	NSNumber* backButtonFontSize = @(17);
+	[nav rnn_setBackButtonIcon:icon withColor:nil title:nil fontFamily:nil fontSize:backButtonFontSize textColor: nil];
 	XCTAssertEqual(icon, viewController.navigationItem.backBarButtonItem.image);
 }
 
@@ -45,7 +48,8 @@
 	[nav setViewControllers:@[viewController, viewController2]];
 	NSString* title = @"Title";
 
-	[nav rnn_setBackButtonIcon:nil withColor:nil title:title];
+    NSNumber* backButtonFontSize = @(17);
+	[nav rnn_setBackButtonIcon:nil withColor:nil title:title fontFamily:nil fontSize:backButtonFontSize textColor: nil];
 	XCTAssertEqual(title, viewController.navigationItem.backBarButtonItem.title);
 }
 

--- a/lib/ios/ReactNativeNavigationTests/UINavigationController+RNNOptionsTest.m
+++ b/lib/ios/ReactNativeNavigationTests/UINavigationController+RNNOptionsTest.m
@@ -17,7 +17,7 @@
 	UIColor* color = [UIColor blackColor];
 	NSNumber* backButtonFontSize = @(17);
 
-	[nav rnn_setBackButtonIcon:nil withColor:color title:nil fontFamily:nil fontSize:backButtonFontSize textColor: nil];
+	[nav rnn_setBackButtonIcon:nil withColor:color title:nil fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	XCTAssertEqual(color, viewController.navigationItem.backBarButtonItem.tintColor);
 }
 
@@ -27,7 +27,7 @@
 	NSString* title = @"Title";
 	NSNumber* backButtonFontSize = @(17);
 
-	[nav rnn_setBackButtonIcon:nil withColor:nil title:title fontFamily:nil fontSize:backButtonFontSize textColor: nil];
+	[nav rnn_setBackButtonIcon:nil withColor:nil title:title fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	XCTAssertEqual(title, viewController.navigationItem.backBarButtonItem.title);
 }
 
@@ -37,7 +37,7 @@
 	UIImage* icon = [UIImage new];
 
 	NSNumber* backButtonFontSize = @(17);
-	[nav rnn_setBackButtonIcon:icon withColor:nil title:nil fontFamily:nil fontSize:backButtonFontSize textColor: nil];
+	[nav rnn_setBackButtonIcon:icon withColor:nil title:nil fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	XCTAssertEqual(icon, viewController.navigationItem.backBarButtonItem.image);
 }
 
@@ -49,7 +49,7 @@
 	NSString* title = @"Title";
 
     NSNumber* backButtonFontSize = @(17);
-	[nav rnn_setBackButtonIcon:nil withColor:nil title:title fontFamily:nil fontSize:backButtonFontSize textColor: nil];
+	[nav rnn_setBackButtonIcon:nil withColor:nil title:title fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	XCTAssertEqual(title, viewController.navigationItem.backBarButtonItem.title);
 }
 

--- a/lib/ios/UINavigationController+RNNOptions.h
+++ b/lib/ios/UINavigationController+RNNOptions.h
@@ -24,7 +24,7 @@
 
 - (void)rnn_setNavigationBarClipsToBounds:(BOOL)clipsToBounds;
 
-- (void)rnn_setBackButtonIcon:(UIImage *)icon withColor:(UIColor *)color title:(NSString *)title;
+- (void)rnn_setBackButtonIcon:(UIImage *)icon withColor:(UIColor *)color title:(NSString *)title fontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize textColor: (UIColor *)textColor;
 
 - (void)rnn_setNavigationBarLargeTitleVisible:(BOOL)visible;
 

--- a/lib/ios/UINavigationController+RNNOptions.m
+++ b/lib/ios/UINavigationController+RNNOptions.m
@@ -99,7 +99,7 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 	}
 }
 
-- (void)rnn_setBackButtonIcon:(UIImage *)icon withColor:(UIColor *)color title:(NSString *)title {
+- (void)rnn_setBackButtonIcon:(UIImage *)icon withColor:(UIColor *)color title:(NSString *)title fontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize textColor: (UIColor *)textColor {
 	UIBarButtonItem *backItem = [[UIBarButtonItem alloc] init];
 	if (icon) {
 		backItem.image = color
@@ -111,6 +111,20 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 	}
 	
 	UIViewController *lastViewControllerInStack = self.viewControllers.count > 1 ? [self.viewControllers objectAtIndex:self.viewControllers.count-2] : self.topViewController;
+	
+
+	NSMutableDictionary* textAttributes = [[NSMutableDictionary alloc] init];
+
+	UIFont *font = fontFamily ? [UIFont fontWithName:fontFamily size:[fontSize floatValue]] : [UIFont systemFontOfSize:[fontSize floatValue]];
+	[textAttributes setObject:font forKey:NSFontAttributeName];
+
+	if(textColor) {
+		[textAttributes setObject:textColor forKey:NSForegroundColorAttributeName];
+	}
+	
+	[backItem setTitleTextAttributes:textAttributes forState:UIControlStateNormal];
+	[backItem setTitleTextAttributes:textAttributes forState:UIControlStateHighlighted];
+	
 	
 	backItem.title = title ? title : lastViewControllerInStack.navigationItem.title;
 	backItem.tintColor = color;


### PR DESCRIPTION
Support for following options in back button:
```javascript
topBar: {
   backButton: {
          fontFamily: "OpenSans",
          fontSize: 13, // default is 17
          textColor: "red"
    }
}
```