### PR TITLE
Handle adding and removing components from registry manually by presenters

### DIFF
--- a/lib/ios/RNNBasePresenter.h
+++ b/lib/ios/RNNBasePresenter.h
@@ -4,6 +4,8 @@
 
 @property (nonatomic, weak) id bindedViewController;
 
+@property (nonatomic, strong) NSString* bindedComponentId;
+
 - (void)bindViewController:(UIViewController *)bindedViewController;
 
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)initialOptions;

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -10,13 +10,14 @@
 
 @implementation RNNBasePresenter
 
-- (instancetype)initWithcomponentRegistry:(RNNReactComponentRegistry *)componentRegistry {
+- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry {
 	self = [super init];
 	self.componentRegistry = componentRegistry;
 	return self;
 }
 
-- (void)bindViewController:(UIViewController *)bindedViewController {
+- (void)bindViewController:(UIViewController<RNNLayoutProtocol> *)bindedViewController {
+	self.bindedComponentId = bindedViewController.layoutInfo.componentId;
 	_bindedViewController = bindedViewController;
 }
 

--- a/lib/ios/RNNBridgeManager.m
+++ b/lib/ios/RNNBridgeManager.m
@@ -92,7 +92,7 @@
 
 - (void)onJavaScriptWillLoad {
 	[_store clean];
-	[_componentRegistry clean];
+	[_componentRegistry clear];
 }
 
 - (void)onJavaScriptLoaded {

--- a/lib/ios/RNNControllerFactory.m
+++ b/lib/ios/RNNControllerFactory.m
@@ -115,7 +115,7 @@
 - (UIViewController<RNNParentProtocol> *)createComponent:(RNNLayoutNode*)node {
 	RNNLayoutInfo* layoutInfo = [[RNNLayoutInfo alloc] initWithNode:node];
 	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];;
-	RNNViewControllerPresenter* presenter = [[RNNViewControllerPresenter alloc] initWithcomponentRegistry:_componentRegistry];
+	RNNViewControllerPresenter* presenter = [[RNNViewControllerPresenter alloc] initWithComponentRegistry:_componentRegistry];
 	
 	RNNRootViewController* component = [[RNNRootViewController alloc] initWithLayoutInfo:layoutInfo rootViewCreator:_creator eventEmitter:_eventEmitter presenter:presenter options:options defaultOptions:_defaultOptions];
 	
@@ -137,7 +137,7 @@
 
 
 - (UIViewController<RNNParentProtocol> *)createStack:(RNNLayoutNode*)node {
-	RNNNavigationControllerPresenter* presenter = [[RNNNavigationControllerPresenter alloc] initWithcomponentRegistry:_componentRegistry];
+	RNNNavigationControllerPresenter* presenter = [[RNNNavigationControllerPresenter alloc] initWithComponentRegistry:_componentRegistry];
 	RNNLayoutInfo* layoutInfo = [[RNNLayoutInfo alloc] initWithNode:node];
 	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];;
 	

--- a/lib/ios/RNNNavigationControllerPresenter.h
+++ b/lib/ios/RNNNavigationControllerPresenter.h
@@ -7,7 +7,7 @@
 
 @property (nonatomic, strong) InteractivePopGestureDelegate *interactivePopGestureDelegate;
 
-- (instancetype)initWithcomponentRegistry:(RNNReactComponentRegistry *)componentRegistry;
+- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry;
 
 - (void)applyOptionsBeforePopping:(RNNNavigationOptions *)options;
 

--- a/lib/ios/RNNNavigationControllerPresenter.m
+++ b/lib/ios/RNNNavigationControllerPresenter.m
@@ -13,14 +13,10 @@
 @end
 @implementation RNNNavigationControllerPresenter
 
-- (instancetype)initWithcomponentRegistry:(RNNReactComponentRegistry *)componentRegistry {
+- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry {
 	self = [super init];
 	_componentRegistry = componentRegistry;
 	return self;
-}
-
-- (void)bindViewController:(UIViewController *)bindedViewController {
-	self.bindedViewController = bindedViewController;
 }
 
 - (void)applyOptions:(RNNNavigationOptions *)options {
@@ -179,7 +175,8 @@
 		readyBlock = nil;
 	}
 	if (options.topBar.component.name.hasValue) {
-		RCTRootView *reactView = [_componentRegistry createComponentIfNotExists:options.topBar.component parentComponentId:navigationController.layoutInfo.componentId reactViewReadyBlock:readyBlock];
+		NSString* currentChildComponentId = [navigationController getCurrentChild].layoutInfo.componentId;
+		RCTRootView *reactView = [_componentRegistry createComponentIfNotExists:options.topBar.component parentComponentId:currentChildComponentId reactViewReadyBlock:readyBlock];
 		
 		if (_customTopBar) {
 			[_customTopBar removeFromSuperview];
@@ -190,6 +187,7 @@
 		[navigationController.navigationBar addSubview:_customTopBar];
 	} else {
 		[_customTopBar removeFromSuperview];
+		_customTopBar = nil;
 		if (readyBlock) {
 			readyBlock();
 		}
@@ -203,15 +201,19 @@
 		readyBlock = nil;
 	}
 	if (options.topBar.background.component.name.hasValue) {
-		RCTRootView *reactView = [_componentRegistry createComponentIfNotExists:options.topBar.background.component parentComponentId:navigationController.layoutInfo.componentId reactViewReadyBlock:readyBlock];
+		NSString* currentChildComponentId = [navigationController getCurrentChild].layoutInfo.componentId;
+		RCTRootView *reactView = [_componentRegistry createComponentIfNotExists:options.topBar.background.component parentComponentId:currentChildComponentId reactViewReadyBlock:readyBlock];
 		
 		if (_customTopBarBackground) {
 			[_customTopBarBackground removeFromSuperview];
 		}
-		_customTopBarBackground = [[RNNCustomTitleView alloc] initWithFrame:navigationController.navigationBar.bounds subView:reactView alignment:@"fill"];
+		RNNCustomTitleView* customTopBarBackground = [[RNNCustomTitleView alloc] initWithFrame:navigationController.navigationBar.bounds subView:reactView alignment:@"fill"];
+		_customTopBarBackground = customTopBarBackground;
+		
 		[navigationController.navigationBar insertSubview:_customTopBarBackground atIndex:1];
 	} else {
 		[_customTopBarBackground removeFromSuperview];
+		_customTopBarBackground = nil;
 		if (readyBlock) {
 			readyBlock();
 		}
@@ -219,8 +221,7 @@
 }
 
 - (void)dealloc {
-	RNNNavigationController* navigationController = self.bindedViewController;
-	[_componentRegistry removeComponent:navigationController.layoutInfo.componentId];
+	[_componentRegistry removeComponent:self.bindedComponentId];
 }
 
 @end

--- a/lib/ios/RNNReactComponentRegistry.h
+++ b/lib/ios/RNNReactComponentRegistry.h
@@ -12,6 +12,8 @@
 
 - (void)removeComponent:(NSString *)componentId;
 
-- (void)clean;
+- (void)clearComponentsForParentId:(NSString *)parentComponentId;
+
+- (void)clear;
 
 @end

--- a/lib/ios/RNNReactComponentRegistry.m
+++ b/lib/ios/RNNReactComponentRegistry.m
@@ -12,7 +12,7 @@
 - (instancetype)initWithCreator:(id<RNNRootViewCreator>)creator {
 	self = [super init];
 	_creator = creator;
-	_componentStore = [NSMapTable strongToWeakObjectsMapTable];
+	_componentStore = [NSMapTable new];
 	return self;
 }
 
@@ -38,13 +38,17 @@
 	return [_componentStore objectForKey:parentComponentId];;
 }
 
+- (void)clearComponentsForParentId:(NSString *)parentComponentId {
+	[_componentStore removeObjectForKey:parentComponentId];;
+}
+
 - (void)removeComponent:(NSString *)componentId {
 	if ([_componentStore objectForKey:componentId]) {
 		[_componentStore removeObjectForKey:componentId];
 	}
 }
 
-- (void)clean {
+- (void)clear {
 	[_componentStore removeAllObjects];
 }
 

--- a/lib/ios/RNNReactView.m
+++ b/lib/ios/RNNReactView.m
@@ -30,8 +30,8 @@
 }
 
 - (void)setRootViewDidChangeIntrinsicSize:(void (^)(CGSize))rootViewDidChangeIntrinsicSize {
-	_rootViewDidChangeIntrinsicSize = rootViewDidChangeIntrinsicSize;
-	self.delegate = self;
+		_rootViewDidChangeIntrinsicSize = rootViewDidChangeIntrinsicSize;
+		self.delegate = self;
 }
 
 - (void)rootViewDidChangeIntrinsicSize:(RCTRootView *)rootView {

--- a/lib/ios/RNNSplitViewControllerPresenter.m
+++ b/lib/ios/RNNSplitViewControllerPresenter.m
@@ -5,10 +5,6 @@
 
 @implementation RNNSplitViewControllerPresenter
 
-- (void)bindViewController:(UISplitViewController *)bindedViewController viewCreator:(id<RNNRootViewCreator>)creator {
-	self.bindedViewController = bindedViewController;
-}
-
 - (void)applyOptions:(RNNNavigationOptions *)options {
 	[super applyOptions:options];
 	

--- a/lib/ios/RNNTopBarOptions.m
+++ b/lib/ios/RNNTopBarOptions.m
@@ -36,6 +36,7 @@
 	self.backButton = [[RNNBackButtonOptions alloc] initWithDict:dict[@"backButton"]];
 	self.leftButtonStyle = [[RNNButtonOptions alloc] initWithDict:dict[@"leftButtonStyle"]];
 	self.rightButtonStyle = [[RNNButtonOptions alloc] initWithDict:dict[@"rightButtonStyle"]];
+	self.component = [[RNNComponentOptions alloc] initWithDict:dict[@"component"]];
 	
 	if (self.leftButtonColor.hasValue) {
 		self.leftButtonStyle.color = self.leftButtonColor;

--- a/lib/ios/RNNViewControllerPresenter.h
+++ b/lib/ios/RNNViewControllerPresenter.h
@@ -4,7 +4,7 @@
 
 @interface RNNViewControllerPresenter : RNNBasePresenter
 
-- (instancetype)initWithcomponentRegistry:(RNNReactComponentRegistry *)componentRegistry;
+- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry;
 
 - (void)renderComponents:(RNNNavigationOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock;
 

--- a/lib/ios/RNNViewControllerPresenter.m
+++ b/lib/ios/RNNViewControllerPresenter.m
@@ -26,14 +26,14 @@
 	return self;
 }
 
-- (instancetype)initWithcomponentRegistry:(RNNReactComponentRegistry *)componentRegistry {
+- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry {
 	self = [self init];
 	_componentRegistry = componentRegistry;
 	return self;
 }
 
-- (void)bindViewController:(UIViewController *)bindedViewController {
-	self.bindedViewController = bindedViewController;
+- (void)bindViewController:(UIViewController<RNNLayoutProtocol> *)bindedViewController {
+	[super bindViewController:bindedViewController];
 	_navigationButtons = [[RNNNavigationButtons alloc] initWithViewController:self.bindedViewController componentRegistry:_componentRegistry];
 }
 
@@ -175,12 +175,13 @@
 	if (options.topBar.title.component.name.hasValue) {
 		_customTitleView = (RNNReactView*)[_componentRegistry createComponentIfNotExists:options.topBar.title.component parentComponentId:viewController.layoutInfo.componentId reactViewReadyBlock:readyBlock];
 		_customTitleView.backgroundColor = UIColor.clearColor;
+		
 		NSString* alignment = [options.topBar.title.component.alignment getWithDefaultValue:@""];
 		[_customTitleView setAlignment:alignment];
+		
 		BOOL isCenter = [alignment isEqualToString:@"center"];
 		__weak RNNReactView *weakTitleView = _customTitleView;
 		CGRect frame = viewController.navigationController.navigationBar.bounds;
-		[_customTitleView setFrame:frame];
 		[_customTitleView setRootViewDidChangeIntrinsicSize:^(CGSize intrinsicContentSize) {
 			if (isCenter) {
 				[weakTitleView setFrame:CGRectMake(0, 0, intrinsicContentSize.width, intrinsicContentSize.height)];
@@ -212,6 +213,10 @@
 		
 		[_titleViewHelper setup];
 	}
+}
+
+- (void)dealloc {
+	[_componentRegistry clearComponentsForParentId:self.bindedComponentId];
 }
 
 - (void)cleanReactLeftovers {

--- a/lib/ios/ReactNativeNavigationTests/RNNBasePresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNBasePresenterTest.m
@@ -2,12 +2,13 @@
 #import "RNNBasePresenter.h"
 #import <OCMock/OCMock.h>
 #import "UIViewController+RNNOptions.h"
+#import "RNNRootViewController.h"
 
 @interface RNNBottomTabPresenterTest : XCTestCase
 
 @property (nonatomic, strong) RNNBasePresenter *uut;
 @property (nonatomic, strong) RNNNavigationOptions *options;
-@property (nonatomic, strong) UIViewController* bindedViewController;
+@property (nonatomic, strong) RNNRootViewController* bindedViewController;
 @property (nonatomic, strong) id mockBindedViewController;
 
 @end
@@ -17,7 +18,7 @@
 - (void)setUp {
     [super setUp];
     self.uut = [[RNNBasePresenter alloc] init];
-	self.bindedViewController = [UIViewController new];
+	  self.bindedViewController = [RNNRootViewController new];
     self.mockBindedViewController = [OCMockObject partialMockForObject:self.bindedViewController];
     [self.uut bindViewController:self.mockBindedViewController];
     self.options = [[RNNNavigationOptions alloc] initEmptyOptions];

--- a/lib/ios/ReactNativeNavigationTests/RNNTabBarPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNTabBarPresenterTest.m
@@ -2,6 +2,7 @@
 #import <OCMock/OCMock.h>
 #import "RNNTabBarPresenter.h"
 #import "UITabBarController+RNNOptions.h"
+#import "RNNTabBarController.h"
 
 @interface RNNTabBarPresenterTest : XCTestCase
 
@@ -16,7 +17,7 @@
 - (void)setUp {
     [super setUp];
 	self.uut = [[RNNTabBarPresenter alloc] init];
-	self.bindedViewController = [OCMockObject partialMockForObject:[UITabBarController new]];
+	self.bindedViewController = [OCMockObject partialMockForObject:[RNNTabBarController new]];
 	[self.uut bindViewController:self.bindedViewController];
 	self.options = [[RNNNavigationOptions alloc] initEmptyOptions];
 }


### PR DESCRIPTION
Until now, components registry held a weak reference to react view components. This resulted in unexpected detaching react views behaviour.

This PR moves the attaching and detaching components from the registry to the presenters, providing explicit behaviour.

Fixes #4929