### PR TITLE
Explicitly clear bottom tabs options after mergeOptions

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -97,6 +97,8 @@ public class BottomTabsController extends ParentController implements AHBottomNa
     public void mergeOptions(Options options) {
         presenter.mergeOptions(options);
         super.mergeOptions(options);
+        this.options.bottomTabsOptions.clearOneTimeOptions();
+        this.initialOptions.bottomTabsOptions.clearOneTimeOptions();
     }
 
     @Override

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.java
@@ -25,7 +25,6 @@ import com.reactnativenavigation.utils.ImageLoader;
 import com.reactnativenavigation.utils.OptionHelper;
 import com.reactnativenavigation.utils.ViewUtils;
 import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
-import com.reactnativenavigation.viewcontrollers.ParentController;
 import com.reactnativenavigation.viewcontrollers.ViewController;
 import com.reactnativenavigation.viewcontrollers.stack.StackController;
 import com.reactnativenavigation.views.BottomTabs;
@@ -93,7 +92,6 @@ public class BottomTabsControllerTest extends BaseTest {
         presenter = spy(new BottomTabsPresenter(tabs, new Options()));
         tabsAttacher = spy(new BottomTabsAttacher(tabs, presenter));
         uut = createBottomTabs();
-        uut.setParentController(Mockito.mock(ParentController.class));
         activity.setContentView(uut.getView());
     }
 

--- a/playground/src/services/Navigation.js
+++ b/playground/src/services/Navigation.js
@@ -25,7 +25,7 @@ const dismissOverlay = (name) => Navigation.dismissOverlay(name);
 
 const popToRoot = (self) => Navigation.popToRoot(self.props.componentId);
 
-const mergeOptions = (self, options) => Navigation.mergeOptions(self.props.componentId, options);
+const mergeOptions = (selfOrCompId, options) => Navigation.mergeOptions(compId(selfOrCompId), options);
 
 const setStackRoot = (self, root) => Navigation.setStackRoot(self.props.componentId, root)
 


### PR DESCRIPTION
When mergeOptions was called on a root view, it’s one time options weren’t cleared properly.
The entire one time options logic is terrible and has to be refactored out.

Fixes #5010