### PR TITLE
[v3] Dont override existing system ui visibility flags when setting statusbar visibility

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/Presenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/Presenter.java
@@ -101,7 +101,11 @@ public class Presenter {
 
     private void setStatusBarVisible(Bool visible) {
         View decorView = activity.getWindow().getDecorView();
-        decorView.setSystemUiVisibility(visible.isFalse() ? View.SYSTEM_UI_FLAG_FULLSCREEN : 0);
+        int flags = decorView.getSystemUiVisibility();
+        if (visible.isFalse()) {
+            flags |= View.SYSTEM_UI_FLAG_FULLSCREEN;
+        }
+        decorView.setSystemUiVisibility(flags);
     }
 
     private void setStatusBarBackgroundColor(StatusBarOptions statusBar) {


### PR DESCRIPTION
When setting a light status bar (grey icons on light background, `TextColorScheme.Dark`), the setting will get overridden by the order of `applyStatusBarOptions`:

```
    private void applyStatusBarOptions(Options options) {
        setStatusBarBackgroundColor(options.statusBar);
        setTextColorScheme(options.statusBar.textColorScheme);
        setTranslucent(options.statusBar);
        setStatusBarVisible(options.statusBar.visible);
    }
```

Since `setStatusBarVisible` is called last, and does not consider previous flags, the flag  `SYSTEM_UI_FLAG_LIGHT_STATUS_BAR` will get overridden.

This PR include previous set flags.