### PR TITLE
[v2][iOS] Feature - support mergeOptions on bottomTab iOS

### DIFF
--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -17,9 +17,6 @@
 	if ((options.bottomTab.text.hasValue || options.bottomTab.icon.hasValue || options.bottomTab.selectedIcon.hasValue)) {
 		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
 		viewController.tabBarItem = tabItem;
-		[options.bottomTab.text consume];
-		[options.bottomTab.icon consume];
-		[options.bottomTab.selectedIcon consume];
 	}
 }
 
@@ -35,6 +32,12 @@
 	UIViewController* viewController = self.bindedViewController;
 	if (newOptions.bottomTab.badge.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
 		[viewController rnn_setTabBarItemBadge:newOptions.bottomTab.badge.get];
+	}
+	
+	if ((newOptions.bottomTab.text.hasValue || newOptions.bottomTab.icon.hasValue || newOptions.bottomTab.selectedIcon.hasValue)) {
+		RNNNavigationOptions* buttonsResolvedOptions = [(RNNNavigationOptions *)[currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
+		viewController.tabBarItem = tabItem;
 	}
 }
 


### PR DESCRIPTION
Actually when you try to do a mergeOptions on bottomTab on iOS nothing happen, this PR fix this, now you can use mergeOptions to update the text and icon of a tab. 