### PR TITLE
Update docs styling.md for modalPresentationStyle and topBar.buttonColor

### DIFF
--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -68,12 +68,13 @@ Navigation.mergeOptions(this.props.componentId, {
     backgroundColor: 'white',
     orientation: ['portrait', 'landscape'] // An array of supported orientations
   },
-  modalPresentationStyle: 'overCurrentContext', // Supported styles are: 'formSheet', 'pageSheet', 'overFullScreen', 'overCurrentContext', 'currentContext', 'popOver', 'fullScreen' and 'none'. On Android, only overCurrentContext and none are supported.
+  modalPresentationStyle: 'overCurrentContext', // Supported styles are: 'formSheet', 'pageSheet', 'overFullScreen', 'overCurrentContext', 'currentContext', 'popover', 'fullScreen' and 'none'. On Android, only overCurrentContext and none are supported.
   topBar: {
     visible: true,
     animate: false, // Controls whether TopBar visibility changes should be animated
     hideOnScroll: true,
-    buttonColor: 'black',
+    leftButtonColor: 'black',
+    rightButtonColor: 'black',
     drawBehind: false,
     testID: 'topBar',
     title: {


### PR DESCRIPTION
- Fix typo for *popOver* value of *modalPresentationStyle*. Should be *popover* (lowercase)
- *topBar.buttonColor* is not works, but *leftButtonColor* and *rightButtonColor* instead works perfect