### PR TITLE
[v2] SharedElement Default Animation Control

### DIFF
--- a/lib/ios/RNNScreenTransition.h
+++ b/lib/ios/RNNScreenTransition.h
@@ -7,6 +7,7 @@
 @property (nonatomic, strong) RNNTransitionStateHolder* content;
 @property (nonatomic, strong) RNNTransitionStateHolder* bottomTabs;
 
+@property (nonatomic) BOOL defaultAnimation;
 @property (nonatomic) BOOL enable;
 @property (nonatomic) BOOL waitForRender;
 

--- a/lib/ios/RNNScreenTransition.m
+++ b/lib/ios/RNNScreenTransition.m
@@ -8,7 +8,7 @@
 	self.topBar = dict[@"topBar"] ? [[RNNTransitionStateHolder alloc] initWithDict:dict[@"topBar"]] : nil;
 	self.content = dict[@"content"] ? [[RNNTransitionStateHolder alloc] initWithDict:dict[@"content"]] : nil;
 	self.bottomTabs = dict[@"bottomTabs"] ? [[RNNTransitionStateHolder alloc] initWithDict:dict[@"bottomTabs"]] : nil;
-
+	self.defaultAnimation = dict[@"defaultAnimation"] ? [dict[@"defaultAnimation"] boolValue] : NO;
 	self.enable = dict[@"enabled"] ? [dict[@"enabled"] boolValue] : YES;
 	self.waitForRender = dict[@"waitForRender"] ? [dict[@"waitForRender"] boolValue] : NO;
 


### PR DESCRIPTION
During sharedElement screen transitions, allow disabling animation (used for screen transitions when rerendered components on previous screens no longer exist). Controlled with the defaultAnimations prop attached to screenTransitionOptions in pop/push animation options.