### PR TITLE
[V2] [iOS] Fix iOS custom topBar background component clipping

### DIFF
--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -236,7 +236,6 @@
 			[[self.navigationController.navigationBar.subviews objectAtIndex:1] removeFromSuperview];
 		}
 		[self.navigationController.navigationBar insertSubview:_customTopBarBackground atIndex:1];
-		self.navigationController.navigationBar.clipsToBounds = YES;
 	}
 }
 


### PR DESCRIPTION
TopBar background component is clipped when you use it with custom title component.

**Example:**

```
Navigation.setRoot({
        root: {
            bottomTabs: {
                children: [
                    {
                        stack: {
                            children: [
                                {
                                    component: {
                                        name: "Welcome",
                                    },
                                    options: {
                                        topBar: {
                                            background: {
                                                component: {
                                                    name: "TopBarBackground"
                                                },
                                                title: {
                                                    component: {
                                                        name: "SelectorHeader",
                                                    }
                                                }
                                            },
                                        }
                                    }
                                }
                            ],
                        }
                    },
                    {
                        stack: {
                            children: [
                                {
                                    component: {
                                        name: "Welcome",
                                    },
                                    options: {
                                        topBar: {
                                            background: {
                                                component: {
                                                    name: "TopBarBackground"
                                                }
                                            },
                                            title: {
                                                component: {
                                                    name: "SelectorHeader",
                                                }
                                            }
                                        }
                                    }
                                }
                            ],
                        }
                    },
                ],
            }
        }
    });
```
After several switchings of tabs it stretches completely, because `self.navigationController.navigationBar.clipsToBounds = YES;` is absent in success `if (!_customTopBarBackground) {...}`

Probably this line are needed for any special cases but I couldn't find it.