### PR TITLE
Safer check around component listener trigger

### DIFF
--- a/lib/src/events/ComponentEventsObserver.ts
+++ b/lib/src/events/ComponentEventsObserver.ts
@@ -94,7 +94,7 @@ export class ComponentEventsObserver {
 
   private triggerOnAllListenersByComponentId(event: ComponentEvent, method: string) {
     _.forEach(this.listeners[event.componentId], (component) => {
-      if (component[method]) {
+      if (component && component[method]) {
         component[method](event);
       }
     });


### PR DESCRIPTION
Had an issue where a screen unmounting and remounting would cause a crash because component was null.

It seems to be caused by a race condition. I'm not totally sure where it comes from but this check makes it safer