### PR TITLE
Fix crash when calling setStackRoot multiple times in quick succession

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
@@ -192,6 +192,7 @@ public class StackController extends ParentController<StackLayout> {
     }
 
     public void setRoot(List<ViewController> children, CommandListener listener) {
+        animator.cancelPushAnimations();
         if (children.size() == 1) {
             backButtonHelper.clear(CollectionUtils.last(children));
             push(CollectionUtils.last(children), new CommandListenerAdapter() {

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
@@ -282,6 +282,19 @@ public class StackControllerTest extends BaseTest {
     }
 
     @Test
+    public void setRoot_doesNotCrashWhenCalledInQuickSuccession() {
+        disablePushAnimation(child1);
+        uut.setRoot(Collections.singletonList(child1), new CommandListenerAdapter());
+
+        uut.setRoot(Collections.singletonList(child2), new CommandListenerAdapter());
+        uut.setRoot(Collections.singletonList(child3), new CommandListenerAdapter());
+        animator.endPushAnimation(child2.getView());
+        animator.endPushAnimation(child3.getView());
+
+        assertContainsOnlyId(child3.getId());
+    }
+
+    @Test
     public synchronized void pop() {
         disablePushAnimation(child1, child2);
         uut.push(child1, new CommandListenerAdapter());


### PR DESCRIPTION
Previous push animation wasn’t cancelled, when it ended the controller tried
to destroy previous view which was already destroyed.
Related to #3767