### PR TITLE
Handle simultaneous recognizers

### DIFF
--- a/lib/ios/InteractivePopGestureDelegate.m
+++ b/lib/ios/InteractivePopGestureDelegate.m
@@ -15,16 +15,4 @@
 	}
 }
 
-- (BOOL)respondsToSelector:(SEL)aSelector {
-	if (aSelector == @selector(gestureRecognizer:shouldReceiveTouch:)) {
-		return YES;
-	} else {
-		return [self.originalDelegate respondsToSelector:aSelector];
-	}
-}
-
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-    return NO;
-}
-
 @end

--- a/lib/ios/InteractivePopGestureDelegate.m
+++ b/lib/ios/InteractivePopGestureDelegate.m
@@ -23,4 +23,8 @@
 	}
 }
 
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return NO;
+}
+
 @end


### PR DESCRIPTION
In very specific cases, there may be multiple gesture recognizers active, which will result in `InteractivePopGestureDelegate` being sent the `shouldRecognizeSimultaneouslyWithGestureRecognizer` selector, which it does not respond to, resulting in the following exception:
```
-[InteractivePopGestureDelegate gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]: unrecognized selector sent to instance 0x600000fb9560
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[InteractivePopGestureDelegate gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]: unrecognized selector sent to instance 0x600000fb9560'
*** First throw call stack:
(
	0   CoreFoundation                      0x000000010f70d6fb __exceptionPreprocess + 331
	1   libobjc.A.dylib                     0x000000010da0fac5 objc_exception_throw + 48
	2   CoreFoundation                      0x000000010f72bab4 -[NSObject(NSObject) doesNotRecognizeSelector:] + 132
	3   CoreFoundation                      0x000000010f7121a1 ___forwarding___ + 769
	4   CoreFoundation                      0x000000010f714238 _CF_forwarding_prep_0 + 120
	5   UIKitCore                           0x000000011cddda83 -[UIGestureRecognizer _delegateCanBePreventedByGestureRecognizer:] + 154
	6   UIKitCore                           0x000000011cdddd05 -[UIGestureRecognizer _isExcludedByExcludable:] + 316
	7   UIKitCore                           0x000000011cde0ac7 _UIExclusionMatrixPerformExclusion + 365
	8   UIKitCore                           0x000000011cdcd8a4 _UIGestureEnvironmentUpdate + 1882
	9   UIKitCore                           0x000000011cdcd108 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 478
	10  UIKitCore                           0x000000011cdcce96 -[UIGestureEnvironment _updateForEvent:window:] + 200
	11  UIKitCore                           0x000000011d2285bc -[UIWindow sendEvent:] + 4057
	12  UIKitCore                           0x000000011d206d16 -[UIApplication sendEvent:] + 356
	13  UIKit                               0x000000012f2c04af -[UIApplicationAccessibility sendEvent:] + 85
	14  UIKitCore                           0x000000011d2d7293 __dispatchPreprocessedEventFromEventQueue + 3232
	15  UIKitCore                           0x000000011d2d9bb9 __handleEventQueueInternal + 5911
	16  CoreFoundation                      0x000000010f674be1 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
	17  CoreFoundation                      0x000000010f674463 __CFRunLoopDoSources0 + 243
	18  CoreFoundation                      0x000000010f66eb1f __CFRunLoopRun + 1231
	19  CoreFoundation                      0x000000010f66e302 CFRunLoopRunSpecific + 626
	20  GraphicsServices                    0x000000011342c2fe GSEventRunModal + 65
	21  UIKitCore                           0x000000011d1ecba2 UIApplicationMain + 140
```

This adds the method, matching what the [Apple docs](https://developer.apple.com/documentation/uikit/uigesturerecognizerdelegate/1624208-gesturerecognizer?language=objc) describe as the default behavior.

There are a couple requirements to expose this issue:

1. Using some other gesture recognizers - in my case [react-native-gesture-handler](https://github.com/kmagiera/react-native-gesture-handler).
2. Starting the react-native-navigation application with multiple screens on a stack, so the `InteractivePopGestureDelegate` is active.

