### PR TITLE
Add iconfont  support in the topbar

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/params/Button.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/params/Button.java
@@ -7,6 +7,7 @@ import android.view.MenuItem;
 import com.reactnativenavigation.parse.Component;
 import com.reactnativenavigation.parse.parsers.BoolParser;
 import com.reactnativenavigation.parse.parsers.ColorParser;
+import com.reactnativenavigation.parse.parsers.FontTextParser;
 import com.reactnativenavigation.parse.parsers.NumberParser;
 import com.reactnativenavigation.parse.parsers.TextParser;
 import com.reactnativenavigation.utils.CompatUtils;
@@ -37,7 +38,7 @@ public class Button {
     private static Button parseJson(JSONObject json, TypefaceLoader typefaceManager) {
         Button button = new Button();
         button.id = json.optString("id");
-        button.text = TextParser.parse(json, "text");
+        button.text = FontTextParser.parse(json, "text");
         button.enabled = BoolParser.parse(json, "enabled");
         button.disableIconTint = BoolParser.parse(json, "disableIconTint");
         button.showAsAction = parseShowAsAction(json);

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/parsers/FontTextParser.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/parsers/FontTextParser.java
@@ -1,0 +1,28 @@
+package com.reactnativenavigation.parse.parsers;
+
+import com.reactnativenavigation.parse.params.NullText;
+import com.reactnativenavigation.parse.params.Text;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import javax.annotation.Nullable;
+
+public class FontTextParser {
+    public static Text parse(@Nullable JSONObject json, String text) {
+        if (json.has(text)) {
+            try {
+                Object val = json.get(text);
+                if (val instanceof Number) {
+                    String unicode = "" + new Character((char)((Number) val).longValue());
+                    return new Text(unicode);
+                } else {
+                    return TextParser.parse(json, text);
+                }
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+        return new NullText();
+    }
+}

--- a/lib/ios/RNNNavigationButtons.m
+++ b/lib/ios/RNNNavigationButtons.m
@@ -71,7 +71,13 @@
 
 -(RNNUIBarButtonItem*)buildButton: (NSDictionary*)dictionary defaultStyle:(RNNButtonOptions *)defaultStyle insets:(UIEdgeInsets)insets {
 	NSString* buttonId = dictionary[@"id"];
-	NSString* title = [self getValue:dictionary[@"text"] withDefault:[defaultStyle.text getWithDefaultValue:nil]];
+	id titleValue = [self getValue:dictionary[@"text"] withDefault:[defaultStyle.text getWithDefaultValue:nil]];
+	NSString *title = nil;
+	if ([titleValue isKindOfClass:[NSNumber class]]) {
+			title = [NSString stringWithFormat:@"%C", [titleValue unsignedShortValue]];
+	} else if ([titleValue isKindOfClass:[NSString class]]){
+			title = titleValue;
+	}
 	NSDictionary* component = dictionary[@"component"];
 	NSString* systemItemName = dictionary[@"systemItem"];
 	

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -281,13 +281,17 @@ export interface OptionsTopBarButton {
    */
   systemItem?: SystemItemIcon;
   /**
-   * Set the button text
+   * Set the button text, if provided a number, parsed as a unicode character
    */
   text?: string | number;
   /**
    * Set the button font family
    */
   fontFamily?: string;
+  /**
+   * Set the size of the text
+   */
+  fontSize?: number;
   /**
    * Set the button enabled or disabled
    * @default true

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -283,7 +283,7 @@ export interface OptionsTopBarButton {
   /**
    * Set the button text
    */
-  text?: string;
+  text?: string | number;
   /**
    * Set the button font family
    */


### PR DESCRIPTION
In current version, the custom topbar component cannot received `onNavigationButtonPressed` event (just like [Bug #4553](https://github.com/wix/react-native-navigation/issues/4553)). To avoid this problem, we can render rightbutton as a `iconfont`, and rendered by native component, so it can received press events. And supported by `react-native-vector-icons`, this feature can make rightbutton more flexible without icon images.

This feature solved the configuration file problem: 
Suppose that I have a stack of components, and each of them have different right button, we have the options as follow, if we use custom component :

```js
{
    rightButtons: [{
        component: {..., options:{
            topBar: {
                rightButtons: [{..., {
                    rightButtons:[{
                        ...
                }]}}]
            }
        }}
    }]
}
```

And in the custom top bar component, the press event can only be responded by callback passed from a prop like `onPress`, otherwise, the handler is defined out of the component, so we can't use `this` as a reference to the custom component without processed based on props.

The implementation in the iOS is:

  1. Parse text value as a `id`;
  2. Recognize it a `NSString` or `NSNumber`;
  3. If a `NSNumber`, transform it to unicode string representation, or the raw string;

number to unicode in OC: `[NSString stringWithFormat:@"%08C", val]`
  
The implementation in the Android is:
  1. Parse text value as an `Object` type.
  2. Recognize it a `String` or `Number`;
  3. If a `Number`, transform it to unicode string representation, or the raw string;

number to unicode in Android: `new Character((char)((Number) val).longValue());`, the unicode character in java just like `\ue450`

We can use this feature by options as follow: 

```
rightButtons: [
                  {
                    fontFamily: 'iconfont',
                    text: 58950,
                    fontSize: 30,
                    color: '#fafafa',
                    id: 'add-icon'
                  }
                ],
```

iOS screenshot: 
![screenshot-iOS](https://user-images.githubusercontent.com/13446458/61108442-e126dd80-a4b4-11e9-9825-7d213b1ed794.png)

Android screenshot: 
![screenshot-android](https://user-images.githubusercontent.com/13446458/61108465-ec7a0900-a4b4-11e9-94d0-f47bc1e301df.png)

The test icon is from [Iconfont](https://iconfont.cn). 