### PR TITLE
Refactor SplitView options and make them work with Tabs

### DIFF
--- a/docs/docs/layout-types.md
+++ b/docs/docs/layout-types.md
@@ -200,10 +200,12 @@ const splitView = {
     // All layout types accepted supported by device, eg. `stack`
   },
   options: {
-    displayMode: 'auto', // Master view display mode: `auto`, `visible`, `hidden` and `overlay`
-    primaryEdge: 'leading', // Master view side: `leading` or `trailing`
-    minWidth: 150, // Minimum width of master view
-    maxWidth: 300, // Maximum width of master view
+    splitView: {
+      displayMode: 'auto', // Master view display mode: `auto`, `visible`, `hidden` and `overlay`
+      primaryEdge: 'leading', // Master view side: `leading` or `trailing`
+      minWidth: 150, // Minimum width of master view
+      maxWidth: 300, // Maximum width of master view
+    },
   },
 }
 ```

--- a/lib/ios/RNNNavigationOptions.h
+++ b/lib/ios/RNNNavigationOptions.h
@@ -10,6 +10,7 @@
 #import "RNNStatusBarOptions.h"
 #import "RNNPreviewOptions.h"
 #import "RNNLayoutOptions.h"
+#import "RNNSplitViewOptions.h"
 
 extern const NSInteger BLUR_TOPBAR_TAG;
 extern const NSInteger TOP_BAR_TRANSPARENT_TAG;
@@ -28,6 +29,7 @@ extern const NSInteger TOP_BAR_TRANSPARENT_TAG;
 @property (nonatomic, strong) RNNStatusBarOptions* statusBar;
 @property (nonatomic, strong) RNNPreviewOptions* preview;
 @property (nonatomic, strong) RNNLayoutOptions* layout;
+@property (nonatomic, strong) RNNSplitViewOptions* splitView;
 
 @property (nonatomic, strong) Bool* popGesture;
 @property (nonatomic, strong) Image* backgroundImage;

--- a/lib/ios/RNNNavigationOptions.m
+++ b/lib/ios/RNNNavigationOptions.m
@@ -7,6 +7,7 @@
 #import "RNNRootViewController.h"
 #import "RNNSplitViewController.h"
 #import "RNNNavigationButtons.h"
+#import "RNNSplitViewOptions.h"
 #import "UIViewController+RNNOptions.h"
 #import "UINavigationController+RNNOptions.h"
 
@@ -21,6 +22,7 @@
 	self.topTabs = [[RNNTopTabsOptions alloc] initWithDict:dict[@"topTabs"]];
 	self.topTab = [[RNNTopTabOptions alloc] initWithDict:dict[@"topTab"]];
 	self.sideMenu = [[RNNSideMenuOptions alloc] initWithDict:dict[@"sideMenu"]];
+	self.splitView = [[RNNSplitViewOptions alloc] initWithDict:dict[@"splitView"]];
 	self.overlay = [[RNNOverlayOptions alloc] initWithDict:dict[@"overlay"]];
 	self.customTransition = [[RNNAnimationOptions alloc] initWithDict:dict[@"customTransition"]];
 	self.animations = [[RNNTransitionsOptions alloc] initWithDict:dict[@"animations"]];

--- a/lib/ios/RNNSplitViewController.m
+++ b/lib/ios/RNNSplitViewController.m
@@ -19,6 +19,12 @@
 	return self;
 }
 
+- (void)willMoveToParentViewController:(UIViewController *)parent {
+	if (parent) {
+		[_presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
+	}
+}
+
 - (void)onChildWillAppear {
 	[_presenter applyOptions:self.resolveOptions];
 	[((UIViewController<RNNParentProtocol> *)self.parentViewController) onChildWillAppear];

--- a/lib/ios/RNNSplitViewOptions.m
+++ b/lib/ios/RNNSplitViewOptions.m
@@ -3,6 +3,19 @@
 
 @implementation RNNSplitViewOptions
 
+- (instancetype)initWithDict:(NSDictionary *)dict {
+	self = [super init];
+	
+	self.displayMode = dict[@"displayMode"];
+	self.primaryEdge = dict[@"primaryEdge"];
+	NSNumberFormatter *f = [[NSNumberFormatter alloc] init];
+	f.numberStyle = NSNumberFormatterDecimalStyle;
+	self.minWidth = [f numberFromString:dict[@"minWidth"]];
+	self.maxWidth = [f numberFromString:dict[@"maxWidth"]];
+	
+	return self;	
+}
+
 -(void)applyOn:(UIViewController<RNNParentProtocol> *)viewController {
 	
 	UISplitViewController *svc = (UISplitViewController*) viewController;

--- a/lib/src/commands/LayoutTreeParser.test.ts
+++ b/lib/src/commands/LayoutTreeParser.test.ts
@@ -1,8 +1,8 @@
 import * as _ from 'lodash';
 import { LayoutTreeParser } from './LayoutTreeParser';
 import { LayoutType } from './LayoutType';
+import { Options } from '../interfaces/Options';
 import { Layout } from '../interfaces/Layout';
-import { OptionsSplitView } from '../interfaces/Options';
 import { UniqueIdProvider } from '../adapters/UniqueIdProvider';
 import { mock, instance, when, anything } from 'ts-mockito';
 
@@ -185,7 +185,7 @@ const passProps = {
   fnProp: () => 'Hello from a function'
 };
 
-const options = {
+const options: Options = {
   topBar: {
     title: {
       text: 'Hello1'
@@ -193,11 +193,18 @@ const options = {
   }
 };
 
-const optionsSplitView: OptionsSplitView = {
-  displayMode: 'auto',
-  primaryEdge: 'leading',
-  minWidth: 150,
-  maxWidth: 300
+const optionsSplitView: Options = {
+  topBar: {
+    title: {
+      text: 'Hello1',
+    }
+  },
+  splitView: {
+    displayMode: 'auto',
+    primaryEdge: 'leading',
+    minWidth: 150,
+    maxWidth: 300
+  }
 };
 
 const singleComponent = {

--- a/lib/src/interfaces/Layout.ts
+++ b/lib/src/interfaces/Layout.ts
@@ -1,4 +1,4 @@
-import { Options, OptionsSplitView } from './Options';
+import { Options } from './Options';
 
 export interface LayoutComponent<P = {}> {
   /**
@@ -110,7 +110,7 @@ export interface LayoutSplitView {
   /**
    * Configure split view
    */
-  options?: OptionsSplitView;
+  options?: Options;
 }
 
 export interface TopTabs {

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -816,6 +816,10 @@ export interface Options {
    */
   sideMenu?: OptionsSideMenu;
   /**
+   * Configure the splitView controller
+   */
+  splitView?: OptionsSplitView;
+  /**
    * Configure the overlay
    */
   overlay?: OptionsOverlay;


### PR DESCRIPTION
The bottomTab settings were not being properly applied if a SplitView
controller was nested. Part of this seems to be that the 'options' for
SplitView were in their V1 form, i.e. they did not have access to the
full topBar/bottomTab/etc.

I refactored the options to be in their own sub object. NOTE: the
settings for `splitView` are not being applied currently -- they weren't
before and they still are not being respected now.

With access to the full options now, I was able to change
RNNSplitViewController to properly override
willMoveToParentViewController to get the bottomTab icon to properly
show up.

I would love to get the actual `splitView` settings to properly work, but I need some guidance on how to do that in the new Presenter framework.  Since this seems to be no worse off than before, I figure it is still worth merging in the meantime.