### PR TITLE
Fix loading local images

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/ImageLoader.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/ImageLoader.java
@@ -66,16 +66,15 @@ public class ImageLoader {
     @NonNull
     private Drawable getDrawable(Context context, String source) throws IOException {
         Drawable drawable;
-
         if (isLocalFile(Uri.parse(source))) {
             drawable = loadFile(source);
         } else {
             drawable = loadResource(source);
-            if (drawable == null || NavigationApplication.instance.isDebug()) {
+            if (drawable == null && NavigationApplication.instance.isDebug()) {
                 drawable = readJsDevImage(context, source);
             }
         }
-
+        if (drawable == null) throw new RuntimeException("Could not load image " + source);
         return drawable;
     }
 


### PR DESCRIPTION
When loading local image resource (images in Drawable folder), RNN mistakingly tried to load the image as a js asset even if it successfully loaded the local image.

Using locals Drawables:
```js
rightButtons: [
  {
    id: 'btn',
    icon: { uri: 'myImageFromDrawablesFolder' }
  }
]
```

Related to (possibly fixes) #4751 