### PR TITLE
[v2] [iOS] Back button: Allow for both icon and title, use topbar title attributes

### DIFF
--- a/lib/ios/UINavigationController+RNNOptions.m
+++ b/lib/ios/UINavigationController+RNNOptions.m
@@ -106,8 +106,8 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 		? [[icon withTintColor:color] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal]
 		: icon;
 
-		[self.navigationBar setBackIndicatorImage:[UIImage new]];
-		[self.navigationBar setBackIndicatorTransitionMaskImage:[UIImage new]];
+		[self.navigationBar setBackIndicatorImage:backImage];
+		[self.navigationBar setBackIndicatorTransitionMaskImage:backImage];
 	}
 
 	UIViewController *lastViewControllerInStack = self.viewControllers.count > 1 ? [self.viewControllers objectAtIndex:self.viewControllers.count-2] : self.topViewController;

--- a/lib/ios/UINavigationController+RNNOptions.m
+++ b/lib/ios/UINavigationController+RNNOptions.m
@@ -16,7 +16,7 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 		backgroundImageView = [[UIImageView alloc] initWithFrame:self.view.bounds];
 		[self.view insertSubview:backgroundImageView atIndex:0];
 	}
-	
+
 	backgroundImageView.layer.masksToBounds = YES;
 	backgroundImageView.image = backgroundImage;
 	[backgroundImageView setContentMode:UIViewContentModeScaleAspectFill];
@@ -48,7 +48,7 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 
 - (void)rnn_setNavigationBarFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize color:(UIColor *)color {
 	NSDictionary* fontAttributes = [RNNFontAttributesCreator createFontAttributesWithFontFamily:fontFamily fontSize:fontSize color:color];
-	
+
 	if (fontAttributes.allKeys.count > 0) {
 		self.navigationBar.titleTextAttributes = fontAttributes;
 	}
@@ -98,20 +98,23 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 
 - (void)rnn_setBackButtonIcon:(UIImage *)icon withColor:(UIColor *)color title:(NSString *)title {
 	UIBarButtonItem *backItem = [[UIBarButtonItem alloc] init];
+    [backItem setTitleTextAttributes:self.navigationBar.titleTextAttributes forState:UIControlStateNormal];
+	[backItem setTitleTextAttributes:self.navigationBar.titleTextAttributes forState:UIControlStateHighlighted];
+
 	if (icon) {
-		backItem.image = color
+		UIImage *backImage = color
 		? [[icon withTintColor:color] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal]
 		: icon;
-		
+
 		[self.navigationBar setBackIndicatorImage:[UIImage new]];
 		[self.navigationBar setBackIndicatorTransitionMaskImage:[UIImage new]];
 	}
-	
+
 	UIViewController *lastViewControllerInStack = self.viewControllers.count > 1 ? [self.viewControllers objectAtIndex:self.viewControllers.count-2] : self.topViewController;
-	
+
 	backItem.title = title ? title : lastViewControllerInStack.navigationItem.title;
 	backItem.tintColor = color;
-	
+
 	lastViewControllerInStack.navigationItem.backBarButtonItem = backItem;
 }
 

--- a/lib/ios/UINavigationController+RNNOptions.m
+++ b/lib/ios/UINavigationController+RNNOptions.m
@@ -98,7 +98,7 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 
 - (void)rnn_setBackButtonIcon:(UIImage *)icon withColor:(UIColor *)color title:(NSString *)title {
 	UIBarButtonItem *backItem = [[UIBarButtonItem alloc] init];
-    [backItem setTitleTextAttributes:self.navigationBar.titleTextAttributes forState:UIControlStateNormal];
+	[backItem setTitleTextAttributes:self.navigationBar.titleTextAttributes forState:UIControlStateNormal];
 	[backItem setTitleTextAttributes:self.navigationBar.titleTextAttributes forState:UIControlStateHighlighted];
 
 	if (icon) {


### PR DESCRIPTION
I'm not an Objective C developer, but this solves an issue I'm currently seeing.

1 - You can't have custom back icon with title, in this scenario it will only render the icon
<img src="https://i.ibb.co/cC7SvNr/before1.png"/>

2- Setting the topbar font has no affect on the back button title
<img src="https://i.ibb.co/TqzhLgf/before2.png"/>

After: Back has both custom font and icon, back button title renders next to icon
<img src="https://i.ibb.co/1TBkZyK/after.png"/>

Also, tiny nit but this also removes some trailing spaces.