### PR TITLE
Tell prop's type with generic. Addition to #4597

### DIFF
--- a/lib/src/Navigation.ts
+++ b/lib/src/Navigation.ts
@@ -115,7 +115,7 @@ export class NavigationRoot {
   /**
    * Show a screen as a modal.
    */
-  public showModal(layout: Layout): Promise<any> {
+  public showModal<P>(layout: Layout<P>): Promise<any> {
     return this.commands.showModal(layout);
   }
 


### PR DESCRIPTION
This is an addition to #4597. I've added a missing type for `showModal` method