### PR TITLE
Fix title flicker on adding back button on Android

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBar.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBar.java
@@ -206,6 +206,10 @@ public class TitleBar extends Toolbar {
 
     private void setLeftButton(TitleBarButtonController button) {
         leftButtonController = button;
+        TextView title = findTitleTextView();
+        if (title != null) {
+            this.alignTextView(titleAlignment, title);
+        }
         button.applyNavigationIcon(this);
     }
 


### PR DESCRIPTION
This should fix #4571 
I know the bug is closed, but the problem is still present as some folks have stated out. This should address the problem with back button appearance make title flicker