### PR TITLE
[Android] Add support for bottom tabs selected icon

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabOptions.java
@@ -26,6 +26,7 @@ public class BottomTabOptions {
         options.textColor = ColorParser.parse(json, "textColor");
         options.selectedTextColor = ColorParser.parse(json, "selectedTextColor");
         if (json.has("icon")) options.icon = TextParser.parse(json.optJSONObject("icon"), "uri");
+        if (json.has("selectedIcon")) options.selectedIcon = TextParser.parse(json.optJSONObject("selectedIcon"), "uri");
         options.iconColor = ColorParser.parse(json, "iconColor");
         options.selectedIconColor = ColorParser.parse(json, "selectedIconColor");
         options.badge = TextParser.parse(json, "badge");
@@ -41,6 +42,7 @@ public class BottomTabOptions {
     public Colour textColor = new NullColor();
     public Colour selectedTextColor = new NullColor();
     public Text icon = new NullText();
+    public Text selectedIcon = new NullText();
     public Colour iconColor = new NullColor();
     public Colour selectedIconColor = new NullColor();
     public Text testId = new NullText();
@@ -56,6 +58,7 @@ public class BottomTabOptions {
         if (other.textColor.hasValue()) textColor = other.textColor;
         if (other.selectedTextColor.hasValue()) selectedTextColor = other.selectedTextColor;
         if (other.icon.hasValue()) icon = other.icon;
+        if (other.selectedIcon.hasValue()) selectedIcon = other.selectedIcon;
         if (other.iconColor.hasValue()) iconColor = other.iconColor;
         if (other.selectedIconColor.hasValue()) selectedIconColor = other.selectedIconColor;
         if (other.badge.hasValue()) badge = other.badge;
@@ -71,6 +74,7 @@ public class BottomTabOptions {
         if (!textColor.hasValue()) textColor = defaultOptions.textColor;
         if (!selectedTextColor.hasValue()) selectedTextColor = defaultOptions.selectedTextColor;
         if (!icon.hasValue()) icon = defaultOptions.icon;
+        if (!selectedIcon.hasValue()) selectedIcon = defaultOptions.selectedIcon;
         if (!iconColor.hasValue()) iconColor = defaultOptions.iconColor;
         if (!selectedIconColor.hasValue()) selectedIconColor = defaultOptions.selectedIconColor;
         if (!badge.hasValue()) badge = defaultOptions.badge;

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -6,6 +6,7 @@ import android.support.annotation.RestrictTo;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.RelativeLayout;
+import android.graphics.drawable.Drawable;
 
 import com.aurelhubert.ahbottomnavigation.AHBottomNavigation;
 import com.aurelhubert.ahbottomnavigation.AHBottomNavigationItem;
@@ -34,15 +35,15 @@ import static com.reactnativenavigation.utils.CollectionUtils.map;
 
 public class BottomTabsController extends ParentController implements AHBottomNavigation.OnTabSelectedListener, TabSelector {
 
-	private BottomTabs bottomTabs;
-	private List<ViewController> tabs;
+    private BottomTabs bottomTabs;
+    private List<ViewController> tabs;
     private EventEmitter eventEmitter;
     private ImageLoader imageLoader;
     private BottomTabsPresenter presenter;
     private BottomTabPresenter tabPresenter;
 
     public BottomTabsController(Activity activity, List<ViewController> tabs, ChildControllersRegistry childRegistry, EventEmitter eventEmitter, ImageLoader imageLoader, String id, Options initialOptions, Presenter presenter, BottomTabsPresenter bottomTabsPresenter, BottomTabPresenter bottomTabPresenter) {
-		super(activity, childRegistry, id, presenter, initialOptions);
+        super(activity, childRegistry, id, presenter, initialOptions);
         this.tabs = tabs;
         this.eventEmitter = eventEmitter;
         this.imageLoader = imageLoader;
@@ -59,20 +60,21 @@ public class BottomTabsController extends ParentController implements AHBottomNa
     }
 
     @NonNull
-	@Override
-	protected ViewGroup createView() {
-		RelativeLayout root = new RelativeLayout(getActivity());
-		bottomTabs = createBottomTabs();
+    @Override
+    protected ViewGroup createView() {
+        RelativeLayout root = new RelativeLayout(getActivity());
+        bottomTabs = createBottomTabs();
         presenter.bindView(bottomTabs, this);
         tabPresenter.bindView(bottomTabs);
         bottomTabs.setOnTabSelectedListener(this);
-		RelativeLayout.LayoutParams lp = new RelativeLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT);
-		lp.addRule(ALIGN_PARENT_BOTTOM);
-		root.addView(bottomTabs, lp);
-		bottomTabs.addItems(createTabs());
+        RelativeLayout.LayoutParams lp = new RelativeLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT);
+        lp.addRule(ALIGN_PARENT_BOTTOM);
+        root.addView(bottomTabs, lp);
+        bottomTabs.addSelectedIconsDrawable(loadSelectedIcons());
+        bottomTabs.addItems(createTabs());
         attachTabs(root);
         return root;
-	}
+    }
 
     @NonNull
     protected BottomTabs createBottomTabs() {
@@ -121,9 +123,9 @@ public class BottomTabsController extends ParentController implements AHBottomNa
     }
 
     @Override
-	public boolean handleBack(CommandListener listener) {
-		return !tabs.isEmpty() && tabs.get(bottomTabs.getCurrentItem()).handleBack(listener);
-	}
+    public boolean handleBack(CommandListener listener) {
+        return !tabs.isEmpty() && tabs.get(bottomTabs.getCurrentItem()).handleBack(listener);
+    }
 
     @Override
     public void sendOnNavigationButtonPressed(String buttonId) {
@@ -141,10 +143,21 @@ public class BottomTabsController extends ParentController implements AHBottomNa
         if (wasSelected) return false;
         selectTab(index);
         return false;
-	}
+    }
 
-	private List<AHBottomNavigationItem> createTabs() {
-		if (tabs.size() > 5) throw new RuntimeException("Too many tabs!");
+    private List<Drawable> loadSelectedIcons() {
+        return map(tabs, tab -> {
+            BottomTabOptions options = tab.resolveCurrentOptions().bottomTabOptions;
+            if(options.selectedIcon.hasValue()) {
+                return imageLoader.loadIcon(getActivity(), options.selectedIcon.get());
+            }
+
+            return null;
+        });
+    }
+
+    private List<AHBottomNavigationItem> createTabs() {
+        if (tabs.size() > 5) throw new RuntimeException("Too many tabs!");
         return map(tabs, tab -> {
             BottomTabOptions options = tab.resolveCurrentOptions().bottomTabOptions;
             return new AHBottomNavigationItem(
@@ -153,7 +166,7 @@ public class BottomTabsController extends ParentController implements AHBottomNa
                     options.testId.get("")
             );
         });
-	}
+    }
 
     private void attachTabs(RelativeLayout root) {
         for (int i = 0; i < tabs.size(); i++) {
@@ -167,20 +180,21 @@ public class BottomTabsController extends ParentController implements AHBottomNa
     }
 
     public int getSelectedIndex() {
-		return bottomTabs.getCurrentItem();
-	}
+        return bottomTabs.getCurrentItem();
+    }
 
-	@NonNull
-	@Override
-	public Collection<ViewController> getChildControllers() {
-		return tabs;
-	}
+    @NonNull
+    @Override
+    public Collection<ViewController> getChildControllers() {
+        return tabs;
+    }
 
     @Override
     public void selectTab(final int newIndex) {
         getCurrentView().setVisibility(View.INVISIBLE);
         bottomTabs.setCurrentItem(newIndex, false);
         getCurrentView().setVisibility(View.VISIBLE);
+        bottomTabs.setSelectedIcon(newIndex);
     }
 
     @NonNull

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
@@ -5,15 +5,24 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.IntRange;
+import android.view.View;
+import android.graphics.Canvas;
+import android.widget.ImageView;
 
 import com.aurelhubert.ahbottomnavigation.AHBottomNavigation;
 import com.aurelhubert.ahbottomnavigation.AHBottomNavigationItem;
+import com.aurelhubert.ahbottomnavigation.R;
 import com.reactnativenavigation.utils.CompatUtils;
+
+import java.util.List;
 
 @SuppressLint("ViewConstructor")
 public class BottomTabs extends AHBottomNavigation {
     private boolean itemsCreationEnabled = true;
     private boolean shouldCreateItems = true;
+
+    private List<Drawable> selectedIconsDrawable;
+
 
     public void disableItemsCreation() {
         itemsCreationEnabled = false;
@@ -81,5 +90,30 @@ public class BottomTabs extends AHBottomNavigation {
             item.setDrawable(icon);
             refresh();
         }
+    }
+
+    public void setSelectedIcon(int bottomTabIndex) {
+        View view = this.getViewAtPosition(bottomTabIndex);
+        if(view != null) {
+            ImageView itemIcon = view.findViewById(R.id.bottom_navigation_item_icon);
+            ImageView smallItemIcon = view.findViewById(R.id.bottom_navigation_small_item_icon);
+            Drawable drawable = this.selectedIconsDrawable.get(bottomTabIndex);
+
+            if(drawable != null) {
+                if(itemIcon != null) {
+                    itemIcon.setImageDrawable(drawable);
+                } else if( smallItemIcon != null) {
+                    smallItemIcon.setImageDrawable(drawable);
+                }
+            }
+        }
+    }
+
+    protected void onDraw(Canvas canvas){
+        setSelectedIcon(getCurrentItem());
+    }
+
+    public void addSelectedIconsDrawable(List<Drawable> icons) {
+        this.selectedIconsDrawable = icons;
     }
 }

--- a/lib/ios/RNNBackButtonOptions.h
+++ b/lib/ios/RNNBackButtonOptions.h
@@ -9,4 +9,8 @@
 @property (nonatomic, strong) Bool* showTitle;
 @property (nonatomic, strong) Bool* visible;
 
+@property (nonatomic, strong) Color* textColor;
+@property (nonatomic, strong) Text* fontFamily;
+@property (nonatomic, strong) Number* fontSize;
+
 @end

--- a/lib/ios/RNNBackButtonOptions.m
+++ b/lib/ios/RNNBackButtonOptions.m
@@ -11,7 +11,11 @@
 	self.color = [ColorParser parse:dict key:@"color"];
 	self.showTitle = [BoolParser parse:dict key:@"showTitle"];
 	self.visible = [BoolParser parse:dict key:@"visible"];
-	
+
+    self.textColor = [ColorParser parse:dict key:@"textColor"];
+    self.fontSize = [NumberParser parse:dict key:@"fontSize"];
+    self.fontFamily = [TextParser parse:dict key:@"fontFamily"];
+
 	return self;
 }
 

--- a/lib/ios/RNNNavigationControllerPresenter.m
+++ b/lib/ios/RNNNavigationControllerPresenter.m
@@ -25,14 +25,14 @@
 	[navigationController rnn_setNavigationBarLargeTitleFontFamily:[options.topBar.largeTitle.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.largeTitle.fontSize getWithDefaultValue:nil] color:[options.topBar.largeTitle.color getWithDefaultValue:nil]];
 	[navigationController rnn_setNavigationBarFontFamily:[options.topBar.title.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.title.fontSize getWithDefaultValue:nil] color:[options.topBar.title.color getWithDefaultValue:nil]];
 	[navigationController rnn_setBackButtonColor:[options.topBar.backButton.color getWithDefaultValue:nil]];
-	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @""];
+	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[options.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.backButton.fontSize getWithDefaultValue:@(14)] textColor:[options.topBar.backButton.textColor getWithDefaultValue:nil]];
 }
 
 - (void)applyOptionsOnWillMoveToParentViewController:(RNNNavigationOptions *)options {
 	[super applyOptionsOnWillMoveToParentViewController:options];
 	
 	RNNNavigationController* navigationController = self.bindedViewController;
-	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @""];
+	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[options.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.backButton.fontSize getWithDefaultValue:@(14)] textColor: [options.topBar.backButton.textColor getWithDefaultValue:nil]];
 }
 
 - (void)applyOptionsBeforePopping:(RNNNavigationOptions *)options {
@@ -96,7 +96,7 @@
 	}
 	
 	if (newOptions.topBar.backButton.icon.hasValue || newOptions.topBar.backButton.showTitle.hasValue || newOptions.topBar.backButton.color.hasValue || newOptions.topBar.backButton.title.hasValue) {
-		[navigationController rnn_setBackButtonIcon:[newOptions.topBar.backButton.icon getWithDefaultValue:nil] withColor:[newOptions.topBar.backButton.color getWithDefaultValue:nil] title:[newOptions.topBar.backButton.showTitle getWithDefaultValue:YES] ? [newOptions.topBar.backButton.title getWithDefaultValue:nil] : @""];
+		[navigationController rnn_setBackButtonIcon:[newOptions.topBar.backButton.icon getWithDefaultValue:nil] withColor:[newOptions.topBar.backButton.color getWithDefaultValue:nil] title:[newOptions.topBar.backButton.showTitle getWithDefaultValue:YES] ? [newOptions.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[newOptions.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[newOptions.topBar.backButton.fontSize getWithDefaultValue:@(14)] textColor: [newOptions.topBar.backButton.textColor getWithDefaultValue:nil]];
 		
 	}
 	

--- a/lib/ios/RNNNavigationControllerPresenter.m
+++ b/lib/ios/RNNNavigationControllerPresenter.m
@@ -25,14 +25,14 @@
 	[navigationController rnn_setNavigationBarLargeTitleFontFamily:[options.topBar.largeTitle.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.largeTitle.fontSize getWithDefaultValue:nil] color:[options.topBar.largeTitle.color getWithDefaultValue:nil]];
 	[navigationController rnn_setNavigationBarFontFamily:[options.topBar.title.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.title.fontSize getWithDefaultValue:nil] color:[options.topBar.title.color getWithDefaultValue:nil]];
 	[navigationController rnn_setBackButtonColor:[options.topBar.backButton.color getWithDefaultValue:nil]];
-	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[options.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.backButton.fontSize getWithDefaultValue:@(14)] textColor:[options.topBar.backButton.textColor getWithDefaultValue:nil]];
+	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[options.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.backButton.fontSize getWithDefaultValue:@(17)] textColor:[options.topBar.backButton.textColor getWithDefaultValue:nil]];
 }
 
 - (void)applyOptionsOnWillMoveToParentViewController:(RNNNavigationOptions *)options {
 	[super applyOptionsOnWillMoveToParentViewController:options];
 	
 	RNNNavigationController* navigationController = self.bindedViewController;
-	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[options.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.backButton.fontSize getWithDefaultValue:@(14)] textColor: [options.topBar.backButton.textColor getWithDefaultValue:nil]];
+	[navigationController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[options.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.backButton.fontSize getWithDefaultValue:@(17)] textColor: [options.topBar.backButton.textColor getWithDefaultValue:nil]];
 }
 
 - (void)applyOptionsBeforePopping:(RNNNavigationOptions *)options {
@@ -96,7 +96,7 @@
 	}
 	
 	if (newOptions.topBar.backButton.icon.hasValue || newOptions.topBar.backButton.showTitle.hasValue || newOptions.topBar.backButton.color.hasValue || newOptions.topBar.backButton.title.hasValue) {
-		[navigationController rnn_setBackButtonIcon:[newOptions.topBar.backButton.icon getWithDefaultValue:nil] withColor:[newOptions.topBar.backButton.color getWithDefaultValue:nil] title:[newOptions.topBar.backButton.showTitle getWithDefaultValue:YES] ? [newOptions.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[newOptions.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[newOptions.topBar.backButton.fontSize getWithDefaultValue:@(14)] textColor: [newOptions.topBar.backButton.textColor getWithDefaultValue:nil]];
+		[navigationController rnn_setBackButtonIcon:[newOptions.topBar.backButton.icon getWithDefaultValue:nil] withColor:[newOptions.topBar.backButton.color getWithDefaultValue:nil] title:[newOptions.topBar.backButton.showTitle getWithDefaultValue:YES] ? [newOptions.topBar.backButton.title getWithDefaultValue:nil] : @"" fontFamily:[newOptions.topBar.backButton.fontFamily getWithDefaultValue:nil] fontSize:[newOptions.topBar.backButton.fontSize getWithDefaultValue:@(17)] textColor: [newOptions.topBar.backButton.textColor getWithDefaultValue:nil]];
 		
 	}
 	

--- a/lib/ios/ReactNativeNavigationTests/RNNNavigationControllerPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNNavigationControllerPresenterTest.m
@@ -40,7 +40,7 @@
 	Text* title = [[Text alloc] initWithValue:@"Title"];
 	NSNumber* backButtonFontSize = @(17);
 	self.options.topBar.backButton.title = title;
-	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:title.get fontFamily:nil fontSize:backButtonFontSize textColor:nil fontFamily:nil fontSize:backButtonFontSize textColor:nil];
+	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:title.get fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptions:self.options];
 	[_bindedViewController verify];
 }

--- a/lib/ios/ReactNativeNavigationTests/RNNNavigationControllerPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNNavigationControllerPresenterTest.m
@@ -38,56 +38,63 @@
 
 - (void)testApplyOptions_shouldSetBackButtonOnBindedViewController_withTitle {
 	Text* title = [[Text alloc] initWithValue:@"Title"];
+	NSNumber* backButtonFontSize = @(17);
 	self.options.topBar.backButton.title = title;
-	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:title.get];
+	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:title.get fontFamily:nil fontSize:backButtonFontSize textColor:nil fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptions:self.options];
 	[_bindedViewController verify];
 }
 
 - (void)testApplyOptions_shouldSetBackButtonOnBindedViewController_withHideTitle {
 	Text* title = [[Text alloc] initWithValue:@"Title"];
+	NSNumber* backButtonFontSize = @(17);
 	self.options.topBar.backButton.title = title;
 	self.options.topBar.backButton.showTitle = [[Bool alloc] initWithValue:@(0)];
-	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:@""];
+	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:@"" fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptions:self.options];
 	[_bindedViewController verify];
 }
 
 - (void)testApplyOptions_shouldSetBackButtonOnBindedViewController_withIcon {
 	Image* image = [[Image alloc] initWithValue:[UIImage new]];
+	NSNumber* backButtonFontSize = @(17);
 	self.options.topBar.backButton.icon = image;
-	[[_bindedViewController expect] rnn_setBackButtonIcon:image.get withColor:nil title:nil];
+	[[_bindedViewController expect] rnn_setBackButtonIcon:image.get withColor:nil title:nil fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptions:self.options];
 	[_bindedViewController verify];
 }
 
 - (void)testApplyOptionsOnWillMoveToParent_shouldSetBackButtonOnBindedViewController_withTitle {
 	Text* title = [[Text alloc] initWithValue:@"Title"];
+	NSNumber* backButtonFontSize = @(17);
 	self.options.topBar.backButton.title = title;
-	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:title.get];
+	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:title.get fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptionsOnWillMoveToParentViewController:self.options];
 	[_bindedViewController verify];
 }
 
 - (void)testApplyOptionsOnWillMoveToParent_shouldSetBackButtonOnBindedViewController_withHideTitle {
 	Text* title = [[Text alloc] initWithValue:@"Title"];
+	NSNumber* backButtonFontSize = @(17);
 	self.options.topBar.backButton.title = title;
 	self.options.topBar.backButton.showTitle = [[Bool alloc] initWithValue:@(0)];
-	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:@""];
+	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:@"" fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptionsOnWillMoveToParentViewController:self.options];
 	[_bindedViewController verify];
 }
 
 - (void)testApplyOptionsOnWillMoveToParent_shouldSetBackButtonOnBindedViewController_withIcon {
 	Image* image = [[Image alloc] initWithValue:[UIImage new]];
+	NSNumber* backButtonFontSize = @(17);
 	self.options.topBar.backButton.icon = image;
-	[[_bindedViewController expect] rnn_setBackButtonIcon:image.get withColor:nil title:nil];
+	[[_bindedViewController expect] rnn_setBackButtonIcon:image.get withColor:nil title:nil fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptionsOnWillMoveToParentViewController:self.options];
 	[_bindedViewController verify];
 }
 
 - (void)testApplyOptionsOnWillMoveToParent_shouldSetBackButtonOnBindedViewController_withDefaultValues {
-	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:nil];
+    NSNumber* backButtonFontSize = @(17);
+	[[_bindedViewController expect] rnn_setBackButtonIcon:nil withColor:nil title:nil fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	[self.uut applyOptionsOnWillMoveToParentViewController:self.options];
 	[_bindedViewController verify];
 }

--- a/lib/ios/ReactNativeNavigationTests/UINavigationController+RNNOptionsTest.m
+++ b/lib/ios/ReactNativeNavigationTests/UINavigationController+RNNOptionsTest.m
@@ -15,8 +15,9 @@
 	UIViewController* viewController = [UIViewController new];
 	UINavigationController* nav = [[UINavigationController alloc] initWithRootViewController:viewController];
 	UIColor* color = [UIColor blackColor];
-	
-	[nav rnn_setBackButtonIcon:nil withColor:color title:nil];
+	NSNumber* backButtonFontSize = @(17);
+
+	[nav rnn_setBackButtonIcon:nil withColor:color title:nil fontFamily:nil fontSize:backButtonFontSize textColor: nil];
 	XCTAssertEqual(color, viewController.navigationItem.backBarButtonItem.tintColor);
 }
 
@@ -24,8 +25,9 @@
 	UIViewController* viewController = [UIViewController new];
 	UINavigationController* nav = [[UINavigationController alloc] initWithRootViewController:viewController];
 	NSString* title = @"Title";
-	
-	[nav rnn_setBackButtonIcon:nil withColor:nil title:title];
+	NSNumber* backButtonFontSize = @(17);
+
+	[nav rnn_setBackButtonIcon:nil withColor:nil title:title fontFamily:nil fontSize:backButtonFontSize textColor: nil];
 	XCTAssertEqual(title, viewController.navigationItem.backBarButtonItem.title);
 }
 
@@ -33,8 +35,9 @@
 	UIViewController* viewController = [UIViewController new];
 	UINavigationController* nav = [[UINavigationController alloc] initWithRootViewController:viewController];
 	UIImage* icon = [UIImage new];
-	
-	[nav rnn_setBackButtonIcon:icon withColor:nil title:nil];
+
+	NSNumber* backButtonFontSize = @(17);
+	[nav rnn_setBackButtonIcon:icon withColor:nil title:nil fontFamily:nil fontSize:backButtonFontSize textColor: nil];
 	XCTAssertEqual(icon, viewController.navigationItem.backBarButtonItem.image);
 }
 
@@ -45,7 +48,8 @@
 	[nav setViewControllers:@[viewController, viewController2]];
 	NSString* title = @"Title";
 
-	[nav rnn_setBackButtonIcon:nil withColor:nil title:title];
+    NSNumber* backButtonFontSize = @(17);
+	[nav rnn_setBackButtonIcon:nil withColor:nil title:title fontFamily:nil fontSize:backButtonFontSize textColor: nil];
 	XCTAssertEqual(title, viewController.navigationItem.backBarButtonItem.title);
 }
 

--- a/lib/ios/ReactNativeNavigationTests/UINavigationController+RNNOptionsTest.m
+++ b/lib/ios/ReactNativeNavigationTests/UINavigationController+RNNOptionsTest.m
@@ -17,7 +17,7 @@
 	UIColor* color = [UIColor blackColor];
 	NSNumber* backButtonFontSize = @(17);
 
-	[nav rnn_setBackButtonIcon:nil withColor:color title:nil fontFamily:nil fontSize:backButtonFontSize textColor: nil];
+	[nav rnn_setBackButtonIcon:nil withColor:color title:nil fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	XCTAssertEqual(color, viewController.navigationItem.backBarButtonItem.tintColor);
 }
 
@@ -27,7 +27,7 @@
 	NSString* title = @"Title";
 	NSNumber* backButtonFontSize = @(17);
 
-	[nav rnn_setBackButtonIcon:nil withColor:nil title:title fontFamily:nil fontSize:backButtonFontSize textColor: nil];
+	[nav rnn_setBackButtonIcon:nil withColor:nil title:title fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	XCTAssertEqual(title, viewController.navigationItem.backBarButtonItem.title);
 }
 
@@ -37,7 +37,7 @@
 	UIImage* icon = [UIImage new];
 
 	NSNumber* backButtonFontSize = @(17);
-	[nav rnn_setBackButtonIcon:icon withColor:nil title:nil fontFamily:nil fontSize:backButtonFontSize textColor: nil];
+	[nav rnn_setBackButtonIcon:icon withColor:nil title:nil fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	XCTAssertEqual(icon, viewController.navigationItem.backBarButtonItem.image);
 }
 
@@ -49,7 +49,7 @@
 	NSString* title = @"Title";
 
     NSNumber* backButtonFontSize = @(17);
-	[nav rnn_setBackButtonIcon:nil withColor:nil title:title fontFamily:nil fontSize:backButtonFontSize textColor: nil];
+	[nav rnn_setBackButtonIcon:nil withColor:nil title:title fontFamily:nil fontSize:backButtonFontSize textColor:nil];
 	XCTAssertEqual(title, viewController.navigationItem.backBarButtonItem.title);
 }
 

--- a/lib/ios/UINavigationController+RNNOptions.h
+++ b/lib/ios/UINavigationController+RNNOptions.h
@@ -24,7 +24,7 @@
 
 - (void)rnn_setNavigationBarClipsToBounds:(BOOL)clipsToBounds;
 
-- (void)rnn_setBackButtonIcon:(UIImage *)icon withColor:(UIColor *)color title:(NSString *)title;
+- (void)rnn_setBackButtonIcon:(UIImage *)icon withColor:(UIColor *)color title:(NSString *)title fontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize textColor: (UIColor *)textColor;
 
 - (void)rnn_setNavigationBarLargeTitleVisible:(BOOL)visible;
 

--- a/lib/ios/UINavigationController+RNNOptions.m
+++ b/lib/ios/UINavigationController+RNNOptions.m
@@ -99,7 +99,7 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 	}
 }
 
-- (void)rnn_setBackButtonIcon:(UIImage *)icon withColor:(UIColor *)color title:(NSString *)title {
+- (void)rnn_setBackButtonIcon:(UIImage *)icon withColor:(UIColor *)color title:(NSString *)title fontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize textColor: (UIColor *)textColor {
 	UIBarButtonItem *backItem = [[UIBarButtonItem alloc] init];
 	if (icon) {
 		backItem.image = color
@@ -111,6 +111,20 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 	}
 	
 	UIViewController *lastViewControllerInStack = self.viewControllers.count > 1 ? [self.viewControllers objectAtIndex:self.viewControllers.count-2] : self.topViewController;
+	
+
+	NSMutableDictionary* textAttributes = [[NSMutableDictionary alloc] init];
+
+	UIFont *font = fontFamily ? [UIFont fontWithName:fontFamily size:[fontSize floatValue]] : [UIFont systemFontOfSize:[fontSize floatValue]];
+	[textAttributes setObject:font forKey:NSFontAttributeName];
+
+	if(textColor) {
+		[textAttributes setObject:textColor forKey:NSForegroundColorAttributeName];
+	}
+	
+	[backItem setTitleTextAttributes:textAttributes forState:UIControlStateNormal];
+	[backItem setTitleTextAttributes:textAttributes forState:UIControlStateHighlighted];
+	
 	
 	backItem.title = title ? title : lastViewControllerInStack.navigationItem.title;
 	backItem.tintColor = color;


### PR DESCRIPTION
Use can use selectedIcon same as iOS on android as following:

```javascript
{
    bottomTab: {
       icon: require('./inactive-icon.png'),
       selectedIcon: require('active-icon.png'), // Same as iOS implementation
       text: 'Tab Test'
   }
}
```