### PR TITLE
Align title after left button is set

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/StringUtils.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/StringUtils.java
@@ -1,5 +1,7 @@
 package com.reactnativenavigation.utils;
 
+import android.support.annotation.Nullable;
+
 public class StringUtils {
 
 	@SuppressWarnings("StringEquality")
@@ -9,4 +11,8 @@ public class StringUtils {
 		}
 		return s1.equals(s2);
 	}
+
+    public static boolean isEmpty(@Nullable CharSequence s) {
+        return s == null || s.length() == 0;
+    }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/UiUtils.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/UiUtils.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewTreeObserver;
@@ -19,7 +20,13 @@ public class UiUtils {
     private static int statusBarHeight = -1;
     private static int topBarHeight = -1;
 
-    public static void runOnPreDrawOnce(final View view, final Runnable task) {
+    public static <T extends View> void runOnPreDrawOnce(@Nullable final T view, final Functions.Func1<T> task) {
+        if (view == null) return;
+        runOnPreDrawOnce(view, () -> task.run(view));
+    }
+
+    public static void runOnPreDrawOnce(@Nullable final View view, final Runnable task) {
+        if (view == null) return;
         view.getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
             @Override
             public boolean onPreDraw() {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBar.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBar.java
@@ -23,6 +23,8 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import static com.reactnativenavigation.utils.UiUtils.runOnPreDrawOnce;
+
 @SuppressLint("ViewConstructor")
 public class TitleBar extends Toolbar {
     public static final int DEFAULT_LEFT_MARGIN = 16;
@@ -61,10 +63,6 @@ public class TitleBar extends Toolbar {
 
     public String getTitle() {
         return super.getTitle() == null ? "" : (String) super.getTitle();
-    }
-
-    public void setTitleTextColor(Colour color) {
-        if (color.hasValue()) setTitleTextColor(color.get());
     }
 
     public void setComponent(View component) {
@@ -106,9 +104,9 @@ public class TitleBar extends Toolbar {
         subtitleAlignment = alignment;
     }
 
-    private void alignTextView(Alignment alignment, TextView view) {
+    public void alignTextView(Alignment alignment, TextView view) {
         Integer direction = view.getParent().getLayoutDirection();
-        Boolean isRTL = direction == View.LAYOUT_DIRECTION_RTL;
+        boolean isRTL = direction == View.LAYOUT_DIRECTION_RTL;
 
         if (alignment == Alignment.Center) {
             //noinspection IntegerDivisionInFloatingPointContext
@@ -206,6 +204,7 @@ public class TitleBar extends Toolbar {
 
     private void setLeftButton(TitleBarButtonController button) {
         leftButtonController = button;
+        runOnPreDrawOnce(findTitleTextView(), title -> alignTextView(titleAlignment, title));
         button.applyNavigationIcon(this);
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBar.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBar.java
@@ -15,6 +15,7 @@ import android.widget.TextView;
 
 import com.reactnativenavigation.parse.Alignment;
 import com.reactnativenavigation.parse.params.Colour;
+import com.reactnativenavigation.utils.StringUtils;
 import com.reactnativenavigation.utils.UiUtils;
 import com.reactnativenavigation.utils.ViewUtils;
 import com.reactnativenavigation.viewcontrollers.TitleBarButtonController;
@@ -105,6 +106,7 @@ public class TitleBar extends Toolbar {
     }
 
     public void alignTextView(Alignment alignment, TextView view) {
+        if (StringUtils.isEmpty(view.getText())) return;
         Integer direction = view.getParent().getLayoutDirection();
         boolean isRTL = direction == View.LAYOUT_DIRECTION_RTL;
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TitleBarTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TitleBarTest.java
@@ -1,22 +1,34 @@
 package com.reactnativenavigation.viewcontrollers;
 
-import android.app.*;
-import android.support.v7.widget.*;
-import android.view.*;
+import android.app.Activity;
+import android.support.v7.widget.ActionMenuView;
+import android.view.View;
+import android.widget.TextView;
 
-import com.reactnativenavigation.*;
-import com.reactnativenavigation.parse.params.*;
-import com.reactnativenavigation.react.*;
-import com.reactnativenavigation.utils.*;
-import com.reactnativenavigation.views.titlebar.*;
+import com.reactnativenavigation.BaseTest;
+import com.reactnativenavigation.parse.params.Button;
+import com.reactnativenavigation.parse.params.Text;
+import com.reactnativenavigation.react.Constants;
+import com.reactnativenavigation.react.ReactView;
+import com.reactnativenavigation.utils.CollectionUtils;
+import com.reactnativenavigation.views.titlebar.TitleBar;
 
-import org.junit.*;
+import org.junit.Test;
+import org.mockito.Mockito;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
-import static com.reactnativenavigation.utils.TitleBarHelper.*;
-import static org.assertj.core.api.Java6Assertions.*;
-import static org.mockito.Mockito.*;
+import static com.reactnativenavigation.utils.TitleBarHelper.createButtonController;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TitleBarTest extends BaseTest {
 
@@ -80,6 +92,18 @@ public class TitleBarTest extends BaseTest {
         uut.setLeftButtons(new ArrayList<>());
         uut.setRightButtons(rightButtons(textButton));
         assertThat(uut.getNavigationIcon()).isNull();
+    }
+
+    @Test
+    public void setLeftButton_titleIsAligned() {
+        uut.setTitle("Title");
+        TextView title = new TextView(activity);
+        uut.addView(title);
+        when(uut.findTitleTextView()).thenReturn(title);
+
+        uut.setLeftButtons(Collections.singletonList(Mockito.mock(TitleBarButtonController.class)));
+        dispatchPreDraw(title);
+        verify(uut).alignTextView(any(), eq(title));
     }
 
     @Test


### PR DESCRIPTION
When setting left button and the title was centred, it got an undesired offset.
Now whenever left button is set we make sure to realign the title.

Related to https://github.com/wix/react-native-navigation/pull/5111