### PR TITLE
Update side menu options on open / close callback - Android

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/sidemenu/SideMenuController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/sidemenu/SideMenuController.java
@@ -11,6 +11,7 @@ import android.view.View;
 
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.parse.SideMenuOptions;
+import com.reactnativenavigation.parse.params.Bool;
 import com.reactnativenavigation.presentation.Presenter;
 import com.reactnativenavigation.presentation.SideMenuPresenter;
 import com.reactnativenavigation.utils.CommandListener;
@@ -103,14 +104,22 @@ public class SideMenuController extends ParentController<DrawerLayout> implement
         return options;
     }
 
+    //For onDrawerOpened and onDrawerClosed :
+    //Merge the options to the current state, if this happened due to a gesture we need to
+    //update the option state
+
     @Override
     public void onDrawerOpened(@NonNull View drawerView) {
-        (left != null && drawerView.equals(left.getView()) ? left : right).onViewAppeared();
+        ViewController view = this.getMatchingView(drawerView);
+        view.mergeOptions(this.getOptionsWithVisability(this.viewIsLeft(drawerView), true));
+        view.onViewAppeared();
     }
 
     @Override
     public void onDrawerClosed(@NonNull View drawerView) {
-        (left != null && drawerView.equals(left.getView()) ? left : right).onViewDisappear();
+        ViewController view = this.getMatchingView(drawerView);
+        view.mergeOptions(this.getOptionsWithVisability(this.viewIsLeft(drawerView), false));
+        view.onViewDisappear();
     }
 
     @Override
@@ -152,6 +161,24 @@ public class SideMenuController extends ParentController<DrawerLayout> implement
             height = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, sideMenuOptions.height.get(), Resources.getSystem().getDisplayMetrics());
         }
         return height;
+    }
+
+    private ViewController getMatchingView (View drawerView) {
+        return this.viewIsLeft(drawerView) ? left : right;
+    }
+
+    private boolean viewIsLeft (View drawerView) {
+        return (left != null && drawerView.equals(left.getView()));
+    }
+
+    private Options getOptionsWithVisability ( boolean isLeft, boolean visible ) {
+        Options options = new Options();
+        if (isLeft) {
+            options.sideMenuRootOptions.left.visible = new Bool(visible);
+        } else {
+            options.sideMenuRootOptions.right.visible = new Bool(visible);
+        }
+        return options;
     }
 
     @Override


### PR DESCRIPTION
Problem:
On Android, If the drawer is closed via options. The open gesture mechanism is broken. The drawer will snap shut on open.

Android Fix
Update the side menu visibility option during the open / close callback

In relation to 
https://github.com/wix/react-native-navigation/issues/4696
https://github.com/wix/react-native-navigation/issues/4636