### PR TITLE
[v2] [iOS] Use autolayout constraints to set size of custom bar button item

### DIFF
--- a/lib/ios/RNNUIBarButtonItem.m
+++ b/lib/ios/RNNUIBarButtonItem.m
@@ -3,6 +3,13 @@
 #import "RNNUIBarButtonItem.h"
 #import "RCTConvert+UIBarButtonSystemItem.h"
 
+@interface RNNUIBarButtonItem ()
+
+@property (nonatomic, strong) NSLayoutConstraint *widthConstraint;
+@property (nonatomic, strong) NSLayoutConstraint *heightConstraint;
+
+@end
+
 @implementation RNNUIBarButtonItem
 
 -(instancetype)init:(NSString*)buttonId withIcon:(UIImage*)iconImage {
@@ -26,11 +33,26 @@
 	reactView.sizeFlexibility = RCTRootViewSizeFlexibilityWidthAndHeight;
 	reactView.delegate = self;
 	reactView.backgroundColor = [UIColor clearColor];
+	self.widthConstraint = [NSLayoutConstraint constraintWithItem:reactView
+														attribute:NSLayoutAttributeWidth
+														relatedBy:NSLayoutRelationEqual
+														   toItem:nil
+														attribute:NSLayoutAttributeNotAnAttribute
+													   multiplier:1.0
+														 constant:1.0];
+	self.heightConstraint = [NSLayoutConstraint constraintWithItem:reactView
+														 attribute:NSLayoutAttributeHeight
+														 relatedBy:NSLayoutRelationEqual
+														   	toItem:nil
+														 attribute:NSLayoutAttributeNotAnAttribute
+													   	multiplier:1.0
+														  constant:1.0];
+	[NSLayoutConstraint activateConstraints:@[self.widthConstraint, self.heightConstraint]];
 	self.buttonId = buttonId;
 	return self;
 }
-
--(instancetype)init:(NSString*)buttonId withSystemItem:(NSString *)systemItemName {
+	
+- (instancetype)init:(NSString*)buttonId withSystemItem:(NSString *)systemItemName {
 	UIBarButtonSystemItem systemItem = [RCTConvert UIBarButtonSystemItem:systemItemName];
 	self = [super initWithBarButtonSystemItem:systemItem target:nil action:nil];
 	self.buttonId = buttonId;
@@ -38,9 +60,10 @@
 }
 
 - (void)rootViewDidChangeIntrinsicSize:(RCTRootView *)rootView {
-	CGSize size = rootView.intrinsicContentSize;
-	rootView.frame = CGRectMake(0, 0, size.width, size.height);
-	self.width = size.width;
+	self.widthConstraint.constant = rootView.intrinsicContentSize.width;
+	self.heightConstraint.constant = rootView.intrinsicContentSize.height;
+	[rootView setNeedsUpdateConstraints];
+	[rootView updateConstraintsIfNeeded];
 }
 
 - (void)onButtonPressed {


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="689" alt="screen shot 2019-02-13 at 4 57 20 pm" src="https://user-images.githubusercontent.com/1051453/52748874-aaa46f80-2fb5-11e9-8310-abd157ec3d4e.png"> | <img width="689" alt="screen shot 2019-02-13 at 5 34 54 pm" src="https://user-images.githubusercontent.com/1051453/52748891-b7c15e80-2fb5-11e9-9f4c-f0503055acc5.png"> |

Note the position of the custom `UIBarButtonItem` in the first image.

This fixes an issue where the `frame` for the custom view can be set to the incorrect y-offset upon setting the custom `frame`.

In iOS 11, this behavior changed, as `UIBarButtonItem` went from being using springs-and-struts for sizing, to using a `UIStackView` internally, and thus using Autolayout.

This lead to the superview of having a `frame` of `(0, 22, 0, 0)` at the first layout pass. From the above screenshot, when setting a breakpoint within [`RNNUIBarButtonItem`'s implementation of `rootViewDidChangeIntrinsicSize:`](https://github.com/wix/react-native-navigation/blob/8ba9796d2d94c5dd58266841c2563bbcd563f635/lib/ios/RNNUIBarButtonItem.m#L42):
```
(lldb) po rootView.superview
<_UITAMICAdaptorView: 0x7f8001507c90; frame = (0 22; 0 0); autoresizesSubviews = NO; layer = <CALayer: 0x600003b92c60>>
```

By moving to using `NSLayoutConstaints`, we can now properly size custom React Native views within `UIBarButtonItem`s 100% of the time.

See also: https://gist.github.com/niw/569b49648fcab22124e1d12c195fe595
See also: https://stackoverflow.com/questions/10988918/change-width-of-a-uibarbuttonitem-in-a-uinavigationbar