### PR TITLE
Stop using lodash in store.js

### DIFF
--- a/lib/src/components/Store.ts
+++ b/lib/src/components/Store.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import { ComponentProvider } from 'react-native';
 
 export class Store {
@@ -6,22 +5,22 @@ export class Store {
   private propsById: Record<string, any> = {};
 
   setPropsForId(componentId: string, props: any) {
-    _.set(this.propsById, componentId, props);
+    this.propsById[componentId] = props;
   }
 
   getPropsForId(componentId: string) {
-    return _.get(this.propsById, componentId, {});
+    return this.propsById[componentId] || {};
   }
 
   cleanId(componentId: string) {
-    _.unset(this.propsById, componentId);
+    delete this.propsById[componentId];
   }
 
   setComponentClassForName(componentName: string | number, ComponentClass: ComponentProvider) {
-    _.set(this.componentsByName, componentName.toString(), ComponentClass);
+    this.componentsByName[componentName.toString()] = ComponentClass;
   }
 
   getComponentClassForName(componentName: string | number): ComponentProvider | undefined {
-    return _.get(this.componentsByName, componentName.toString());
+    return this.componentsByName[componentName.toString()];
   }
 }


### PR DESCRIPTION
Using loads.set caused issues when keys contained the dot symbol. _.set created objects inside the store, which is intended to be a simple key value dictionary -
In some cases, set would overwrite previously set values.