### PR TITLE
Move animationType property to parent

### DIFF
--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -192,14 +192,13 @@ Navigation.mergeOptions(this.props.componentId, {
   sideMenu: {
     left: {
       shouldStretchDrawer: false, // defaults to true, when false sideMenu contents not stretched when opened past the width
-      animationVelocity: 2500, // defaults to 840, high number is a faster sideMenu open/close animation
-      animationType: 'parallax' // defaults to none if not provided, options are 'parallax', 'door', 'slide', or 'slide-and-scale'    
+      animationVelocity: 2500 // defaults to 840, high number is a faster sideMenu open/close animation
     },
     right: {
       shouldStretchDrawer: false, // defaults to true, when false sideMenu contents not stretched when opened past the width
-      animationVelocity: 2500, // defaults to 840, high number is a faster sideMenu open/close animation
-      animationType: 'parallax' // defaults to none if not provided, options are 'parallax', 'door', 'slide', or 'slide-and-scale'    
+      animationVelocity: 2500 // defaults to 840, high number is a faster sideMenu open/close animation
     },
+    animationType: 'parallax', // defaults to none if not provided, options are 'parallax', 'door', 'slide', or 'slide-and-scale'    
     openGestureMode: 'entireScreen' | 'bezel'
   }
   bottomTabs: {


### PR DESCRIPTION
The docs is not correct. The `animationType` is not part of `left`, `right` or `center`, but should be listed under the `sideMenu` object.