### PR TITLE
[V2][iOS] Enable and fix Custom Transitions that use a shared element

### DIFF
--- a/lib/ios/RNNViewLocation.h
+++ b/lib/ios/RNNViewLocation.h
@@ -14,8 +14,4 @@
 
 -(instancetype)initWithFromElement:(RNNElementView*)fromElement toElement:(RNNElementView*)toElement startPoint:(CGPoint)startPoint endPoint:(CGPoint)endPoint andVC:(UIViewController*)vc;
 
--(CGRect)frameFromSuperViewController:(UIView*)view andVC:(UIViewController*)vc;
-
--(CGPoint)centerFromSuperViewController:(UIView*)view andVC:(UIViewController*)vc;
-
 @end

--- a/lib/ios/RNNViewLocation.m
+++ b/lib/ios/RNNViewLocation.m
@@ -5,25 +5,30 @@
 - (instancetype)initWithFromElement:(RNNElementView *)fromElement toElement:(RNNElementView *)toElement startPoint:(CGPoint)startPoint endPoint:(CGPoint)endPoint andVC:(UIViewController *)vc {
 	self = [super init];
 	
-	self.fromFrame = [self frameFromSuperViewController:[fromElement subviews][0] andVC:vc];
+	UIView *fromView = [fromElement subviews][0];
+	UIView *toView = [toElement subviews][0];
+	UIWindow *window = fromView.window;
+	
+	self.fromFrame = [fromView convertRect:fromView.bounds toView:window];
 	CGSize fromSize = self.fromFrame.size;
-	CGPoint fromCenter = [self centerFromSuperViewController:[fromElement subviews][0] andVC:vc];
+	CGPoint fromCenter = CGPointMake(CGRectGetMidX(self.fromFrame), CGRectGetMidY(self.fromFrame));
 	fromCenter.x = fromCenter.x + startPoint.x;
 	fromCenter.y = fromCenter.y + startPoint.y;
 	self.fromCenter = fromCenter;
-	CGRect toFrame = [self frameFromSuperViewController:[fromElement subviews][0] andVC:vc];
+	
+	CGRect toFrame = self.fromFrame;
 	CGSize toSize = self.fromFrame.size;
-	CGPoint toCenter = [self centerFromSuperViewController:[fromElement subviews][0] andVC:vc];
+	CGPoint toCenter = CGPointMake(CGRectGetMidX(self.fromFrame), CGRectGetMidY(self.fromFrame));
 	if (toElement) {
-	   toFrame = [self frameFromSuperViewController:[toElement subviews][0] andVC:vc];
+		toFrame = [toView convertRect:toView.bounds toView:window];
 		toSize = toFrame.size;
-		toCenter = [self centerFromSuperViewController:[toElement subviews][0] andVC:vc];
+		toCenter = CGPointMake(CGRectGetMidX(toFrame), CGRectGetMidY(toFrame));
 	}
 	toCenter.x = toCenter.x + endPoint.x;
 	toCenter.y = toCenter.y + endPoint.y;
 	
-	CGAffineTransform transform = CGAffineTransformMakeScale(toSize.width/fromSize.width ,toSize.height/fromSize.height);
-	CGAffineTransform transformBack = CGAffineTransformMakeScale(fromSize.width/toSize.width ,fromSize.height/toSize.height);
+	CGAffineTransform transform = CGAffineTransformMakeScale(toSize.width/fromSize.width, toSize.height/fromSize.height);
+	CGAffineTransform transformBack = CGAffineTransformMakeScale(fromSize.width/toSize.width, fromSize.height/toSize.height);
 	
 	self.toFrame = toFrame;
 	self.fromSize = fromSize;
@@ -33,21 +38,6 @@
 	self.transformBack = transformBack;
 	
 	return self;
-}
-
-- (CGRect)frameFromSuperViewController:(UIView *)view andVC:(UIViewController *)vc{
-	CGPoint sharedViewFrameOrigin = [view.superview convertPoint:view.frame.origin toView:vc.view];
-	CGRect originRect = CGRectMake(sharedViewFrameOrigin.x, sharedViewFrameOrigin.y, view.frame.size.width, view.frame.size.height);
-	return originRect;
-}
-
-- (CGPoint)centerFromSuperViewController:(UIView *)view andVC:(UIViewController *)vc{
-	CGPoint sharedViewFrameOrigin = [view.superview convertPoint:view.frame.origin toView:vc.view];
-	CGRect originRect = CGRectMake(sharedViewFrameOrigin.x, sharedViewFrameOrigin.y, view.frame.size.width, view.frame.size.height);
-	CGFloat x = originRect.origin.x + view.frame.size.width/2;
-	CGFloat y = originRect.origin.y + view.frame.size.height/2;
-	CGPoint center = CGPointMake(x, y);
-	return center;
 }
 
 @end

--- a/playground/src/screens/CustomTransitionDestination.js
+++ b/playground/src/screens/CustomTransitionDestination.js
@@ -103,7 +103,7 @@ module.exports = CustomTransitionDestination;
 const styles = {
   root: {
     flexGrow: 1,
-    justifyContent: 'center',
+    justifyContent: 'flex-start',
     alignItems: 'center',
     backgroundColor: '#f5fcff'
   },

--- a/playground/src/screens/NavigationScreen.js
+++ b/playground/src/screens/NavigationScreen.js
@@ -39,6 +39,7 @@ class NavigationScreen  extends React.Component {
         <Button label='Static Events' testID={SHOW_STATIC_EVENTS_SCREEN} onPress={this.pushStaticEventsScreen} />
         <Button label='Orientation' testID={SHOW_ORIENTATION_SCREEN} onPress={this.orientation} />
         <Button label='React Context API' onPress={this.pushContextScreen} />
+        <Button label='CustomTransitionOrigin' onPress={this.customTransitionOrigin} />
         <Navigation.TouchablePreview
           touchableComponent={Button}
           onPressIn={this.preview}
@@ -54,6 +55,11 @@ class NavigationScreen  extends React.Component {
   pushStaticEventsScreen = () => Navigation.showModal(Screens.EventsScreen)
   orientation = () => Navigation.showModal(Screens.Orientation);
   pushContextScreen = () => Navigation.push(this, Screens.ContextScreen);
+  customTransitionOrigin = () => Navigation.push(this.props.componentId, {
+    component: {
+      name: 'navigation.playground.CustomTransitionOrigin'
+    }
+  })
   preview = ({reactTag}) => {
     Navigation.push(this.props.componentId, {
       component: {

--- a/playground/src/screens/Screens.js
+++ b/playground/src/screens/Screens.js
@@ -28,5 +28,6 @@ module.exports = {
   Alert: 'Alert',
   Orientation: 'Orientation',
   OrientationDetect: 'OrientationDetect',
+  CustomTransitionOrigin: 'CustomTransitionOrigin',
   Search: 'Search'
 }


### PR DESCRIPTION
- fix the relative positioning of the shared item
- work around a RN flexbox issue causing content to be laid out behind the navigation bar.