### PR TITLE
Allow setting UITabBarItem.title to default value

### DIFF
--- a/lib/ios/RNNTabBarItemCreator.m
+++ b/lib/ios/RNNTabBarItemCreator.m
@@ -12,7 +12,7 @@
 	
 	tabItem.image = [self getIconImage:icon withTint:iconColor];
 	tabItem.selectedImage = [self getSelectedIconImage:selectedIcon selectedIconColor:selectedIconColor];
-	tabItem.title = [bottomTabOptions.text getWithDefaultValue:@""];
+	tabItem.title = [bottomTabOptions.text getWithDefaultValue:nil];
 	tabItem.tag = bottomTabOptions.tag;
 	tabItem.accessibilityIdentifier = [bottomTabOptions.testID getWithDefaultValue:nil];
 	


### PR DESCRIPTION
The default value for `UITabBarItem.title` is `nil` as specified by the docs:
> You should set this property before adding the item to a bar. The default value is nil.
https://developer.apple.com/documentation/uikit/uibaritem/1616412-title

This changes allows for this to be `nil`.