### PR TITLE
Fix top bar layout frame

### DIFF
--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -5,17 +5,10 @@
 #import "UIViewController+LayoutProtocol.h"
 
 @interface RNNBasePresenter ()
-@property (nonatomic, strong) RNNReactComponentRegistry* componentRegistry;
 @end
 
 
 @implementation RNNBasePresenter
-
-- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry {
-	self = [super init];
-	self.componentRegistry = componentRegistry;
-	return self;
-}
 
 - (void)bindViewController:(UIViewController<RNNLayoutProtocol> *)bindedViewController {
 	self.bindedComponentId = bindedViewController.layoutInfo.componentId;

--- a/lib/ios/RNNControllerFactory.m
+++ b/lib/ios/RNNControllerFactory.m
@@ -141,8 +141,7 @@
 	
 	NSArray *childViewControllers = [self extractChildrenViewControllersFromNode:node];
 	
-	RNNNavigationController* stack = [[RNNNavigationController alloc] initWithLayoutInfo:layoutInfo creator:_creator options:options defaultOptions:_defaultOptions presenter:presenter eventEmitter:_eventEmitter];
-	[stack setViewControllers:childViewControllers];
+	RNNNavigationController* stack = [[RNNNavigationController alloc] initWithLayoutInfo:layoutInfo creator:_creator options:options defaultOptions:_defaultOptions presenter:presenter eventEmitter:_eventEmitter childViewControllers:childViewControllers];
 	
 	return stack;
 }
@@ -154,8 +153,7 @@
 
 	NSArray *childViewControllers = [self extractChildrenViewControllersFromNode:node];
 	
-	RNNTabBarController* tabsController = [[RNNTabBarController alloc] initWithLayoutInfo:layoutInfo creator:_creator options:options defaultOptions:_defaultOptions presenter:presenter eventEmitter:_eventEmitter];
-	[tabsController setViewControllers:childViewControllers];
+	RNNTabBarController* tabsController = [[RNNTabBarController alloc] initWithLayoutInfo:layoutInfo creator:_creator options:options defaultOptions:_defaultOptions presenter:presenter eventEmitter:_eventEmitter childViewControllers:childViewControllers];
 	
 	return tabsController;
 }
@@ -167,8 +165,7 @@
 
 	NSArray *childViewControllers = [self extractChildrenViewControllersFromNode:node];
 	
-	RNNTopTabsViewController* topTabsController = [[RNNTopTabsViewController alloc] initWithLayoutInfo:layoutInfo creator:_creator options:options defaultOptions:_defaultOptions presenter:presenter eventEmitter:_eventEmitter];
-	[topTabsController setViewControllers:childViewControllers];
+	RNNTopTabsViewController* topTabsController = [[RNNTopTabsViewController alloc] initWithLayoutInfo:layoutInfo creator:_creator options:options defaultOptions:_defaultOptions presenter:presenter eventEmitter:_eventEmitter childViewControllers:childViewControllers];
 	
 	return topTabsController;
 }
@@ -203,8 +200,7 @@
 
 	NSArray *childViewControllers = [self extractChildrenViewControllersFromNode:node];
 
-	RNNSplitViewController* splitViewController = [[RNNSplitViewController alloc] initWithLayoutInfo:layoutInfo creator:_creator options:options defaultOptions:_defaultOptions presenter:presenter eventEmitter:_eventEmitter];
-	[splitViewController bindChildViewControllers:childViewControllers];
+	RNNSplitViewController* splitViewController = [[RNNSplitViewController alloc] initWithLayoutInfo:layoutInfo creator:_creator options:options defaultOptions:_defaultOptions presenter:presenter eventEmitter:_eventEmitter childViewControllers:childViewControllers];
 	
 	return splitViewController;
 }

--- a/lib/ios/RNNControllerFactory.m
+++ b/lib/ios/RNNControllerFactory.m
@@ -188,7 +188,7 @@
 	RNNLayoutInfo* layoutInfo = [[RNNLayoutInfo alloc] initWithNode:node];
 	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];;
 
-	RNNSideMenuChildVC *sideMenuChild = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:layoutInfo childViewControllers:@[childVc] options:options defaultOptions:_defaultOptions presenter:[[RNNViewControllerPresenter alloc] init] type:type];
+	RNNSideMenuChildVC *sideMenuChild = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:layoutInfo creator:_creator options:options defaultOptions:_defaultOptions presenter:[[RNNViewControllerPresenter alloc] init] eventEmitter:_eventEmitter childViewController:childVc type:type];
 	
 	return sideMenuChild;
 }

--- a/lib/ios/RNNLayoutProtocol.h
+++ b/lib/ios/RNNLayoutProtocol.h
@@ -14,7 +14,8 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 						   options:(RNNNavigationOptions *)options
 					defaultOptions:(RNNNavigationOptions *)defaultOptions
 						 presenter:(RNNBasePresenter *)presenter
-					  eventEmitter:(RNNEventEmitter *)eventEmitter;
+					  eventEmitter:(RNNEventEmitter *)eventEmitter
+			  childViewControllers:(NSArray *)childViewControllers;
 
 - (void)renderTreeAndWait:(BOOL)wait perform:(RNNReactViewReadyCompletionBlock)readyBlock;
 

--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -11,7 +11,7 @@
 @synthesize previewCallback;
 
 - (instancetype)initWithLayoutInfo:(RNNLayoutInfo *)layoutInfo rootViewCreator:(id<RNNRootViewCreator>)creator eventEmitter:(RNNEventEmitter *)eventEmitter presenter:(RNNViewControllerPresenter *)presenter options:(RNNNavigationOptions *)options defaultOptions:(RNNNavigationOptions *)defaultOptions {
-	self = [super initWithLayoutInfo:layoutInfo creator:creator options:options defaultOptions:defaultOptions presenter:presenter eventEmitter:eventEmitter];
+	self = [super initWithLayoutInfo:layoutInfo creator:creator options:options defaultOptions:defaultOptions presenter:presenter eventEmitter:eventEmitter childViewControllers:nil];
 	
 	self.animator = [[RNNAnimator alloc] initWithTransitionOptions:self.resolveOptions.customTransition];
 	

--- a/lib/ios/RNNSideMenuChildVC.h
+++ b/lib/ios/RNNSideMenuChildVC.h
@@ -11,11 +11,11 @@ typedef NS_ENUM(NSInteger, RNNSideMenuChildType) {
 
 @interface RNNSideMenuChildVC : UIViewController <RNNLayoutProtocol>
 
+- (instancetype)initWithLayoutInfo:(RNNLayoutInfo *)layoutInfo creator:(id<RNNRootViewCreator>)creator options:(RNNNavigationOptions *)options defaultOptions:(RNNNavigationOptions *)defaultOptions presenter:(RNNBasePresenter *)presenter eventEmitter:(RNNEventEmitter *)eventEmitter childViewController:(UIViewController *)childViewController type:(RNNSideMenuChildType)type;
+
 @property (readonly) RNNSideMenuChildType type;
 @property (readonly) UIViewController<RNNLayoutProtocol> *child;
 
-
-- (instancetype)initWithLayoutInfo:(RNNLayoutInfo *)layoutInfo childViewControllers:(NSArray *)childViewControllers options:(RNNNavigationOptions *)options defaultOptions:(RNNNavigationOptions *)defaultOptions presenter:(RNNViewControllerPresenter *)presenter type:(RNNSideMenuChildType)type;
 
 - (void)setWidth:(CGFloat)width;
 

--- a/lib/ios/RNNSideMenuChildVC.m
+++ b/lib/ios/RNNSideMenuChildVC.m
@@ -9,28 +9,11 @@
 
 @implementation RNNSideMenuChildVC
 
-- (instancetype)initWithLayoutInfo:(RNNLayoutInfo *)layoutInfo childViewControllers:(NSArray *)childViewControllers options:(RNNNavigationOptions *)options defaultOptions:(RNNNavigationOptions *)defaultOptions presenter:(RNNViewControllerPresenter *)presenter type:(RNNSideMenuChildType)type {
-	self = [self initWithLayoutInfo:layoutInfo childViewControllers:childViewControllers options:options defaultOptions:defaultOptions presenter:presenter];
-	
+
+- (instancetype)initWithLayoutInfo:(RNNLayoutInfo *)layoutInfo creator:(id<RNNRootViewCreator>)creator options:(RNNNavigationOptions *)options defaultOptions:(RNNNavigationOptions *)defaultOptions presenter:(RNNBasePresenter *)presenter eventEmitter:(RNNEventEmitter *)eventEmitter childViewController:(UIViewController *)childViewController type:(RNNSideMenuChildType)type {
+	self = [super initWithLayoutInfo:layoutInfo creator:creator options:options defaultOptions:defaultOptions presenter:presenter eventEmitter:eventEmitter childViewControllers:nil];
 	self.type = type;
-
-	return self;
-}
-
-- (instancetype)initWithLayoutInfo:(RNNLayoutInfo *)layoutInfo childViewControllers:(NSArray *)childViewControllers options:(RNNNavigationOptions *)options defaultOptions:(RNNNavigationOptions *)defaultOptions presenter:(RNNViewControllerPresenter *)presenter {
-	self = [super init];
-	
-	self.child = childViewControllers[0];
-	
-	self.presenter = presenter;
-	[self.presenter bindViewController:self];
-	
-	self.defaultOptions = defaultOptions;
-	self.options = options;
-	self.layoutInfo = layoutInfo;
-	
-	[self bindChildViewController:self.child];
-
+	self.child = childViewController;
 	return self;
 }
 
@@ -38,8 +21,8 @@
 	[self.getCurrentChild renderTreeAndWait:wait perform:readyBlock];
 }
 
-- (void)bindChildViewController:(UIViewController<RNNLayoutProtocol>*)child {
-	self.child = child;
+- (void)setChild:(UIViewController<RNNLayoutProtocol> *)child {
+	_child = child;
 	[self addChildViewController:self.child];
 	[self.child.view setFrame:self.view.bounds];
 	[self.view addSubview:self.child.view];

--- a/lib/ios/RNNTopTabsViewController.m
+++ b/lib/ios/RNNTopTabsViewController.m
@@ -14,21 +14,6 @@
 
 @implementation RNNTopTabsViewController
 
-- (instancetype)initWithLayoutInfo:(RNNLayoutInfo *)layoutInfo childViewControllers:(NSArray *)childViewControllers options:(RNNNavigationOptions *)options defaultOptions:(RNNNavigationOptions *)defaultOptions presenter:(RNNViewControllerPresenter *)presenter {
-	self = [self init];
-	
-	self.presenter = presenter;
-	[self.presenter bindViewController:self];
-	
-	self.defaultOptions = defaultOptions;
-	self.options = options;
-	self.layoutInfo = layoutInfo;
-	
-	[self setViewControllers:childViewControllers];
-	
-	return self;
-}
-
 - (instancetype)init {
 	self = [super init];
 	

--- a/lib/ios/RNNViewControllerPresenter.m
+++ b/lib/ios/RNNViewControllerPresenter.m
@@ -173,6 +173,7 @@
 		BOOL isCenter = [alignment isEqualToString:@"center"];
 		__weak RNNReactView *weakTitleView = _customTitleView;
 		CGRect frame = viewController.navigationController.navigationBar.bounds;
+		[_customTitleView setFrame:frame];
 		[_customTitleView setRootViewDidChangeIntrinsicSize:^(CGSize intrinsicContentSize) {
 			if (isCenter) {
 				[weakTitleView setFrame:CGRectMake(0, 0, intrinsicContentSize.width, intrinsicContentSize.height)];

--- a/lib/ios/ReactNativeNavigationTests/RNNCommandsHandlerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNCommandsHandlerTest.m
@@ -122,8 +122,7 @@
 	RNNViewControllerPresenter* presenter = [[RNNViewControllerPresenter alloc] init];
 	RNNRootViewController* vc = [[RNNRootViewController alloc] initWithLayoutInfo:layoutInfo rootViewCreator:creator eventEmitter:nil presenter:presenter options:initialOptions defaultOptions:nil];
 
-	RNNNavigationController* nav = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:creator options:[[RNNNavigationOptions alloc] initEmptyOptions] defaultOptions:nil presenter:[[RNNNavigationControllerPresenter alloc] init] eventEmitter:nil];
-	[nav setViewControllers:@[vc]];
+	RNNNavigationController* nav = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:creator options:[[RNNNavigationOptions alloc] initEmptyOptions] defaultOptions:nil presenter:[[RNNNavigationControllerPresenter alloc] init] eventEmitter:nil childViewControllers:@[vc]];
 	
 	[vc viewWillAppear:false];
 	XCTAssertTrue([vc.navigationItem.title isEqual:@"the title"]);

--- a/lib/ios/ReactNativeNavigationTests/RNNNavigationControllerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNNavigationControllerTest.m
@@ -27,8 +27,7 @@
 	_vc2Mock = [OCMockObject partialMockForObject:_vc2];
 	_vc3 = [UIViewController new];
 	_options = [OCMockObject partialMockForObject:[[RNNNavigationOptions alloc] initEmptyOptions]];
-	self.uut = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:_creator options:_options defaultOptions:nil presenter:[OCMockObject partialMockForObject:[[RNNNavigationControllerPresenter alloc] init]] eventEmitter:nil];
-	[self.uut setViewControllers:@[_vc1, _vc2]];
+	self.uut = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:_creator options:_options defaultOptions:nil presenter:[OCMockObject partialMockForObject:[[RNNNavigationControllerPresenter alloc] init]] eventEmitter:nil childViewControllers:@[_vc1, _vc2]];
 }
 
 - (void)testInitWithLayoutInfo_shouldBindPresenter {
@@ -36,8 +35,7 @@
 }
 
 - (void)testInitWithLayoutInfo_shouldSetMultipleViewControllers {
-	self.uut = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:_creator options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:[[RNNViewControllerPresenter alloc] init] eventEmitter:nil];
-	[self.uut setViewControllers:@[_vc1, _vc2]];
+	self.uut = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:_creator options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:[[RNNViewControllerPresenter alloc] init] eventEmitter:nil childViewControllers:@[_vc1, _vc2]];
 	XCTAssertTrue(self.uut.viewControllers.count == 2);
 }
 
@@ -155,8 +153,7 @@
 }
 
 - (RNNNavigationController *)createNavigationControllerWithOptions:(RNNNavigationOptions *)options {
-	RNNNavigationController* nav = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:_creator options:options defaultOptions:nil presenter:[[RNNNavigationControllerPresenter alloc] init] eventEmitter:nil];
-	[nav setViewControllers:@[_vc1]];
+	RNNNavigationController* nav = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:_creator options:options defaultOptions:nil presenter:[[RNNNavigationControllerPresenter alloc] init] eventEmitter:nil childViewControllers:@[_vc1]];
 	return nav;
 }
 

--- a/lib/ios/ReactNativeNavigationTests/RNNRootViewControllerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNRootViewControllerTest.m
@@ -415,8 +415,7 @@
 -(void)testRightButtonsWithTitle_withoutStyle {
 	self.options.topBar.rightButtons = @[@{@"id": @"testId", @"text": @"test"}];
 	self.uut = [[RNNRootViewController alloc] initWithLayoutInfo:nil rootViewCreator:nil eventEmitter:nil presenter:[RNNViewControllerPresenter new] options:self.options defaultOptions:nil];
-	RNNNavigationController* nav = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:_creator options:nil defaultOptions:nil presenter:nil eventEmitter:nil];
-	[nav setViewControllers:@[self.uut]];
+	RNNNavigationController* nav = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:_creator options:nil defaultOptions:nil presenter:nil eventEmitter:nil childViewControllers:@[self.uut]];
 
 	RNNUIBarButtonItem* button = (RNNUIBarButtonItem*)[nav.topViewController.navigationItem.rightBarButtonItems objectAtIndex:0];
 	NSString* expectedButtonId = @"testId";
@@ -431,8 +430,7 @@
 
 	self.options.topBar.rightButtons = @[@{@"id": @"testId", @"text": @"test", @"enabled": @false, @"buttonColor": inputColor, @"buttonFontSize": @22, @"buttonFontWeight": @"800"}];
 	self.uut = [[RNNRootViewController alloc] initWithLayoutInfo:nil rootViewCreator:nil eventEmitter:nil presenter:[RNNViewControllerPresenter new] options:self.options defaultOptions:nil];
-	RNNNavigationController* nav = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:_creator options:nil defaultOptions:nil presenter:nil eventEmitter:nil];
-	[nav setViewControllers:@[self.uut]];
+	RNNNavigationController* nav = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:_creator options:nil defaultOptions:nil presenter:nil eventEmitter:nil childViewControllers:@[self.uut]];
 
 	RNNUIBarButtonItem* button = (RNNUIBarButtonItem*)[nav.topViewController.navigationItem.rightBarButtonItems objectAtIndex:0];
 	NSString* expectedButtonId = @"testId";
@@ -448,8 +446,7 @@
 -(void)testLeftButtonsWithTitle_withoutStyle {
 	self.options.topBar.leftButtons = @[@{@"id": @"testId", @"text": @"test"}];
 	self.uut = [[RNNRootViewController alloc] initWithLayoutInfo:nil rootViewCreator:nil eventEmitter:nil presenter:[RNNViewControllerPresenter new] options:self.options defaultOptions:nil];
-	RNNNavigationController* nav = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:_creator options:nil defaultOptions:nil presenter:nil eventEmitter:nil];
-	[nav setViewControllers:@[self.uut]];
+	RNNNavigationController* nav = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:_creator options:nil defaultOptions:nil presenter:nil eventEmitter:nil childViewControllers:@[self.uut]];
 	
 	RNNUIBarButtonItem* button = (RNNUIBarButtonItem*)[nav.topViewController.navigationItem.leftBarButtonItems objectAtIndex:0];
 	NSString* expectedButtonId = @"testId";
@@ -464,8 +461,7 @@
 
 	self.options.topBar.leftButtons = @[@{@"id": @"testId", @"text": @"test", @"enabled": @false, @"buttonColor": inputColor, @"buttonFontSize": @22, @"buttonFontWeight": @"800"}];
 	self.uut = [[RNNRootViewController alloc] initWithLayoutInfo:nil rootViewCreator:nil eventEmitter:nil presenter:[RNNViewControllerPresenter new] options:self.options defaultOptions:nil];
-	RNNNavigationController* nav = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:_creator options:nil defaultOptions:nil presenter:nil eventEmitter:nil];
-	[nav setViewControllers:@[self.uut]];
+	RNNNavigationController* nav = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:_creator options:nil defaultOptions:nil presenter:nil eventEmitter:nil childViewControllers:@[self.uut]];
 
 	RNNUIBarButtonItem* button = (RNNUIBarButtonItem*)[nav.topViewController.navigationItem.leftBarButtonItems objectAtIndex:0];
 	NSString* expectedButtonId = @"testId";
@@ -569,8 +565,7 @@
 
 
 - (RNNNavigationController *)createNavigationController {
-	RNNNavigationController* nav = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initEmptyOptions] defaultOptions:nil presenter:[[RNNNavigationControllerPresenter alloc] init] eventEmitter:nil];
-	[nav setViewControllers:@[self.uut]];
+	RNNNavigationController* nav = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initEmptyOptions] defaultOptions:nil presenter:[[RNNNavigationControllerPresenter alloc] init] eventEmitter:nil childViewControllers:@[self.uut]];
 	
 	return nav;
 }

--- a/lib/ios/ReactNativeNavigationTests/RNNSideMenuControllerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNSideMenuControllerTest.m
@@ -13,9 +13,9 @@
 
 - (void)setUp {
     [super setUp];
-	_leftVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil childViewControllers:@[[RNNRootViewController new]] options:nil defaultOptions:nil presenter:nil type:RNNSideMenuChildTypeLeft];
-	_rightVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil childViewControllers:@[[RNNRootViewController new]] options:nil defaultOptions:nil presenter:nil type:RNNSideMenuChildTypeRight];
-	_centerVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil childViewControllers:@[[RNNRootViewController new]] options:nil defaultOptions:nil presenter:nil type:RNNSideMenuChildTypeCenter];
+	_leftVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil creator:nil options:nil defaultOptions:nil presenter:nil eventEmitter:nil childViewController:[RNNRootViewController new] type:RNNSideMenuChildTypeLeft];
+	_rightVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil creator:nil options:nil defaultOptions:nil presenter:nil eventEmitter:nil childViewController:[RNNRootViewController new] type:RNNSideMenuChildTypeRight];
+	_centerVC =[[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil creator:nil options:nil defaultOptions:nil presenter:nil eventEmitter:nil childViewController:[RNNRootViewController new] type:RNNSideMenuChildTypeCenter];
 	self.uut = [[RNNSideMenuController alloc] initWithLayoutInfo:nil creator:nil childViewControllers:@[_leftVC, _centerVC, _rightVC] options:[[RNNNavigationOptions alloc] initEmptyOptions] defaultOptions:nil presenter:nil eventEmitter:nil];
 }
 

--- a/lib/ios/ReactNativeNavigationTests/RNNTabBarControllerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNTabBarControllerTest.m
@@ -26,8 +26,7 @@
 	self.mockTabBarPresenter = [OCMockObject partialMockForObject:[[RNNTabBarPresenter alloc] init]];
 	self.mockChildViewController = [OCMockObject partialMockForObject:[RNNRootViewController new]];
 	self.mockEventEmmiter = [OCMockObject partialMockForObject:[RNNEventEmitter new]];
-	self.mockUut = [OCMockObject partialMockForObject:[[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:self.mockTabBarPresenter eventEmitter:self.mockEventEmmiter]];
-	[self.mockUut setViewControllers:@[[[UIViewController alloc] init]]];
+	self.mockUut = [OCMockObject partialMockForObject:[[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:self.mockTabBarPresenter eventEmitter:self.mockEventEmmiter childViewControllers:@[[[UIViewController alloc] init]]]];
 	OCMStub([self.mockUut selectedViewController]).andReturn(self.mockChildViewController);
 }
 
@@ -39,8 +38,7 @@
 	UIViewController* vc1 = [[UIViewController alloc] init];
 	UIViewController* vc2 = [[UIViewController alloc] init];
 	
-	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:[[RNNViewControllerPresenter alloc] init] eventEmitter:nil];
-	[uut setViewControllers:@[vc1, vc2]];
+	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:[[RNNViewControllerPresenter alloc] init] eventEmitter:nil childViewControllers:@[vc1, vc2]];
 	XCTAssertTrue(uut.viewControllers.count == 2);
 }
 
@@ -50,8 +48,7 @@
 	RNNTabBarPresenter* presenter = [[RNNTabBarPresenter alloc] init];
 	NSArray* childViewControllers = @[[UIViewController new]];
 	
-	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:layoutInfo creator:nil options:options defaultOptions:nil presenter:presenter eventEmitter:nil];
-	[uut setViewControllers:childViewControllers];
+	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:layoutInfo creator:nil options:options defaultOptions:nil presenter:presenter eventEmitter:nil childViewControllers:childViewControllers];
 	XCTAssertTrue(uut.layoutInfo == layoutInfo);
 	XCTAssertTrue(uut.options == options);
 	XCTAssertTrue(uut.presenter == presenter);
@@ -66,8 +63,7 @@
 
 	NSArray* childViewControllers = @[[UIViewController new]];
 	
-	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:layoutInfo creator:nil options:options defaultOptions:nil presenter:presenter eventEmitter:eventEmmiter];
-	[uut setViewControllers:childViewControllers];
+	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:layoutInfo creator:nil options:options defaultOptions:nil presenter:presenter eventEmitter:eventEmmiter childViewControllers:childViewControllers];
 	XCTAssertTrue(uut.layoutInfo == layoutInfo);
 	XCTAssertTrue(uut.options == options);
 	XCTAssertTrue(uut.presenter == presenter);
@@ -76,7 +72,7 @@
 }
 
 - (void)testInitWithLayoutInfo_shouldSetDelegate {
-	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:[[RNNBasePresenter alloc] init] eventEmitter:nil];
+	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:[[RNNBasePresenter alloc] init] eventEmitter:nil childViewControllers:nil];
 	
 	XCTAssertTrue(uut.delegate == uut);
 }
@@ -152,8 +148,7 @@
 	
 	RNNRootViewController* vc = [[RNNRootViewController alloc] initWithLayoutInfo:layoutInfo rootViewCreator:nil eventEmitter:nil presenter:nil options:nil defaultOptions:nil];
 	
-	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:nil defaultOptions:nil presenter:[RNNTabBarPresenter new] eventEmitter:nil];
-	[uut setViewControllers:@[[UIViewController new], vc]];
+	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:nil defaultOptions:nil presenter:[RNNTabBarPresenter new] eventEmitter:nil childViewControllers:@[[UIViewController new], vc]];
 	[uut setSelectedIndexByComponentID:@"componentId"];
 	XCTAssertTrue(uut.selectedIndex == 1);
 }

--- a/lib/ios/ReactNativeNavigationTests/UIViewController+LayoutProtocolTest.m
+++ b/lib/ios/ReactNativeNavigationTests/UIViewController+LayoutProtocolTest.m
@@ -1,6 +1,8 @@
 #import <XCTest/XCTest.h>
 #import <OCMock/OCMock.h>
 #import "UIViewController+LayoutProtocol.h"
+#import "RNNViewControllerPresenter.h"
+#import "RCTConvert+Modal.h"
 
 @interface UIViewController_LayoutProtocolTest : XCTestCase
 
@@ -15,6 +17,26 @@
 	self.uut = [OCMockObject partialMockForObject:[UIViewController new]];
     self.uut.layoutInfo = [[RNNLayoutInfo alloc] init];
     self.uut.layoutInfo.componentId = @"componentId";
+}
+
+- (void)testInitWithLayoutApplyDefaultOptions {
+    RNNViewControllerPresenter* presenter = [[RNNViewControllerPresenter alloc] init];
+    RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initEmptyOptions];
+    RNNNavigationOptions* defaultOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
+    defaultOptions.modalPresentationStyle = [[Text alloc] initWithValue:@"fullScreen"];
+
+    UIViewController* uut = [[UIViewController alloc] initWithLayoutInfo:nil creator:nil options:options defaultOptions:defaultOptions presenter:presenter eventEmitter:nil childViewControllers:nil];
+    XCTAssertEqual(uut.modalPresentationStyle, [RCTConvert UIModalPresentationStyle:@"fullScreen"]);
+}
+
+- (void)testInitWithLayoutInfoShouldSetChildViewControllers {
+	UIViewController* child1 = [UIViewController new];
+	UIViewController* child2 = [UIViewController new];
+	NSArray* childViewControllers = @[child1, child2];
+	UINavigationController* uut = [[UINavigationController alloc] initWithLayoutInfo:nil creator:nil options:nil defaultOptions:nil presenter:nil eventEmitter:nil childViewControllers:childViewControllers];
+	
+	XCTAssertEqual(uut.viewControllers[0], child1);
+	XCTAssertEqual(uut.viewControllers[1], child2);
 }
 
 

--- a/lib/ios/UIViewController+LayoutProtocol.m
+++ b/lib/ios/UIViewController+LayoutProtocol.m
@@ -9,7 +9,8 @@
 						   options:(RNNNavigationOptions *)options
 					defaultOptions:(RNNNavigationOptions *)defaultOptions
 						 presenter:(RNNBasePresenter *)presenter
-					  eventEmitter:(RNNEventEmitter *)eventEmitter {
+					  eventEmitter:(RNNEventEmitter *)eventEmitter
+			  childViewControllers:(NSArray *)childViewControllers {
 	self = [self init];
 	
 	self.options = options;
@@ -17,9 +18,13 @@
 	self.layoutInfo = layoutInfo;
 	self.creator = creator;
 	self.eventEmitter = eventEmitter;
+	if ([self respondsToSelector:@selector(setViewControllers:)]) {
+		[self performSelector:@selector(setViewControllers:) withObject:childViewControllers];
+	}
 	self.presenter = presenter;
 	[self.presenter bindViewController:self];
 	[self.presenter applyOptionsOnInit:self.resolveOptions];
+	
 
 	return self;
 }

--- a/lib/ios/UIViewController+LayoutProtocol.m
+++ b/lib/ios/UIViewController+LayoutProtocol.m
@@ -19,7 +19,7 @@
 	self.eventEmitter = eventEmitter;
 	self.presenter = presenter;
 	[self.presenter bindViewController:self];
-	[self.presenter applyOptionsOnInit:self.options];
+	[self.presenter applyOptionsOnInit:self.resolveOptions];
 
 	return self;
 }


### PR DESCRIPTION
• Fix top bar component layout frame size - Closes #5003
• Clean duplicate initWithLayoutInfo implementations
• Initialize parent child controllers in the constructors and not with `setViewControllers`
