### PR TITLE
Added ExternalComponent where missing

### DIFF
--- a/lib/src/interfaces/Layout.ts
+++ b/lib/src/interfaces/Layout.ts
@@ -24,6 +24,10 @@ export interface LayoutStackChildren {
    * Set component
    */
   component?: LayoutComponent;
+  /**
+   * Set the external component
+   */
+  externalComponent?: ExternalComponent;
 }
 
 export interface LayoutStack {
@@ -51,6 +55,10 @@ export interface LayoutBottomTabsChildren {
    * Set component
    */
   component?: LayoutComponent;
+  /**
+   * Set the external component
+   */
+  externalComponent?: ExternalComponent;
 }
 
 export interface LayoutBottomTabs {


### PR DESCRIPTION
extenalComponent?: ExternalComponent was not an option for interfaces LayoutStack and LayoutStackChildren, despite being valid.