### PR TITLE
update gradle typo

### DIFF
--- a/docs/docs/Installing.md
+++ b/docs/docs/Installing.md
@@ -226,7 +226,7 @@ To do so edit `android/build.gradle` and add:
 +            android {
 +                variantFilter { variant ->
 +                    def names = variant.flavors*.name
-+                    if (names.contains("reactNative51") || names.contains("reactNative55")) {
++                    if (!names.contains("reactNative57")) {
 +                        setIgnore(true)
 +                    }
 +                }
@@ -236,7 +236,7 @@ To do so edit `android/build.gradle` and add:
 +}
 ```
 
-**Note**: As more build variants come available in the future, you will need to adjust the list (`names.contains("reactNative51") || names.contains("reactNative55")`). This is why we recommend the first solution.
+**Note**: Replace `reactNative57` with whatever flavor you are using in your project so that all other flavors are ignored.
 
 
 ### 6. Update `MainActivity.java`

--- a/docs/docs/Installing.md
+++ b/docs/docs/Installing.md
@@ -215,7 +215,7 @@ Now run `npm run android` to build your application
 
 #### 5.2 Ignore other RNN flavors
 
-If you don't want to run `npm run android` and want to keep the default `react-native run-android` command, you need to specify to graddle to ignore the other flavors RNN provides.
+If you don't want to run `npm run android` and want to keep the default `react-native run-android` command, you need to specify to gradle to ignore the other flavors RNN provides.
 
 To do so edit `android/build.gradle` and add:
 


### PR DESCRIPTION
This PR now implements a much simpler solution for ignoring the other RNN flavors and fixes a typo found while installing.