### PR TITLE
Add support for React Native 0.60

### DIFF
--- a/docs/docs/Installing.md
+++ b/docs/docs/Installing.md
@@ -36,18 +36,18 @@
 	{
 		NSURL *jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
 		[ReactNativeNavigation bootstrap:jsCodeLocation launchOptions:launchOptions];
-		
+
 		return YES;
 	}
 
 	@end
 	```
 
-3a. If, in Xcode, you see the following error message in `AppDelegate.m` next to `#import "RCTBundleURLProvider.h"`: 
+3a. If, in Xcode, you see the following error message in `AppDelegate.m` next to `#import "RCTBundleURLProvider.h"`:
 ```
 ! 'RCTBundleURLProvider.h' file not found
 ```
-This is because the `React` scheme is missing from your project. You can verify this by opening the `Product` menu and the `Scheme` submenu. 
+This is because the `React` scheme is missing from your project. You can verify this by opening the `Product` menu and the `Scheme` submenu.
 
 To make the `React` scheme available to your project, run `npm install -g react-native-git-upgrade` followed by `react-native-git-upgrade`. Once this is done, you can click back to the menu in Xcode: `Product -> Scheme -> Manage Schemes`, then click '+' to add a new scheme. From the `Target` menu, select "React", and click the checkbox to make the scheme `shared`. This should make the error disappear.
 
@@ -197,10 +197,11 @@ android {
 >`reactNative56` - RN 0.56.x<Br>
 >`reactNative57` - RN 0.57.0 - 0.57.4<Br>
 >`reactNative57_5` - RN 0.57.5 and above<Br>
+>`reactNative60` - RN 0.60.0
 
 Now we need to instruct gradle how to build that flavor. To do so here two solutions:
 
-#### 5.1 Build app with gradle command 
+#### 5.1 Build app with gradle command
 
 **prefered solution** The RNN flavor you would like to build is specified in `app/build.gradle`. Therefore in order to compile only that flavor, instead of building your entire project using `./gradlew assembleDebug`, you should instruct gradle to build the app module: `./gradlew app:assembleDebug`. The easiest way is to add a package.json command to build and install your debug Android APK .
 
@@ -249,7 +250,7 @@ This file is located in `android/app/src/main/java/com/<yourproject>/MainActivit
 -import com.facebook.react.ReactActivity;
 +import com.reactnativenavigation.NavigationActivity;
 
--public class MainActivity extends ReactActivity { 
+-public class MainActivity extends ReactActivity {
 +public class MainActivity extends NavigationActivity {
 -    @Override
 -    protected String getMainComponentName() {
@@ -263,7 +264,7 @@ If you have any **react-native** related methods, you can safely delete them.
 ### 7. Update `MainApplication.java`
 
 This file is located in `android/app/src/main/java/com/<yourproject>/MainApplication.java`.
-	
+
 ```diff
 ...
 import android.app.Application;
@@ -283,7 +284,7 @@ import java.util.List;
 
 -public class MainApplication extends Application implements ReactApplication {
 +public class MainApplication extends NavigationApplication {
-+    
++
 +    @Override
 +    protected ReactGateway createReactGateway() {
 +        ReactNativeHost host = new NavigationReactNativeHost(this, isDebug(), createAdditionalReactPackages()) {
@@ -307,7 +308,7 @@ import java.util.List;
 +            // eg. new VectorIconsPackage()
 +        );
 +    }
-+  
++
 +    @Override
 +    public List<ReactPackage> createAdditionalReactPackages() {
 +        return getPackages();
@@ -315,6 +316,82 @@ import java.util.List;
 - ...
 +}
 
+```
+
+If you have upgraded to React Native 0.60, a new feature called `AutoLink` is introduced. Make changes to `MainApplication.java` to take advantage of this feature:
+
+```diff
+...
+-import android.app.Application;
+
++import com.facebook.react.PackageList;
+-import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+-import com.facebook.react.shell.MainReactPackage;
+-import com.facebook.soloader.SoLoader;
+
++import com.reactnativenavigation.NavigationApplication;
++import com.reactnativenavigation.react.NavigationPackage;
++import com.reactnativenavigation.react.NavigationReactNativeHost;
++import com.reactnativenavigation.react.ReactGateway;
+
++/**
++ * Add this line if you use `react-native-code-push`
++ */
++import com.microsoft.codepush.react.CodePush;
+
+import java.util.Arrays;
+import java.util.List;
+
+-public class MainApplication extends Application implements ReactApplication {
++public class MainApplication extends NavigationApplication {
++
++    @Override
++    protected ReactGateway createReactGateway() {
++        ReactNativeHost host = new NavigationReactNativeHost(this, isDebug(), createAdditionalReactPackages()) {
++            @Override
++            protected String getJSMainModuleName() {
++                return "index";
++            }
++
++            /**
++            * Add this block if you use `react-native-code-push`
++            */
++            @Override
++            protected String getJSBundleFile() {
++                return CodePush.getJSBundleFile();
++            }
++
++            @Override
++            protected List<ReactPackage> getPackages() {
++                @SuppressWarnings("UnnecessaryLocalVariable")
++                List<ReactPackage> packages = new PackageList(this).getPackages();
++                packages.add(new NavigationPackage(this));
++                /**
++                 * Add other packages that fail to be auto-detected here
++                 */
++                return packages;
++            }
++        };
++        return new ReactGateway(this, isDebug(), host);
++    }
++
++    @Override
++    public boolean isDebug() {
++        return BuildConfig.DEBUG;
++    }
++
++    @Override
++    public List<ReactPackage> createAdditionalReactPackages() {
++        /**
++         * We used function override above,
++         * so we just return an empty list here
++         */
++        return Arrays.<ReactPackage>asList();
++    }
+-...
++}
 ```
 
 ### 8. Force the same support library version across all dependencies (optional)

--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -76,6 +76,10 @@ android {
             dimension "RNN.reactNativeVersion"
             buildConfigField("int", "REACT_NATVE_VERSION_MINOR", "57")
         }
+        reactNative60 {
+            dimension "RNN.reactNativeVersion"
+            buildConfigField("int", "REACT_NATVE_VERSION_MINOR", "60")
+        }
     }
 }
 

--- a/lib/android/app/src/reactNative60/java/com/reactnativenavigation/react/DevBundleDownloadListenerAdapter.java
+++ b/lib/android/app/src/reactNative60/java/com/reactnativenavigation/react/DevBundleDownloadListenerAdapter.java
@@ -1,0 +1,28 @@
+package com.reactnativenavigation.react;
+
+import com.facebook.react.bridge.NativeDeltaClient;
+import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+
+import javax.annotation.Nullable;
+
+public class DevBundleDownloadListenerAdapter implements DevBundleDownloadListener, NavigationDevBundleDownloadListener {
+    @Override
+    public void onSuccess(@Nullable NativeDeltaClient nativeDeltaClient) {
+        onSuccess();
+    }
+
+    @Override
+    public void onSuccess() {
+
+    }
+
+    @Override
+    public void onProgress(@Nullable String status, @Nullable Integer done, @Nullable Integer total) {
+
+    }
+
+    @Override
+    public void onFailure(Exception cause) {
+
+    }
+}

--- a/lib/android/app/src/reactNative60/java/com/reactnativenavigation/react/JsDevReloadHandlerFacade.java
+++ b/lib/android/app/src/reactNative60/java/com/reactnativenavigation/react/JsDevReloadHandlerFacade.java
@@ -1,0 +1,28 @@
+package com.reactnativenavigation.react;
+
+import com.facebook.react.bridge.NativeDeltaClient;
+import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+
+import javax.annotation.Nullable;
+
+public class JsDevReloadHandlerFacade implements DevBundleDownloadListener, NavigationDevBundleDownloadListener {
+    @Override
+    public void onSuccess(@Nullable NativeDeltaClient nativeDeltaClient) {
+        onSuccess();
+    }
+
+    @Override
+    public void onProgress(@Nullable String status, @Nullable Integer done, @Nullable Integer total) {
+
+    }
+
+    @Override
+    public void onFailure(Exception cause) {
+
+    }
+
+    @Override
+    public void onSuccess() {
+
+    }
+}

--- a/lib/android/app/src/reactNative60/java/com/reactnativenavigation/react/NavigationReactNativeHost.java
+++ b/lib/android/app/src/reactNative60/java/com/reactnativenavigation/react/NavigationReactNativeHost.java
@@ -1,0 +1,107 @@
+package com.reactnativenavigation.react;
+
+import android.app.Application;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.common.LifecycleState;
+import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+import com.facebook.react.shell.MainReactPackage;
+import com.reactnativenavigation.NavigationApplication;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Default implementation of {@link ReactNativeHost} that includes {@link NavigationPackage}
+ * and user-defined additional packages.
+ */
+public class NavigationReactNativeHost extends ReactNativeHost implements BundleDownloadListenerProvider {
+
+    private final boolean isDebug;
+    private final List<ReactPackage> additionalReactPackages;
+    private @Nullable NavigationDevBundleDownloadListener bundleListener;
+    private final DevBundleDownloadListener bundleListenerMediator = new DevBundleDownloadListenerAdapter() {
+        @Override
+        public void onSuccess() {
+            if (bundleListener != null) {
+                bundleListener.onSuccess();
+            }
+        }
+    };
+
+    public NavigationReactNativeHost(NavigationApplication application) {
+        this(application, application.isDebug(), application.createAdditionalReactPackages());
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public NavigationReactNativeHost(Application application, boolean isDebug, final List<ReactPackage> additionalReactPackages) {
+        super(application);
+        this.isDebug = isDebug;
+        this.additionalReactPackages = additionalReactPackages;
+    }
+
+    @Override
+    public void setBundleLoaderListener(NavigationDevBundleDownloadListener listener) {
+        bundleListener = listener;
+    }
+
+    @Override
+    public boolean getUseDeveloperSupport() {
+        return isDebug;
+    }
+
+    @Override
+    protected List<ReactPackage> getPackages() {
+        List<ReactPackage> packages = new ArrayList<>();
+        boolean hasMainReactPackage = false;
+        packages.add(new NavigationPackage(this));
+        if (additionalReactPackages != null) {
+            for (ReactPackage p : additionalReactPackages) {
+                if (!(p instanceof NavigationPackage)) {
+                    packages.add(p);
+                }
+                if (p instanceof MainReactPackage) hasMainReactPackage = true;
+            }
+        }
+        if (!hasMainReactPackage) {
+            packages.add(new MainReactPackage());
+        }
+        return packages;
+    }
+
+    protected ReactInstanceManager createReactInstanceManager() {
+        ReactInstanceManagerBuilder builder = ReactInstanceManager.builder()
+                .setApplication(getApplication())
+                .setJSMainModulePath(getJSMainModuleName())
+                .setUseDeveloperSupport(getUseDeveloperSupport())
+                .setRedBoxHandler(getRedBoxHandler())
+                .setJavaScriptExecutorFactory(getJavaScriptExecutorFactory())
+                .setUIImplementationProvider(getUIImplementationProvider())
+                .setInitialLifecycleState(LifecycleState.BEFORE_CREATE)
+                .setDevBundleDownloadListener(getDevBundleDownloadListener());
+
+        for (ReactPackage reactPackage : getPackages()) {
+            builder.addPackage(reactPackage);
+        }
+
+        String jsBundleFile = getJSBundleFile();
+        if (jsBundleFile != null) {
+            builder.setJSBundleFile(jsBundleFile);
+        } else {
+            builder.setBundleAssetName(Assertions.assertNotNull(getBundleAssetName()));
+        }
+        return builder.build();
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    @NonNull
+    protected DevBundleDownloadListener getDevBundleDownloadListener() {
+        return bundleListenerMediator;
+    }
+}

--- a/lib/android/app/src/reactNative60/java/com/reactnativenavigation/react/ReloadHandlerFacade.java
+++ b/lib/android/app/src/reactNative60/java/com/reactnativenavigation/react/ReloadHandlerFacade.java
@@ -1,0 +1,25 @@
+package com.reactnativenavigation.react;
+
+import com.facebook.react.bridge.NativeDeltaClient;
+import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+
+import javax.annotation.Nullable;
+
+public abstract class ReloadHandlerFacade implements DevBundleDownloadListener {
+    @Override
+    public void onSuccess(@Nullable NativeDeltaClient nativeDeltaClient) {
+
+    }
+
+    @Override
+    public void onProgress(@Nullable String status, @Nullable Integer done, @Nullable Integer total) {
+
+    }
+
+    @Override
+    public void onFailure(Exception cause) {
+
+    }
+
+    protected abstract void onSuccess();
+}

--- a/lib/android/app/src/reactNative60/java/com/reactnativenavigation/react/SyncUiImplementation.java
+++ b/lib/android/app/src/reactNative60/java/com/reactnativenavigation/react/SyncUiImplementation.java
@@ -1,0 +1,82 @@
+package com.reactnativenavigation.react;
+
+import android.view.View;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIImplementation;
+import com.facebook.react.uimanager.UIImplementationProvider;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.uimanager.events.EventDispatcher;
+
+import java.util.List;
+
+@SuppressWarnings("WeakerAccess")
+public class SyncUiImplementation extends UIImplementation {
+    private static final Object lock = new Object();
+
+    public static class Provider extends UIImplementationProvider {
+        @Override
+        public UIImplementation createUIImplementation(ReactApplicationContext reactContext, List<ViewManager> viewManagerList, EventDispatcher eventDispatcher, int minTimeLeftInFrameForNonBatchedOperationMs) {
+            return new SyncUiImplementation(reactContext, viewManagerList, eventDispatcher, minTimeLeftInFrameForNonBatchedOperationMs);
+        }
+
+        @Override
+        public UIImplementation createUIImplementation(ReactApplicationContext reactContext, UIManagerModule.ViewManagerResolver viewManagerResolver, EventDispatcher eventDispatcher, int minTimeLeftInFrameForNonBatchedOperationMs) {
+            return new SyncUiImplementation(reactContext, viewManagerResolver, eventDispatcher, minTimeLeftInFrameForNonBatchedOperationMs);
+        }
+    }
+
+    public SyncUiImplementation(ReactApplicationContext reactContext, List<ViewManager> viewManagerList, EventDispatcher eventDispatcher, int minTimeLeftInFrameForNonBatchedOperationMs) {
+        super(reactContext, viewManagerList, eventDispatcher, minTimeLeftInFrameForNonBatchedOperationMs);
+    }
+
+    public SyncUiImplementation(ReactApplicationContext reactContext, UIManagerModule.ViewManagerResolver viewManagerResolver, EventDispatcher eventDispatcher, int minTimeLeftInFrameForNonBatchedOperationMs) {
+        super(reactContext, viewManagerResolver, eventDispatcher, minTimeLeftInFrameForNonBatchedOperationMs);
+    }
+
+    @Override
+    public void manageChildren(
+            int viewTag,
+            @Nullable ReadableArray moveFrom,
+            @Nullable ReadableArray moveTo,
+            @Nullable ReadableArray addChildTags,
+            @Nullable ReadableArray addAtIndices,
+            @Nullable ReadableArray removeFrom) {
+        synchronized (lock) {
+            super.manageChildren(viewTag, moveFrom, moveTo, addChildTags, addAtIndices, removeFrom);
+        }
+    }
+
+    @Override
+    public void setChildren(int viewTag, ReadableArray childrenTags) {
+        synchronized (lock) {
+            super.setChildren(viewTag, childrenTags);
+        }
+    }
+
+    @Override
+    public void createView(int tag, String className, int rootViewTag, ReadableMap props) {
+        synchronized (lock) {
+            super.createView(tag, className, rootViewTag, props);
+        }
+    }
+
+    @Override
+    public void removeRootShadowNode(int rootViewTag) {
+        synchronized (lock) {
+            super.removeRootShadowNode(rootViewTag);
+        }
+    }
+
+    @Override
+    public <T extends View> void registerRootView(T rootView, int tag, ThemedReactContext context) {
+        synchronized (lock) {
+            super.registerRootView(rootView, tag, context);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This pull request makes RNN compatible with the latest RN 0.60.0-rc.2. Since there will not be fundamental changes in the same minor version, we can assure this pull request can work for some time.

## Changes

- Remove `MeasureSpecProvider` & `SizeMonitoringFrameLayout`. They no longer exist.
- Change imports to AndroidX, because RN 0.60 uses it as default.
- Add a new build flavor so users won't be effected even they stay on the old RN version.
- Update doc to demonstrate how to modify `MainApplication.java` to utilize RN new AutoLink feature.

## Tests

Since there is no API change, all tests apply to this pull request as long as it passes build.