### PR TITLE
Fix issue with status bar draw behind change from screen to screen

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/Presenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/Presenter.java
@@ -106,10 +106,8 @@ public class Presenter {
     }
 
     private void setDrawBehindStatusBar(View view, StatusBarOptions statusBar) {
-        if (statusBar.visible.isFalse()) {
-            ((MarginLayoutParams) view.getLayoutParams()).topMargin = statusBar.drawBehind.isTrue() ?
-                    0 : UiUtils.getStatusBarHeight(activity);
-        }
+        ((MarginLayoutParams) view.getLayoutParams()).topMargin = statusBar.drawBehind.isTrue() ?
+                0 : UiUtils.getStatusBarHeight(activity);
     }
 
 


### PR DESCRIPTION
Right now if you set `statusBar` `drawBehind` to true the `topBar` will always get drawn under the `statusBar` even if the screen settings are to `drawBehind:false`. This fix allows the `topMargin` to change even if the `statusBar` is still visible.

Addresses: https://github.com/wix/react-native-navigation/issues/5047