### PR TITLE
Bottom tabs attach mode

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabsOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabsOptions.java
@@ -34,6 +34,7 @@ public class BottomTabsOptions {
         options.elevation = FractionParser.parse(json, "elevation");
         options.testId = TextParser.parse(json, "testID");
         options.titleDisplayMode = TitleDisplayMode.fromString(json.optString("titleDisplayMode"));
+        options.tabsAttachMode = TabsAttachMode.fromString(json.optString("tabsAttachMode"));
 
 		return options;
 	}
@@ -47,6 +48,7 @@ public class BottomTabsOptions {
 	public Text currentTabId = new NullText();
     public Text testId = new NullText();
     public TitleDisplayMode titleDisplayMode = TitleDisplayMode.UNDEFINED;
+    public TabsAttachMode tabsAttachMode = TabsAttachMode.UNDEFINED;
 
 	void mergeWith(final BottomTabsOptions other) {
 		if (other.currentTabId.hasValue()) currentTabId = other.currentTabId;
@@ -58,6 +60,7 @@ public class BottomTabsOptions {
         if (other.backgroundColor.hasValue()) backgroundColor = other.backgroundColor;
         if (other.testId.hasValue()) testId = other.testId;
         if (other.titleDisplayMode.hasValue()) titleDisplayMode = other.titleDisplayMode;
+        if (other.tabsAttachMode.hasValue()) tabsAttachMode = other.tabsAttachMode;
     }
 
     void mergeWithDefault(final BottomTabsOptions defaultOptions) {
@@ -69,6 +72,7 @@ public class BottomTabsOptions {
         if (!elevation.hasValue()) elevation = defaultOptions.elevation;
         if (!backgroundColor.hasValue()) backgroundColor = defaultOptions.backgroundColor;
         if (!titleDisplayMode.hasValue()) titleDisplayMode = defaultOptions.titleDisplayMode;
+        if (!tabsAttachMode.hasValue()) tabsAttachMode = defaultOptions.tabsAttachMode;
     }
 
     public void clearOneTimeOptions() {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutFactory.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutFactory.java
@@ -16,6 +16,7 @@ import com.reactnativenavigation.utils.TypefaceLoader;
 import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
 import com.reactnativenavigation.viewcontrollers.ComponentViewController;
 import com.reactnativenavigation.viewcontrollers.ViewController;
+import com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabsAttacher;
 import com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabsController;
 import com.reactnativenavigation.viewcontrollers.externalcomponent.ExternalComponentCreator;
 import com.reactnativenavigation.viewcontrollers.externalcomponent.ExternalComponentViewController;
@@ -193,6 +194,7 @@ public class LayoutFactory {
         for (int i = 0; i < node.children.size(); i++) {
             tabs.add(create(node.children.get(i)));
         }
+        BottomTabsPresenter bottomTabsPresenter = new BottomTabsPresenter(tabs, defaultOptions);
         return new BottomTabsController(activity,
                 tabs,
                 childRegistry,
@@ -201,7 +203,8 @@ public class LayoutFactory {
                 node.id,
                 parse(typefaceManager, node.getOptions()),
                 new Presenter(activity, defaultOptions),
-                new BottomTabsPresenter(tabs, defaultOptions),
+                new BottomTabsAttacher(tabs, bottomTabsPresenter),
+                bottomTabsPresenter,
                 new BottomTabPresenter(activity, tabs, new ImageLoader(), defaultOptions));
 	}
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/TabsAttachMode.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/TabsAttachMode.java
@@ -1,0 +1,25 @@
+package com.reactnativenavigation.parse;
+
+public enum  TabsAttachMode {
+    TOGETHER,
+    AFTER_INITIAL_TAB,
+    ON_SWITCH_TO_TAB,
+    UNDEFINED;
+
+    public static TabsAttachMode fromString(String mode) {
+        switch (mode) {
+            case "together":
+                return TOGETHER;
+            case "afterInitialTab":
+                return AFTER_INITIAL_TAB;
+            case "onSwitchToTab":
+                return ON_SWITCH_TO_TAB;
+            default:
+                return UNDEFINED;
+        }
+    }
+
+    public boolean hasValue() {
+        return this != UNDEFINED;
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/OverlayManager.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/OverlayManager.java
@@ -12,7 +12,7 @@ public class OverlayManager {
 
     public void show(ViewGroup overlaysContainer, ViewController overlay, CommandListener listener) {
         overlayRegistry.put(overlay.getId(), overlay);
-        overlay.setOnAppearedListener(() -> listener.onSuccess(overlay.getId()));
+        overlay.addOnAppearedListener(() -> listener.onSuccess(overlay.getId()));
         overlaysContainer.addView(overlay.getView());
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/CollectionUtils.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/CollectionUtils.java
@@ -72,6 +72,13 @@ public class CollectionUtils {
         if (items != null) forEach(new ArrayList(items), 0, apply);
     }
 
+    public static <T> void forEach(@Nullable T[] items, Apply<T> apply) {
+        if (items == null) return;
+        for (T item : items) {
+            apply.on(item);
+        }
+    }
+
     public static <T> void forEach(@Nullable List<T> items, Apply<T> apply) {
         forEach(items, 0, apply);
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/CollectionUtils.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/CollectionUtils.java
@@ -69,9 +69,17 @@ public class CollectionUtils {
     }
 
     public static <T> void forEach(@Nullable Collection<T> items, Apply<T> apply) {
+        if (items != null) forEach(new ArrayList(items), 0, apply);
+    }
+
+    public static <T> void forEach(@Nullable List<T> items, Apply<T> apply) {
+        forEach(items, 0, apply);
+    }
+
+    public static <T> void forEach(@Nullable List<T> items, int startIndex, Apply<T> apply) {
         if (items == null) return;
-        for (T item : items) {
-            apply.on(item);
+        for (int i = startIndex; i < items.size(); i++) {
+            apply.on(items.get(i));
         }
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ViewController.java
@@ -80,11 +80,11 @@ public abstract class ViewController<T extends ViewGroup> implements ViewTreeObs
         this.waitForRender = waitForRender;
     }
 
-    public void addOnAppearedListener(@NonNull Runnable onAppearedListener) {
+    public void addOnAppearedListener(Runnable onAppearedListener) {
         onAppearedListeners.add(onAppearedListener);
     }
 
-    public void removeOnAppearedListener(@NonNull Runnable onAppearedListener) {
+    public void removeOnAppearedListener(Runnable onAppearedListener) {
         onAppearedListeners.remove(onAppearedListener);
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ViewController.java
@@ -25,12 +25,15 @@ import com.reactnativenavigation.views.Component;
 import com.reactnativenavigation.views.Renderable;
 import com.reactnativenavigation.views.element.Element;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.reactnativenavigation.utils.CollectionUtils.forEach;
+
 public abstract class ViewController<T extends ViewGroup> implements ViewTreeObserver.OnGlobalLayoutListener, ViewGroup.OnHierarchyChangeListener {
 
-    private Runnable onAppearedListener;
+    private final List<Runnable> onAppearedListeners = new ArrayList();
     private boolean appearEventPosted;
     private boolean isFirstLayout = true;
     private Bool waitForRender = new NullBool();
@@ -47,7 +50,7 @@ public abstract class ViewController<T extends ViewGroup> implements ViewTreeObs
         boolean onViewDisappear(View view);
     }
 
-    protected Options initialOptions;
+    public Options initialOptions;
     public Options options;
 
     private final Activity activity;
@@ -77,8 +80,12 @@ public abstract class ViewController<T extends ViewGroup> implements ViewTreeObs
         this.waitForRender = waitForRender;
     }
 
-    public void setOnAppearedListener(Runnable onAppearedListener) {
-        this.onAppearedListener = onAppearedListener;
+    public void addOnAppearedListener(@NonNull Runnable onAppearedListener) {
+        onAppearedListeners.add(onAppearedListener);
+    }
+
+    public void removeOnAppearedListener(@NonNull Runnable onAppearedListener) {
+        onAppearedListeners.remove(onAppearedListener);
     }
 
     protected abstract T createView();
@@ -199,11 +206,11 @@ public abstract class ViewController<T extends ViewGroup> implements ViewTreeObs
             parentController.clearOptions();
             if (getView() instanceof Component) parentController.applyChildOptions(options, (Component) getView());
         });
-        if (onAppearedListener != null && !appearEventPosted) {
+        if (!onAppearedListeners.isEmpty() && !appearEventPosted) {
             appearEventPosted = true;
             UiThread.post(() -> {
-                onAppearedListener.run();
-                onAppearedListener = null;
+                forEach(onAppearedListeners, Runnable::run);
+                onAppearedListeners.clear();
             });
         }
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/AfterInitialTab.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/AfterInitialTab.java
@@ -1,0 +1,36 @@
+package com.reactnativenavigation.viewcontrollers.bottomtabs;
+
+import android.view.*;
+
+import com.reactnativenavigation.parse.*;
+import com.reactnativenavigation.presentation.*;
+import com.reactnativenavigation.viewcontrollers.*;
+
+import java.util.*;
+
+import static com.reactnativenavigation.utils.CollectionUtils.filter;
+import static com.reactnativenavigation.utils.CollectionUtils.forEach;
+
+public class AfterInitialTab extends AttachMode {
+    private final Runnable attachOtherTabs;
+
+    public AfterInitialTab(ViewGroup parent, List<ViewController> tabs, BottomTabsPresenter presenter, Options resolved) {
+        super(parent, tabs, presenter, resolved);
+        attachOtherTabs = () -> forEach(otherTabs(), this::attach);
+    }
+
+    @Override
+    public void attach() {
+        initialTab.addOnAppearedListener(attachOtherTabs);
+        attach(initialTab);
+    }
+
+    @Override
+    public void destroy() {
+        initialTab.removeOnAppearedListener(attachOtherTabs);
+    }
+
+    private List<ViewController> otherTabs() {
+        return filter(tabs, t -> t != initialTab);
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/AttachMode.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/AttachMode.java
@@ -1,0 +1,62 @@
+package com.reactnativenavigation.viewcontrollers.bottomtabs;
+
+import android.support.annotation.*;
+import android.view.*;
+import android.widget.*;
+
+import com.reactnativenavigation.parse.*;
+import com.reactnativenavigation.presentation.*;
+import com.reactnativenavigation.viewcontrollers.*;
+
+import java.util.*;
+
+import static android.view.ViewGroup.LayoutParams.*;
+
+public abstract class AttachMode {
+    protected final ViewGroup parent;
+    protected final BottomTabsPresenter presenter;
+    protected final List<ViewController> tabs;
+    final ViewController initialTab;
+    private final Options resolved;
+
+
+    public static AttachMode get(ViewGroup parent, List<ViewController> tabs, BottomTabsPresenter presenter, Options resolved) {
+        switch (resolved.bottomTabsOptions.tabsAttachMode) {
+            case AFTER_INITIAL_TAB:
+                return new AfterInitialTab(parent, tabs, presenter, resolved);
+            case ON_SWITCH_TO_TAB:
+                return new OnSwitchToTab(parent, tabs, presenter, resolved);
+            case UNDEFINED:
+            case TOGETHER:
+            default:
+                return new Together(parent, tabs, presenter, resolved);
+        }
+    }
+
+    AttachMode(ViewGroup parent, List<ViewController> tabs, BottomTabsPresenter presenter, Options resolved) {
+        this.parent = parent;
+        this.tabs = tabs;
+        this.presenter = presenter;
+        this.resolved = resolved;
+        initialTab = tabs.get(resolved.bottomTabsOptions.currentTabIndex.get(0));
+    }
+
+    public abstract void attach();
+
+    public void destroy() {
+
+    }
+
+    public void onTabSelected(ViewController tab) {
+
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+    public void attach(ViewController tab) {
+        ViewGroup view = tab.getView();
+        view.setLayoutParams(new RelativeLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT));
+        presenter.applyLayoutParamsOptions(resolved, tabs.indexOf(tab));
+        view.setVisibility(tab == initialTab ? View.VISIBLE : View.INVISIBLE);
+        parent.addView(view);
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsAttacher.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsAttacher.java
@@ -1,0 +1,48 @@
+package com.reactnativenavigation.viewcontrollers.bottomtabs;
+
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.RelativeLayout;
+
+import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.presentation.BottomTabsPresenter;
+import com.reactnativenavigation.viewcontrollers.ViewController;
+
+import java.util.List;
+
+import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
+import static com.reactnativenavigation.utils.CollectionUtils.filter;
+import static com.reactnativenavigation.utils.CollectionUtils.forEach;
+
+public class BottomTabsAttacher {
+    private List<ViewController> tabs;
+    private BottomTabsPresenter presenter;
+    private Runnable onAppeared;
+
+    public BottomTabsAttacher(List<ViewController> tabs, BottomTabsPresenter presenter) {
+        this.tabs = tabs;
+        this.presenter = presenter;
+    }
+
+    void attach(ViewGroup parent, Options current) {
+        int currentTab = current.bottomTabsOptions.currentTabIndex.get(0);
+        List<ViewController> otherTabs = filter(tabs, (t) -> tabs.indexOf(t) != currentTab);
+        onAppeared = () -> forEach(otherTabs, (t) -> attachInternal(parent, current, t));
+        tabs.get(currentTab).addOnAppearedListener(onAppeared);
+        attachInternal(parent, current, tabs.get(currentTab));
+    }
+
+    private void attachInternal(ViewGroup parent, Options current, ViewController tab) {
+        ViewGroup view = tab.getView();
+        view.setLayoutParams(new RelativeLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT));
+        int index = tabs.indexOf(tab);
+        presenter.applyLayoutParamsOptions(current, index);
+        view.setVisibility(index == 0 ? View.VISIBLE : View.INVISIBLE);
+        parent.addView(view);
+    }
+
+    public void destroy() {
+        tabs.get(0).removeOnAppearedListener(onAppeared);
+        onAppeared = null;
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -38,14 +38,16 @@ public class BottomTabsController extends ParentController implements AHBottomNa
 	private List<ViewController> tabs;
     private EventEmitter eventEmitter;
     private ImageLoader imageLoader;
+    private final BottomTabsAttacher tabsAttacher;
     private BottomTabsPresenter presenter;
     private BottomTabPresenter tabPresenter;
 
-    public BottomTabsController(Activity activity, List<ViewController> tabs, ChildControllersRegistry childRegistry, EventEmitter eventEmitter, ImageLoader imageLoader, String id, Options initialOptions, Presenter presenter, BottomTabsPresenter bottomTabsPresenter, BottomTabPresenter bottomTabPresenter) {
+    public BottomTabsController(Activity activity, List<ViewController> tabs, ChildControllersRegistry childRegistry, EventEmitter eventEmitter, ImageLoader imageLoader, String id, Options initialOptions, Presenter presenter, BottomTabsAttacher tabsAttacher, BottomTabsPresenter bottomTabsPresenter, BottomTabPresenter bottomTabPresenter) {
 		super(activity, childRegistry, id, presenter, initialOptions);
         this.tabs = tabs;
         this.eventEmitter = eventEmitter;
         this.imageLoader = imageLoader;
+        this.tabsAttacher = tabsAttacher;
         this.presenter = bottomTabsPresenter;
         this.tabPresenter = bottomTabPresenter;
         forEach(tabs, (tab) -> tab.setParentController(this));
@@ -70,7 +72,7 @@ public class BottomTabsController extends ParentController implements AHBottomNa
 		lp.addRule(ALIGN_PARENT_BOTTOM);
 		root.addView(bottomTabs, lp);
 		bottomTabs.addItems(createTabs());
-        attachTabs(root);
+        tabsAttacher.attach(root, resolveCurrentOptions());
         return root;
 	}
 
@@ -154,17 +156,6 @@ public class BottomTabsController extends ParentController implements AHBottomNa
             );
         });
 	}
-
-    private void attachTabs(RelativeLayout root) {
-        for (int i = 0; i < tabs.size(); i++) {
-            ViewGroup tab = tabs.get(i).getView();
-            tab.setLayoutParams(new RelativeLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT));
-            Options options = resolveCurrentOptions();
-            presenter.applyLayoutParamsOptions(options, i);
-            if (i != 0) tab.setVisibility(View.INVISIBLE);
-            root.addView(tab);
-        }
-    }
 
     public int getSelectedIndex() {
 		return bottomTabs.getCurrentItem();

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -65,6 +65,7 @@ public class BottomTabsController extends ParentController implements AHBottomNa
 	protected ViewGroup createView() {
 		RelativeLayout root = new RelativeLayout(getActivity());
 		bottomTabs = createBottomTabs();
+        tabsAttacher.init(root, resolveCurrentOptions());
         presenter.bindView(bottomTabs, this);
         tabPresenter.bindView(bottomTabs);
         bottomTabs.setOnTabSelectedListener(this);
@@ -72,7 +73,7 @@ public class BottomTabsController extends ParentController implements AHBottomNa
 		lp.addRule(ALIGN_PARENT_BOTTOM);
 		root.addView(bottomTabs, lp);
 		bottomTabs.addItems(createTabs());
-        tabsAttacher.attach(root, resolveCurrentOptions());
+        tabsAttacher.attach();
         return root;
 	}
 
@@ -168,7 +169,14 @@ public class BottomTabsController extends ParentController implements AHBottomNa
 	}
 
     @Override
+    public void destroy() {
+        tabsAttacher.destroy();
+        super.destroy();
+    }
+
+    @Override
     public void selectTab(final int newIndex) {
+        tabsAttacher.onTabSelected(tabs.get(newIndex));
         getCurrentView().setVisibility(View.INVISIBLE);
         bottomTabs.setCurrentItem(newIndex, false);
         getCurrentView().setVisibility(View.VISIBLE);

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/OnSwitchToTab.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/OnSwitchToTab.java
@@ -1,0 +1,34 @@
+package com.reactnativenavigation.viewcontrollers.bottomtabs;
+
+import android.view.*;
+
+import com.reactnativenavigation.parse.*;
+import com.reactnativenavigation.presentation.*;
+import com.reactnativenavigation.viewcontrollers.*;
+
+import java.util.*;
+
+public class OnSwitchToTab extends AttachMode {
+    private final ViewController initialTab;
+
+    public OnSwitchToTab(ViewGroup parent, List<ViewController> tabs, BottomTabsPresenter presenter, Options resolved) {
+        super(parent, tabs, presenter, resolved);
+        this.initialTab = tabs.get(resolved.bottomTabsOptions.currentTabIndex.get(0));
+    }
+
+    @Override
+    public void attach() {
+        attach(initialTab);
+    }
+
+    @Override
+    public void onTabSelected(ViewController tab) {
+        if (tab != initialTab && isNotAttached(tab)) {
+            attach(tab);
+        }
+    }
+
+    private boolean isNotAttached(ViewController tab) {
+        return tab.getView().getParent() == null;
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/Together.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/Together.java
@@ -1,0 +1,22 @@
+package com.reactnativenavigation.viewcontrollers.bottomtabs;
+
+import android.view.*;
+
+import com.reactnativenavigation.parse.*;
+import com.reactnativenavigation.presentation.*;
+import com.reactnativenavigation.viewcontrollers.*;
+
+import java.util.*;
+
+import static com.reactnativenavigation.utils.CollectionUtils.*;
+
+public class Together extends AttachMode {
+    public Together(ViewGroup parent, List<ViewController> tabs, BottomTabsPresenter presenter, Options resolved) {
+        super(parent, tabs, presenter, resolved);
+    }
+
+    @Override
+    public void attach() {
+        forEach(tabs, this::attach);
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/modal/ModalPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/modal/ModalPresenter.java
@@ -44,13 +44,13 @@ public class ModalPresenter {
         modalsLayout.addView(toAdd.getView());
         if (options.animations.showModal.enabled.isTrueOrUndefined()) {
             if (options.animations.showModal.waitForRender.isTrue()) {
-                toAdd.setOnAppearedListener(() -> animateShow(toAdd, toRemove, listener, options));
+                toAdd.addOnAppearedListener(() -> animateShow(toAdd, toRemove, listener, options));
             } else {
                 animateShow(toAdd, toRemove, listener, options);
             }
         } else {
             if (options.animations.showModal.waitForRender.isTrue()) {
-                toAdd.setOnAppearedListener(() -> onShowModalEnd(toAdd, toRemove, listener));
+                toAdd.addOnAppearedListener(() -> onShowModalEnd(toAdd, toRemove, listener));
             } else {
                 onShowModalEnd(toAdd, toRemove, listener);
             }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/navigator/RootPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/navigator/RootPresenter.java
@@ -31,7 +31,7 @@ public class RootPresenter {
         root.setWaitForRender(options.animations.setRoot.waitForRender);
         if (options.animations.setRoot.waitForRender.isTrue()) {
             root.getView().setAlpha(0);
-            root.setOnAppearedListener(() -> {
+            root.addOnAppearedListener(() -> {
                 root.getView().setAlpha(1);
                 animateSetRootAndReportSuccess(root, listener, options);
             });

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
@@ -162,7 +162,7 @@ public class StackController extends ParentController<StackLayout> {
             if (resolvedOptions.animations.push.enabled.isTrueOrUndefined()) {
                 if (resolvedOptions.animations.push.waitForRender.isTrue()) {
                     child.getView().setAlpha(0);
-                    child.setOnAppearedListener(() -> animator.push(child.getView(), resolvedOptions.animations.push, resolvedOptions.transitions, toRemove.getElements(), child.getElements(), () -> {
+                    child.addOnAppearedListener(() -> animator.push(child.getView(), resolvedOptions.animations.push, resolvedOptions.transitions, toRemove.getElements(), child.getElements(), () -> {
                         getView().removeView(toRemove.getView());
                         listener.onSuccess(child.getId());
                     }));

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/topbar/TopBarController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/topbar/TopBarController.java
@@ -25,7 +25,9 @@ public class TopBarController {
     }
 
     public void clear() {
-        topBar.clear();
+        if (topBar != null) {
+            topBar.clear();
+        }
     }
 
     public TopBar getView() {

--- a/lib/android/app/src/test/java/com/reactnativenavigation/BaseTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/BaseTest.java
@@ -19,6 +19,9 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
+import java.util.Arrays;
+
+import static com.reactnativenavigation.utils.CollectionUtils.forEach;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
@@ -42,10 +45,18 @@ public abstract class BaseTest {
         return Robolectric.buildActivity(clazz);
     }
 
+    public void assertIsChild(ViewGroup parent, ViewController... children) {
+        forEach(Arrays.asList(children),c -> assertIsChild(parent, c.getView()));
+    }
+
     public void assertIsChild(ViewGroup parent, View child) {
         assertThat(parent).isNotNull();
         assertThat(child).isNotNull();
         assertThat(ViewUtils.isChildOf(parent, child)).isTrue();
+    }
+
+    public void assertNotChildOf(ViewGroup parent, ViewController... children) {
+        forEach(Arrays.asList(children), c -> assertNotChildOf(parent, c.getView()));
     }
 
     public void assertNotChildOf(ViewGroup parent, View child) {

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TopBarControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TopBarControllerTest.java
@@ -13,6 +13,7 @@ import com.reactnativenavigation.views.topbar.TopBar;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -46,5 +47,16 @@ public class TopBarControllerTest extends BaseTest {
         uut.createView(activity, Mockito.mock(StackLayout.class));
         uut.clear();
         verify(titleBar[0], times(1)).clear();
+    }
+
+    @Test
+    public void destroy() {
+        uut.createView(newActivity(), mock(StackLayout.class));
+        uut.clear();
+    }
+
+    @Test
+    public void destroy_canBeCalledBeforeViewIsCreated() {
+        uut.clear();
     }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsAttacherTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsAttacherTest.java
@@ -1,104 +1,45 @@
 package com.reactnativenavigation.viewcontrollers.bottomtabs;
 
-import android.app.Activity;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.FrameLayout;
-
 import com.reactnativenavigation.BaseTest;
-import com.reactnativenavigation.mocks.SimpleViewController;
-import com.reactnativenavigation.parse.Options;
-import com.reactnativenavigation.parse.params.Number;
 import com.reactnativenavigation.presentation.BottomTabsPresenter;
-import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
-import com.reactnativenavigation.viewcontrollers.ViewController;
+import com.reactnativenavigation.viewcontrollers.*;
 
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.Collections;
 
-import static com.reactnativenavigation.utils.CollectionUtils.forEach;
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class BottomTabsAttacherTest extends BaseTest {
-    private Activity activity;
-    private ChildControllersRegistry childRegistry;
 
     private BottomTabsAttacher uut;
-    private ViewController tab1;
-    private ViewController tab2;
-    private ViewController tab3;
-    private List<ViewController> tabs;
-    private ViewGroup parent;
-    private BottomTabsPresenter presenter;
+    private AttachMode mode;
 
     @Override
     public void beforeEach() {
-        activity = newActivity();
-        childRegistry = new ChildControllersRegistry();
-        parent = new FrameLayout(activity);
-        tabs = createTabs();
-        presenter = Mockito.mock(BottomTabsPresenter.class);
-        uut = new BottomTabsAttacher(tabs, presenter);
-    }
-
-    private List<ViewController> createTabs() {
-        tab1 = new SimpleViewController(activity, childRegistry, "child1", new Options());
-        tab2 = new SimpleViewController(activity, childRegistry, "child2", new Options());
-        tab3 = new SimpleViewController(activity, childRegistry, "child3", new Options());
-        return Arrays.asList(tab1, tab2, tab3);
+        mode = Mockito.mock(AttachMode.class);
+        uut = new BottomTabsAttacher(Collections.EMPTY_LIST, Mockito.mock(BottomTabsPresenter.class));
+        uut.attachStrategy = mode;
     }
 
     @Test
-    public void attach_firstTabIsAttachedToParent() {
-        uut.attach(parent, Options.EMPTY);
-        assertThat(tab1.getView().getParent()).isEqualTo(parent);
+    public void attach_delegatesToStrategy() {
+        uut.attach();
+        verify(mode).attach();
     }
 
     @Test
-    public void attach_otherTabsAreAttachedAfterFirstTabIsAttached() {
-        uut.attach(parent, Options.EMPTY);
-        assertNotChildOf(parent, tab2, tab3);
-
-        tab1.onViewAppeared();
-        assertIsChild(parent, tab2, tab3);
+    public void onTabSelected() {
+        ViewController tab = mock(ViewController.class);
+        uut.onTabSelected(tab);
+        verify(mode).onTabSelected(tab);
     }
 
     @Test
-    public void attach_otherTabsAreInvisibleWhenAttached() {
-        uut.attach(parent, Options.EMPTY);
-        tab1.onViewAppeared();
-        forEach(tabs, 1, t -> assertThat(t.getView().getVisibility()).isEqualTo(View.INVISIBLE));
-    }
-
-    @Test
-    public void attach_layoutOptionsAreApplied() {
-        Options current = Options.EMPTY;
-        uut.attach(parent, current);
-        tab1.onViewAppeared();
-        forEach(tabs, (t) -> verify(presenter).applyLayoutParamsOptions(current, tabs.indexOf(t)));
-    }
-
-    @Test
-    public void attach_initialTabIsAttachedFirst() {
-        Options current = new Options();
-        current.bottomTabsOptions.currentTabIndex = new Number(1);
-
-        uut.attach(parent, current);
-        assertThat(tab1.getView().getParent()).isNull();
-        assertThat(tab2.getView().getParent()).isEqualTo(parent);
-        assertThat(tab3.getView().getParent()).isNull();
-    }
-
-    @Test
-    public void destroy_removesOnAppearListener() {
-        uut.attach(parent, Options.EMPTY);
-
+    public void destroy_delegatesToStrategy() {
         uut.destroy();
-        tab1.onViewAppeared();
-        assertNotChildOf(parent, tab2, tab3);
+        verify(mode).destroy();
     }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsAttacherTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsAttacherTest.java
@@ -1,0 +1,104 @@
+package com.reactnativenavigation.viewcontrollers.bottomtabs;
+
+import android.app.Activity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+
+import com.reactnativenavigation.BaseTest;
+import com.reactnativenavigation.mocks.SimpleViewController;
+import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.parse.params.Number;
+import com.reactnativenavigation.presentation.BottomTabsPresenter;
+import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
+import com.reactnativenavigation.viewcontrollers.ViewController;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.reactnativenavigation.utils.CollectionUtils.forEach;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+public class BottomTabsAttacherTest extends BaseTest {
+    private Activity activity;
+    private ChildControllersRegistry childRegistry;
+
+    private BottomTabsAttacher uut;
+    private ViewController tab1;
+    private ViewController tab2;
+    private ViewController tab3;
+    private List<ViewController> tabs;
+    private ViewGroup parent;
+    private BottomTabsPresenter presenter;
+
+    @Override
+    public void beforeEach() {
+        activity = newActivity();
+        childRegistry = new ChildControllersRegistry();
+        parent = new FrameLayout(activity);
+        tabs = createTabs();
+        presenter = Mockito.mock(BottomTabsPresenter.class);
+        uut = new BottomTabsAttacher(tabs, presenter);
+    }
+
+    private List<ViewController> createTabs() {
+        tab1 = new SimpleViewController(activity, childRegistry, "child1", new Options());
+        tab2 = new SimpleViewController(activity, childRegistry, "child2", new Options());
+        tab3 = new SimpleViewController(activity, childRegistry, "child3", new Options());
+        return Arrays.asList(tab1, tab2, tab3);
+    }
+
+    @Test
+    public void attach_firstTabIsAttachedToParent() {
+        uut.attach(parent, Options.EMPTY);
+        assertThat(tab1.getView().getParent()).isEqualTo(parent);
+    }
+
+    @Test
+    public void attach_otherTabsAreAttachedAfterFirstTabIsAttached() {
+        uut.attach(parent, Options.EMPTY);
+        assertNotChildOf(parent, tab2, tab3);
+
+        tab1.onViewAppeared();
+        assertIsChild(parent, tab2, tab3);
+    }
+
+    @Test
+    public void attach_otherTabsAreInvisibleWhenAttached() {
+        uut.attach(parent, Options.EMPTY);
+        tab1.onViewAppeared();
+        forEach(tabs, 1, t -> assertThat(t.getView().getVisibility()).isEqualTo(View.INVISIBLE));
+    }
+
+    @Test
+    public void attach_layoutOptionsAreApplied() {
+        Options current = Options.EMPTY;
+        uut.attach(parent, current);
+        tab1.onViewAppeared();
+        forEach(tabs, (t) -> verify(presenter).applyLayoutParamsOptions(current, tabs.indexOf(t)));
+    }
+
+    @Test
+    public void attach_initialTabIsAttachedFirst() {
+        Options current = new Options();
+        current.bottomTabsOptions.currentTabIndex = new Number(1);
+
+        uut.attach(parent, current);
+        assertThat(tab1.getView().getParent()).isNull();
+        assertThat(tab2.getView().getParent()).isEqualTo(parent);
+        assertThat(tab3.getView().getParent()).isNull();
+    }
+
+    @Test
+    public void destroy_removesOnAppearListener() {
+        uut.attach(parent, Options.EMPTY);
+
+        uut.destroy();
+        tab1.onViewAppeared();
+        assertNotChildOf(parent, tab2, tab3);
+    }
+}

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.java
@@ -1,4 +1,4 @@
-package com.reactnativenavigation.viewcontrollers;
+package com.reactnativenavigation.viewcontrollers.bottomtabs;
 
 import android.app.Activity;
 import android.graphics.Color;
@@ -24,7 +24,8 @@ import com.reactnativenavigation.utils.CommandListenerAdapter;
 import com.reactnativenavigation.utils.ImageLoader;
 import com.reactnativenavigation.utils.OptionHelper;
 import com.reactnativenavigation.utils.ViewUtils;
-import com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabsController;
+import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
+import com.reactnativenavigation.viewcontrollers.ViewController;
 import com.reactnativenavigation.viewcontrollers.stack.StackController;
 import com.reactnativenavigation.views.BottomTabs;
 import com.reactnativenavigation.views.ReactComponent;
@@ -66,6 +67,7 @@ public class BottomTabsControllerTest extends BaseTest {
     private ChildControllersRegistry childRegistry;
     private List<ViewController> tabs;
     private BottomTabsPresenter presenter;
+    private BottomTabsAttacher tabsAttacher;
 
     @Override
     public void beforeEach() {
@@ -88,6 +90,7 @@ public class BottomTabsControllerTest extends BaseTest {
         when(child5.handleBack(any())).thenReturn(true);
         tabs = createTabs();
         presenter = spy(new BottomTabsPresenter(tabs, new Options()));
+        tabsAttacher = new BottomTabsAttacher(tabs, presenter);
         uut = createBottomTabs();
         activity.setContentView(uut.getView());
     }
@@ -241,6 +244,7 @@ public class BottomTabsControllerTest extends BaseTest {
         child4 = createStack(pushedScreen);
 
         tabs = new ArrayList<>(Collections.singletonList(child4));
+        tabsAttacher = new BottomTabsAttacher(tabs, presenter);
 
         initialOptions.bottomTabsOptions.currentTabIndex = new Number(3);
         Options resolvedOptions = new Options();
@@ -252,6 +256,7 @@ public class BottomTabsControllerTest extends BaseTest {
                 "uut",
                 initialOptions,
                 new Presenter(activity, new Options()),
+                tabsAttacher,
                 presenter,
                 new BottomTabPresenter(activity, tabs, ImageLoaderMock.mock(), new Options())) {
             @Override
@@ -372,6 +377,7 @@ public class BottomTabsControllerTest extends BaseTest {
                 "uut",
                 initialOptions,
                 new Presenter(activity, new Options()),
+                tabsAttacher,
                 presenter,
                 new BottomTabPresenter(activity, tabs, ImageLoaderMock.mock(), new Options())) {
             @Override

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.java
@@ -90,7 +90,7 @@ public class BottomTabsControllerTest extends BaseTest {
         when(child5.handleBack(any())).thenReturn(true);
         tabs = createTabs();
         presenter = spy(new BottomTabsPresenter(tabs, new Options()));
-        tabsAttacher = new BottomTabsAttacher(tabs, presenter);
+        tabsAttacher = spy(new BottomTabsAttacher(tabs, presenter));
         uut = createBottomTabs();
         activity.setContentView(uut.getView());
     }
@@ -246,7 +246,7 @@ public class BottomTabsControllerTest extends BaseTest {
         tabs = new ArrayList<>(Collections.singletonList(child4));
         tabsAttacher = new BottomTabsAttacher(tabs, presenter);
 
-        initialOptions.bottomTabsOptions.currentTabIndex = new Number(3);
+        initialOptions.bottomTabsOptions.currentTabIndex = new Number(0);
         Options resolvedOptions = new Options();
         uut = new BottomTabsController(activity,
                 tabs,
@@ -343,6 +343,18 @@ public class BottomTabsControllerTest extends BaseTest {
         assertThat(uut.getSelectedIndex()).isOne();
         assertThat(uut.options.bottomTabsOptions.currentTabIndex.hasValue()).isFalse();
         assertThat(uut.initialOptions.bottomTabsOptions.currentTabIndex.hasValue()).isFalse();
+    }
+
+    @Test
+    public void selectTab() {
+        uut.selectTab(1);
+        verify(tabsAttacher).onTabSelected(tabs.get(1));
+    }
+
+    @Test
+    public void destroy() {
+        uut.destroy();
+        verify(tabsAttacher).destroy();
     }
 
     @NonNull

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/attachmode/AfterInitialTabTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/attachmode/AfterInitialTabTest.java
@@ -1,0 +1,39 @@
+package com.reactnativenavigation.viewcontrollers.bottomtabs.attachmode;
+
+
+import com.reactnativenavigation.viewcontrollers.bottomtabs.*;
+
+import org.junit.*;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class AfterInitialTabTest extends AttachModeTest {
+
+    @Override
+    public void beforeEach() {
+        super.beforeEach();
+        uut = new AfterInitialTab(parent, tabs, presenter, options);
+    }
+
+    @Test
+    public void attach_initialTabIsAttached() {
+        uut.attach();
+        assertIsChild(parent, tab2);
+    }
+
+    @Test
+    public void attach_otherTabsAreAttachedAfterInitialTab() {
+        uut.attach();
+        assertNotChildOf(parent, otherTabs());
+
+        initialTab().onViewAppeared();
+        assertIsChild(parent, otherTabs());
+    }
+
+    @Test
+    public void destroy() {
+        uut.destroy();
+        verify(initialTab()).removeOnAppearedListener(any());
+    }
+}

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/attachmode/AttachModeTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/attachmode/AttachModeTest.java
@@ -1,0 +1,80 @@
+package com.reactnativenavigation.viewcontrollers.bottomtabs.attachmode;
+
+import android.app.*;
+import android.view.*;
+import android.widget.*;
+
+import com.reactnativenavigation.*;
+import com.reactnativenavigation.mocks.*;
+import com.reactnativenavigation.parse.*;
+import com.reactnativenavigation.parse.params.Number;
+import com.reactnativenavigation.presentation.*;
+import com.reactnativenavigation.viewcontrollers.*;
+import com.reactnativenavigation.viewcontrollers.bottomtabs.*;
+
+import org.junit.*;
+import org.mockito.*;
+
+import java.util.*;
+
+import static com.reactnativenavigation.utils.CollectionUtils.*;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public abstract class AttachModeTest extends BaseTest {
+    private static final int INITIAL_TAB = 1;
+
+    private Activity activity;
+    private ChildControllersRegistry childRegistry;
+    protected ViewGroup parent;
+    ViewController tab1;
+    ViewController tab2;
+    List<ViewController> tabs;
+    protected Options options;
+    protected BottomTabsPresenter presenter;
+    protected AttachMode uut;
+
+    @Override
+    public void beforeEach() {
+        activity = newActivity();
+        childRegistry = new ChildControllersRegistry();
+        parent = new FrameLayout(activity);
+        tabs = createTabs();
+        options = new Options();
+        options.bottomTabsOptions.currentTabIndex = new Number(INITIAL_TAB);
+        presenter = Mockito.mock(BottomTabsPresenter.class);
+    }
+
+    @Test
+    public void attach_layoutOptionsAreApplied() {
+        uut.attach(tab1);
+        verify(presenter).applyLayoutParamsOptions(options, tabs.indexOf(tab1));
+    }
+
+    @Test
+    public void attach_initialTabIsVisible() {
+        uut.attach(initialTab());
+        assertThat(initialTab().getView().getVisibility()).isEqualTo(View.VISIBLE);
+    }
+
+    @Test
+    public void attach_otherTabsAreInvisibleWhenAttached() {
+        forEach(otherTabs(), t -> uut.attach(t));
+        forEach(otherTabs(), t -> assertThat(t.getView().getVisibility()).isEqualTo(View.INVISIBLE));
+    }
+
+    ViewController[] otherTabs() {
+        return filter(tabs, t -> t != initialTab()).toArray(new ViewController[0]);
+    }
+
+    ViewController initialTab() {
+        return tabs.get(INITIAL_TAB);
+    }
+
+    private List<ViewController> createTabs() {
+        tab1 = new SimpleViewController(activity, childRegistry, "child1", new Options());
+        tab2 = spy(new SimpleViewController(activity, childRegistry, "child2", new Options()));
+        ViewController tab3 = new SimpleViewController(activity, childRegistry, "child3", new Options());
+        return Arrays.asList(tab1, tab2, tab3);
+    }
+}

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/attachmode/OnSwitchToTabTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/attachmode/OnSwitchToTabTest.java
@@ -1,0 +1,33 @@
+package com.reactnativenavigation.viewcontrollers.bottomtabs.attachmode;
+
+import com.reactnativenavigation.viewcontrollers.bottomtabs.*;
+
+import org.junit.*;
+
+public class OnSwitchToTabTest extends AttachModeTest {
+
+    @Override
+    public void beforeEach() {
+        super.beforeEach();
+        uut = new OnSwitchToTab(parent, tabs, presenter, options);
+    }
+
+    @Test
+    public void attach_onlyInitialTabIsAttached() {
+        uut.attach();
+        assertIsChild(parent, initialTab());
+        assertNotChildOf(parent, otherTabs());
+    }
+
+    @Test
+    public void onTabSelected_initialTabIsNotHandled() {
+        uut.onTabSelected(initialTab());
+        assertNotChildOf(parent, initialTab());
+    }
+
+    @Test
+    public void onTabSelected_otherTabIsAttached() {
+        uut.onTabSelected(tab1);
+        assertIsChild(parent, tab1);
+    }
+}

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/attachmode/TogetherTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/attachmode/TogetherTest.java
@@ -1,0 +1,21 @@
+package com.reactnativenavigation.viewcontrollers.bottomtabs.attachmode;
+
+import com.reactnativenavigation.viewcontrollers.*;
+import com.reactnativenavigation.viewcontrollers.bottomtabs.*;
+
+import org.junit.*;
+
+public class TogetherTest extends AttachModeTest {
+
+    @Override
+    public void beforeEach() {
+        super.beforeEach();
+        uut = new Together(parent, tabs, presenter, options);
+    }
+
+    @Test
+    public void attach_allTabsAreAttached() {
+        uut.attach();
+        assertIsChild(parent, tabs.toArray(new ViewController[0]));
+    }
+}

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalPresenterTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalPresenterTest.java
@@ -138,7 +138,7 @@ public class ModalPresenterTest extends BaseTest {
     public void showModal_waitForRender() {
         modal1.options.animations.showModal.waitForRender = new Bool(true);
         uut.showModal(modal1, root, new CommandListenerAdapter());
-        verify(modal1).setOnAppearedListener(any());
+        verify(modal1).addOnAppearedListener(any());
         verifyZeroInteractions(animator);
     }
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/NavigatorTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/NavigatorTest.java
@@ -28,6 +28,7 @@ import com.reactnativenavigation.utils.ViewUtils;
 import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
 import com.reactnativenavigation.viewcontrollers.ComponentViewController;
 import com.reactnativenavigation.viewcontrollers.ViewController;
+import com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabsAttacher;
 import com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabsController;
 import com.reactnativenavigation.viewcontrollers.modal.ModalStack;
 import com.reactnativenavigation.viewcontrollers.stack.StackController;
@@ -350,7 +351,8 @@ public class NavigatorTest extends BaseTest {
 
     @NonNull
     private BottomTabsController newTabs(List<ViewController> tabs) {
-        return new BottomTabsController(activity, tabs, childRegistry, eventEmitter, imageLoaderMock, "tabsController", new Options(), new Presenter(activity, new Options()), new BottomTabsPresenter(tabs, new Options()), new BottomTabPresenter(activity, tabs, ImageLoaderMock.mock(), new Options())) {
+        BottomTabsPresenter bottomTabsPresenter = new BottomTabsPresenter(tabs, new Options());
+        return new BottomTabsController(activity, tabs, childRegistry, eventEmitter, imageLoaderMock, "tabsController", new Options(), new Presenter(activity, new Options()), new BottomTabsAttacher(tabs, bottomTabsPresenter), bottomTabsPresenter, new BottomTabPresenter(activity, tabs, ImageLoaderMock.mock(), new Options())) {
             @NonNull
             @Override
             protected BottomTabs createBottomTabs() {

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/RootPresenterTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/RootPresenterTest.java
@@ -106,7 +106,7 @@ public class RootPresenterTest extends BaseTest {
         ViewController spy = spy(root);
         CommandListenerAdapter listener = spy(new CommandListenerAdapter());
         uut.setRoot(spy, defaultOptions, listener);
-        verify(spy).setOnAppearedListener(any());
+        verify(spy).addOnAppearedListener(any());
         assertThat(spy.getView().getAlpha()).isZero();
         verifyZeroInteractions(listener);
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
@@ -989,7 +989,6 @@ public class StackControllerTest extends BaseTest {
 
     @Test
     public void destroy() {
-        uut.ensureViewIsCreated();
         uut.destroy();
         verify(topBarController, times(1)).clear();
     }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
@@ -203,7 +203,7 @@ public class StackControllerTest extends BaseTest {
 
         child2.options.animations.push.waitForRender = new Bool(true);
         uut.push(child2, new CommandListenerAdapter());
-        verify(child2).setOnAppearedListener(any());
+        verify(child2).addOnAppearedListener(any());
         verify(animator, times(0)).push(eq(child1.getView()), eq(child1.options.animations.push), any());
     }
 

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -446,6 +446,11 @@ export interface OptionsBottomTabs {
    */
   backgroundColor?: Color;
   /**
+   * Set when tabs are attached to hierarchy consequently when the
+   * RootView's constructor is called.
+   */
+  tabsAttachMode?: 'together' | 'afterInitialTab' | 'onSwitchToTab';
+  /**
    * Control the Bottom Tabs blur style
    * #### (iOS specific)
    * @requires translucent: true


### PR DESCRIPTION
This pr adds support for changing tab initialisation mode. Currently bottom tabs are attached together and consequently, their corresponding react root views are created and rendered. This adds lots of stress on the js thread and hiders app start time.

To mitigate this issue, this pr adds support for three modes
* `together` (default, current behaviour) - all tabs are loaded together, adding unnecessary load on the js thread as we're loading invisible views, which leads to increased app start time.
* `afterInitialTab` - Initial tab is loaded first. After it is rendered, other tabs are loaded as well. This should shave a few hunderdish ms from app start time. Since other tabs are loaded after the initial tab is visible, the ui might be unresponsive for a few hunderdish ms as multiple root views (which are typically complex) are being created and attached to hierarchy at once.
* `onSwitchToTab` - initial tab is loaded. Other tabs are loaded when switching to them (tab click or programmatically). While this won't stress js thread after initial tab is rendered, there will be a flicker when entering a tab for the first time as it's ui isn't ready.

 