### PR TITLE
Set titleDisplayMode to hidden when tabes have no labels

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsPresenter.java
@@ -10,6 +10,7 @@ import com.reactnativenavigation.anim.BottomTabsAnimator;
 import com.reactnativenavigation.parse.AnimationsOptions;
 import com.reactnativenavigation.parse.BottomTabsOptions;
 import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.utils.CollectionUtils;
 import com.reactnativenavigation.utils.UiUtils;
 import com.reactnativenavigation.viewcontrollers.ViewController;
 import com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabFinder;
@@ -137,7 +138,7 @@ public class BottomTabsPresenter {
     }
 
     private void applyBottomTabsOptions(BottomTabsOptions options, AnimationsOptions animationsOptions) {
-        bottomTabs.setTitleState(options.titleDisplayMode.get(TitleState.SHOW_WHEN_ACTIVE));
+        bottomTabs.setTitleState(getTitleDisplayMode(options));
         bottomTabs.setBackgroundColor(options.backgroundColor.get(Color.WHITE));
         if (options.currentTabIndex.hasValue()) {
             int tabIndex = options.currentTabIndex.get();
@@ -165,5 +166,10 @@ public class BottomTabsPresenter {
         if (options.elevation.hasValue()) {
             bottomTabs.setUseElevation(true, options.elevation.get().floatValue());
         }
+    }
+
+    private TitleState getTitleDisplayMode(BottomTabsOptions options) {
+        boolean hasTabWithTitle = CollectionUtils.reduce(tabs, false, (item, currentValue) -> currentValue || item.resolveCurrentOptions().bottomTabOptions.text.hasValue());
+        return hasTabWithTitle ? options.titleDisplayMode.get(TitleState.SHOW_WHEN_ACTIVE) : TitleState.ALWAYS_HIDE;
     }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabsPresenterTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabsPresenterTest.java
@@ -2,12 +2,15 @@ package com.reactnativenavigation.viewcontrollers;
 
 import android.app.Activity;
 
+import com.aurelhubert.ahbottomnavigation.AHBottomNavigation;
 import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.mocks.SimpleViewController;
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.parse.params.Bool;
 import com.reactnativenavigation.parse.params.Colour;
+import com.reactnativenavigation.parse.params.NullText;
 import com.reactnativenavigation.presentation.BottomTabsPresenter;
+import com.reactnativenavigation.utils.OptionHelper;
 import com.reactnativenavigation.viewcontrollers.bottomtabs.TabSelector;
 import com.reactnativenavigation.views.BottomTabs;
 import com.reactnativenavigation.views.Component;
@@ -18,25 +21,48 @@ import org.mockito.Mockito;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.reactnativenavigation.utils.CollectionUtils.*;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class BottomTabsPresenterTest extends BaseTest {
     private List<ViewController> tabs;
     private BottomTabsPresenter uut;
     private BottomTabs bottomTabs;
+    private Options tabOptions = OptionHelper.createBottomTabOptions();
 
     @Override
     public void beforeEach() {
         Activity activity = newActivity();
         ChildControllersRegistry childRegistry = new ChildControllersRegistry();
-        ViewController child1 = spy(new SimpleViewController(activity, childRegistry, "child1", new Options()));
-        ViewController child2 = spy(new SimpleViewController(activity, childRegistry, "child2", new Options()));
+        ViewController child1 = spy(new SimpleViewController(activity, childRegistry, "child1", tabOptions));
+        ViewController child2 = spy(new SimpleViewController(activity, childRegistry, "child2", tabOptions));
         tabs = Arrays.asList(child1, child2);
         uut = new BottomTabsPresenter(tabs, new Options());
-        bottomTabs = Mockito.mock(BottomTabs.class);
+        bottomTabs = createBottomTabsMock();
         uut.bindView(bottomTabs, Mockito.mock(TabSelector.class));
+    }
+
+    private BottomTabs createBottomTabsMock() {
+        BottomTabs mock = Mockito.mock(BottomTabs.class);
+        doCallRealMethod().when(mock).setTitleState(any());
+        when(mock.getTitleState()).thenCallRealMethod();
+        return mock;
+    }
+
+    @Test
+    public void applyBottomTabsOptions_TitleDisplayModeHiddenIsUsedIfTabsHaveNoTitles() {
+        uut.applyOptions(Options.EMPTY);
+        assertThat(bottomTabs.getTitleState()).isEqualTo(AHBottomNavigation.TitleState.SHOW_WHEN_ACTIVE);
+
+        forEach(tabs, t -> t.options.bottomTabOptions.text = new NullText());
+        uut.applyOptions(Options.EMPTY);
+        assertThat(bottomTabs.getTitleState()).isEqualTo(AHBottomNavigation.TitleState.ALWAYS_HIDE);
     }
 
     @Test


### PR DESCRIPTION
If all BottomTab items have no labels defined - set TitleDIsplayMode to ALWAYS_HIDE so the icons are centred vertically.