### PR TITLE
Updated OptionsAnimations and OptionsAnimationSeparate to match native implementations

### DIFF
--- a/lib/src/commands/OptionsProcessor.test.ts
+++ b/lib/src/commands/OptionsProcessor.test.ts
@@ -33,14 +33,14 @@ describe('navigation options', () => {
       blurOnUnmount: false,
       popGesture: false,
       modalPresentationStyle: OptionsModalPresentationStyle.fullScreen,
-      animations: { dismissModal: { alpha: { from: 0, to: 1 } } },
+      animations: { dismissModal: { content: { alpha: { from: 0, to: 1 } } } },
     };
     uut.processOptions(options);
     expect(options).toEqual({
       blurOnUnmount: false,
       popGesture: false,
       modalPresentationStyle: OptionsModalPresentationStyle.fullScreen,
-      animations: { dismissModal: { alpha: { from: 0, to: 1 } } },
+      animations: { dismissModal: { content: { alpha: { from: 0, to: 1 } } } },
     });
   });
 

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -763,6 +763,11 @@ export interface OptionsAnimationSeparate {
    */
   waitForRender?: boolean;
   /**
+   * Enable or disable the animation
+   * @default true
+   */
+  enabled?: boolean;
+  /**
    * Configure animations for the top bar
    */
   topBar?: OptionsAnimationPropertiesId;
@@ -780,7 +785,7 @@ export interface OptionsAnimations {
   /**
    * Configure the setRoot animation
    */
-  setRoot?: OptionsAnimationProperties;
+  setRoot?: OptionsAnimationSeparate;
   /**
    * Configure what animates when a screen is pushed
    */
@@ -792,11 +797,15 @@ export interface OptionsAnimations {
   /**
    * Configure what animates when modal is shown
    */
-  showModal?: OptionsAnimationProperties;
+  showModal?: OptionsAnimationSeparate;
   /**
    * Configure what animates when modal is dismissed
    */
-  dismissModal?: OptionsAnimationProperties;
+  dismissModal?: OptionsAnimationSeparate;
+  /**
+   * Configure what animates when stack root is changed
+   */
+  setStackRoot?: OptionsAnimationSeparate;
 }
 
 export interface OptionsCustomTransition {


### PR DESCRIPTION
OptionsAnimations:
- Added `setStackRoot` property
- Changed `setRoot` and `showModal` type to match all the other options (`OptionsAnimationSeparate`), since the native code uses the same code for all of them.

OptionsAnimationSeparate:
- Added `enabled` property (same change as #4832)