### PR TITLE
Prevent unwanted app destroy on Android

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -55,6 +55,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
      * Along with that, we should handle commands from the bridge using onNewIntent
      */
     static NavigationActivity currentActivity;
+    static int numberOfActivities = 0;
     private static Promise startAppPromise;
 
     private ActivityParams activityParams;
@@ -76,7 +77,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
             finish();
             return;
         }
-
+        numberOfActivities += 1;
         activityParams = NavigationCommandsHandler.parseActivityParams(getIntent());
         disableActivityShowAnimationIfNeeded();
         setOrientation();
@@ -184,6 +185,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     protected void onDestroy() {
         destroyLayouts();
         destroyJsIfNeeded();
+        numberOfActivities -= 1;
         NavigationApplication.instance.getActivityCallbacks().onActivityDestroyed(this);
         super.onDestroy();
     }
@@ -202,9 +204,8 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
         if ( killedBySystem ) {
             return;
         }
-
-        if (currentActivity == null || currentActivity.isFinishing()) {
-            getReactGateway().onDestroyApp(this);
+        if ((currentActivity == null && numberOfActivities < 2) || (currentActivity != null && currentActivity.isFinishing())) {
+        getReactGateway().onDestroyApp(this);
         }
     }
 


### PR DESCRIPTION
Hi,

I was running into an annoying issue while trying to ask user permissions in my home screen on android (I have a map on the Deals maps screen so I need to ask the user for his location). I am using react-native-maps and since it requires location permission so when the user accepts or decline the permission, user will end up with the error `Tried to use permissions API while not attached to an Activity`.

So after some investigations I realize that when the native permissions pop up shows up, the app is put in pause and the `currentActivity` is null. I forgot to mention that I have a Login flow first and at the end I call `startSingleScreenApp` so the first activity is destroyed and replaced by the new one. The problem here is that the `onDestroy` callback is called after the `onPause` of the new screen. So when is get trough `destroyJsIfNeeded` function, `currentActivity` is null and the app is destroyed, causing the `Tried to use permissions API while not attached to an Activity`.

I apologize if it is not very clear but it is pretty hard to explain !
I don't have a global view of the project so please tell me if I am doing something wrong