### PR TITLE
[v1] [iOS] Add init bridge with custom delegate

### DIFF
--- a/ios/RCCManager.h
+++ b/ios/RCCManager.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
+#import <React/RCTBridgeDelegate.h>
 #import <UIKit/UIKit.h>
 
 @interface RCCManager : NSObject
@@ -9,6 +10,7 @@
 
 -(void)initBridgeWithBundleURL:(NSURL *)bundleURL;
 -(void)initBridgeWithBundleURL:(NSURL *)bundleURL launchOptions:(NSDictionary *)launchOptions;
+-(void)initBridgeWithDelegate:(id<RCTBridgeDelegate>)delegate launchOptions:(NSDictionary *)launchOptions;
 -(RCTBridge*)getBridge;
 -(UIWindow*)getAppWindow;
 -(void)setAppStyle:(NSDictionary*)appStyle;

--- a/ios/RCCManager.m
+++ b/ios/RCCManager.m
@@ -148,6 +148,15 @@
     [[self class] showSplashScreen];
 }
 
+-(void)initBridgeWithDelegate:(id<RCTBridgeDelegate>)delegate launchOptions:(NSDictionary *)launchOptions {
+    if (self.sharedBridge && [self.sharedBridge isValid]) return;
+    
+    self.sharedBridge = [[RCTBridge alloc] initWithDelegate:delegate launchOptions:launchOptions];
+    self.bundleURL = [delegate sourceURLForBridge:self.sharedBridge];
+    
+    [[self class] showSplashScreen];
+}
+
 -(RCTBridge*)getBridge {
     return self.sharedBridge;
 }


### PR DESCRIPTION
Hello. On iOS to add the modules from Expo (https://github.com/unimodules/core) we need to provide extra bridge modules (https://gist.github.com/brentvatne/949d9cc3508cc45f54af5196b3ca497b/revisions) so we need custom bridge delegate.  

v1 RCCManager doesn't use bridge delegate, and since v1 won't have new features, so I assume it won't use the delegate in the future. It looks like this situation with delegates are handled in a better way in v2, but we are still stuck on v1.

If you agree to merge this one and you think it's better to follow the single source of truth in this case, I can refactor the code to make 1 method with 3 params which will know how to construct the bridge and the other methods will just call it.