### PR TITLE
Fixed padding of buttons and title by considering status bar height

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBar.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBar.java
@@ -220,6 +220,7 @@ public class TitleBar extends Toolbar {
     public void setHeight(int height) {
         int pixelHeight = UiUtils.dpToPx(getContext(), height);
         if (pixelHeight == getLayoutParams().height) return;
+        setPadding(getPaddingLeft(), UiUtils.getStatusBarHeight(getContext()) / 2, getPaddingRight(), getPaddingBottom());
         ViewGroup.LayoutParams lp = getLayoutParams();
         lp.height = pixelHeight;
         setLayoutParams(lp);


### PR DESCRIPTION
This PR should fix #5092, basically I'm adding a padding based on statusBar to have title and especially buttons centered when you set height to topbar and titlebar