### PR TITLE
Cancel in-flight push animation on pop

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/anim/NavigationAnimator.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/anim/NavigationAnimator.java
@@ -4,6 +4,7 @@ import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.AnimatorSet;
 import android.content.Context;
+import android.support.annotation.RestrictTo;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -19,7 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.reactnativenavigation.utils.CollectionUtils.merge;
+import static com.reactnativenavigation.utils.CollectionUtils.*;
 
 @SuppressWarnings("ResourceType")
 public class NavigationAnimator extends BaseAnimator {
@@ -107,5 +108,19 @@ public class NavigationAnimator extends BaseAnimator {
             }
         });
         set.start();
+    }
+
+    public void cancelPushAnimations() {
+        for (View view : runningPushAnimations.keySet()) {
+            runningPushAnimations.get(view).cancel();
+            runningPushAnimations.remove(view);
+        }
+    }
+
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    public void endPushAnimation(View view) {
+        if (runningPushAnimations.containsKey(view)) {
+            runningPushAnimations.get(view).end();
+        }
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
@@ -275,7 +275,7 @@ public class StackController extends ParentController<StackLayout> {
             return;
         }
 
-
+        animator.cancelPushAnimations();
         String currentControlId;
         for (int i = stack.size() - 2; i >= 0; i--) {
             currentControlId = stack.get(i).getId();
@@ -297,6 +297,7 @@ public class StackController extends ParentController<StackLayout> {
             return;
         }
 
+        animator.cancelPushAnimations();
         Iterator<String> iterator = stack.iterator();
         iterator.next();
         while (stack.size() > 2) {

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
@@ -42,9 +42,7 @@ import org.assertj.core.api.iterable.Extractor;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
+import org.mockito.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -295,6 +293,18 @@ public class StackControllerTest extends BaseTest {
                 assertContainsOnlyId(child1.getId());
             }
         });
+    }
+
+    @Test
+    public void pop_screenCurrentlyBeingPushedIsPopped() {
+        disablePushAnimation(child1, child2);
+        uut.push(child1, Mockito.mock(CommandListenerAdapter.class));
+        uut.push(child2, Mockito.mock(CommandListenerAdapter.class));
+
+        uut.push(child3, Mockito.mock(CommandListenerAdapter.class));
+        uut.pop(Options.EMPTY, Mockito.mock(CommandListenerAdapter.class));
+        assertThat(uut.size()).isEqualTo(2);
+        assertContainsOnlyId(child1.getId(), child2.getId());
     }
 
     @Test
@@ -623,6 +633,19 @@ public class StackControllerTest extends BaseTest {
     }
 
     @Test
+    public void popTo_pushAnimationIsCancelled() {
+        disablePushAnimation(child1, child2);
+        uut.push(child1, Mockito.mock(CommandListenerAdapter.class));
+        uut.push(child2, Mockito.mock(CommandListenerAdapter.class));
+
+        ViewGroup pushed = child3.getView();
+        uut.push(child3, Mockito.mock(CommandListenerAdapter.class));
+        uut.popTo(child1, Options.EMPTY, Mockito.mock(CommandListenerAdapter.class));
+        animator.endPushAnimation(pushed);
+        assertContainsOnlyId(child1.getId());
+    }
+
+    @Test
     public void popToRoot_PopsEverythingAboveFirstController() {
         child1.options.animations.push.enabled = new Bool(false);
         child2.options.animations.push.enabled = new Bool(false);
@@ -705,6 +728,19 @@ public class StackControllerTest extends BaseTest {
         uut.popToRoot(mergeOptions, new CommandListenerAdapter());
         verify(child2).mergeOptions(mergeOptions);
         verify(child1, times(0)).mergeOptions(mergeOptions);
+    }
+
+    @Test
+    public void popToRoot_screenPushedBeforePopAnimationCompletesIsPopped() {
+        disablePushAnimation(child1, child2);
+        uut.push(child1, Mockito.mock(CommandListenerAdapter.class));
+        uut.push(child2, Mockito.mock(CommandListenerAdapter.class));
+
+        ViewGroup pushed = child3.getView();
+        uut.push(child3, Mockito.mock(CommandListenerAdapter.class));
+        uut.popToRoot(Options.EMPTY, Mockito.mock(CommandListenerAdapter.class));
+        animator.endPushAnimation(pushed);
+        assertContainsOnlyId(child1.getId());
     }
 
     @Test


### PR DESCRIPTION
When popToRoot or popTo were called while a screen was pushed, at the end of the push animation RNN tried to destroy an already destroyed ViewController.
Related to #3767