### PR TITLE
Pull from the root TabBarController height

### DIFF
--- a/lib/ios/Constants.m
+++ b/lib/ios/Constants.m
@@ -15,7 +15,7 @@
 }
 
 + (CGFloat)bottomTabsHeight {
-	return UIApplication.sharedApplication.delegate.window.rootViewController.tabBarController.tabBar.frame.size.height;
+	return CGRectGetHeight(((UITabBarController *)((UIWindow *)(UIApplication.sharedApplication.windows[0])).rootViewController).tabBar.frame);
 }
 
 @end


### PR DESCRIPTION
Pulls the height from the root UITabBarController.

Fixes #4190 