### PR TITLE
BottomTab dot indicator

### DIFF
--- a/e2e/BottomTabs.test.js
+++ b/e2e/BottomTabs.test.js
@@ -32,7 +32,7 @@ describe('BottomTabs', () => {
     await expect(element(by.text('NEW'))).toBeVisible();
   });
 
-  it(':ios: set Tab Bar badge null on a current Tab should reset badge', async () => {
+  it('set empty string badge on a current Tab should clear badge', async () => {
     await elementById(TestIDs.SET_BADGE_BTN).tap();
     await expect(element(by.text('NEW'))).toBeVisible();
     await elementById(TestIDs.CLEAR_BADGE_BTN).tap();

--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -92,12 +92,11 @@ allprojects { p ->
 def supportLibVersion = safeExtGet('supportLibVersion', DEFAULT_SUPPORT_LIB_VERSION)
 
 dependencies {
-    implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "com.android.support:design:${supportLibVersion}"
     implementation "com.android.support:appcompat-v7:${supportLibVersion}"
     implementation "com.android.support:support-v4:${supportLibVersion}"
 
-    implementation 'com.github.wix-playground:ahbottomnavigation:2.4.9'
+    implementation 'com.github.wix-playground:ahbottomnavigation:2.4.13'
     implementation 'com.github.wix-playground:reflow-animator:1.0.4'
     implementation 'com.github.clans:fab:1.6.4'
 

--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     implementation "com.android.support:appcompat-v7:${supportLibVersion}"
     implementation "com.android.support:support-v4:${supportLibVersion}"
 
-    implementation 'com.github.wix-playground:ahbottomnavigation:2.4.13'
+    implementation 'com.github.wix-playground:ahbottomnavigation:2.4.15'
     implementation 'com.github.wix-playground:reflow-animator:1.0.4'
     implementation 'com.github.clans:fab:1.6.4'
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabOptions.java
@@ -30,6 +30,7 @@ public class BottomTabOptions {
         options.selectedIconColor = ColorParser.parse(json, "selectedIconColor");
         options.badge = TextParser.parse(json, "badge");
         options.badgeColor = ColorParser.parse(json, "badgeColor");
+        options.badgeSize = NumberParser.parse(json, "badgeSize");
         options.testId = TextParser.parse(json, "testID");
         options.fontFamily = typefaceManager.getTypeFace(json.optString("fontFamily", ""));
         options.fontSize = NumberParser.parse(json, "fontSize");
@@ -46,6 +47,7 @@ public class BottomTabOptions {
     public Text testId = new NullText();
     public Text badge = new NullText();
     public Colour badgeColor = new NullColor();
+    public Number badgeSize = new NullNumber();
     public Number fontSize = new NullNumber();
     public Number selectedFontSize = new NullNumber();
     @Nullable public Typeface fontFamily;
@@ -60,6 +62,7 @@ public class BottomTabOptions {
         if (other.selectedIconColor.hasValue()) selectedIconColor = other.selectedIconColor;
         if (other.badge.hasValue()) badge = other.badge;
         if (other.badgeColor.hasValue()) badgeColor = other.badgeColor;
+        if (other.badgeSize.hasValue()) badgeSize = other.badgeSize;
         if (other.testId.hasValue()) testId = other.testId;
         if (other.fontSize.hasValue()) fontSize = other.fontSize;
         if (other.selectedFontSize.hasValue()) selectedFontSize = other.selectedFontSize;
@@ -75,6 +78,7 @@ public class BottomTabOptions {
         if (!selectedIconColor.hasValue()) selectedIconColor = defaultOptions.selectedIconColor;
         if (!badge.hasValue()) badge = defaultOptions.badge;
         if (!badgeColor.hasValue()) badgeColor = defaultOptions.badgeColor;
+        if (!badgeSize.hasValue()) badgeSize = defaultOptions.badgeSize;
         if (!fontSize.hasValue()) fontSize = defaultOptions.fontSize;
         if (!selectedFontSize.hasValue()) selectedFontSize = defaultOptions.selectedFontSize;
         if (fontFamily == null) fontFamily = defaultOptions.fontFamily;

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabOptions.java
@@ -30,11 +30,11 @@ public class BottomTabOptions {
         options.selectedIconColor = ColorParser.parse(json, "selectedIconColor");
         options.badge = TextParser.parse(json, "badge");
         options.badgeColor = ColorParser.parse(json, "badgeColor");
-        options.badgeSize = NumberParser.parse(json, "badgeSize");
         options.testId = TextParser.parse(json, "testID");
         options.fontFamily = typefaceManager.getTypeFace(json.optString("fontFamily", ""));
         options.fontSize = NumberParser.parse(json, "fontSize");
         options.selectedFontSize = NumberParser.parse(json, "selectedFontSize");
+        options.dotIndicator = DotIndicatorOptions.parse(json.optJSONObject("dotIndicator"));
         return options;
     }
 
@@ -47,7 +47,7 @@ public class BottomTabOptions {
     public Text testId = new NullText();
     public Text badge = new NullText();
     public Colour badgeColor = new NullColor();
-    public Number badgeSize = new NullNumber();
+    public DotIndicatorOptions dotIndicator = new DotIndicatorOptions();
     public Number fontSize = new NullNumber();
     public Number selectedFontSize = new NullNumber();
     @Nullable public Typeface fontFamily;
@@ -62,11 +62,11 @@ public class BottomTabOptions {
         if (other.selectedIconColor.hasValue()) selectedIconColor = other.selectedIconColor;
         if (other.badge.hasValue()) badge = other.badge;
         if (other.badgeColor.hasValue()) badgeColor = other.badgeColor;
-        if (other.badgeSize.hasValue()) badgeSize = other.badgeSize;
         if (other.testId.hasValue()) testId = other.testId;
         if (other.fontSize.hasValue()) fontSize = other.fontSize;
         if (other.selectedFontSize.hasValue()) selectedFontSize = other.selectedFontSize;
         if (other.fontFamily != null) fontFamily = other.fontFamily;
+        if (other.dotIndicator.hasValue()) dotIndicator = other.dotIndicator;
     }
 
     void mergeWithDefault(final BottomTabOptions defaultOptions) {
@@ -78,10 +78,10 @@ public class BottomTabOptions {
         if (!selectedIconColor.hasValue()) selectedIconColor = defaultOptions.selectedIconColor;
         if (!badge.hasValue()) badge = defaultOptions.badge;
         if (!badgeColor.hasValue()) badgeColor = defaultOptions.badgeColor;
-        if (!badgeSize.hasValue()) badgeSize = defaultOptions.badgeSize;
         if (!fontSize.hasValue()) fontSize = defaultOptions.fontSize;
         if (!selectedFontSize.hasValue()) selectedFontSize = defaultOptions.selectedFontSize;
         if (fontFamily == null) fontFamily = defaultOptions.fontFamily;
         if (!testId.hasValue()) testId = defaultOptions.testId;
+        if (!dotIndicator.hasValue()) dotIndicator = defaultOptions.dotIndicator;
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/DotIndicatorOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/DotIndicatorOptions.java
@@ -1,0 +1,36 @@
+package com.reactnativenavigation.parse;
+
+import android.support.annotation.Nullable;
+
+import com.reactnativenavigation.parse.params.Bool;
+import com.reactnativenavigation.parse.params.Colour;
+import com.reactnativenavigation.parse.params.NullBool;
+import com.reactnativenavigation.parse.params.NullColor;
+import com.reactnativenavigation.parse.params.NullNumber;
+import com.reactnativenavigation.parse.params.Number;
+import com.reactnativenavigation.parse.parsers.BoolParser;
+import com.reactnativenavigation.parse.parsers.ColorParser;
+import com.reactnativenavigation.parse.parsers.NumberParser;
+
+import org.json.JSONObject;
+
+public class DotIndicatorOptions {
+    public static DotIndicatorOptions parse(@Nullable JSONObject json) {
+        DotIndicatorOptions options = new DotIndicatorOptions();
+        if (json == null) return options;
+
+        options.color = ColorParser.parse(json, "color");
+        options.size = NumberParser.parse(json, "size");
+        options.visible = BoolParser.parse(json, "visible");
+
+        return options;
+    }
+
+    public Colour color = new NullColor();
+    public Number size = new NullNumber();
+    public Bool visible = new NullBool();
+
+    public boolean hasValue() {
+        return visible.hasValue();
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
@@ -5,14 +5,19 @@ import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 
-import com.reactnativenavigation.parse.*;
-import com.reactnativenavigation.utils.*;
-import com.reactnativenavigation.viewcontrollers.*;
-import com.reactnativenavigation.viewcontrollers.bottomtabs.*;
-import com.reactnativenavigation.views.*;
+import com.aurelhubert.ahbottomnavigation.notification.AHNotification;
+import com.reactnativenavigation.parse.BottomTabOptions;
+import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.utils.ImageLoader;
+import com.reactnativenavigation.utils.ImageLoadingListenerAdapter;
+import com.reactnativenavigation.viewcontrollers.ViewController;
+import com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabFinder;
+import com.reactnativenavigation.views.BottomTabs;
 import com.reactnativenavigation.views.Component;
 
-import java.util.*;
+import java.util.List;
+
+import static com.reactnativenavigation.utils.UiUtils.dpToPx;
 
 public class BottomTabPresenter {
     private final Context context;
@@ -45,8 +50,6 @@ public class BottomTabPresenter {
     public void applyOptions() {
         for (int i = 0; i < tabs.size(); i++) {
             BottomTabOptions tab = tabs.get(i).resolveCurrentOptions(defaultOptions).bottomTabOptions;
-            bottomTabs.setBadge(i, tab.badge.get(""));
-            bottomTabs.setBadgeColor(tab.badgeColor.get(null));
             bottomTabs.setTitleTypeface(i, tab.fontFamily);
             bottomTabs.setIconActiveColor(i, tab.selectedIconColor.get(null));
             bottomTabs.setIconInactiveColor(i, tab.iconColor.get(null));
@@ -55,6 +58,7 @@ public class BottomTabPresenter {
             bottomTabs.setTitleInactiveTextSizeInSp(i, tab.fontSize.hasValue() ? Float.valueOf(tab.fontSize.get()) : null);
             bottomTabs.setTitleActiveTextSizeInSp(i, tab.selectedFontSize.hasValue() ? Float.valueOf(tab.selectedFontSize.get()) : null);
             if (tab.testId.hasValue()) bottomTabs.setTag(i, tab.testId.get());
+            applyBadge(i, tab);
         }
     }
 
@@ -62,8 +66,6 @@ public class BottomTabPresenter {
         int index = bottomTabFinder.findByComponent(child);
         if (index >= 0) {
             BottomTabOptions bto = options.bottomTabOptions;
-            if (bto.badge.hasValue()) bottomTabs.setBadge(index, bto.badge.get());
-            if (bto.badgeColor.hasValue()) bottomTabs.setBadgeColor(bto.badgeColor.get());
             if (bto.fontFamily != null) bottomTabs.setTitleTypeface(index, bto.fontFamily);
             if (bto.selectedIconColor.hasValue()) bottomTabs.setIconActiveColor(index, bto.selectedIconColor.get());
             if (bto.iconColor.hasValue()) bottomTabs.setIconInactiveColor(index, bto.iconColor.get());
@@ -77,6 +79,24 @@ public class BottomTabPresenter {
                 }
             });
             if (bto.testId.hasValue()) bottomTabs.setTag(index, bto.testId.get());
+            mergeBadge(index, bto);
         }
+    }
+
+    private void applyBadge(int tabIndex, BottomTabOptions tab) {
+        AHNotification.Builder builder = new AHNotification.Builder();
+        builder.setText(tab.badge.get(""));
+        builder.setBackgroundColor(tab.badgeColor.get(null));
+        builder.setSize(dpToPx(bottomTabs.getContext(), tab.badgeSize.get(AHNotification.NOTIFICATION_SIZE_DEFAULT)));
+        bottomTabs.setNotification(builder.build(), tabIndex);
+    }
+
+    private void mergeBadge(int index, BottomTabOptions bto) {
+        AHNotification.Builder builder = new AHNotification.Builder();
+        if (bto.badge.hasValue()) builder.setText(bto.badge.get(""));
+        if (bto.badgeColor.hasValue()) builder.setBackgroundColor(bto.badgeColor.get());
+        if (bto.badgeSize.hasValue()) builder.setSize(dpToPx(bottomTabs.getContext(), bto.badgeSize.get()));
+        AHNotification notification = builder.build();
+        if (notification.hasValue()) bottomTabs.setNotification(notification, index);
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
@@ -103,10 +103,10 @@ public class BottomTabPresenter {
 
     private void mergeBadge(int index, BottomTabOptions tab) {
         AHNotification.Builder builder = new AHNotification.Builder();
-        if (tab.badge.hasValue()) builder.setText(tab.badge.get(""));
+        if (tab.badge.hasValue()) builder.setText(tab.badge.get(null));
         if (tab.badgeColor.hasValue()) builder.setBackgroundColor(tab.badgeColor.get());
         AHNotification notification = builder.build();
-        if (notification.hasValue()) bottomTabs.setNotification(notification, index);
+        if (tab.badge.hasValue()) bottomTabs.setNotification(notification, index);
     }
 
     private void mergeDotIndicator(int index, DotIndicatorOptions dotIndicator) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
@@ -7,6 +7,7 @@ import android.support.v4.content.ContextCompat;
 
 import com.aurelhubert.ahbottomnavigation.notification.AHNotification;
 import com.reactnativenavigation.parse.BottomTabOptions;
+import com.reactnativenavigation.parse.DotIndicatorOptions;
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.utils.ImageLoader;
 import com.reactnativenavigation.utils.ImageLoadingListenerAdapter;
@@ -28,6 +29,7 @@ public class BottomTabPresenter {
     private final int defaultSelectedTextColor;
     private final int defaultTextColor;
     private final List<ViewController> tabs;
+    private final int defaultDotIndicatorSize;
 
     public BottomTabPresenter(Context context, List<ViewController> tabs, ImageLoader imageLoader, Options defaultOptions) {
         this.tabs = tabs;
@@ -37,6 +39,7 @@ public class BottomTabPresenter {
         this.defaultOptions = defaultOptions;
         defaultSelectedTextColor = defaultOptions.bottomTabOptions.selectedIconColor.get(ContextCompat.getColor(context, com.aurelhubert.ahbottomnavigation.R.color.colorBottomNavigationAccent));
         defaultTextColor = defaultOptions.bottomTabOptions.iconColor.get(ContextCompat.getColor(context, com.aurelhubert.ahbottomnavigation.R.color.colorBottomNavigationInactive));
+        defaultDotIndicatorSize = dpToPx(context, 6);
     }
 
     public void setDefaultOptions(Options defaultOptions) {
@@ -58,45 +61,63 @@ public class BottomTabPresenter {
             bottomTabs.setTitleInactiveTextSizeInSp(i, tab.fontSize.hasValue() ? Float.valueOf(tab.fontSize.get()) : null);
             bottomTabs.setTitleActiveTextSizeInSp(i, tab.selectedFontSize.hasValue() ? Float.valueOf(tab.selectedFontSize.get()) : null);
             if (tab.testId.hasValue()) bottomTabs.setTag(i, tab.testId.get());
-            applyBadge(i, tab);
+            if (shouldApplyDot(tab)) applyDotIndicator(i, tab.dotIndicator); else applyBadge(i, tab);
         }
     }
 
     public void mergeChildOptions(Options options, Component child) {
         int index = bottomTabFinder.findByComponent(child);
         if (index >= 0) {
-            BottomTabOptions bto = options.bottomTabOptions;
-            if (bto.fontFamily != null) bottomTabs.setTitleTypeface(index, bto.fontFamily);
-            if (bto.selectedIconColor.hasValue()) bottomTabs.setIconActiveColor(index, bto.selectedIconColor.get());
-            if (bto.iconColor.hasValue()) bottomTabs.setIconInactiveColor(index, bto.iconColor.get());
-            if (bto.selectedTextColor.hasValue()) bottomTabs.setTitleActiveColor(index, bto.selectedTextColor.get());
-            if (bto.textColor.hasValue()) bottomTabs.setTitleInactiveColor(index, bto.textColor.get());
-            if (bto.text.hasValue()) bottomTabs.setText(index, bto.text.get());
-            if (bto.icon.hasValue()) imageLoader.loadIcon(context, bto.icon.get(), new ImageLoadingListenerAdapter() {
+            BottomTabOptions tab = options.bottomTabOptions;
+            if (tab.fontFamily != null) bottomTabs.setTitleTypeface(index, tab.fontFamily);
+            if (tab.selectedIconColor.hasValue()) bottomTabs.setIconActiveColor(index, tab.selectedIconColor.get());
+            if (tab.iconColor.hasValue()) bottomTabs.setIconInactiveColor(index, tab.iconColor.get());
+            if (tab.selectedTextColor.hasValue()) bottomTabs.setTitleActiveColor(index, tab.selectedTextColor.get());
+            if (tab.textColor.hasValue()) bottomTabs.setTitleInactiveColor(index, tab.textColor.get());
+            if (tab.text.hasValue()) bottomTabs.setText(index, tab.text.get());
+            if (tab.icon.hasValue()) imageLoader.loadIcon(context, tab.icon.get(), new ImageLoadingListenerAdapter() {
                 @Override
                 public void onComplete(@NonNull Drawable drawable) {
                     bottomTabs.setIcon(index, drawable);
                 }
             });
-            if (bto.testId.hasValue()) bottomTabs.setTag(index, bto.testId.get());
-            mergeBadge(index, bto);
+            if (tab.testId.hasValue()) bottomTabs.setTag(index, tab.testId.get());
+            if (shouldApplyDot(tab)) mergeDotIndicator(index, tab.dotIndicator); else mergeBadge(index, tab);
         }
+    }
+
+    private void applyDotIndicator(int tabIndex, DotIndicatorOptions dotIndicator) {
+        AHNotification.Builder builder = new AHNotification.Builder();
+        builder.setText("");
+        builder.setBackgroundColor(dotIndicator.color.get(null));
+        builder.setSize(dotIndicator.size.get(defaultDotIndicatorSize));
+        bottomTabs.setNotification(builder.build(), tabIndex);
     }
 
     private void applyBadge(int tabIndex, BottomTabOptions tab) {
         AHNotification.Builder builder = new AHNotification.Builder();
         builder.setText(tab.badge.get(""));
         builder.setBackgroundColor(tab.badgeColor.get(null));
-        builder.setSize(dpToPx(bottomTabs.getContext(), tab.badgeSize.get(AHNotification.NOTIFICATION_SIZE_DEFAULT)));
         bottomTabs.setNotification(builder.build(), tabIndex);
     }
 
-    private void mergeBadge(int index, BottomTabOptions bto) {
+    private void mergeBadge(int index, BottomTabOptions tab) {
         AHNotification.Builder builder = new AHNotification.Builder();
-        if (bto.badge.hasValue()) builder.setText(bto.badge.get(""));
-        if (bto.badgeColor.hasValue()) builder.setBackgroundColor(bto.badgeColor.get());
-        if (bto.badgeSize.hasValue()) builder.setSize(dpToPx(bottomTabs.getContext(), bto.badgeSize.get()));
+        if (tab.badge.hasValue()) builder.setText(tab.badge.get(""));
+        if (tab.badgeColor.hasValue()) builder.setBackgroundColor(tab.badgeColor.get());
         AHNotification notification = builder.build();
         if (notification.hasValue()) bottomTabs.setNotification(notification, index);
+    }
+
+    private void mergeDotIndicator(int index, DotIndicatorOptions dotIndicator) {
+        AHNotification.Builder builder = new AHNotification.Builder();
+        if (dotIndicator.color.hasValue()) builder.setBackgroundColor(dotIndicator.color.get());
+        builder.setSize(dotIndicator.visible.isFalse() ? 0 : dotIndicator.size.get(defaultDotIndicatorSize));
+        AHNotification notification = builder.build();
+        if (notification.hasValue()) bottomTabs.setNotification(notification, index);
+    }
+
+    private boolean shouldApplyDot(BottomTabOptions tab) {
+        return tab.dotIndicator.visible.hasValue() && !tab.badge.hasValue();
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
@@ -87,26 +87,26 @@ public class BottomTabPresenter {
     }
 
     private void applyDotIndicator(int tabIndex, DotIndicatorOptions dotIndicator) {
-        AHNotification.Builder builder = new AHNotification.Builder();
-        builder.setText("");
-        builder.setBackgroundColor(dotIndicator.color.get(null));
-        builder.setSize(dotIndicator.size.get(defaultDotIndicatorSize));
+        AHNotification.Builder builder = new AHNotification.Builder()
+                .setText("")
+                .setBackgroundColor(dotIndicator.color.get(null))
+                .setSize(dotIndicator.size.get(defaultDotIndicatorSize));
         bottomTabs.setNotification(builder.build(), tabIndex);
     }
 
     private void applyBadge(int tabIndex, BottomTabOptions tab) {
-        AHNotification.Builder builder = new AHNotification.Builder();
-        builder.setText(tab.badge.get(""));
-        builder.setBackgroundColor(tab.badgeColor.get(null));
+        AHNotification.Builder builder = new AHNotification.Builder()
+                .setText(tab.badge.get(""))
+                .setBackgroundColor(tab.badgeColor.get(null));
         bottomTabs.setNotification(builder.build(), tabIndex);
     }
 
     private void mergeBadge(int index, BottomTabOptions tab) {
+        if (!tab.badge.hasValue()) return;
         AHNotification.Builder builder = new AHNotification.Builder();
-        if (tab.badge.hasValue()) builder.setText(tab.badge.get(null));
+        if (tab.badge.hasValue()) builder.setText(tab.badge.get());
         if (tab.badgeColor.hasValue()) builder.setBackgroundColor(tab.badgeColor.get());
-        AHNotification notification = builder.build();
-        if (tab.badge.hasValue()) bottomTabs.setNotification(notification, index);
+        bottomTabs.setNotification(builder.build(), index);
     }
 
     private void mergeDotIndicator(int index, DotIndicatorOptions dotIndicator) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/UiUtils.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/UiUtils.java
@@ -110,6 +110,7 @@ public class UiUtils {
     }
 
     public static int dpToPx(Context context, int dp) {
+        if (dp <= 0) return dp;
         Resources resources = context.getResources();
         DisplayMetrics metrics = resources.getDisplayMetrics();
         return (int) (dp * ((float)metrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT));

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/BottomTabs.java
@@ -3,7 +3,6 @@ package com.reactnativenavigation.views;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
-import android.support.annotation.ColorInt;
 import android.support.annotation.IntRange;
 
 import com.aurelhubert.ahbottomnavigation.AHBottomNavigation;
@@ -49,11 +48,6 @@ public class BottomTabs extends AHBottomNavigation {
 
     public void setBadge(int bottomTabIndex, String badge) {
         setNotification(badge, bottomTabIndex);
-    }
-
-    public void setBadgeColor(@ColorInt Integer color) {
-        if (color == null) return;
-        setNotificationBackgroundColor(color);
     }
 
     @Override

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabPresenterTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/BottomTabPresenterTest.java
@@ -3,6 +3,7 @@ package com.reactnativenavigation.viewcontrollers;
 import android.app.Activity;
 import android.graphics.Color;
 
+import com.aurelhubert.ahbottomnavigation.notification.AHNotification;
 import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.mocks.ImageLoaderMock;
 import com.reactnativenavigation.mocks.SimpleViewController;
@@ -19,6 +20,7 @@ import org.mockito.Mockito;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -53,7 +55,7 @@ public class BottomTabPresenterTest extends BaseTest {
     public void present() {
         uut.applyOptions();
         for (int i = 0; i < tabs.size(); i++) {
-            verify(bottomTabs, times(1)).setBadge(i, tabs.get(i).options.bottomTabOptions.badge.get(""));
+            verify(bottomTabs, times(1)).setNotification(any(AHNotification.class), eq(i));
             verify(bottomTabs, times(1)).setTitleInactiveColor(i, tabs.get(i).options.bottomTabOptions.textColor.get(null));
             verify(bottomTabs, times(1)).setTitleActiveColor(i, tabs.get(i).options.bottomTabOptions.selectedTextColor.get(null));
         }
@@ -64,7 +66,7 @@ public class BottomTabPresenterTest extends BaseTest {
         for (int i = 0; i < 2; i++) {
             Options options = tabs.get(i).options;
             uut.mergeChildOptions(options, (Component) tabs.get(i).getView());
-            verify(bottomTabs, times(1)).setBadge(i, options.bottomTabOptions.badge.get());
+            verify(bottomTabs, times(1)).setNotification(any(AHNotification.class), eq(i));
             verify(bottomTabs, times(1)).setIconActiveColor(eq(i), anyInt());
             verify(bottomTabs, times(1)).setIconInactiveColor(eq(i), anyInt());
         }

--- a/lib/ios/Bool.h
+++ b/lib/ios/Bool.h
@@ -10,4 +10,6 @@
 
 - (BOOL)getWithDefaultValue:(BOOL)value;
 
+- (bool) isFalse;
+
 @end

--- a/lib/ios/Bool.m
+++ b/lib/ios/Bool.m
@@ -29,4 +29,9 @@
 	}
 }
 
+- (bool)isFalse {
+    return self.value != nil && ![self.value boolValue];
+}
+
+
 @end

--- a/lib/ios/DotIndicatorOptions.h
+++ b/lib/ios/DotIndicatorOptions.h
@@ -1,0 +1,11 @@
+#import "RNNOptions.h"
+
+@interface DotIndicatorOptions : RNNOptions
+
+@property(nonatomic, strong) Color *color;
+@property(nonatomic, strong) Number *size;
+@property(nonatomic, strong) Bool *visible;
+
+- (bool)hasValue;
+
+@end

--- a/lib/ios/DotIndicatorOptions.m
+++ b/lib/ios/DotIndicatorOptions.m
@@ -1,4 +1,7 @@
 #import "DotIndicatorOptions.h"
+#import "NullColor.h"
+#import "NullNumber.h"
+#import "NullBool.h"
 
 
 @implementation DotIndicatorOptions
@@ -8,6 +11,13 @@
     self.color = [ColorParser parse:dict key:@"color"];
     self.size = [NumberParser parse:dict key:@"size"];
     self.visible = [BoolParser parse:dict key:@"visible"];
+    return self;
+}
+
+- (instancetype)init {
+    _color = [NullColor new];
+    _size = [NullNumber new];
+    _visible = [NullBool new];
     return self;
 }
 

--- a/lib/ios/DotIndicatorOptions.m
+++ b/lib/ios/DotIndicatorOptions.m
@@ -1,0 +1,18 @@
+#import "DotIndicatorOptions.h"
+
+
+@implementation DotIndicatorOptions
+- (instancetype)initWithDict:(NSDictionary *)dict {
+    self = [super init];
+
+    self.color = [ColorParser parse:dict key:@"color"];
+    self.size = [NumberParser parse:dict key:@"size"];
+    self.visible = [BoolParser parse:dict key:@"visible"];
+    return self;
+}
+
+- (bool)hasValue {
+    return [self.visible hasValue];
+}
+
+@end

--- a/lib/ios/DotIndicatorParser.h
+++ b/lib/ios/DotIndicatorParser.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@class DotIndicatorOptions;
+
+@interface DotIndicatorParser : NSObject
++ (DotIndicatorOptions *)parse:(NSDictionary *)dict;
+@end

--- a/lib/ios/DotIndicatorParser.m
+++ b/lib/ios/DotIndicatorParser.m
@@ -1,0 +1,10 @@
+#import "DotIndicatorParser.h"
+#import "DotIndicatorOptions.h"
+
+
+@implementation DotIndicatorParser
++ (DotIndicatorOptions *)parse:(NSDictionary *)dict {
+    return [[DotIndicatorOptions alloc] initWithDict:dict[@"dotIndicator"]];
+}
+
+@end

--- a/lib/ios/RNNBasePresenter.h
+++ b/lib/ios/RNNBasePresenter.h
@@ -6,9 +6,9 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 @property(nonatomic, weak) id boundViewController;
 
-@property(nonatomic, strong) NSString *bindedComponentId;
+@property(nonatomic, strong) NSString *boundComponentId;
 
-- (void)bindViewController:(UIViewController *)bindedViewController;
+- (void)bindViewController:(UIViewController *)boundViewController;
 
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)initialOptions;
 

--- a/lib/ios/RNNBasePresenter.h
+++ b/lib/ios/RNNBasePresenter.h
@@ -4,7 +4,7 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 @interface RNNBasePresenter : NSObject
 
-@property(nonatomic, weak) id bindedViewController;
+@property(nonatomic, weak) id boundViewController;
 
 @property(nonatomic, strong) NSString *bindedComponentId;
 

--- a/lib/ios/RNNBasePresenter.h
+++ b/lib/ios/RNNBasePresenter.h
@@ -4,9 +4,9 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 @interface RNNBasePresenter : NSObject
 
-@property (nonatomic, weak) id bindedViewController;
+@property(nonatomic, weak) id bindedViewController;
 
-@property (nonatomic, strong) NSString* bindedComponentId;
+@property(nonatomic, strong) NSString *bindedComponentId;
 
 - (void)bindViewController:(UIViewController *)bindedViewController;
 
@@ -18,8 +18,11 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 - (void)applyOptionsOnWillMoveToParentViewController:(RNNNavigationOptions *)options;
 
+- (void)applyBadgeSize:(UIViewController *)child;
+
 - (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions;
 
 - (void)renderComponents:(RNNNavigationOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock;
 
+- (void)viewDidLayoutSubviews;
 @end

--- a/lib/ios/RNNBasePresenter.h
+++ b/lib/ios/RNNBasePresenter.h
@@ -18,7 +18,7 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 - (void)applyOptionsOnWillMoveToParentViewController:(RNNNavigationOptions *)options;
 
-- (void)applyBadgeSize:(UIViewController *)child;
+- (void)applyDotIndicator:(UIViewController *)child;
 
 - (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions;
 

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -5,11 +5,19 @@
 #import "UIViewController+LayoutProtocol.h"
 #import "DotIndicatorOptions.h"
 #import "UITabBar+Utils.h"
+#import "RNNDotIndicatorPresenter.h"
 
 @interface RNNBasePresenter ()
+@property(nonatomic, strong) RNNDotIndicatorPresenter* dotIndicatorPresenter;
 @end
 
 @implementation RNNBasePresenter
+
+-(instancetype)init {
+    self = [super init];
+    self.dotIndicatorPresenter = [RNNDotIndicatorPresenter new];
+    return self;
+}
 
 - (void)bindViewController:(UIViewController <RNNLayoutProtocol> *)boundViewController {
     self.boundComponentId = boundViewController.layoutInfo.componentId;
@@ -91,7 +99,7 @@
     }
 
     if ([newOptions.bottomTab.dotIndicator hasValue] && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
-        [self applyDotIndicator:viewController];
+        [[self dotIndicatorPresenter] apply:viewController];
     }
 
     if (newOptions.bottomTab.text.hasValue) {
@@ -149,44 +157,6 @@
 }
 
 - (void)applyDotIndicator:(UIViewController *)child {
-    DotIndicatorOptions *options = [[self boundViewController] resolveChildOptions:child].bottomTab.dotIndicator;
-    if (![options hasValue]) return;
-
-    if ([options.visible isFalse] && [child tabBarItem].tag > 0) {
-        UIView *view = [[[[self boundViewController] tabBarController] tabBar] viewWithTag:[child tabBarItem].tag];
-        [view removeFromSuperview];
-        [child tabBarItem].tag = -1;
-        return;
-    }
-
-    if ([child tabBarItem].tag > 0) return;
-
-    UITabBarController *bottomTabs = [self getTabBarController];
-    int index = (int) [[bottomTabs childViewControllers] indexOfObject:child];
-    UITabBar *tabBar = [bottomTabs tabBar];
-    UIView *tab = [tabBar getTabView:index];
-    UIView *icon = [tabBar getTabIcon:index];
-
-    float size = [[options.size getWithDefaultValue:@6] floatValue];
-    UIView *badge = [UIView new];
-    badge.translatesAutoresizingMaskIntoConstraints = NO;
-
-    badge.layer.cornerRadius = size / 2;
-    badge.backgroundColor = [options.color getWithDefaultValue:[UIColor redColor]];
-    badge.tag = arc4random();
-
-    [child tabBarItem].tag = badge.tag;
-    [tab addSubview:badge];
-
-    [NSLayoutConstraint activateConstraints:@[
-            [badge.leftAnchor constraintEqualToAnchor:icon.rightAnchor constant:-size / 2],
-            [badge.topAnchor constraintEqualToAnchor:icon.topAnchor constant:-size / 2],
-            [badge.widthAnchor constraintEqualToConstant:size],
-            [badge.heightAnchor constraintEqualToConstant:size]
-    ]];
-}
-
-- (UITabBarController *)getTabBarController {
-    return [[self boundViewController] isKindOfClass:[UITabBarController class]] ? [self boundViewController] : [[self boundViewController] tabBarController];
+    [[self dotIndicatorPresenter] apply:child];
 }
 @end

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -98,7 +98,7 @@
     }
 
     if ([newOptions.bottomTab.dotIndicator hasValue] && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
-        [[self dotIndicatorPresenter] apply:viewController];
+        [[self dotIndicatorPresenter] apply:viewController:newOptions.bottomTab.dotIndicator];
     }
 
     if (newOptions.bottomTab.text.hasValue) {
@@ -156,6 +156,6 @@
 }
 
 - (void)applyDotIndicator:(UIViewController *)child {
-    [[self dotIndicatorPresenter] apply:child];
+    [[self dotIndicatorPresenter] apply:child:[child resolveOptions].bottomTab.dotIndicator];
 }
 @end

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -3,19 +3,17 @@
 #import "RNNTabBarItemCreator.h"
 #import "RNNReactComponentRegistry.h"
 #import "UIViewController+LayoutProtocol.h"
-#import "UITabBar+Utils.h"
-#import "UIView+Utils.h"
 #import "DotIndicatorOptions.h"
+#import "UITabBar+Utils.h"
 
 @interface RNNBasePresenter ()
 @end
 
-
 @implementation RNNBasePresenter
 
-- (void)bindViewController:(UIViewController <RNNLayoutProtocol> *)bindedViewController {
-    self.bindedComponentId = bindedViewController.layoutInfo.componentId;
-    _boundViewController = bindedViewController;
+- (void)bindViewController:(UIViewController <RNNLayoutProtocol> *)boundViewController {
+    self.boundComponentId = boundViewController.layoutInfo.componentId;
+    _boundViewController = boundViewController;
 }
 
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)initialOptions {

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -4,7 +4,6 @@
 #import "RNNReactComponentRegistry.h"
 #import "UIViewController+LayoutProtocol.h"
 #import "DotIndicatorOptions.h"
-#import "UITabBar+Utils.h"
 #import "RNNDotIndicatorPresenter.h"
 
 @interface RNNBasePresenter ()

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -151,10 +151,11 @@
 
 - (void)applyBadgeSize:(UIViewController *)child {
     RNNNavigationOptions *options = [[self boundViewController] resolveChildOptions:child];
-    if (![options.bottomTab.badgeSize hasValue]) return;
+    if ([options.bottomTab.badgeSize hasValue] == false) return;
 
-    if (options.bottomTab.badgeSize.get.floatValue == 0 && [child tabBarItem].tag > 0) {
-        [[[[[self boundViewController] tabBarController] tabBar] viewWithTag:[child tabBarItem].tag] removeFromSuperview];
+    if (options.bottomTab.badgeSize.get.floatValue <= 0 && [child tabBarItem].tag > 0) {
+        UIView *view = [[[[self boundViewController] tabBarController] tabBar] viewWithTag:[child tabBarItem].tag];
+        [view removeFromSuperview];
         [child tabBarItem].tag = -1;
         return;
     }
@@ -164,6 +165,7 @@
     UITabBarController *bottomTabs = [self getTabBarController];
     int index = (int) [[bottomTabs childViewControllers] indexOfObject:child];
     UITabBar *tabBar = [bottomTabs tabBar];
+    UIView * tab = [tabBar getTabView:index];
     UIView *icon = [tabBar getTabIcon:index];
 
     float size = [options.bottomTab.badgeSize.get floatValue];
@@ -175,7 +177,7 @@
     badge.tag = arc4random();
 
     [child tabBarItem].tag = badge.tag;
-    [child.tabBarController.tabBar addSubview:badge];
+    [tab addSubview:badge];
 
     [NSLayoutConstraint activateConstraints:@[
             [badge.leftAnchor constraintEqualToAnchor:icon.rightAnchor constant:-size / 2],

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -5,6 +5,7 @@
 #import "UIViewController+LayoutProtocol.h"
 #import "UITabBar+Utils.h"
 #import "UIView+Utils.h"
+#import "DotIndicatorOptions.h"
 
 @interface RNNBasePresenter ()
 @end
@@ -91,8 +92,8 @@
         [viewController rnn_setTabBarItemBadgeColor:newOptions.bottomTab.badgeColor.get];
     }
 
-    if (newOptions.bottomTab.badgeSize.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
-        [self applyBadgeSize:viewController];
+    if ([newOptions.bottomTab.dotIndicator hasValue] && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
+        [self applyDotIndicator:viewController];
     }
 
     if (newOptions.bottomTab.text.hasValue) {
@@ -149,11 +150,11 @@
 
 }
 
-- (void)applyBadgeSize:(UIViewController *)child {
-    RNNNavigationOptions *options = [[self boundViewController] resolveChildOptions:child];
-    if ([options.bottomTab.badgeSize hasValue] == false) return;
+- (void)applyDotIndicator:(UIViewController *)child {
+    DotIndicatorOptions *options = [[self boundViewController] resolveChildOptions:child].bottomTab.dotIndicator;
+    if (![options hasValue]) return;
 
-    if (options.bottomTab.badgeSize.get.floatValue <= 0 && [child tabBarItem].tag > 0) {
+    if ([options.visible isFalse] && [child tabBarItem].tag > 0) {
         UIView *view = [[[[self boundViewController] tabBarController] tabBar] viewWithTag:[child tabBarItem].tag];
         [view removeFromSuperview];
         [child tabBarItem].tag = -1;
@@ -165,15 +166,15 @@
     UITabBarController *bottomTabs = [self getTabBarController];
     int index = (int) [[bottomTabs childViewControllers] indexOfObject:child];
     UITabBar *tabBar = [bottomTabs tabBar];
-    UIView * tab = [tabBar getTabView:index];
+    UIView *tab = [tabBar getTabView:index];
     UIView *icon = [tabBar getTabIcon:index];
 
-    float size = [options.bottomTab.badgeSize.get floatValue];
+    float size = [[options.size getWithDefaultValue:@6] floatValue];
     UIView *badge = [UIView new];
     badge.translatesAutoresizingMaskIntoConstraints = NO;
 
     badge.layer.cornerRadius = size / 2;
-    badge.backgroundColor = UIColor.redColor;
+    badge.backgroundColor = [options.color getWithDefaultValue:[UIColor redColor]];
     badge.tag = arc4random();
 
     [child tabBarItem].tag = badge.tag;

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -3,6 +3,8 @@
 #import "RNNTabBarItemCreator.h"
 #import "RNNReactComponentRegistry.h"
 #import "UIViewController+LayoutProtocol.h"
+#import "UITabBar+Utils.h"
+#import "UIView+Utils.h"
 
 @interface RNNBasePresenter ()
 @end
@@ -10,133 +12,182 @@
 
 @implementation RNNBasePresenter
 
-- (void)bindViewController:(UIViewController<RNNLayoutProtocol> *)bindedViewController {
-	self.bindedComponentId = bindedViewController.layoutInfo.componentId;
-	_bindedViewController = bindedViewController;
+- (void)bindViewController:(UIViewController <RNNLayoutProtocol> *)bindedViewController {
+    self.bindedComponentId = bindedViewController.layoutInfo.componentId;
+    _bindedViewController = bindedViewController;
 }
 
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)initialOptions {
-	
+
 }
 
 - (void)applyOptionsOnViewDidLayoutSubviews:(RNNNavigationOptions *)options {
-	
+
 }
 
 - (void)applyOptionsOnWillMoveToParentViewController:(RNNNavigationOptions *)options {
-	UIViewController* viewController = self.bindedViewController;
-	
-	if (options.bottomTab.text.hasValue) {
-		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
-		viewController.tabBarItem = tabItem;
-	}
-	
-	if (options.bottomTab.icon.hasValue) {
-		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
-		viewController.tabBarItem = tabItem;
-	}
-	
-	if (options.bottomTab.selectedIcon.hasValue) {
-		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
-		viewController.tabBarItem = tabItem;
-	}
-	
-	if (options.bottomTab.badgeColor.hasValue) {
-		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
-		viewController.tabBarItem = tabItem;
-	}
-	
-	if (options.bottomTab.textColor.hasValue) {
-		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
-		viewController.tabBarItem = tabItem;
-	}
-	
-	if (options.bottomTab.iconColor.hasValue) {
-		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
-		viewController.tabBarItem = tabItem;
-	}
-	
-	if (options.bottomTab.selectedTextColor.hasValue) {
-		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
-		viewController.tabBarItem = tabItem;
-	}
-	
-	if (options.bottomTab.selectedIconColor.hasValue) {
-		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
-		viewController.tabBarItem = tabItem;
-	}
+    UIViewController *viewController = self.bindedViewController;
+
+    if (options.bottomTab.text.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+        viewController.tabBarItem = tabItem;
+    }
+
+    if (options.bottomTab.icon.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+        viewController.tabBarItem = tabItem;
+    }
+
+    if (options.bottomTab.selectedIcon.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+        viewController.tabBarItem = tabItem;
+    }
+
+    if (options.bottomTab.badgeColor.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+        viewController.tabBarItem = tabItem;
+    }
+
+    if (options.bottomTab.textColor.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+        viewController.tabBarItem = tabItem;
+    }
+
+    if (options.bottomTab.iconColor.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+        viewController.tabBarItem = tabItem;
+    }
+
+    if (options.bottomTab.selectedTextColor.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+        viewController.tabBarItem = tabItem;
+    }
+
+    if (options.bottomTab.selectedIconColor.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+        viewController.tabBarItem = tabItem;
+    }
 }
 
 - (void)applyOptions:(RNNNavigationOptions *)options {
-	UIViewController* viewController = self.bindedViewController;
-	
-	if (options.bottomTab.badge.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
-		[viewController rnn_setTabBarItemBadge:options.bottomTab.badge.get];
-	}
-	
-	if (options.bottomTab.badgeColor.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
-		[viewController rnn_setTabBarItemBadgeColor:options.bottomTab.badgeColor.get];
-	}
+    UIViewController *viewController = self.bindedViewController;
+
+    if (options.bottomTab.badge.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
+        [viewController rnn_setTabBarItemBadge:options.bottomTab];
+    }
+
+    if (options.bottomTab.badgeColor.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
+        [viewController rnn_setTabBarItemBadgeColor:options.bottomTab.badgeColor.get];
+    }
 }
 
 - (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions {
-	UIViewController* viewController = self.bindedViewController;
-	if (newOptions.bottomTab.badge.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
-		[viewController rnn_setTabBarItemBadge:newOptions.bottomTab.badge.get];
-	}
-	
-	if (newOptions.bottomTab.badgeColor.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
-		[viewController rnn_setTabBarItemBadgeColor:newOptions.bottomTab.badgeColor.get];
-	}
-	
-	if (newOptions.bottomTab.text.hasValue) {
-		RNNNavigationOptions* buttonsResolvedOptions = [(RNNNavigationOptions *)[currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
-		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
-		viewController.tabBarItem = tabItem;
-	}
-	
-	if (newOptions.bottomTab.icon.hasValue) {
-		RNNNavigationOptions* buttonsResolvedOptions = [(RNNNavigationOptions *)[currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
-		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
-		viewController.tabBarItem = tabItem;
-	}
-	
-	if (newOptions.bottomTab.selectedIcon.hasValue) {
-		RNNNavigationOptions* buttonsResolvedOptions = [(RNNNavigationOptions *)[currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
-		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
-		viewController.tabBarItem = tabItem;
-	}
-	
-	if (newOptions.bottomTab.textColor.hasValue) {
-		RNNNavigationOptions* buttonsResolvedOptions = [(RNNNavigationOptions *)[currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
-		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
-		viewController.tabBarItem = tabItem;
-	}
-	
-	if (newOptions.bottomTab.selectedTextColor.hasValue) {
-		RNNNavigationOptions* buttonsResolvedOptions = [(RNNNavigationOptions *)[currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
-		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
-		viewController.tabBarItem = tabItem;
-	}
-	
-	if (newOptions.bottomTab.iconColor.hasValue) {
-		RNNNavigationOptions* buttonsResolvedOptions = [(RNNNavigationOptions *)[currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
-		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
-		viewController.tabBarItem = tabItem;
-	}
-	
-	if (newOptions.bottomTab.selectedIconColor.hasValue) {
-		RNNNavigationOptions* buttonsResolvedOptions = [(RNNNavigationOptions *)[currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
-		UITabBarItem* tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
-		viewController.tabBarItem = tabItem;
-	}
+    UIViewController *viewController = self.bindedViewController;
+    if (newOptions.bottomTab.badge.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
+        [viewController rnn_setTabBarItemBadge:newOptions.bottomTab];
+    }
+
+    if (newOptions.bottomTab.badgeColor.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
+        [viewController rnn_setTabBarItemBadgeColor:newOptions.bottomTab.badgeColor.get];
+    }
+
+    if (newOptions.bottomTab.badgeSize.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
+        [self applyBadgeSize:viewController];
+    }
+
+    if (newOptions.bottomTab.text.hasValue) {
+        RNNNavigationOptions *buttonsResolvedOptions = [(RNNNavigationOptions *) [currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
+        viewController.tabBarItem = tabItem;
+    }
+
+    if (newOptions.bottomTab.icon.hasValue) {
+        RNNNavigationOptions *buttonsResolvedOptions = [(RNNNavigationOptions *) [currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
+        viewController.tabBarItem = tabItem;
+    }
+
+    if (newOptions.bottomTab.selectedIcon.hasValue) {
+        RNNNavigationOptions *buttonsResolvedOptions = [(RNNNavigationOptions *) [currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
+        viewController.tabBarItem = tabItem;
+    }
+
+    if (newOptions.bottomTab.textColor.hasValue) {
+        RNNNavigationOptions *buttonsResolvedOptions = [(RNNNavigationOptions *) [currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
+        viewController.tabBarItem = tabItem;
+    }
+
+    if (newOptions.bottomTab.selectedTextColor.hasValue) {
+        RNNNavigationOptions *buttonsResolvedOptions = [(RNNNavigationOptions *) [currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
+        viewController.tabBarItem = tabItem;
+    }
+
+    if (newOptions.bottomTab.iconColor.hasValue) {
+        RNNNavigationOptions *buttonsResolvedOptions = [(RNNNavigationOptions *) [currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
+        viewController.tabBarItem = tabItem;
+    }
+
+    if (newOptions.bottomTab.selectedIconColor.hasValue) {
+        RNNNavigationOptions *buttonsResolvedOptions = [(RNNNavigationOptions *) [currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
+        viewController.tabBarItem = tabItem;
+    }
 }
 
 - (void)renderComponents:(RNNNavigationOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock {
-	if (readyBlock) {
-		readyBlock();
-		readyBlock = nil;
-	}
+    if (readyBlock) {
+        readyBlock();
+        readyBlock = nil;
+    }
 }
 
+- (void)viewDidLayoutSubviews {
+
+}
+
+- (void)applyBadgeSize:(UIViewController *)child {
+    RNNNavigationOptions *options = [[self bindedViewController] resolveChildOptions:child];
+    if ([options.bottomTab.badgeSize hasValue]) {
+        if (options.bottomTab.badgeSize.get.floatValue <= 0) {
+            if ([child tabBarItem].tag > 0) {
+                [[[[[self bindedViewController] tabBarController] tabBar] viewWithTag:[child tabBarItem].tag] removeFromSuperview];
+                [child tabBarItem].tag = -1;
+            }
+            return;
+        }
+
+        if ([child tabBarItem].tag > 0) return;
+
+        UITabBarController *bottomTabs = [self getTabBarController];
+        int index = (int) [[bottomTabs childViewControllers] indexOfObject:child];
+        UITabBar *tabBar = [bottomTabs tabBar];
+        UIView *icon = [tabBar getTabIcon:index];
+
+        float size = [options.bottomTab.badgeSize.get floatValue];
+        UIView *badge = [UIView new];
+        badge.translatesAutoresizingMaskIntoConstraints = NO;
+
+        badge.layer.cornerRadius = size / 2;
+        badge.backgroundColor = UIColor.redColor;
+        badge.tag = arc4random();
+
+        [child tabBarItem].tag = badge.tag;
+        [child.tabBarController.tabBar addSubview:badge];
+
+        [NSLayoutConstraint activateConstraints:@[
+                [badge.leftAnchor constraintEqualToAnchor:icon.rightAnchor constant:-size / 2],
+                [badge.topAnchor constraintEqualToAnchor:icon.topAnchor constant:-size / 2],
+                [badge.widthAnchor constraintEqualToConstant:size],
+                [badge.heightAnchor constraintEqualToConstant:size]
+        ]];
+    }
+}
+
+- (UITabBarController *)getTabBarController {
+    return [[self bindedViewController] isKindOfClass:[UITabBarController class]] ? [self bindedViewController] : [[self bindedViewController] tabBarController];
+}
 @end

--- a/lib/ios/RNNBottomTabOptions.h
+++ b/lib/ios/RNNBottomTabOptions.h
@@ -5,6 +5,7 @@
 @property (nonatomic) NSUInteger tag;
 @property (nonatomic, strong) Text* text;
 @property (nonatomic, strong) Text* badge;
+@property (nonatomic, strong) Number* badgeSize;
 @property (nonatomic, strong) Text* fontFamily;
 @property (nonatomic, strong) Text* testID;
 @property (nonatomic, strong) Color* badgeColor;

--- a/lib/ios/RNNBottomTabOptions.h
+++ b/lib/ios/RNNBottomTabOptions.h
@@ -1,23 +1,25 @@
 #import "RNNOptions.h"
 
+@class DotIndicatorOptions;
+
 @interface RNNBottomTabOptions : RNNOptions
 
-@property (nonatomic) NSUInteger tag;
-@property (nonatomic, strong) Text* text;
-@property (nonatomic, strong) Text* badge;
-@property (nonatomic, strong) Number* badgeSize;
-@property (nonatomic, strong) Text* fontFamily;
-@property (nonatomic, strong) Text* testID;
-@property (nonatomic, strong) Color* badgeColor;
-@property (nonatomic, strong) Image* icon;
-@property (nonatomic, strong) Image* selectedIcon;
-@property (nonatomic, strong) Color* iconColor;
-@property (nonatomic, strong) Color* selectedIconColor;
-@property (nonatomic, strong) Color* selectedTextColor;
-@property (nonatomic, strong) Dictionary* iconInsets;
-@property (nonatomic, strong) Color* textColor;
-@property (nonatomic, strong) Number* fontSize;
-@property (nonatomic, strong) Bool* visible;
+@property(nonatomic) NSUInteger tag;
+@property(nonatomic, strong) Text *text;
+@property(nonatomic, strong) Text *badge;
+@property(nonatomic, strong) Color *badgeColor;
+@property(nonatomic, strong) DotIndicatorOptions *dotIndicator;
+@property(nonatomic, strong) Text *fontFamily;
+@property(nonatomic, strong) Text *testID;
+@property(nonatomic, strong) Image *icon;
+@property(nonatomic, strong) Image *selectedIcon;
+@property(nonatomic, strong) Color *iconColor;
+@property(nonatomic, strong) Color *selectedIconColor;
+@property(nonatomic, strong) Color *selectedTextColor;
+@property(nonatomic, strong) Dictionary *iconInsets;
+@property(nonatomic, strong) Color *textColor;
+@property(nonatomic, strong) Number *fontSize;
+@property(nonatomic, strong) Bool *visible;
 
 
 @end

--- a/lib/ios/RNNBottomTabOptions.m
+++ b/lib/ios/RNNBottomTabOptions.m
@@ -1,21 +1,18 @@
 #import "RNNBottomTabOptions.h"
-#import "UIImage+tint.h"
-#import "UITabBarController+RNNOptions.h"
-#import "UIViewController+RNNOptions.h"
-#import "RNNTabBarItemCreator.h"
 
 @implementation RNNBottomTabOptions
 
 - (instancetype)initWithDict:(NSDictionary *)dict {
 	self = [super init];
+	self.tag = arc4random();
 	
 	self.text = [TextParser parse:dict key:@"text"];
 	self.badge = [TextParser parse:dict key:@"badge"];
+	self.badgeSize = [NumberParser parse:dict key:@"badgeSize"];
+	self.badgeColor = [ColorParser parse:dict key:@"badgeColor"];
 	self.fontFamily = [TextParser parse:dict key:@"fontFamily"];
 	self.testID = [TextParser parse:dict key:@"testID"];
-	
-	
-	self.badgeColor = [ColorParser parse:dict key:@"badgeColor"];
+
 	self.icon = [ImageParser parse:dict key:@"icon"];
 	self.selectedIcon = [ImageParser parse:dict key:@"selectedIcon"];
 	self.iconColor = [ColorParser parse:dict key:@"iconColor"];
@@ -28,16 +25,6 @@
 	self.visible = [BoolParser parse:dict key:@"visible"];
 	
 	return self;
-}
-
--(void)resetOptions {
-	self.text = nil;
-	self.badge = nil;
-	self.visible = nil;
-	self.icon = nil;
-	self.testID = nil;
-	self.iconInsets = nil;
-	self.selectedIcon = nil;
 }
 
 @end

--- a/lib/ios/RNNBottomTabOptions.m
+++ b/lib/ios/RNNBottomTabOptions.m
@@ -1,30 +1,33 @@
 #import "RNNBottomTabOptions.h"
+#import "DotIndicatorOptions.h"
+#import "DotIndicatorParser.h"
 
 @implementation RNNBottomTabOptions
 
 - (instancetype)initWithDict:(NSDictionary *)dict {
-	self = [super init];
-	self.tag = arc4random();
-	
-	self.text = [TextParser parse:dict key:@"text"];
-	self.badge = [TextParser parse:dict key:@"badge"];
-	self.badgeSize = [NumberParser parse:dict key:@"badgeSize"];
-	self.badgeColor = [ColorParser parse:dict key:@"badgeColor"];
-	self.fontFamily = [TextParser parse:dict key:@"fontFamily"];
-	self.testID = [TextParser parse:dict key:@"testID"];
+    self = [super init];
+    self.tag = arc4random();
 
-	self.icon = [ImageParser parse:dict key:@"icon"];
-	self.selectedIcon = [ImageParser parse:dict key:@"selectedIcon"];
-	self.iconColor = [ColorParser parse:dict key:@"iconColor"];
-	self.selectedIconColor = [ColorParser parse:dict key:@"selectedIconColor"];
-	self.selectedTextColor = [ColorParser parse:dict key:@"selectedTextColor"];
-	self.iconInsets = [DictionaryParser parse:dict key:@"iconInsets"];
-	
-	self.textColor = [ColorParser parse:dict key:@"textColor"];
-	self.fontSize = [NumberParser parse:dict key:@"fontSize"];
-	self.visible = [BoolParser parse:dict key:@"visible"];
-	
-	return self;
+    self.text = [TextParser parse:dict key:@"text"];
+    self.badge = [TextParser parse:dict key:@"badge"];
+    self.badgeColor = [ColorParser parse:dict key:@"badgeColor"];
+    self.fontFamily = [TextParser parse:dict key:@"fontFamily"];
+    self.testID = [TextParser parse:dict key:@"testID"];
+
+    self.dotIndicator = [DotIndicatorParser parse:dict];
+
+    self.icon = [ImageParser parse:dict key:@"icon"];
+    self.selectedIcon = [ImageParser parse:dict key:@"selectedIcon"];
+    self.iconColor = [ColorParser parse:dict key:@"iconColor"];
+    self.selectedIconColor = [ColorParser parse:dict key:@"selectedIconColor"];
+    self.selectedTextColor = [ColorParser parse:dict key:@"selectedTextColor"];
+    self.iconInsets = [DictionaryParser parse:dict key:@"iconInsets"];
+
+    self.textColor = [ColorParser parse:dict key:@"textColor"];
+    self.fontSize = [NumberParser parse:dict key:@"fontSize"];
+    self.visible = [BoolParser parse:dict key:@"visible"];
+
+    return self;
 }
 
 @end

--- a/lib/ios/RNNControllerFactory.m
+++ b/lib/ios/RNNControllerFactory.m
@@ -62,7 +62,7 @@
 	}
 	
 	else if (node.isTabs) {
-		result = [self createTabs:node];
+		result = [self createBottomTabs:node];
 	}
 	
 	else if (node.isTopTabs) {
@@ -120,7 +120,7 @@
 	RNNRootViewController* component = [[RNNRootViewController alloc] initExternalComponentWithLayoutInfo:layoutInfo eventEmitter:_eventEmitter presenter:presenter options:options defaultOptions:_defaultOptions];
 	[component bindViewController:externalVC];
 	
-	return (UIViewController *)component;
+	return component;
 }
 
 
@@ -136,10 +136,10 @@
 	return stack;
 }
 
--(UIViewController *)createTabs:(RNNLayoutNode*)node {
+-(UIViewController *)createBottomTabs:(RNNLayoutNode*)node {
 	RNNLayoutInfo* layoutInfo = [[RNNLayoutInfo alloc] initWithNode:node];
 	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];;
-	RNNTabBarPresenter* presenter = [[RNNTabBarPresenter alloc] init];
+	RNNTabBarPresenter* presenter = [RNNTabBarPresenter new];
 
 	NSArray *childViewControllers = [self extractChildrenViewControllersFromNode:node];
 	

--- a/lib/ios/RNNControllerFactory.m
+++ b/lib/ios/RNNControllerFactory.m
@@ -1,20 +1,10 @@
 #import "RNNControllerFactory.h"
-#import "RNNLayoutNode.h"
 #import "RNNSplitViewController.h"
-#import "RNNSplitViewOptions.h"
 #import "RNNSideMenuController.h"
-#import "RNNSideMenuChildVC.h"
 #import "RNNNavigationController.h"
 #import "RNNTabBarController.h"
 #import "RNNTopTabsViewController.h"
-#import "RNNLayoutInfo.h"
 #import "RNNRootViewController.h"
-#import "UIViewController+SideMenuController.h"
-#import "RNNViewControllerPresenter.h"
-#import "RNNNavigationControllerPresenter.h"
-#import "RNNTabBarPresenter.h"
-#import "RNNSideMenuPresenter.h"
-#import "RNNSplitViewControllerPresenter.h"
 
 @implementation RNNControllerFactory {
 	id<RNNRootViewCreator> _creator;
@@ -117,7 +107,7 @@
 	
 	RNNRootViewController* component = [[RNNRootViewController alloc] initWithLayoutInfo:layoutInfo rootViewCreator:_creator eventEmitter:_eventEmitter presenter:presenter options:options defaultOptions:_defaultOptions];
 	
-	return (UIViewController *)component;
+	return component;
 }
 
 - (UIViewController *)createExternalComponent:(RNNLayoutNode*)node {
@@ -153,7 +143,14 @@
 
 	NSArray *childViewControllers = [self extractChildrenViewControllersFromNode:node];
 	
-	RNNTabBarController* tabsController = [[RNNTabBarController alloc] initWithLayoutInfo:layoutInfo creator:_creator options:options defaultOptions:_defaultOptions presenter:presenter eventEmitter:_eventEmitter childViewControllers:childViewControllers];
+	RNNTabBarController* tabsController = [[RNNTabBarController alloc] initWithLayoutInfo:layoutInfo
+            creator:_creator
+            options:options
+			defaultOptions:_defaultOptions
+			presenter:presenter
+			eventEmitter:_eventEmitter
+			childViewControllers:childViewControllers
+	];
 	
 	return tabsController;
 }

--- a/lib/ios/RNNDotIndicatorPresenter.h
+++ b/lib/ios/RNNDotIndicatorPresenter.h
@@ -1,8 +1,9 @@
 #import <Foundation/Foundation.h>
 
 @class UIViewController;
+@class DotIndicatorOptions;
 
 
 @interface RNNDotIndicatorPresenter : NSObject
-- (void)apply:(UIViewController *)child;
+- (void)apply:(UIViewController *)child: (DotIndicatorOptions *) options;
 @end

--- a/lib/ios/RNNDotIndicatorPresenter.h
+++ b/lib/ios/RNNDotIndicatorPresenter.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+@class UIViewController;
+
+
+@interface RNNDotIndicatorPresenter : NSObject
+- (void)apply:(UIViewController *)child;
+@end

--- a/lib/ios/RNNDotIndicatorPresenter.h
+++ b/lib/ios/RNNDotIndicatorPresenter.h
@@ -5,5 +5,5 @@
 
 
 @interface RNNDotIndicatorPresenter : NSObject
-- (void)apply:(UIViewController *)child: (DotIndicatorOptions *) options;
+- (void)apply:(UIViewController *)child :(DotIndicatorOptions *)options;
 @end

--- a/lib/ios/RNNDotIndicatorPresenter.m
+++ b/lib/ios/RNNDotIndicatorPresenter.m
@@ -3,7 +3,6 @@
 #import "UIViewController+LayoutProtocol.h"
 #import "DotIndicatorOptions.h"
 #import "UITabBarController+RNNUtils.h"
-#import "BottomTabsViewFinder.h"
 
 @implementation RNNDotIndicatorPresenter
 

--- a/lib/ios/RNNDotIndicatorPresenter.m
+++ b/lib/ios/RNNDotIndicatorPresenter.m
@@ -3,6 +3,7 @@
 #import "UIViewController+LayoutProtocol.h"
 #import "DotIndicatorOptions.h"
 #import "UITabBarController+RNNUtils.h"
+#import "BottomTabsViewFinder.h"
 
 @implementation RNNDotIndicatorPresenter
 

--- a/lib/ios/RNNDotIndicatorPresenter.m
+++ b/lib/ios/RNNDotIndicatorPresenter.m
@@ -6,8 +6,7 @@
 
 @implementation RNNDotIndicatorPresenter
 
-- (void)apply:(UIViewController *)child {
-    DotIndicatorOptions *options = [child resolveChildOptions:child].bottomTab.dotIndicator;
+- (void)apply:(UIViewController *)child: (DotIndicatorOptions *) options {
     if (![options hasValue]) return;
 
     if ([self shouldRemoveIndicator:child options:options]) {

--- a/lib/ios/RNNDotIndicatorPresenter.m
+++ b/lib/ios/RNNDotIndicatorPresenter.m
@@ -6,23 +6,35 @@
 
 @implementation RNNDotIndicatorPresenter
 
-- (void)apply:(UIViewController *)child: (DotIndicatorOptions *) options {
+- (void)apply:(UIViewController *)child :(DotIndicatorOptions *)options {
     if (![options hasValue]) return;
 
     if ([self shouldRemoveIndicator:child options:options]) {
         [self remove:child];
         return;
     }
-    if ([self hasVisibleIndicator:child]) return;
+    if ([self currentIndicatorEquals:child :options]) return;
 
-    UIView *badge = [self createIndicator:options];
-    [child tabBarItem].tag = badge.tag;
+    if ([self hasIndicator:child]) [self remove:child];
+
+    UIView *indicator = [self createIndicator:options];
+    [child tabBarItem].tag = indicator.tag;
 
     UITabBarController *bottomTabs = [self getTabBarController:child];
     int index = (int) [[bottomTabs childViewControllers] indexOfObject:child];
-    [[bottomTabs getTabView:index] addSubview:badge];
-    [self applyConstraints:options badge:badge tabBar:bottomTabs index:index];
+    [[bottomTabs getTabView:index] addSubview:indicator];
+    [self applyConstraints:options badge:indicator tabBar:bottomTabs index:index];
 }
+
+- (UIView *)createIndicator:(DotIndicatorOptions *)options {
+    UIView * indicator = [UIView new];
+    indicator.translatesAutoresizingMaskIntoConstraints = NO;
+    indicator.layer.cornerRadius = [[options.size getWithDefaultValue:@6] floatValue] / 2;
+    indicator.backgroundColor = [options.color getWithDefaultValue:[UIColor redColor]];
+    indicator.tag = arc4random();
+    return indicator;
+}
+
 
 - (void)applyConstraints:(DotIndicatorOptions *)options badge:(UIView *)badge tabBar:(UITabBarController *)bottomTabs index:(int)index {
     UIView *icon = [bottomTabs getTabIcon:index];
@@ -35,16 +47,19 @@
     ]];
 }
 
-- (UIView *)createIndicator:(DotIndicatorOptions *)options {
-    UIView *badge = [UIView new];
-    badge.translatesAutoresizingMaskIntoConstraints = NO;
-    badge.layer.cornerRadius = [[options.size getWithDefaultValue:@6] floatValue] / 2;
-    badge.backgroundColor = [options.color getWithDefaultValue:[UIColor redColor]];
-    badge.tag = arc4random();
-    return badge;
+- (BOOL)currentIndicatorEquals:(UIViewController *)child :(DotIndicatorOptions *)options {
+    if (![self hasIndicator:child]) return NO;
+    UIView *currentIndicator = [self getCurrentIndicator:child];
+    return [[currentIndicator backgroundColor] isEqual:[options.color getWithDefaultValue:[UIColor redColor]]];
 }
 
-- (signed char)hasVisibleIndicator:(UIViewController *)child {
+- (UIView *)getCurrentIndicator:(UIViewController *)child {
+    UITabBarController *bottomTabs = [self getTabBarController:child];
+    int tabIndex = (int) [[bottomTabs childViewControllers] indexOfObject:child];
+    return [[bottomTabs getTabView:tabIndex] viewWithTag:[child tabBarItem].tag];
+}
+
+- (BOOL)hasIndicator:(UIViewController *)child {
     return [child tabBarItem].tag > 0;
 }
 

--- a/lib/ios/RNNDotIndicatorPresenter.m
+++ b/lib/ios/RNNDotIndicatorPresenter.m
@@ -1,0 +1,51 @@
+#import <UIKit/UIKit.h>
+#import "RNNDotIndicatorPresenter.h"
+#import "UITabBar+Utils.h"
+#import "UIViewController+LayoutProtocol.h"
+#import "DotIndicatorOptions.h"
+
+@implementation RNNDotIndicatorPresenter
+
+- (void)apply:(UIViewController *)child {
+    DotIndicatorOptions *options = [child resolveChildOptions:child].bottomTab.dotIndicator;
+    if (![options hasValue]) return;
+
+    if ([options.visible isFalse] && [child tabBarItem].tag > 0) {
+        UIView *view = [[[child tabBarController] tabBar] viewWithTag:[child tabBarItem].tag];
+        [view removeFromSuperview];
+        [child tabBarItem].tag = -1;
+        return;
+    }
+
+    if ([child tabBarItem].tag > 0) return;
+
+    UITabBarController *bottomTabs = [self getTabBarController:child];
+    int index = (int) [[bottomTabs childViewControllers] indexOfObject:child];
+    UITabBar *tabBar = [bottomTabs tabBar];
+    UIView *tab = [tabBar getTabView:index];
+    UIView *icon = [tabBar getTabIcon:index];
+
+    float size = [[options.size getWithDefaultValue:@6] floatValue];
+    UIView *badge = [UIView new];
+    badge.translatesAutoresizingMaskIntoConstraints = NO;
+
+    badge.layer.cornerRadius = size / 2;
+    badge.backgroundColor = [options.color getWithDefaultValue:[UIColor redColor]];
+    badge.tag = arc4random();
+
+    [child tabBarItem].tag = badge.tag;
+    [tab addSubview:badge];
+
+    [NSLayoutConstraint activateConstraints:@[
+            [badge.leftAnchor constraintEqualToAnchor:icon.rightAnchor constant:-size / 2],
+            [badge.topAnchor constraintEqualToAnchor:icon.topAnchor constant:-size / 2],
+            [badge.widthAnchor constraintEqualToConstant:size],
+            [badge.heightAnchor constraintEqualToConstant:size]
+    ]];
+}
+
+- (UITabBarController *)getTabBarController:(id) viewController {
+    return [viewController isKindOfClass:[UITabBarController class]] ? viewController : [viewController tabBarController];
+}
+
+@end

--- a/lib/ios/RNNDotIndicatorPresenter.m
+++ b/lib/ios/RNNDotIndicatorPresenter.m
@@ -9,8 +9,8 @@
 - (void)apply:(UIViewController *)child :(DotIndicatorOptions *)options {
     if (![options hasValue]) return;
 
-    if ([self shouldRemoveIndicator:child options:options]) {
-        [self remove:child];
+    if ([options.visible isFalse]) {
+        if ([child tabBarItem].tag > 0) [self remove:child];
         return;
     }
     if ([self currentIndicatorEquals:child :options]) return;
@@ -67,10 +67,6 @@
     UIView *view = [[[child tabBarController] tabBar] viewWithTag:[child tabBarItem].tag];
     [view removeFromSuperview];
     [child tabBarItem].tag = -1;
-}
-
-- (signed char)shouldRemoveIndicator:(UIViewController *)child options:(DotIndicatorOptions *)options {
-    return [options.visible isFalse] && [child tabBarItem].tag > 0;
 }
 
 - (UITabBarController *)getTabBarController:(id)viewController {

--- a/lib/ios/RNNNavigationControllerPresenter.m
+++ b/lib/ios/RNNNavigationControllerPresenter.m
@@ -225,7 +225,7 @@
 }
 
 - (void)dealloc {
-	[_componentRegistry removeComponent:self.bindedComponentId];
+	[_componentRegistry removeComponent:self.boundComponentId];
 }
 
 @end

--- a/lib/ios/RNNNavigationControllerPresenter.m
+++ b/lib/ios/RNNNavigationControllerPresenter.m
@@ -24,7 +24,7 @@
 - (void)applyOptions:(RNNNavigationOptions *)options {
 	[super applyOptions:options];
 	
-	RNNNavigationController* navigationController = self.bindedViewController;
+	RNNNavigationController* navigationController = self.boundViewController;
 	
 	self.interactivePopGestureDelegate = [InteractivePopGestureDelegate new];
 	self.interactivePopGestureDelegate.navigationController = navigationController;
@@ -59,7 +59,7 @@
 }
 
 - (void)applyOptionsBeforePopping:(RNNNavigationOptions *)options {
-	RNNNavigationController* navigationController = self.bindedViewController;
+	RNNNavigationController* navigationController = self.boundViewController;
 	[navigationController setTopBarBackgroundColor:[options.topBar.background.color getWithDefaultValue:nil]];
 	[navigationController rnn_setNavigationBarFontFamily:[options.topBar.title.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.title.fontSize getWithDefaultValue:@(17)] color:[options.topBar.title.color getWithDefaultValue:[UIColor blackColor]]];
 	[navigationController rnn_setNavigationBarLargeTitleVisible:[options.topBar.largeTitle.visible getWithDefaultValue:NO]];
@@ -68,7 +68,7 @@
 - (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions {
 	[super mergeOptions:newOptions currentOptions:currentOptions defaultOptions:defaultOptions];
 	
-	RNNNavigationController* navigationController = self.bindedViewController;
+	RNNNavigationController* navigationController = self.boundViewController;
 	
 	if (newOptions.popGesture.hasValue) {
 		[navigationController rnn_setInteractivePopGestureEnabled:newOptions.popGesture.get];
@@ -168,7 +168,7 @@
 }
 
 - (void)setCustomNavigationBarView:(RNNNavigationOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock {
-	RNNNavigationController* navigationController = self.bindedViewController;
+	RNNNavigationController* navigationController = self.boundViewController;
 	if (![options.topBar.component.waitForRender getWithDefaultValue:NO] && readyBlock) {
 		readyBlock();
 		readyBlock = nil;
@@ -194,7 +194,7 @@
 }
 
 - (void)setCustomNavigationComponentBackground:(RNNNavigationOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock {
-	RNNNavigationController* navigationController = self.bindedViewController;
+	RNNNavigationController* navigationController = self.boundViewController;
 	if (![options.topBar.background.component.waitForRender getWithDefaultValue:NO] && readyBlock) {
 		readyBlock();
 		readyBlock = nil;
@@ -214,7 +214,7 @@
 }
 
 - (void)presentBackgroundComponent {
-	RNNNavigationController* navigationController = self.bindedViewController;
+	RNNNavigationController* navigationController = self.boundViewController;
 	if (_customTopBarBackground) {
 		[_customTopBarBackground removeFromSuperview];
 	}

--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -29,7 +29,7 @@
 
 - (void)mergeOptions:(RNNNavigationOptions *)options {
 	[_presenter mergeOptions:options currentOptions:self.options defaultOptions:self.defaultOptions];
-	[((UIViewController<RNNLayoutProtocol> *)self.parentViewController) mergeOptions:options];
+	[self.parentViewController mergeOptions:options];
 }
 
 - (void)overrideOptions:(RNNNavigationOptions *)options {
@@ -42,7 +42,7 @@
 	[_presenter applyOptions:self.resolveOptions];
 	[_presenter renderComponents:self.resolveOptions perform:nil];
 	
-	[((UIViewController *)self.parentViewController) onChildWillAppear];
+	[self.parentViewController onChildWillAppear];
 }
 
 -(void)viewDidAppear:(BOOL)animated {

--- a/lib/ios/RNNSideMenuPresenter.m
+++ b/lib/ios/RNNSideMenuPresenter.m
@@ -6,7 +6,7 @@
 - (void)applyOptions:(RNNNavigationOptions *)options {
 	[super applyOptions:options];
 		
-	RNNSideMenuController* sideMenuController = self.bindedViewController;
+	RNNSideMenuController* sideMenuController = self.boundViewController;
 	
 	[sideMenuController side:MMDrawerSideLeft enabled:[options.sideMenu.left.enabled getWithDefaultValue:YES]];
 	[sideMenuController side:MMDrawerSideRight enabled:[options.sideMenu.right.enabled getWithDefaultValue:YES]];
@@ -41,7 +41,7 @@
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)initialOptions {
 	[super applyOptionsOnInit:initialOptions];
 	
-	RNNSideMenuController* sideMenuController = self.bindedViewController;
+	RNNSideMenuController* sideMenuController = self.boundViewController;
 	if (initialOptions.sideMenu.left.width.hasValue) {
 		[sideMenuController side:MMDrawerSideLeft width:initialOptions.sideMenu.left.width.get];
 	}
@@ -56,7 +56,7 @@
 - (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions {
 	[super mergeOptions:newOptions currentOptions:currentOptions defaultOptions:defaultOptions];
 	
-	RNNSideMenuController* sideMenuController = self.bindedViewController;
+	RNNSideMenuController* sideMenuController = self.boundViewController;
 	
 	if (newOptions.sideMenu.left.enabled.hasValue) {
 		[sideMenuController side:MMDrawerSideLeft enabled:newOptions.sideMenu.left.enabled.get];

--- a/lib/ios/RNNSplitViewControllerPresenter.m
+++ b/lib/ios/RNNSplitViewControllerPresenter.m
@@ -8,7 +8,7 @@
 - (void)applyOptions:(RNNNavigationOptions *)options {
 	[super applyOptions:options];
 	
-	UISplitViewController* splitViewController = self.bindedViewController;
+	UISplitViewController* splitViewController = self.boundViewController;
 	[splitViewController rnn_setDisplayMode:options.splitView.displayMode];
 	[splitViewController rnn_setPrimaryEdge:options.splitView.primaryEdge];
 	[splitViewController rnn_setMinWidth:options.splitView.minWidth];
@@ -19,7 +19,7 @@
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)initialOptions {
 	[super applyOptionsOnInit:initialOptions];
 	
-	UISplitViewController* splitViewController = self.bindedViewController;
+	UISplitViewController* splitViewController = self.boundViewController;
 	[splitViewController rnn_setDisplayMode:initialOptions.splitView.displayMode];
 	[splitViewController rnn_setPrimaryEdge:initialOptions.splitView.primaryEdge];
 	[splitViewController rnn_setMinWidth:initialOptions.splitView.minWidth];
@@ -29,7 +29,7 @@
 - (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions {
 	[super mergeOptions:newOptions currentOptions:currentOptions defaultOptions:defaultOptions];
 	
-	UISplitViewController* splitViewController = self.bindedViewController;
+	UISplitViewController* splitViewController = self.boundViewController;
 
 	if (newOptions.splitView.displayMode) {
 		[splitViewController rnn_setDisplayMode:newOptions.splitView.displayMode];

--- a/lib/ios/RNNTabBarController.m
+++ b/lib/ios/RNNTabBarController.m
@@ -8,6 +8,10 @@
 	return self;
 }
 
+- (void)viewDidLayoutSubviews {
+	[self.presenter viewDidLayoutSubviews];
+}
+
 - (UIViewController *)getCurrentChild {
 	return self.selectedViewController;
 }

--- a/lib/ios/RNNTabBarItemCreator.m
+++ b/lib/ios/RNNTabBarItemCreator.m
@@ -1,5 +1,4 @@
 #import "RNNTabBarItemCreator.h"
-#import <React/RCTConvert.h>
 #import "UIImage+tint.h"
 
 @implementation RNNTabBarItemCreator
@@ -13,7 +12,6 @@
 	tabItem.image = [self getIconImage:icon withTint:iconColor];
 	tabItem.selectedImage = [self getSelectedIconImage:selectedIcon selectedIconColor:selectedIconColor];
 	tabItem.title = [bottomTabOptions.text getWithDefaultValue:@""];
-	tabItem.tag = bottomTabOptions.tag;
 	tabItem.accessibilityIdentifier = [bottomTabOptions.testID getWithDefaultValue:nil];
 	
 	NSDictionary* iconInsets = [bottomTabOptions.iconInsets getWithDefaultValue:nil];

--- a/lib/ios/RNNTabBarPresenter.h
+++ b/lib/ios/RNNTabBarPresenter.h
@@ -1,5 +1,5 @@
 #import "RNNBasePresenter.h"
 
 @interface RNNTabBarPresenter : RNNBasePresenter
-- (void)applyBadgeSize;
+- (void)applyDotIndicator;
 @end

--- a/lib/ios/RNNTabBarPresenter.h
+++ b/lib/ios/RNNTabBarPresenter.h
@@ -1,5 +1,5 @@
 #import "RNNBasePresenter.h"
 
 @interface RNNTabBarPresenter : RNNBasePresenter
-
+- (void)applyBadgeSize;
 @end

--- a/lib/ios/RNNTabBarPresenter.m
+++ b/lib/ios/RNNTabBarPresenter.m
@@ -72,8 +72,9 @@
 }
 
 - (void)applyDotIndicator {
-    [self.boundViewController forEachChild:^(UIViewController * child) {
-        [self applyDotIndicator:child];}];
+    [self.boundViewController forEachChild:^(UIViewController *child) {
+        [self applyDotIndicator:child];
+    }];
 }
 
 @end

--- a/lib/ios/RNNTabBarPresenter.m
+++ b/lib/ios/RNNTabBarPresenter.m
@@ -67,12 +67,13 @@
 
 - (void)viewDidLayoutSubviews {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self applyBadgeSize];
+        [self applyDotIndicator];
     });
 }
 
-- (void)applyBadgeSize {
-    [self.boundViewController forEachChild:^(UIViewController * child) {[self applyBadgeSize:child];}];
+- (void)applyDotIndicator {
+    [self.boundViewController forEachChild:^(UIViewController * child) {
+        [self applyDotIndicator:child];}];
 }
 
 @end

--- a/lib/ios/RNNTabBarPresenter.m
+++ b/lib/ios/RNNTabBarPresenter.m
@@ -1,66 +1,80 @@
 #import "RNNTabBarPresenter.h"
 #import "UITabBarController+RNNOptions.h"
+#import "UIViewController+LayoutProtocol.h"
 
 @implementation RNNTabBarPresenter
 
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)options {
-	UITabBarController* tabBarController = self.bindedViewController;
-	[tabBarController rnn_setCurrentTabIndex:[options.bottomTabs.currentTabIndex getWithDefaultValue:0]];
+    UITabBarController *tabBarController = self.bindedViewController;
+    [tabBarController rnn_setCurrentTabIndex:[options.bottomTabs.currentTabIndex getWithDefaultValue:0]];
 }
 
 - (void)applyOptions:(RNNNavigationOptions *)options {
-	UITabBarController* tabBarController = self.bindedViewController;
-	
-	[tabBarController rnn_setTabBarTestID:[options.bottomTabs.testID getWithDefaultValue:nil]];
-	[tabBarController rnn_setTabBarBackgroundColor:[options.bottomTabs.backgroundColor getWithDefaultValue:nil]];
-	[tabBarController rnn_setTabBarTranslucent:[options.bottomTabs.translucent getWithDefaultValue:NO]];
-	[tabBarController rnn_setTabBarHideShadow:[options.bottomTabs.hideShadow getWithDefaultValue:NO]];
-	[tabBarController rnn_setTabBarStyle:[RCTConvert UIBarStyle:[options.bottomTabs.barStyle getWithDefaultValue:@"default"]]];
-	[tabBarController rnn_setTabBarVisible:[options.bottomTabs.visible getWithDefaultValue:YES] animated:[options.bottomTabs.animate getWithDefaultValue:NO]];
+    UITabBarController *tabBarController = self.bindedViewController;
+
+    [tabBarController rnn_setTabBarTestID:[options.bottomTabs.testID getWithDefaultValue:nil]];
+    [tabBarController rnn_setTabBarBackgroundColor:[options.bottomTabs.backgroundColor getWithDefaultValue:nil]];
+    [tabBarController rnn_setTabBarTranslucent:[options.bottomTabs.translucent getWithDefaultValue:NO]];
+    [tabBarController rnn_setTabBarHideShadow:[options.bottomTabs.hideShadow getWithDefaultValue:NO]];
+    [tabBarController rnn_setTabBarStyle:[RCTConvert UIBarStyle:[options.bottomTabs.barStyle getWithDefaultValue:@"default"]]];
+    [tabBarController rnn_setTabBarVisible:[options.bottomTabs.visible getWithDefaultValue:YES] animated:[options.bottomTabs.animate getWithDefaultValue:NO]];
 }
 
 - (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions {
-	[super mergeOptions:newOptions currentOptions:currentOptions defaultOptions:defaultOptions];
-	
-	UITabBarController* tabBarController = self.bindedViewController;
-	
-	if (newOptions.bottomTabs.currentTabIndex.hasValue) {
-		[tabBarController rnn_setCurrentTabIndex:newOptions.bottomTabs.currentTabIndex.get];
-		[newOptions.bottomTabs.currentTabIndex consume];
-	}
-	
-	if (newOptions.bottomTabs.currentTabId.hasValue) {
-		[tabBarController rnn_setCurrentTabID:newOptions.bottomTabs.currentTabId.get];
-		[newOptions.bottomTabs.currentTabId consume];
-	}
-	
-	if (newOptions.bottomTabs.testID.hasValue) {
-		[tabBarController rnn_setTabBarTestID:newOptions.bottomTabs.testID.get];
-	}
-	
-	if (newOptions.bottomTabs.backgroundColor.hasValue) {
-		[tabBarController rnn_setTabBarBackgroundColor:newOptions.bottomTabs.backgroundColor.get];
-	}
-	
-	if (newOptions.bottomTabs.barStyle.hasValue) {
-		[tabBarController rnn_setTabBarStyle:[RCTConvert UIBarStyle:newOptions.bottomTabs.barStyle.get]];
-	}
-	
-	if (newOptions.bottomTabs.translucent.hasValue) {
-		[tabBarController rnn_setTabBarTranslucent:newOptions.bottomTabs.translucent.get];
-	}
-	
-	if (newOptions.bottomTabs.hideShadow.hasValue) {
-		[tabBarController rnn_setTabBarHideShadow:newOptions.bottomTabs.hideShadow.get];
-	}
-	
-	if (newOptions.bottomTabs.visible.hasValue) {
-		if (newOptions.bottomTabs.animate.hasValue) {
-			[tabBarController rnn_setTabBarVisible:newOptions.bottomTabs.visible.get animated:[newOptions.bottomTabs.animate getWithDefaultValue:NO]];
-		} else {
-			[tabBarController rnn_setTabBarVisible:newOptions.bottomTabs.visible.get animated:NO];
-		}
-	}
+    [super mergeOptions:newOptions currentOptions:currentOptions defaultOptions:defaultOptions];
+
+    UITabBarController *tabBarController = self.bindedViewController;
+
+    if (newOptions.bottomTabs.currentTabIndex.hasValue) {
+        [tabBarController rnn_setCurrentTabIndex:newOptions.bottomTabs.currentTabIndex.get];
+        [newOptions.bottomTabs.currentTabIndex consume];
+    }
+
+    if (newOptions.bottomTabs.currentTabId.hasValue) {
+        [tabBarController rnn_setCurrentTabID:newOptions.bottomTabs.currentTabId.get];
+        [newOptions.bottomTabs.currentTabId consume];
+    }
+
+    if (newOptions.bottomTabs.testID.hasValue) {
+        [tabBarController rnn_setTabBarTestID:newOptions.bottomTabs.testID.get];
+    }
+
+    if (newOptions.bottomTabs.backgroundColor.hasValue) {
+        [tabBarController rnn_setTabBarBackgroundColor:newOptions.bottomTabs.backgroundColor.get];
+    }
+
+    if (newOptions.bottomTabs.barStyle.hasValue) {
+        [tabBarController rnn_setTabBarStyle:[RCTConvert UIBarStyle:newOptions.bottomTabs.barStyle.get]];
+    }
+
+    if (newOptions.bottomTabs.translucent.hasValue) {
+        [tabBarController rnn_setTabBarTranslucent:newOptions.bottomTabs.translucent.get];
+    }
+
+    if (newOptions.bottomTabs.hideShadow.hasValue) {
+        [tabBarController rnn_setTabBarHideShadow:newOptions.bottomTabs.hideShadow.get];
+    }
+
+    if (newOptions.bottomTabs.visible.hasValue) {
+        if (newOptions.bottomTabs.animate.hasValue) {
+            [tabBarController rnn_setTabBarVisible:newOptions.bottomTabs.visible.get animated:[newOptions.bottomTabs.animate getWithDefaultValue:NO]];
+        } else {
+            [tabBarController rnn_setTabBarVisible:newOptions.bottomTabs.visible.get animated:NO];
+        }
+    }
+}
+
+- (void)viewDidLayoutSubviews {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self applyBadgeSize];
+    });
+}
+
+- (void)applyBadgeSize {
+    UITabBarController *tabBarController = self.bindedViewController;
+    [tabBarController rnn_forEachTabView:^(UIView *tab, int tabIndex) {
+        [super applyBadgeSize:tabBarController.childViewControllers[(NSUInteger) tabIndex]];
+    }];
 }
 
 @end

--- a/lib/ios/RNNTabBarPresenter.m
+++ b/lib/ios/RNNTabBarPresenter.m
@@ -1,16 +1,17 @@
 #import "RNNTabBarPresenter.h"
 #import "UITabBarController+RNNOptions.h"
 #import "UIViewController+LayoutProtocol.h"
+#import "UIViewController+Utils.h"
 
 @implementation RNNTabBarPresenter
 
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)options {
-    UITabBarController *tabBarController = self.bindedViewController;
+    UITabBarController *tabBarController = self.boundViewController;
     [tabBarController rnn_setCurrentTabIndex:[options.bottomTabs.currentTabIndex getWithDefaultValue:0]];
 }
 
 - (void)applyOptions:(RNNNavigationOptions *)options {
-    UITabBarController *tabBarController = self.bindedViewController;
+    UITabBarController *tabBarController = self.boundViewController;
 
     [tabBarController rnn_setTabBarTestID:[options.bottomTabs.testID getWithDefaultValue:nil]];
     [tabBarController rnn_setTabBarBackgroundColor:[options.bottomTabs.backgroundColor getWithDefaultValue:nil]];
@@ -23,7 +24,7 @@
 - (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions {
     [super mergeOptions:newOptions currentOptions:currentOptions defaultOptions:defaultOptions];
 
-    UITabBarController *tabBarController = self.bindedViewController;
+    UITabBarController *tabBarController = self.boundViewController;
 
     if (newOptions.bottomTabs.currentTabIndex.hasValue) {
         [tabBarController rnn_setCurrentTabIndex:newOptions.bottomTabs.currentTabIndex.get];
@@ -71,10 +72,7 @@
 }
 
 - (void)applyBadgeSize {
-    UITabBarController *tabBarController = self.bindedViewController;
-    [tabBarController rnn_forEachTabView:^(UIView *tab, int tabIndex) {
-        [super applyBadgeSize:tabBarController.childViewControllers[(NSUInteger) tabIndex]];
-    }];
+    [self.boundViewController forEachChild:^(UIViewController * child) {[self applyBadgeSize:child];}];
 }
 
 @end

--- a/lib/ios/RNNViewControllerPresenter.m
+++ b/lib/ios/RNNViewControllerPresenter.m
@@ -206,7 +206,7 @@
 }
 
 - (void)dealloc {
-	[_componentRegistry clearComponentsForParentId:self.bindedComponentId];
+	[_componentRegistry clearComponentsForParentId:self.boundComponentId];
 }
 
 

--- a/lib/ios/RNNViewControllerPresenter.m
+++ b/lib/ios/RNNViewControllerPresenter.m
@@ -174,7 +174,7 @@
 	}
 	
 	if (options.topBar.title.component.name.hasValue) {
-		_customTitleView = (RNNReactView*)[_componentRegistry createComponentIfNotExists:options.topBar.title.component parentComponentId:viewController.layoutInfo.componentId reactViewReadyBlock:readyBlock];
+		_customTitleView = [_componentRegistry createComponentIfNotExists:options.topBar.title.component parentComponentId:viewController.layoutInfo.componentId reactViewReadyBlock:readyBlock];
 		_customTitleView.backgroundColor = UIColor.clearColor;
 		NSString* alignment = [options.topBar.title.component.alignment getWithDefaultValue:@""];
 		[_customTitleView setAlignment:alignment inFrame:viewController.navigationController.navigationBar.frame];

--- a/lib/ios/RNNViewControllerPresenter.m
+++ b/lib/ios/RNNViewControllerPresenter.m
@@ -25,19 +25,19 @@
 
 - (void)bindViewController:(UIViewController<RNNLayoutProtocol> *)bindedViewController {
 	[super bindViewController:bindedViewController];
-	_navigationButtons = [[RNNNavigationButtons alloc] initWithViewController:self.bindedViewController componentRegistry:_componentRegistry];
+	_navigationButtons = [[RNNNavigationButtons alloc] initWithViewController:self.boundViewController componentRegistry:_componentRegistry];
 }
 
 - (void)applyOptionsOnWillMoveToParentViewController:(RNNNavigationOptions *)options {
 	[super applyOptionsOnWillMoveToParentViewController:options];
-	UIViewController* viewController = self.bindedViewController;
+	UIViewController* viewController = self.boundViewController;
 	[viewController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @""];
 }
 
 - (void)applyOptions:(RNNNavigationOptions *)options {
 	[super applyOptions:options];
 	
-	UIViewController* viewController = self.bindedViewController;
+	UIViewController* viewController = self.boundViewController;
 	[viewController rnn_setBackgroundImage:[options.backgroundImage getWithDefaultValue:nil]];
 	[viewController rnn_setNavigationItemTitle:[options.topBar.title.text getWithDefaultValue:nil]];
 	[viewController rnn_setTopBarPrefersLargeTitle:[options.topBar.largeTitle.visible getWithDefaultValue:NO]];
@@ -65,7 +65,7 @@
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)options {
 	[super applyOptionsOnInit:options];
 	
-	UIViewController* viewController = self.bindedViewController;
+	UIViewController* viewController = self.boundViewController;
 	[viewController rnn_setModalPresentationStyle:[RCTConvert UIModalPresentationStyle:[options.modalPresentationStyle getWithDefaultValue:@"fullScreen"]]];
 	[viewController rnn_setModalTransitionStyle:[RCTConvert UIModalTransitionStyle:[options.modalTransitionStyle getWithDefaultValue:@"coverVertical"]]];
 	[viewController rnn_setDrawBehindTopBar:[options.topBar.drawBehind getWithDefaultValue:NO]];
@@ -79,7 +79,7 @@
 - (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions {
 	[super mergeOptions:newOptions currentOptions:currentOptions defaultOptions:defaultOptions];
 	
-	UIViewController* viewController = self.bindedViewController;
+	UIViewController* viewController = self.boundViewController;
 	
 	if (newOptions.backgroundImage.hasValue) {
 		[viewController rnn_setBackgroundImage:newOptions.backgroundImage.get];
@@ -167,7 +167,7 @@
 }
 
 - (void)setCustomNavigationTitleView:(RNNNavigationOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock {
-	UIViewController<RNNLayoutProtocol>* viewController = self.bindedViewController;
+	UIViewController<RNNLayoutProtocol>* viewController = self.boundViewController;
 	if (![options.topBar.title.component.waitForRender getWithDefaultValue:NO] && readyBlock) {
 		readyBlock();
 		readyBlock = nil;
@@ -191,7 +191,7 @@
 
 - (void)setTitleViewWithSubtitle:(RNNNavigationOptions *)options {
 	if (!_customTitleView && options.topBar.subtitle.text.hasValue) {
-		_titleViewHelper = [[RNNTitleViewHelper alloc] initWithTitleViewOptions:options.topBar.title subTitleOptions:options.topBar.subtitle viewController:self.bindedViewController];
+		_titleViewHelper = [[RNNTitleViewHelper alloc] initWithTitleViewOptions:options.topBar.title subTitleOptions:options.topBar.subtitle viewController:self.boundViewController];
 		[_titleViewHelper setup];
 	} else if (_titleViewHelper) {
 		if (options.topBar.title.text.hasValue) {

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -35,11 +35,13 @@
 		2DCD9195200014A900EDC75D /* RNNBridgeManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DCD9193200014A900EDC75D /* RNNBridgeManager.h */; };
 		2DCD9196200014A900EDC75D /* RNNBridgeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DCD9194200014A900EDC75D /* RNNBridgeManager.m */; };
 		309871343F09F2C6776DFA67 /* UIViewController+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987D981545DCBBCCAB34F0 /* UIViewController+Utils.m */; };
+		3098730BC3B4DE41104D9CC4 /* RNNDotIndicatorPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 309878B02F15ECDD1A286722 /* RNNDotIndicatorPresenter.h */; };
 		309874B40D202C9718F15CBD /* UIView+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 309877F25920CFE113FADEE0 /* UIView+Utils.h */; };
 		30987680135A8C78E62D5B8E /* DotIndicatorOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987122507D8CBF16624F93 /* DotIndicatorOptions.h */; };
 		309877B0B5AAA7788F56F3D9 /* UIViewController+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */; };
 		309879260BC6FD19E7A7F33A /* UIView+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987F787A14D232AB091E7E /* UIView+Utils.m */; };
 		30987AB5137F264FA06DA289 /* DotIndicatorOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 309876223177761614786DCC /* DotIndicatorOptions.m */; };
+		30987B23F288EB3A78B7F27C /* RNNDotIndicatorPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987E66AA7AB38E7370F8C8 /* RNNDotIndicatorPresenter.m */; };
 		30987BDAD5C84B7CF8C73AE7 /* UITabBar+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987C81CD660B9DD77A3FEA /* UITabBar+Utils.h */; };
 		30987CA5048A48D6CE76B06C /* DotIndicatorParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 309871FBA64AD937CEF3E191 /* DotIndicatorParser.h */; };
 		30987D71FB4FEEAC8D8978E8 /* DotIndicatorParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 309874E37C7E9764C7B694E5 /* DotIndicatorParser.m */; };
@@ -368,9 +370,11 @@
 		309874E37C7E9764C7B694E5 /* DotIndicatorParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DotIndicatorParser.m; sourceTree = "<group>"; };
 		309876223177761614786DCC /* DotIndicatorOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DotIndicatorOptions.m; sourceTree = "<group>"; };
 		309877F25920CFE113FADEE0 /* UIView+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+Utils.h"; sourceTree = "<group>"; };
+		309878B02F15ECDD1A286722 /* RNNDotIndicatorPresenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNDotIndicatorPresenter.h; sourceTree = "<group>"; };
 		30987C81CD660B9DD77A3FEA /* UITabBar+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITabBar+Utils.h"; sourceTree = "<group>"; };
 		30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Utils.h"; sourceTree = "<group>"; };
 		30987D981545DCBBCCAB34F0 /* UIViewController+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Utils.m"; sourceTree = "<group>"; };
+		30987E66AA7AB38E7370F8C8 /* RNNDotIndicatorPresenter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNDotIndicatorPresenter.m; sourceTree = "<group>"; };
 		30987EBB1AE9276A5BF04CD0 /* UITabBar+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITabBar+Utils.m"; sourceTree = "<group>"; };
 		30987F787A14D232AB091E7E /* UIView+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+Utils.m"; sourceTree = "<group>"; };
 		390AD475200F499D00A8250D /* RNNSwizzles.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNSwizzles.h; sourceTree = "<group>"; };
@@ -926,6 +930,8 @@
 				5012240921735959000F5F98 /* RNNSideMenuPresenter.m */,
 				651E1F8B21FD63F400DFEA19 /* RNNSplitViewControllerPresenter.h */,
 				651E1F8C21FD642100DFEA19 /* RNNSplitViewControllerPresenter.m */,
+				30987E66AA7AB38E7370F8C8 /* RNNDotIndicatorPresenter.m */,
+				309878B02F15ECDD1A286722 /* RNNDotIndicatorPresenter.h */,
 			);
 			name = Presenters;
 			sourceTree = "<group>";
@@ -1287,6 +1293,7 @@
 				309877B0B5AAA7788F56F3D9 /* UIViewController+Utils.h in Headers */,
 				30987680135A8C78E62D5B8E /* DotIndicatorOptions.h in Headers */,
 				30987CA5048A48D6CE76B06C /* DotIndicatorParser.h in Headers */,
+				3098730BC3B4DE41104D9CC4 /* RNNDotIndicatorPresenter.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1545,6 +1552,7 @@
 				309871343F09F2C6776DFA67 /* UIViewController+Utils.m in Sources */,
 				30987AB5137F264FA06DA289 /* DotIndicatorOptions.m in Sources */,
 				30987D71FB4FEEAC8D8978E8 /* DotIndicatorParser.m in Sources */,
+				30987B23F288EB3A78B7F27C /* RNNDotIndicatorPresenter.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		30987680135A8C78E62D5B8E /* DotIndicatorOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987122507D8CBF16624F93 /* DotIndicatorOptions.h */; };
 		309877B0B5AAA7788F56F3D9 /* UIViewController+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */; };
 		309877F473AECC05FB3B9362 /* UITabBarController+RNNUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987FED6F982D322416CAF2 /* UITabBarController+RNNUtils.h */; };
-		30987A33E891E784B84CFCC3 /* RNNTestBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 3098727A36771B4902A14FEA /* RNNTestBase.m */; };
 		30987AB5137F264FA06DA289 /* DotIndicatorOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 309876223177761614786DCC /* DotIndicatorOptions.m */; };
 		30987B23F288EB3A78B7F27C /* RNNDotIndicatorPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987E66AA7AB38E7370F8C8 /* RNNDotIndicatorPresenter.m */; };
 		30987CA5048A48D6CE76B06C /* DotIndicatorParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 309871FBA64AD937CEF3E191 /* DotIndicatorParser.h */; };
@@ -294,6 +293,7 @@
 		E5F6C3AD22DB4D0F0093C2CE /* UITabBarController+RNNUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = E5F6C3A222DB4D0F0093C2CE /* UITabBarController+RNNUtils.m */; };
 		E5F6C3AE22DB4D0F0093C2CE /* UITabBarController+RNNUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = E5F6C3A222DB4D0F0093C2CE /* UITabBarController+RNNUtils.m */; };
 		E5F6C3AF22DB4D0F0093C2CE /* UIView+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = E5F6C3A322DB4D0F0093C2CE /* UIView+Utils.h */; };
+		E5F6C3BF22DB51E10093C2CE /* RNNTestBase.m in Sources */ = {isa = PBXBuildFile; fileRef = E5F6C3BD22DB51E00093C2CE /* RNNTestBase.m */; };
 		E8367B801F7A8A4700675C05 /* VICMAImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = E8367B7E1F7A8A4700675C05 /* VICMAImageView.h */; };
 		E8367B811F7A8A4700675C05 /* VICMAImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = E8367B7F1F7A8A4700675C05 /* VICMAImageView.m */; };
 		E83BAD681F2734B500A9F3DD /* RNNNavigationOptionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E83BAD671F2734B500A9F3DD /* RNNNavigationOptionsTest.m */; };
@@ -645,6 +645,8 @@
 		E5F6C3A122DB4D0F0093C2CE /* UITabBarController+RNNUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UITabBarController+RNNUtils.h"; path = "Utils/UITabBarController+RNNUtils.h"; sourceTree = "<group>"; };
 		E5F6C3A222DB4D0F0093C2CE /* UITabBarController+RNNUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UITabBarController+RNNUtils.m"; path = "Utils/UITabBarController+RNNUtils.m"; sourceTree = "<group>"; };
 		E5F6C3A322DB4D0F0093C2CE /* UIView+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIView+Utils.h"; path = "Utils/UIView+Utils.h"; sourceTree = "<group>"; };
+		E5F6C3BD22DB51E00093C2CE /* RNNTestBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNTestBase.m; sourceTree = "<group>"; };
+		E5F6C3BE22DB51E00093C2CE /* RNNTestBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNTestBase.h; sourceTree = "<group>"; };
 		E8367B7E1F7A8A4700675C05 /* VICMAImageView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VICMAImageView.h; sourceTree = "<group>"; };
 		E8367B7F1F7A8A4700675C05 /* VICMAImageView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VICMAImageView.m; sourceTree = "<group>"; };
 		E83BAD671F2734B500A9F3DD /* RNNNavigationOptionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNNavigationOptionsTest.m; sourceTree = "<group>"; };
@@ -1026,6 +1028,7 @@
 		7B49FEBC1E95090800DEB3EA /* ReactNativeNavigationTests */ = {
 			isa = PBXGroup;
 			children = (
+				E5F6C3BC22DB51E00093C2CE /* utils */,
 				7B49FEC61E95098500DEB3EA /* RNNControllerFactoryTest.m */,
 				7B49FEC71E95098500DEB3EA /* RNNExternalComponentStoreTest.m */,
 				7B49FEC81E95098500DEB3EA /* RNNModalManagerTest.m */,
@@ -1150,6 +1153,15 @@
 				E5F6C39E22DB4D0E0093C2CE /* UIViewController+Utils.m */,
 			);
 			name = Utils;
+			sourceTree = "<group>";
+		};
+		E5F6C3BC22DB51E00093C2CE /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				E5F6C3BD22DB51E00093C2CE /* RNNTestBase.m */,
+				E5F6C3BE22DB51E00093C2CE /* RNNTestBase.h */,
+			);
+			path = utils;
 			sourceTree = "<group>";
 		};
 		E8367B791F77BA1F00675C05 /* Recovered References */ = {
@@ -1454,6 +1466,7 @@
 				50AB0B1F22562FA10039DAED /* UIViewController+LayoutProtocolTest.m in Sources */,
 				7B49FECF1E95098500DEB3EA /* RNNNavigationStackManagerTest.m in Sources */,
 				509B2480217873FF00C83C23 /* UINavigationController+RNNOptionsTest.m in Sources */,
+				E5F6C3BF22DB51E10093C2CE /* RNNTestBase.m in Sources */,
 				506F630D216A599300AD0D0A /* RNNTabBarControllerTest.m in Sources */,
 				7B49FECB1E95098500DEB3EA /* RNNControllerFactoryTest.m in Sources */,
 				50206A6D21AFE75400B7BB1A /* RNNSideMenuParserTest.m in Sources */,
@@ -1467,7 +1480,6 @@
 				E5F6C3A722DB4D0F0093C2CE /* UIViewController+Utils.m in Sources */,
 				E8DA243D1F973C1900CD552B /* RNNTransitionStateHolderTest.m in Sources */,
 				7B49FECC1E95098500DEB3EA /* RNNExternalComponentStoreTest.m in Sources */,
-				30987A33E891E784B84CFCC3 /* RNNTestBase.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		309877B0B5AAA7788F56F3D9 /* UIViewController+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */; };
 		309877F473AECC05FB3B9362 /* UITabBarController+RNNUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987FED6F982D322416CAF2 /* UITabBarController+RNNUtils.h */; };
 		309879260BC6FD19E7A7F33A /* UIView+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987F787A14D232AB091E7E /* UIView+Utils.m */; };
+		30987A33E891E784B84CFCC3 /* RNNTestBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 3098727A36771B4902A14FEA /* RNNTestBase.m */; };
 		30987AB5137F264FA06DA289 /* DotIndicatorOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 309876223177761614786DCC /* DotIndicatorOptions.m */; };
 		30987AFDE159314AEC9AC18B /* UITabBarController+RNNUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987F749DCD552D95979721 /* UITabBarController+RNNUtils.m */; };
 		30987B23F288EB3A78B7F27C /* RNNDotIndicatorPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987E66AA7AB38E7370F8C8 /* RNNDotIndicatorPresenter.m */; };
@@ -283,6 +284,7 @@
 		E33AC20020B5BA0B0090DB8A /* RNNSplitViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E33AC1FF20B5BA0B0090DB8A /* RNNSplitViewController.m */; };
 		E33AC20820B5C4F90090DB8A /* RNNSplitViewOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = E33AC20720B5C4F90090DB8A /* RNNSplitViewOptions.m */; };
 		E3458D3E20BD9CE40023149B /* RNNPreviewOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = E3458D3D20BD9CE40023149B /* RNNPreviewOptions.m */; };
+		E57D1C6322D5CA2400BF7FEE /* RNNDotIndicatorPresenterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987758777622B7D6CCD695 /* RNNDotIndicatorPresenterTest.m */; };
 		E8367B801F7A8A4700675C05 /* VICMAImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = E8367B7E1F7A8A4700675C05 /* VICMAImageView.h */; };
 		E8367B811F7A8A4700675C05 /* VICMAImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = E8367B7F1F7A8A4700675C05 /* VICMAImageView.m */; };
 		E83BAD681F2734B500A9F3DD /* RNNNavigationOptionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E83BAD671F2734B500A9F3DD /* RNNNavigationOptionsTest.m */; };
@@ -366,9 +368,12 @@
 		2DCD9193200014A900EDC75D /* RNNBridgeManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNBridgeManager.h; sourceTree = "<group>"; };
 		2DCD9194200014A900EDC75D /* RNNBridgeManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNBridgeManager.m; sourceTree = "<group>"; };
 		30987122507D8CBF16624F93 /* DotIndicatorOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DotIndicatorOptions.h; sourceTree = "<group>"; };
+		309871B5745A207D2102609E /* RNNTestBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNTestBase.h; sourceTree = "<group>"; };
 		309871FBA64AD937CEF3E191 /* DotIndicatorParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DotIndicatorParser.h; sourceTree = "<group>"; };
+		3098727A36771B4902A14FEA /* RNNTestBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNTestBase.m; sourceTree = "<group>"; };
 		309874E37C7E9764C7B694E5 /* DotIndicatorParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DotIndicatorParser.m; sourceTree = "<group>"; };
 		309876223177761614786DCC /* DotIndicatorOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DotIndicatorOptions.m; sourceTree = "<group>"; };
+		30987758777622B7D6CCD695 /* RNNDotIndicatorPresenterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNDotIndicatorPresenterTest.m; sourceTree = "<group>"; };
 		309877F25920CFE113FADEE0 /* UIView+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+Utils.h"; sourceTree = "<group>"; };
 		309878B02F15ECDD1A286722 /* RNNDotIndicatorPresenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNDotIndicatorPresenter.h; sourceTree = "<group>"; };
 		30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Utils.h"; sourceTree = "<group>"; };
@@ -1032,6 +1037,8 @@
 				509B247F217873FF00C83C23 /* UINavigationController+RNNOptionsTest.m */,
 				50AB0B1E22562FA10039DAED /* UIViewController+LayoutProtocolTest.m */,
 				505963F622676A0000EBB63C /* RNNLayoutManagerTest.m */,
+				30987758777622B7D6CCD695 /* RNNDotIndicatorPresenterTest.m */,
+				3098712A7C7419F1D395AB46 /* utils */,
 			);
 			path = ReactNativeNavigationTests;
 			sourceTree = "<group>";
@@ -1390,6 +1397,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				502F0E142178CF8200367CC3 /* UIViewController+RNNOptionsTest.m in Sources */,
+				E57D1C6322D5CA2400BF7FEE /* RNNDotIndicatorPresenterTest.m in Sources */,
 				5038A377216CF252009280BC /* UITabBarController+RNNOptionsTest.m in Sources */,
 				E83BAD7C1F27643000A9F3DD /* RNNTestRootViewCreator.m in Sources */,
 				502F0E162178D09600367CC3 /* RNNBasePresenterTest.m in Sources */,
@@ -1414,6 +1422,7 @@
 				50CE8503217C6C9B00084EBF /* RNNSideMenuPresenterTest.m in Sources */,
 				E8DA243D1F973C1900CD552B /* RNNTransitionStateHolderTest.m in Sources */,
 				7B49FECC1E95098500DEB3EA /* RNNExternalComponentStoreTest.m in Sources */,
+				30987A33E891E784B84CFCC3 /* RNNTestBase.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -34,17 +34,13 @@
 		26916C991E4B9E7700D13680 /* RNNReactRootViewCreator.m in Sources */ = {isa = PBXBuildFile; fileRef = 26916C971E4B9E7700D13680 /* RNNReactRootViewCreator.m */; };
 		2DCD9195200014A900EDC75D /* RNNBridgeManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DCD9193200014A900EDC75D /* RNNBridgeManager.h */; };
 		2DCD9196200014A900EDC75D /* RNNBridgeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DCD9194200014A900EDC75D /* RNNBridgeManager.m */; };
-		309871343F09F2C6776DFA67 /* UIViewController+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987D981545DCBBCCAB34F0 /* UIViewController+Utils.m */; };
 		3098730BC3B4DE41104D9CC4 /* RNNDotIndicatorPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 309878B02F15ECDD1A286722 /* RNNDotIndicatorPresenter.h */; };
 		309874B40D202C9718F15CBD /* UIView+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 309877F25920CFE113FADEE0 /* UIView+Utils.h */; };
 		30987680135A8C78E62D5B8E /* DotIndicatorOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987122507D8CBF16624F93 /* DotIndicatorOptions.h */; };
 		309877B0B5AAA7788F56F3D9 /* UIViewController+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */; };
 		309877F473AECC05FB3B9362 /* UITabBarController+RNNUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987FED6F982D322416CAF2 /* UITabBarController+RNNUtils.h */; };
-		309879260BC6FD19E7A7F33A /* UIView+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987F787A14D232AB091E7E /* UIView+Utils.m */; };
-		3098793BDFB6E2620CDCDDF3 /* UIColor+RNNUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 309878E2849D565E907C0F4B /* UIColor+RNNUtils.m */; };
 		30987A33E891E784B84CFCC3 /* RNNTestBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 3098727A36771B4902A14FEA /* RNNTestBase.m */; };
 		30987AB5137F264FA06DA289 /* DotIndicatorOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 309876223177761614786DCC /* DotIndicatorOptions.m */; };
-		30987AFDE159314AEC9AC18B /* UITabBarController+RNNUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987F749DCD552D95979721 /* UITabBarController+RNNUtils.m */; };
 		30987B23F288EB3A78B7F27C /* RNNDotIndicatorPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987E66AA7AB38E7370F8C8 /* RNNDotIndicatorPresenter.m */; };
 		30987CA5048A48D6CE76B06C /* DotIndicatorParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 309871FBA64AD937CEF3E191 /* DotIndicatorParser.h */; };
 		30987D71FB4FEEAC8D8978E8 /* DotIndicatorParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 309874E37C7E9764C7B694E5 /* DotIndicatorParser.m */; };
@@ -286,6 +282,18 @@
 		E33AC20820B5C4F90090DB8A /* RNNSplitViewOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = E33AC20720B5C4F90090DB8A /* RNNSplitViewOptions.m */; };
 		E3458D3E20BD9CE40023149B /* RNNPreviewOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = E3458D3D20BD9CE40023149B /* RNNPreviewOptions.m */; };
 		E57D1C6322D5CA2400BF7FEE /* RNNDotIndicatorPresenterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987758777622B7D6CCD695 /* RNNDotIndicatorPresenterTest.m */; };
+		E5F6C3A422DB4D0F0093C2CE /* UIColor+RNNUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = E5F6C39C22DB4D0E0093C2CE /* UIColor+RNNUtils.h */; };
+		E5F6C3A522DB4D0F0093C2CE /* UIViewController+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = E5F6C39D22DB4D0E0093C2CE /* UIViewController+Utils.h */; };
+		E5F6C3A622DB4D0F0093C2CE /* UIViewController+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = E5F6C39E22DB4D0E0093C2CE /* UIViewController+Utils.m */; };
+		E5F6C3A722DB4D0F0093C2CE /* UIViewController+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = E5F6C39E22DB4D0E0093C2CE /* UIViewController+Utils.m */; };
+		E5F6C3A822DB4D0F0093C2CE /* UIView+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = E5F6C39F22DB4D0E0093C2CE /* UIView+Utils.m */; };
+		E5F6C3A922DB4D0F0093C2CE /* UIView+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = E5F6C39F22DB4D0E0093C2CE /* UIView+Utils.m */; };
+		E5F6C3AA22DB4D0F0093C2CE /* UIColor+RNNUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = E5F6C3A022DB4D0F0093C2CE /* UIColor+RNNUtils.m */; };
+		E5F6C3AB22DB4D0F0093C2CE /* UIColor+RNNUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = E5F6C3A022DB4D0F0093C2CE /* UIColor+RNNUtils.m */; };
+		E5F6C3AC22DB4D0F0093C2CE /* UITabBarController+RNNUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = E5F6C3A122DB4D0F0093C2CE /* UITabBarController+RNNUtils.h */; };
+		E5F6C3AD22DB4D0F0093C2CE /* UITabBarController+RNNUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = E5F6C3A222DB4D0F0093C2CE /* UITabBarController+RNNUtils.m */; };
+		E5F6C3AE22DB4D0F0093C2CE /* UITabBarController+RNNUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = E5F6C3A222DB4D0F0093C2CE /* UITabBarController+RNNUtils.m */; };
+		E5F6C3AF22DB4D0F0093C2CE /* UIView+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = E5F6C3A322DB4D0F0093C2CE /* UIView+Utils.h */; };
 		E8367B801F7A8A4700675C05 /* VICMAImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = E8367B7E1F7A8A4700675C05 /* VICMAImageView.h */; };
 		E8367B811F7A8A4700675C05 /* VICMAImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = E8367B7F1F7A8A4700675C05 /* VICMAImageView.m */; };
 		E83BAD681F2734B500A9F3DD /* RNNNavigationOptionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E83BAD671F2734B500A9F3DD /* RNNNavigationOptionsTest.m */; };
@@ -369,7 +377,6 @@
 		2DCD9193200014A900EDC75D /* RNNBridgeManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNBridgeManager.h; sourceTree = "<group>"; };
 		2DCD9194200014A900EDC75D /* RNNBridgeManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNBridgeManager.m; sourceTree = "<group>"; };
 		30987122507D8CBF16624F93 /* DotIndicatorOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DotIndicatorOptions.h; sourceTree = "<group>"; };
-		309871B5745A207D2102609E /* RNNTestBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNTestBase.h; sourceTree = "<group>"; };
 		309871FBA64AD937CEF3E191 /* DotIndicatorParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DotIndicatorParser.h; sourceTree = "<group>"; };
 		3098727A36771B4902A14FEA /* RNNTestBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNTestBase.m; sourceTree = "<group>"; };
 		309874E37C7E9764C7B694E5 /* DotIndicatorParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DotIndicatorParser.m; sourceTree = "<group>"; };
@@ -377,11 +384,9 @@
 		30987758777622B7D6CCD695 /* RNNDotIndicatorPresenterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNDotIndicatorPresenterTest.m; sourceTree = "<group>"; };
 		309877F25920CFE113FADEE0 /* UIView+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+Utils.h"; sourceTree = "<group>"; };
 		309878B02F15ECDD1A286722 /* RNNDotIndicatorPresenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNDotIndicatorPresenter.h; sourceTree = "<group>"; };
-		309878E2849D565E907C0F4B /* UIColor+RNNUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIColor+RNNUtils.m"; sourceTree = "<group>"; };
 		30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Utils.h"; sourceTree = "<group>"; };
 		30987D981545DCBBCCAB34F0 /* UIViewController+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Utils.m"; sourceTree = "<group>"; };
 		30987E66AA7AB38E7370F8C8 /* RNNDotIndicatorPresenter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNDotIndicatorPresenter.m; sourceTree = "<group>"; };
-		30987E987B31220F08556B80 /* UIColor+RNNUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIColor+RNNUtils.h"; sourceTree = "<group>"; };
 		30987F749DCD552D95979721 /* UITabBarController+RNNUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITabBarController+RNNUtils.m"; sourceTree = "<group>"; };
 		30987F787A14D232AB091E7E /* UIView+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+Utils.m"; sourceTree = "<group>"; };
 		30987FED6F982D322416CAF2 /* UITabBarController+RNNUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITabBarController+RNNUtils.h"; sourceTree = "<group>"; };
@@ -632,6 +637,14 @@
 		E33AC20720B5C4F90090DB8A /* RNNSplitViewOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNSplitViewOptions.m; sourceTree = "<group>"; };
 		E3458D3C20BD9CA10023149B /* RNNPreviewOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNPreviewOptions.h; sourceTree = "<group>"; };
 		E3458D3D20BD9CE40023149B /* RNNPreviewOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNPreviewOptions.m; sourceTree = "<group>"; };
+		E5F6C39C22DB4D0E0093C2CE /* UIColor+RNNUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIColor+RNNUtils.h"; path = "Utils/UIColor+RNNUtils.h"; sourceTree = "<group>"; };
+		E5F6C39D22DB4D0E0093C2CE /* UIViewController+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIViewController+Utils.h"; path = "Utils/UIViewController+Utils.h"; sourceTree = "<group>"; };
+		E5F6C39E22DB4D0E0093C2CE /* UIViewController+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+Utils.m"; path = "Utils/UIViewController+Utils.m"; sourceTree = "<group>"; };
+		E5F6C39F22DB4D0E0093C2CE /* UIView+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIView+Utils.m"; path = "Utils/UIView+Utils.m"; sourceTree = "<group>"; };
+		E5F6C3A022DB4D0F0093C2CE /* UIColor+RNNUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIColor+RNNUtils.m"; path = "Utils/UIColor+RNNUtils.m"; sourceTree = "<group>"; };
+		E5F6C3A122DB4D0F0093C2CE /* UITabBarController+RNNUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UITabBarController+RNNUtils.h"; path = "Utils/UITabBarController+RNNUtils.h"; sourceTree = "<group>"; };
+		E5F6C3A222DB4D0F0093C2CE /* UITabBarController+RNNUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UITabBarController+RNNUtils.m"; path = "Utils/UITabBarController+RNNUtils.m"; sourceTree = "<group>"; };
+		E5F6C3A322DB4D0F0093C2CE /* UIView+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIView+Utils.h"; path = "Utils/UIView+Utils.h"; sourceTree = "<group>"; };
 		E8367B7E1F7A8A4700675C05 /* VICMAImageView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VICMAImageView.h; sourceTree = "<group>"; };
 		E8367B7F1F7A8A4700675C05 /* VICMAImageView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VICMAImageView.m; sourceTree = "<group>"; };
 		E83BAD671F2734B500A9F3DD /* RNNNavigationOptionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNNavigationOptionsTest.m; sourceTree = "<group>"; };
@@ -1041,7 +1054,6 @@
 				50AB0B1E22562FA10039DAED /* UIViewController+LayoutProtocolTest.m */,
 				505963F622676A0000EBB63C /* RNNLayoutManagerTest.m */,
 				30987758777622B7D6CCD695 /* RNNDotIndicatorPresenterTest.m */,
-				3098712A7C7419F1D395AB46 /* utils */,
 			);
 			path = ReactNativeNavigationTests;
 			sourceTree = "<group>";
@@ -1083,6 +1095,7 @@
 		D8AFADB41BEE6F3F00A4592D = {
 			isa = PBXGroup;
 			children = (
+				E5F6C39B22DB4CB90093C2CE /* Utils */,
 				214545271F4DC7ED006E8DA1 /* Helpers */,
 				7BA500731E2544B9001B9E1B /* ReactNativeNavigation.h */,
 				7BA500741E2544B9001B9E1B /* ReactNativeNavigation.m */,
@@ -1109,7 +1122,6 @@
 				D8AFADBE1BEE6F3F00A4592D /* Products */,
 				7B49FED01E950A7A00DEB3EA /* Frameworks */,
 				E8367B791F77BA1F00675C05 /* Recovered References */,
-				3098708E3B2E973E80C8ED24 /* Utils */,
 			);
 			sourceTree = "<group>";
 			tabWidth = 4;
@@ -1125,10 +1137,32 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		E5F6C39B22DB4CB90093C2CE /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				E5F6C39C22DB4D0E0093C2CE /* UIColor+RNNUtils.h */,
+				E5F6C3A022DB4D0F0093C2CE /* UIColor+RNNUtils.m */,
+				E5F6C3A122DB4D0F0093C2CE /* UITabBarController+RNNUtils.h */,
+				E5F6C3A222DB4D0F0093C2CE /* UITabBarController+RNNUtils.m */,
+				E5F6C3A322DB4D0F0093C2CE /* UIView+Utils.h */,
+				E5F6C39F22DB4D0E0093C2CE /* UIView+Utils.m */,
+				E5F6C39D22DB4D0E0093C2CE /* UIViewController+Utils.h */,
+				E5F6C39E22DB4D0E0093C2CE /* UIViewController+Utils.m */,
+			);
+			name = Utils;
+			sourceTree = "<group>";
+		};
 		E8367B791F77BA1F00675C05 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
 				E8A5CD581F48CCC300E89D0D /* RNNNavigationController.h */,
+				30987F787A14D232AB091E7E /* UIView+Utils.m */,
+				30987D981545DCBBCCAB34F0 /* UIViewController+Utils.m */,
+				30987F749DCD552D95979721 /* UITabBarController+RNNUtils.m */,
+				309877F25920CFE113FADEE0 /* UIView+Utils.h */,
+				30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */,
+				30987FED6F982D322416CAF2 /* UITabBarController+RNNUtils.h */,
+				3098727A36771B4902A14FEA /* RNNTestBase.m */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -1209,6 +1243,7 @@
 				50E02BDD21A6EE7900A43942 /* SideMenuOpenGestureModeParser.h in Headers */,
 				5038A3B5216DF602009280BC /* UINavigationController+RNNOptions.h in Headers */,
 				50E5F78D223F9FAF002AFEAD /* RNNElementTransitionOptions.h in Headers */,
+				E5F6C3A422DB4D0F0093C2CE /* UIColor+RNNUtils.h in Headers */,
 				5038A3C1216E1E66009280BC /* RNNFontAttributesCreator.h in Headers */,
 				5016E8EF20209690009D4F7C /* RNNCustomTitleView.h in Headers */,
 				50415CBA20553B8E00BB682E /* RNNScreenTransition.h in Headers */,
@@ -1230,6 +1265,7 @@
 				5012242621737278000F5F98 /* NullImage.h in Headers */,
 				5038A3B9216DFCFD009280BC /* UITabBarController+RNNOptions.h in Headers */,
 				50644A2020E11A720026709C /* Constants.h in Headers */,
+				E5F6C3AF22DB4D0F0093C2CE /* UIView+Utils.h in Headers */,
 				5012241E217366D4000F5F98 /* ColorParser.h in Headers */,
 				E8367B801F7A8A4700675C05 /* VICMAImageView.h in Headers */,
 				263905E61E4CAC950023D7D3 /* RNNSideMenuChildVC.h in Headers */,
@@ -1244,10 +1280,12 @@
 				50E5F7952240EBD6002AFEAD /* RNNAnimationsTransitionDelegate.h in Headers */,
 				7B1126A71E2D2B6C00F9B03B /* RNNEventEmitter.h in Headers */,
 				E8A430111F9CB87B00B61A20 /* RNNAnimatedView.h in Headers */,
+				E5F6C3AC22DB4D0F0093C2CE /* UITabBarController+RNNUtils.h in Headers */,
 				506317AA220B547400B26FC3 /* UIImage+insets.h in Headers */,
 				5038A3C6216E2D93009280BC /* Number.h in Headers */,
 				50887C1520ECC5C200D06111 /* RNNButtonOptions.h in Headers */,
 				5049593E216F5D73006D2B81 /* BoolParser.h in Headers */,
+				E5F6C3A522DB4D0F0093C2CE /* UIViewController+Utils.h in Headers */,
 				50C4A496206BDDBB00DB292E /* RNNSubtitleOptions.h in Headers */,
 				5039559B2174867000B0A663 /* DoubleParser.h in Headers */,
 				E8AEDB3C1F55A1C2000F5A6A /* RNNElementView.h in Headers */,
@@ -1409,6 +1447,7 @@
 				506F630F216A5AD700AD0D0A /* RNNViewControllerPresenterTest.m in Sources */,
 				505963F722676A0000EBB63C /* RNNLayoutManagerTest.m in Sources */,
 				7B49FECE1E95098500DEB3EA /* RNNCommandsHandlerTest.m in Sources */,
+				E5F6C3AB22DB4D0F0093C2CE /* UIColor+RNNUtils.m in Sources */,
 				5038A379216D01F6009280BC /* RNNBottomTabOptionsTest.m in Sources */,
 				E83BAD681F2734B500A9F3DD /* RNNNavigationOptionsTest.m in Sources */,
 				505EDD32214E4BE80071C7DE /* RNNNavigationControllerTest.m in Sources */,
@@ -1423,6 +1462,9 @@
 				5085DD2D21DCF75A0032E64B /* RNNSideMenuControllerTest.m in Sources */,
 				E83BAD791F27416B00A9F3DD /* RNNRootViewControllerTest.m in Sources */,
 				50CE8503217C6C9B00084EBF /* RNNSideMenuPresenterTest.m in Sources */,
+				E5F6C3AE22DB4D0F0093C2CE /* UITabBarController+RNNUtils.m in Sources */,
+				E5F6C3A922DB4D0F0093C2CE /* UIView+Utils.m in Sources */,
+				E5F6C3A722DB4D0F0093C2CE /* UIViewController+Utils.m in Sources */,
 				E8DA243D1F973C1900CD552B /* RNNTransitionStateHolderTest.m in Sources */,
 				7B49FECC1E95098500DEB3EA /* RNNExternalComponentStoreTest.m in Sources */,
 				30987A33E891E784B84CFCC3 /* RNNTestBase.m in Sources */,
@@ -1443,6 +1485,7 @@
 				5012241B21736678000F5F98 /* Image.m in Sources */,
 				50495943216F5E5D006D2B81 /* NullBool.m in Sources */,
 				5038A3C7216E2D93009280BC /* Number.m in Sources */,
+				E5F6C3A622DB4D0F0093C2CE /* UIViewController+Utils.m in Sources */,
 				50451D0E2042F70900695F00 /* RNNTransition.m in Sources */,
 				5048862E20BE976D000908DE /* RNNLayoutOptions.m in Sources */,
 				501CD320214A5B6900A6E225 /* RNNLayoutInfo.m in Sources */,
@@ -1487,6 +1530,7 @@
 				50395590217482FE00B0A663 /* NullIntNumber.m in Sources */,
 				E8A5CD631F49114F00E89D0D /* RNNElement.m in Sources */,
 				5038A3CB216E328A009280BC /* Param.m in Sources */,
+				E5F6C3AA22DB4D0F0093C2CE /* UIColor+RNNUtils.m in Sources */,
 				651E1F8A21FD624600DFEA19 /* UISplitViewController+RNNOptions.m in Sources */,
 				50395594217485B000B0A663 /* Double.m in Sources */,
 				504AFE751FFFF0540076E904 /* RNNTopTabsOptions.m in Sources */,
@@ -1511,6 +1555,7 @@
 				507F43CA1FF4F9CC00D9425B /* RNNTopTabOptions.m in Sources */,
 				26916C991E4B9E7700D13680 /* RNNReactRootViewCreator.m in Sources */,
 				5064495E20DC62B90026709C /* RNNSideMenuSideOptions.m in Sources */,
+				E5F6C3AD22DB4D0F0093C2CE /* UITabBarController+RNNUtils.m in Sources */,
 				214545251F4DC125006E8DA1 /* RNNUIBarButtonItem.m in Sources */,
 				263905B81E4C6F440023D7D3 /* UIViewController+MMDrawerController.m in Sources */,
 				505EDD3D214FA8000071C7DE /* RNNViewControllerPresenter.m in Sources */,
@@ -1528,6 +1573,7 @@
 				501224072173592D000F5F98 /* RNNTabBarPresenter.m in Sources */,
 				50A00C38200F84D6000F01A6 /* RNNOverlayOptions.m in Sources */,
 				5039559C2174867000B0A663 /* DoubleParser.m in Sources */,
+				E5F6C3A822DB4D0F0093C2CE /* UIView+Utils.m in Sources */,
 				5049593F216F5D73006D2B81 /* BoolParser.m in Sources */,
 				50EB93421FE14A3E00BD8EEE /* RNNBottomTabOptions.m in Sources */,
 				50E5F792223FA04C002AFEAD /* RNNAnimationConfigurationOptions.m in Sources */,
@@ -1559,12 +1605,9 @@
 				E8E518371F83B94A000467AC /* RNNViewLocation.m in Sources */,
 				E3458D3E20BD9CE40023149B /* RNNPreviewOptions.m in Sources */,
 				5012242B217372B3000F5F98 /* ImageParser.m in Sources */,
-				309879260BC6FD19E7A7F33A /* UIView+Utils.m in Sources */,
-				309871343F09F2C6776DFA67 /* UIViewController+Utils.m in Sources */,
 				30987AB5137F264FA06DA289 /* DotIndicatorOptions.m in Sources */,
 				30987D71FB4FEEAC8D8978E8 /* DotIndicatorParser.m in Sources */,
 				30987B23F288EB3A78B7F27C /* RNNDotIndicatorPresenter.m in Sources */,
-				30987AFDE159314AEC9AC18B /* UITabBarController+RNNUtils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -39,13 +39,13 @@
 		309874B40D202C9718F15CBD /* UIView+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 309877F25920CFE113FADEE0 /* UIView+Utils.h */; };
 		30987680135A8C78E62D5B8E /* DotIndicatorOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987122507D8CBF16624F93 /* DotIndicatorOptions.h */; };
 		309877B0B5AAA7788F56F3D9 /* UIViewController+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */; };
+		309877F473AECC05FB3B9362 /* UITabBarController+RNNUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987FED6F982D322416CAF2 /* UITabBarController+RNNUtils.h */; };
 		309879260BC6FD19E7A7F33A /* UIView+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987F787A14D232AB091E7E /* UIView+Utils.m */; };
 		30987AB5137F264FA06DA289 /* DotIndicatorOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 309876223177761614786DCC /* DotIndicatorOptions.m */; };
+		30987AFDE159314AEC9AC18B /* UITabBarController+RNNUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987F749DCD552D95979721 /* UITabBarController+RNNUtils.m */; };
 		30987B23F288EB3A78B7F27C /* RNNDotIndicatorPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987E66AA7AB38E7370F8C8 /* RNNDotIndicatorPresenter.m */; };
-		30987BDAD5C84B7CF8C73AE7 /* UITabBar+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987C81CD660B9DD77A3FEA /* UITabBar+Utils.h */; };
 		30987CA5048A48D6CE76B06C /* DotIndicatorParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 309871FBA64AD937CEF3E191 /* DotIndicatorParser.h */; };
 		30987D71FB4FEEAC8D8978E8 /* DotIndicatorParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 309874E37C7E9764C7B694E5 /* DotIndicatorParser.m */; };
-		30987FFE550A3534BB9066A1 /* UITabBar+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987EBB1AE9276A5BF04CD0 /* UITabBar+Utils.m */; };
 		390AD477200F499D00A8250D /* RNNSwizzles.h in Headers */ = {isa = PBXBuildFile; fileRef = 390AD475200F499D00A8250D /* RNNSwizzles.h */; };
 		390AD478200F499D00A8250D /* RNNSwizzles.m in Sources */ = {isa = PBXBuildFile; fileRef = 390AD476200F499D00A8250D /* RNNSwizzles.m */; };
 		4534E72520CB6724009F8185 /* RNNLargeTitleOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4534E72320CB6724009F8185 /* RNNLargeTitleOptions.h */; };
@@ -371,12 +371,12 @@
 		309876223177761614786DCC /* DotIndicatorOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DotIndicatorOptions.m; sourceTree = "<group>"; };
 		309877F25920CFE113FADEE0 /* UIView+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+Utils.h"; sourceTree = "<group>"; };
 		309878B02F15ECDD1A286722 /* RNNDotIndicatorPresenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNDotIndicatorPresenter.h; sourceTree = "<group>"; };
-		30987C81CD660B9DD77A3FEA /* UITabBar+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITabBar+Utils.h"; sourceTree = "<group>"; };
 		30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Utils.h"; sourceTree = "<group>"; };
 		30987D981545DCBBCCAB34F0 /* UIViewController+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Utils.m"; sourceTree = "<group>"; };
 		30987E66AA7AB38E7370F8C8 /* RNNDotIndicatorPresenter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNDotIndicatorPresenter.m; sourceTree = "<group>"; };
-		30987EBB1AE9276A5BF04CD0 /* UITabBar+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITabBar+Utils.m"; sourceTree = "<group>"; };
+		30987F749DCD552D95979721 /* UITabBarController+RNNUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITabBarController+RNNUtils.m"; sourceTree = "<group>"; };
 		30987F787A14D232AB091E7E /* UIView+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+Utils.m"; sourceTree = "<group>"; };
+		30987FED6F982D322416CAF2 /* UITabBarController+RNNUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITabBarController+RNNUtils.h"; sourceTree = "<group>"; };
 		390AD475200F499D00A8250D /* RNNSwizzles.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNSwizzles.h; sourceTree = "<group>"; };
 		390AD476200F499D00A8250D /* RNNSwizzles.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNSwizzles.m; sourceTree = "<group>"; };
 		4534E72320CB6724009F8185 /* RNNLargeTitleOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNLargeTitleOptions.h; sourceTree = "<group>"; };
@@ -1288,12 +1288,12 @@
 				5049595A216F6B46006D2B81 /* NullDictionary.h in Headers */,
 				501224062173592D000F5F98 /* RNNTabBarPresenter.h in Headers */,
 				50706E6D20CE7CA5003345C3 /* UIImage+tint.h in Headers */,
-				30987BDAD5C84B7CF8C73AE7 /* UITabBar+Utils.h in Headers */,
 				309874B40D202C9718F15CBD /* UIView+Utils.h in Headers */,
 				309877B0B5AAA7788F56F3D9 /* UIViewController+Utils.h in Headers */,
 				30987680135A8C78E62D5B8E /* DotIndicatorOptions.h in Headers */,
 				30987CA5048A48D6CE76B06C /* DotIndicatorParser.h in Headers */,
 				3098730BC3B4DE41104D9CC4 /* RNNDotIndicatorPresenter.h in Headers */,
+				309877F473AECC05FB3B9362 /* UITabBarController+RNNUtils.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1547,12 +1547,12 @@
 				E8E518371F83B94A000467AC /* RNNViewLocation.m in Sources */,
 				E3458D3E20BD9CE40023149B /* RNNPreviewOptions.m in Sources */,
 				5012242B217372B3000F5F98 /* ImageParser.m in Sources */,
-				30987FFE550A3534BB9066A1 /* UITabBar+Utils.m in Sources */,
 				309879260BC6FD19E7A7F33A /* UIView+Utils.m in Sources */,
 				309871343F09F2C6776DFA67 /* UIViewController+Utils.m in Sources */,
 				30987AB5137F264FA06DA289 /* DotIndicatorOptions.m in Sources */,
 				30987D71FB4FEEAC8D8978E8 /* DotIndicatorParser.m in Sources */,
 				30987B23F288EB3A78B7F27C /* RNNDotIndicatorPresenter.m in Sources */,
+				30987AFDE159314AEC9AC18B /* UITabBarController+RNNUtils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		309877B0B5AAA7788F56F3D9 /* UIViewController+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */; };
 		309877F473AECC05FB3B9362 /* UITabBarController+RNNUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987FED6F982D322416CAF2 /* UITabBarController+RNNUtils.h */; };
 		309879260BC6FD19E7A7F33A /* UIView+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987F787A14D232AB091E7E /* UIView+Utils.m */; };
+		3098793BDFB6E2620CDCDDF3 /* UIColor+RNNUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 309878E2849D565E907C0F4B /* UIColor+RNNUtils.m */; };
 		30987A33E891E784B84CFCC3 /* RNNTestBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 3098727A36771B4902A14FEA /* RNNTestBase.m */; };
 		30987AB5137F264FA06DA289 /* DotIndicatorOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 309876223177761614786DCC /* DotIndicatorOptions.m */; };
 		30987AFDE159314AEC9AC18B /* UITabBarController+RNNUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987F749DCD552D95979721 /* UITabBarController+RNNUtils.m */; };
@@ -376,9 +377,11 @@
 		30987758777622B7D6CCD695 /* RNNDotIndicatorPresenterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNDotIndicatorPresenterTest.m; sourceTree = "<group>"; };
 		309877F25920CFE113FADEE0 /* UIView+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+Utils.h"; sourceTree = "<group>"; };
 		309878B02F15ECDD1A286722 /* RNNDotIndicatorPresenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNDotIndicatorPresenter.h; sourceTree = "<group>"; };
+		309878E2849D565E907C0F4B /* UIColor+RNNUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIColor+RNNUtils.m"; sourceTree = "<group>"; };
 		30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Utils.h"; sourceTree = "<group>"; };
 		30987D981545DCBBCCAB34F0 /* UIViewController+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Utils.m"; sourceTree = "<group>"; };
 		30987E66AA7AB38E7370F8C8 /* RNNDotIndicatorPresenter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNDotIndicatorPresenter.m; sourceTree = "<group>"; };
+		30987E987B31220F08556B80 /* UIColor+RNNUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIColor+RNNUtils.h"; sourceTree = "<group>"; };
 		30987F749DCD552D95979721 /* UITabBarController+RNNUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITabBarController+RNNUtils.m"; sourceTree = "<group>"; };
 		30987F787A14D232AB091E7E /* UIView+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+Utils.m"; sourceTree = "<group>"; };
 		30987FED6F982D322416CAF2 /* UITabBarController+RNNUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITabBarController+RNNUtils.h"; sourceTree = "<group>"; };

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -36,9 +36,13 @@
 		2DCD9196200014A900EDC75D /* RNNBridgeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DCD9194200014A900EDC75D /* RNNBridgeManager.m */; };
 		309871343F09F2C6776DFA67 /* UIViewController+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987D981545DCBBCCAB34F0 /* UIViewController+Utils.m */; };
 		309874B40D202C9718F15CBD /* UIView+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 309877F25920CFE113FADEE0 /* UIView+Utils.h */; };
+		30987680135A8C78E62D5B8E /* DotIndicatorOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987122507D8CBF16624F93 /* DotIndicatorOptions.h */; };
 		309877B0B5AAA7788F56F3D9 /* UIViewController+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */; };
 		309879260BC6FD19E7A7F33A /* UIView+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987F787A14D232AB091E7E /* UIView+Utils.m */; };
+		30987AB5137F264FA06DA289 /* DotIndicatorOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 309876223177761614786DCC /* DotIndicatorOptions.m */; };
 		30987BDAD5C84B7CF8C73AE7 /* UITabBar+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987C81CD660B9DD77A3FEA /* UITabBar+Utils.h */; };
+		30987CA5048A48D6CE76B06C /* DotIndicatorParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 309871FBA64AD937CEF3E191 /* DotIndicatorParser.h */; };
+		30987D71FB4FEEAC8D8978E8 /* DotIndicatorParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 309874E37C7E9764C7B694E5 /* DotIndicatorParser.m */; };
 		30987FFE550A3534BB9066A1 /* UITabBar+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987EBB1AE9276A5BF04CD0 /* UITabBar+Utils.m */; };
 		390AD477200F499D00A8250D /* RNNSwizzles.h in Headers */ = {isa = PBXBuildFile; fileRef = 390AD475200F499D00A8250D /* RNNSwizzles.h */; };
 		390AD478200F499D00A8250D /* RNNSwizzles.m in Sources */ = {isa = PBXBuildFile; fileRef = 390AD476200F499D00A8250D /* RNNSwizzles.m */; };
@@ -359,6 +363,10 @@
 		26916C971E4B9E7700D13680 /* RNNReactRootViewCreator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNReactRootViewCreator.m; sourceTree = "<group>"; };
 		2DCD9193200014A900EDC75D /* RNNBridgeManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNBridgeManager.h; sourceTree = "<group>"; };
 		2DCD9194200014A900EDC75D /* RNNBridgeManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNBridgeManager.m; sourceTree = "<group>"; };
+		30987122507D8CBF16624F93 /* DotIndicatorOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DotIndicatorOptions.h; sourceTree = "<group>"; };
+		309871FBA64AD937CEF3E191 /* DotIndicatorParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DotIndicatorParser.h; sourceTree = "<group>"; };
+		309874E37C7E9764C7B694E5 /* DotIndicatorParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DotIndicatorParser.m; sourceTree = "<group>"; };
+		309876223177761614786DCC /* DotIndicatorOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DotIndicatorOptions.m; sourceTree = "<group>"; };
 		309877F25920CFE113FADEE0 /* UIView+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+Utils.h"; sourceTree = "<group>"; };
 		30987C81CD660B9DD77A3FEA /* UITabBar+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITabBar+Utils.h"; sourceTree = "<group>"; };
 		30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Utils.h"; sourceTree = "<group>"; };
@@ -832,6 +840,8 @@
 				5039558A2174829400B0A663 /* IntNumberParser.m */,
 				503955992174867000B0A663 /* DoubleParser.h */,
 				5039559A2174867000B0A663 /* DoubleParser.m */,
+				309874E37C7E9764C7B694E5 /* DotIndicatorParser.m */,
+				309871FBA64AD937CEF3E191 /* DotIndicatorParser.h */,
 			);
 			name = Parsers;
 			sourceTree = "<group>";
@@ -895,6 +905,8 @@
 				E3458D3D20BD9CE40023149B /* RNNPreviewOptions.m */,
 				506317AC220B550600B26FC3 /* RNNInsetsOptions.h */,
 				506317AD220B550600B26FC3 /* RNNInsetsOptions.m */,
+				309876223177761614786DCC /* DotIndicatorOptions.m */,
+				30987122507D8CBF16624F93 /* DotIndicatorOptions.h */,
 			);
 			name = Options;
 			sourceTree = "<group>";
@@ -1273,6 +1285,8 @@
 				30987BDAD5C84B7CF8C73AE7 /* UITabBar+Utils.h in Headers */,
 				309874B40D202C9718F15CBD /* UIView+Utils.h in Headers */,
 				309877B0B5AAA7788F56F3D9 /* UIViewController+Utils.h in Headers */,
+				30987680135A8C78E62D5B8E /* DotIndicatorOptions.h in Headers */,
+				30987CA5048A48D6CE76B06C /* DotIndicatorParser.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1529,6 +1543,8 @@
 				30987FFE550A3534BB9066A1 /* UITabBar+Utils.m in Sources */,
 				309879260BC6FD19E7A7F33A /* UIView+Utils.m in Sources */,
 				309871343F09F2C6776DFA67 /* UIViewController+Utils.m in Sources */,
+				30987AB5137F264FA06DA289 /* DotIndicatorOptions.m in Sources */,
+				30987D71FB4FEEAC8D8978E8 /* DotIndicatorParser.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -34,6 +34,10 @@
 		26916C991E4B9E7700D13680 /* RNNReactRootViewCreator.m in Sources */ = {isa = PBXBuildFile; fileRef = 26916C971E4B9E7700D13680 /* RNNReactRootViewCreator.m */; };
 		2DCD9195200014A900EDC75D /* RNNBridgeManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DCD9193200014A900EDC75D /* RNNBridgeManager.h */; };
 		2DCD9196200014A900EDC75D /* RNNBridgeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DCD9194200014A900EDC75D /* RNNBridgeManager.m */; };
+		309874B40D202C9718F15CBD /* UIView+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 309877F25920CFE113FADEE0 /* UIView+Utils.h */; };
+		309879260BC6FD19E7A7F33A /* UIView+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987F787A14D232AB091E7E /* UIView+Utils.m */; };
+		30987BDAD5C84B7CF8C73AE7 /* UITabBar+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987C81CD660B9DD77A3FEA /* UITabBar+Utils.h */; };
+		30987FFE550A3534BB9066A1 /* UITabBar+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987EBB1AE9276A5BF04CD0 /* UITabBar+Utils.m */; };
 		390AD477200F499D00A8250D /* RNNSwizzles.h in Headers */ = {isa = PBXBuildFile; fileRef = 390AD475200F499D00A8250D /* RNNSwizzles.h */; };
 		390AD478200F499D00A8250D /* RNNSwizzles.m in Sources */ = {isa = PBXBuildFile; fileRef = 390AD476200F499D00A8250D /* RNNSwizzles.m */; };
 		4534E72520CB6724009F8185 /* RNNLargeTitleOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4534E72320CB6724009F8185 /* RNNLargeTitleOptions.h */; };
@@ -353,6 +357,10 @@
 		26916C971E4B9E7700D13680 /* RNNReactRootViewCreator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNReactRootViewCreator.m; sourceTree = "<group>"; };
 		2DCD9193200014A900EDC75D /* RNNBridgeManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNBridgeManager.h; sourceTree = "<group>"; };
 		2DCD9194200014A900EDC75D /* RNNBridgeManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNBridgeManager.m; sourceTree = "<group>"; };
+		309877F25920CFE113FADEE0 /* UIView+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+Utils.h"; sourceTree = "<group>"; };
+		30987C81CD660B9DD77A3FEA /* UITabBar+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITabBar+Utils.h"; sourceTree = "<group>"; };
+		30987EBB1AE9276A5BF04CD0 /* UITabBar+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITabBar+Utils.m"; sourceTree = "<group>"; };
+		30987F787A14D232AB091E7E /* UIView+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+Utils.m"; sourceTree = "<group>"; };
 		390AD475200F499D00A8250D /* RNNSwizzles.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNSwizzles.h; sourceTree = "<group>"; };
 		390AD476200F499D00A8250D /* RNNSwizzles.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNSwizzles.m; sourceTree = "<group>"; };
 		4534E72320CB6724009F8185 /* RNNLargeTitleOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNLargeTitleOptions.h; sourceTree = "<group>"; };
@@ -1069,6 +1077,7 @@
 				D8AFADBE1BEE6F3F00A4592D /* Products */,
 				7B49FED01E950A7A00DEB3EA /* Frameworks */,
 				E8367B791F77BA1F00675C05 /* Recovered References */,
+				3098708E3B2E973E80C8ED24 /* Utils */,
 			);
 			sourceTree = "<group>";
 			tabWidth = 4;
@@ -1257,6 +1266,8 @@
 				5049595A216F6B46006D2B81 /* NullDictionary.h in Headers */,
 				501224062173592D000F5F98 /* RNNTabBarPresenter.h in Headers */,
 				50706E6D20CE7CA5003345C3 /* UIImage+tint.h in Headers */,
+				30987BDAD5C84B7CF8C73AE7 /* UITabBar+Utils.h in Headers */,
+				309874B40D202C9718F15CBD /* UIView+Utils.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1510,6 +1521,8 @@
 				E8E518371F83B94A000467AC /* RNNViewLocation.m in Sources */,
 				E3458D3E20BD9CE40023149B /* RNNPreviewOptions.m in Sources */,
 				5012242B217372B3000F5F98 /* ImageParser.m in Sources */,
+				30987FFE550A3534BB9066A1 /* UITabBar+Utils.m in Sources */,
+				309879260BC6FD19E7A7F33A /* UIView+Utils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1679,7 +1692,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = NO;
-				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = ReactNativeNavigation;
@@ -1696,7 +1709,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = NO;
-				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = ReactNativeNavigation;

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -34,7 +34,9 @@
 		26916C991E4B9E7700D13680 /* RNNReactRootViewCreator.m in Sources */ = {isa = PBXBuildFile; fileRef = 26916C971E4B9E7700D13680 /* RNNReactRootViewCreator.m */; };
 		2DCD9195200014A900EDC75D /* RNNBridgeManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DCD9193200014A900EDC75D /* RNNBridgeManager.h */; };
 		2DCD9196200014A900EDC75D /* RNNBridgeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DCD9194200014A900EDC75D /* RNNBridgeManager.m */; };
+		309871343F09F2C6776DFA67 /* UIViewController+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987D981545DCBBCCAB34F0 /* UIViewController+Utils.m */; };
 		309874B40D202C9718F15CBD /* UIView+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 309877F25920CFE113FADEE0 /* UIView+Utils.h */; };
+		309877B0B5AAA7788F56F3D9 /* UIViewController+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */; };
 		309879260BC6FD19E7A7F33A /* UIView+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987F787A14D232AB091E7E /* UIView+Utils.m */; };
 		30987BDAD5C84B7CF8C73AE7 /* UITabBar+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987C81CD660B9DD77A3FEA /* UITabBar+Utils.h */; };
 		30987FFE550A3534BB9066A1 /* UITabBar+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987EBB1AE9276A5BF04CD0 /* UITabBar+Utils.m */; };
@@ -359,6 +361,8 @@
 		2DCD9194200014A900EDC75D /* RNNBridgeManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNBridgeManager.m; sourceTree = "<group>"; };
 		309877F25920CFE113FADEE0 /* UIView+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+Utils.h"; sourceTree = "<group>"; };
 		30987C81CD660B9DD77A3FEA /* UITabBar+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITabBar+Utils.h"; sourceTree = "<group>"; };
+		30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Utils.h"; sourceTree = "<group>"; };
+		30987D981545DCBBCCAB34F0 /* UIViewController+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Utils.m"; sourceTree = "<group>"; };
 		30987EBB1AE9276A5BF04CD0 /* UITabBar+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITabBar+Utils.m"; sourceTree = "<group>"; };
 		30987F787A14D232AB091E7E /* UIView+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+Utils.m"; sourceTree = "<group>"; };
 		390AD475200F499D00A8250D /* RNNSwizzles.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNSwizzles.h; sourceTree = "<group>"; };
@@ -1268,6 +1272,7 @@
 				50706E6D20CE7CA5003345C3 /* UIImage+tint.h in Headers */,
 				30987BDAD5C84B7CF8C73AE7 /* UITabBar+Utils.h in Headers */,
 				309874B40D202C9718F15CBD /* UIView+Utils.h in Headers */,
+				309877B0B5AAA7788F56F3D9 /* UIViewController+Utils.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1523,6 +1528,7 @@
 				5012242B217372B3000F5F98 /* ImageParser.m in Sources */,
 				30987FFE550A3534BB9066A1 /* UITabBar+Utils.m in Sources */,
 				309879260BC6FD19E7A7F33A /* UIView+Utils.m in Sources */,
+				309871343F09F2C6776DFA67 /* UIViewController+Utils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/lib/ios/ReactNativeNavigationTests/RNNBasePresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNBasePresenterTest.m
@@ -6,10 +6,10 @@
 
 @interface RNNBottomTabPresenterTest : XCTestCase
 
-@property (nonatomic, strong) RNNBasePresenter *uut;
-@property (nonatomic, strong) RNNNavigationOptions *options;
-@property (nonatomic, strong) RNNRootViewController* bindedViewController;
-@property (nonatomic, strong) id mockBindedViewController;
+@property(nonatomic, strong) RNNBasePresenter *uut;
+@property(nonatomic, strong) RNNNavigationOptions *options;
+@property(nonatomic, strong) RNNRootViewController *bindedViewController;
+@property(nonatomic, strong) id mockBindedViewController;
 
 @end
 
@@ -18,46 +18,46 @@
 - (void)setUp {
     [super setUp];
     self.uut = [[RNNBasePresenter alloc] init];
-	  self.bindedViewController = [RNNRootViewController new];
+    self.bindedViewController = [RNNRootViewController new];
     self.mockBindedViewController = [OCMockObject partialMockForObject:self.bindedViewController];
     [self.uut bindViewController:self.mockBindedViewController];
     self.options = [[RNNNavigationOptions alloc] initEmptyOptions];
 }
 
 - (void)tearDown {
-	[super tearDown];
-	[self.mockBindedViewController stopMocking];
-	self.bindedViewController = nil;
+    [super tearDown];
+    [self.mockBindedViewController stopMocking];
+    self.bindedViewController = nil;
 }
 
 - (void)testApplyOptions_shouldSetTabBarItemBadgeOnlyWhenParentIsUITabBarController {
-	[[self.mockBindedViewController reject] rnn_setTabBarItemBadge:[OCMArg any]];
-	[self.uut applyOptions:self.options];
-	[self.mockBindedViewController verify];
+    [[self.mockBindedViewController reject] rnn_setTabBarItemBadge:[OCMArg any]];
+    [self.uut applyOptions:self.options];
+    [self.mockBindedViewController verify];
 }
 
 - (void)testApplyOptions_shouldSetTabBarItemBadgeWithValue {
-	OCMStub([self.mockBindedViewController parentViewController]).andReturn([UITabBarController new]);
-	self.options.bottomTab.badge = [[Text alloc] initWithValue:@"badge"];
-	[[self.mockBindedViewController expect] rnn_setTabBarItemBadge:self.options.bottomTab];
-	[self.uut applyOptions:self.options];
-	[self.mockBindedViewController verify];
+    OCMStub([self.mockBindedViewController parentViewController]).andReturn([UITabBarController new]);
+    self.options.bottomTab.badge = [[Text alloc] initWithValue:@"badge"];
+    [[self.mockBindedViewController expect] rnn_setTabBarItemBadge:self.options.bottomTab];
+    [self.uut applyOptions:self.options];
+    [self.mockBindedViewController verify];
 }
 
 - (void)testApplyOptions_setTabBarItemBadgeShouldNotCalledOnUITabBarController {
-	[self.uut bindViewController:self.mockBindedViewController];
-	self.options.bottomTab.badge = [[Text alloc] initWithValue:@"badge"];
-	[[self.mockBindedViewController reject] rnn_setTabBarItemBadge:[[RNNBottomTabOptions alloc] initWithDict:@{@"badge": @"badge"}]];
-	[self.uut applyOptions:self.options];
-	[self.mockBindedViewController verify];
+    [self.uut bindViewController:self.mockBindedViewController];
+    self.options.bottomTab.badge = [[Text alloc] initWithValue:@"badge"];
+    [[self.mockBindedViewController reject] rnn_setTabBarItemBadge:[[RNNBottomTabOptions alloc] initWithDict:@{@"badge": @"badge"}]];
+    [self.uut applyOptions:self.options];
+    [self.mockBindedViewController verify];
 }
 
 - (void)testApplyOptions_setTabBarItemBadgeShouldWhenNoValue {
-	[self.uut bindViewController:self.mockBindedViewController];
-	self.options.bottomTab.badge = nil;
-	[[self.mockBindedViewController reject] rnn_setTabBarItemBadge:[OCMArg any]];
-	[self.uut applyOptions:self.options];
-	[self.mockBindedViewController verify];
+    [self.uut bindViewController:self.mockBindedViewController];
+    self.options.bottomTab.badge = nil;
+    [[self.mockBindedViewController reject] rnn_setTabBarItemBadge:[OCMArg any]];
+    [self.uut applyOptions:self.options];
+    [self.mockBindedViewController verify];
 }
 
 @end

--- a/lib/ios/ReactNativeNavigationTests/RNNBasePresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNBasePresenterTest.m
@@ -39,7 +39,7 @@
 - (void)testApplyOptions_shouldSetTabBarItemBadgeWithValue {
 	OCMStub([self.mockBindedViewController parentViewController]).andReturn([UITabBarController new]);
 	self.options.bottomTab.badge = [[Text alloc] initWithValue:@"badge"];
-	[[self.mockBindedViewController expect] rnn_setTabBarItemBadge:@"badge"];
+	[[self.mockBindedViewController expect] rnn_setTabBarItemBadge:self.options.bottomTab];
 	[self.uut applyOptions:self.options];
 	[self.mockBindedViewController verify];
 }
@@ -47,7 +47,7 @@
 - (void)testApplyOptions_setTabBarItemBadgeShouldNotCalledOnUITabBarController {
 	[self.uut bindViewController:self.mockBindedViewController];
 	self.options.bottomTab.badge = [[Text alloc] initWithValue:@"badge"];
-	[[self.mockBindedViewController reject] rnn_setTabBarItemBadge:@"badge"];
+	[[self.mockBindedViewController reject] rnn_setTabBarItemBadge:[[RNNBottomTabOptions alloc] initWithDict:@{@"badge": @"badge"}]];
 	[self.uut applyOptions:self.options];
 	[self.mockBindedViewController verify];
 }

--- a/lib/ios/ReactNativeNavigationTests/RNNDotIndicatorPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNDotIndicatorPresenterTest.m
@@ -61,9 +61,26 @@
     XCTAssertEqualObjects([indicator1 superview], [_bottomTabs getTabView:0]);
 }
 
+- (void)testApply_itRemovesPreviousDotIndicator {
+    NSUInteger childCountBeforeApplyingIndicator = [[_bottomTabs getTabView:0] subviews].count;
+    [self applyIndicator];
+    NSUInteger childCountAfterApplyingIndicatorOnce = [[_bottomTabs getTabView:0] subviews].count;
+    XCTAssertEqual(childCountBeforeApplyingIndicator + 1, childCountAfterApplyingIndicatorOnce);
+
+    [self applyIndicator:[UIColor greenColor]];
+    NSUInteger childCountAfterApplyingIndicatorTwice = [[_bottomTabs getTabView:0] subviews].count;
+    XCTAssertEqual([[self getIndicator] backgroundColor], [UIColor greenColor]);
+    XCTAssertEqual(childCountAfterApplyingIndicatorOnce, childCountAfterApplyingIndicatorTwice);
+}
+
 - (void)applyIndicator {
+    [self applyIndicator:[UIColor redColor]];
+}
+
+- (void)applyIndicator:(UIColor *) color {
     DotIndicatorOptions *options = [DotIndicatorOptions new];
     options.visible = [[Bool alloc] initWithBOOL:YES];
+    options.color = [[Color alloc] initWithValue:color];
     [[self uut] apply:self.child :options];
 }
 

--- a/lib/ios/ReactNativeNavigationTests/RNNDotIndicatorPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNDotIndicatorPresenterTest.m
@@ -1,0 +1,50 @@
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "RNNDotIndicatorPresenter.h"
+#import "DotIndicatorOptions.h"
+#import "RNNTabBarController.h"
+#import "RNNRootViewController.h"
+#import "RNNTestBase.h"
+
+@interface RNNDotIndicatorPresenterTest : RNNTestBase
+@property(nonatomic, strong) id uut;
+@property(nonatomic, strong) RNNRootViewController *child;
+@property(nonatomic, strong) id bottomTabs;
+@end
+
+@implementation RNNDotIndicatorPresenterTest
+- (void)setUp {
+    [super setUp];
+    self.uut = [OCMockObject partialMockForObject:[RNNDotIndicatorPresenter new]];
+    self.bottomTabs = [OCMockObject partialMockForObject:[RNNTabBarController new]];
+    self.child = [self createChild];
+    [self.bottomTabs addChildViewController:self.child];
+
+    [self setupTopLevelUI:self.bottomTabs];
+}
+
+- (void)testApply_doesNothingIfDoesNotHaveValue {
+    DotIndicatorOptions *empty = [DotIndicatorOptions new];
+    [[self uut] apply:self.child :empty];
+    XCTAssertFalse([self tabHasIndicator]);
+}
+
+- (void)testApply_indicatorIsAddedToTabView {
+    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    DotIndicatorOptions *options = [DotIndicatorOptions new];
+    options.visible = [[Bool alloc] initWithBOOL:YES];
+    [[self uut] apply:self.child :options];
+    XCTAssertTrue([self tabHasIndicator]);
+}
+
+- (RNNRootViewController *)createChild {
+    RNNNavigationOptions *options = [RNNNavigationOptions new];
+    options.bottomTab = [RNNBottomTabOptions new];
+    options.bottomTab.icon = [[Image alloc] initWithValue:[UIImage new]];
+    return [OCMockObject partialMockForObject:[[RNNRootViewController alloc] initWithLayoutInfo:nil rootViewCreator:nil eventEmitter:nil presenter:[RNNViewControllerPresenter new] options:options defaultOptions:nil]];
+}
+
+- (BOOL)tabHasIndicator {
+    return [self.child tabBarItem].tag > 0;
+}
+@end

--- a/lib/ios/ReactNativeNavigationTests/RNNDotIndicatorPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNDotIndicatorPresenterTest.m
@@ -5,6 +5,7 @@
 #import "RNNTabBarController.h"
 #import "RNNRootViewController.h"
 #import "RNNTestBase.h"
+#import "UITabBarController+RNNUtils.h"
 
 @interface RNNDotIndicatorPresenterTest : RNNTestBase
 @property(nonatomic, strong) id uut;
@@ -30,21 +31,56 @@
 }
 
 - (void)testApply_indicatorIsAddedToTabView {
-    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    [self applyIndicator];
+    XCTAssertTrue([self tabHasIndicator]);
+}
+
+- (void)testApply_indicatorIsRemovedIsNotVisible {
+    [self applyIndicator];
+    XCTAssertTrue([self tabHasIndicator]);
+
+    DotIndicatorOptions *options = [DotIndicatorOptions new];
+    options.visible = [[Bool alloc] initWithBOOL:NO];
+    [[self uut] apply:self.child :options];
+
+    XCTAssertFalse([self tabHasIndicator]);
+}
+
+- (void)testApply_itDoesNotRecreateIfEqualToCurrentlyVisibleIndicator {
+    [self applyIndicator];
+    UIView *indicator1 = [self getIndicator];
+
+    [self applyIndicator];
+    UIView *indicator2 = [self getIndicator];
+    XCTAssertEqualObjects(indicator1, indicator2);
+}
+
+- (void)testApply_itAddsIndicatorToCorrectTabView {
+    [self applyIndicator];
+    UIView *indicator1 = [self getIndicator];
+    XCTAssertEqualObjects([indicator1 superview], [_bottomTabs getTabView:0]);
+}
+
+- (void)applyIndicator {
     DotIndicatorOptions *options = [DotIndicatorOptions new];
     options.visible = [[Bool alloc] initWithBOOL:YES];
     [[self uut] apply:self.child :options];
-    XCTAssertTrue([self tabHasIndicator]);
 }
 
 - (RNNRootViewController *)createChild {
     RNNNavigationOptions *options = [RNNNavigationOptions new];
     options.bottomTab = [RNNBottomTabOptions new];
-    options.bottomTab.icon = [[Image alloc] initWithValue:[UIImage new]];
+    id img = [OCMockObject partialMockForObject:[UIImage new]];
+
+    options.bottomTab.icon = [[Image alloc] initWithValue:img];
     return [OCMockObject partialMockForObject:[[RNNRootViewController alloc] initWithLayoutInfo:nil rootViewCreator:nil eventEmitter:nil presenter:[RNNViewControllerPresenter new] options:options defaultOptions:nil]];
 }
 
 - (BOOL)tabHasIndicator {
     return [self.child tabBarItem].tag > 0;
+}
+
+- (UIView *)getIndicator {
+    return [self tabHasIndicator] ? [[((UITabBarController *) _bottomTabs) tabBar] viewWithTag:_child.tabBarItem.tag] : nil;
 }
 @end

--- a/lib/ios/ReactNativeNavigationTests/RNNDotIndicatorPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNDotIndicatorPresenterTest.m
@@ -35,10 +35,18 @@
     XCTAssertTrue([self tabHasIndicator]);
 }
 
-- (void)testApply_indicatorIsRemovedIsNotVisible {
+- (void)testApply_indicatorIsRemovedIfNotVisible {
     [self applyIndicator];
     XCTAssertTrue([self tabHasIndicator]);
 
+    DotIndicatorOptions *options = [DotIndicatorOptions new];
+    options.visible = [[Bool alloc] initWithBOOL:NO];
+    [[self uut] apply:self.child :options];
+
+    XCTAssertFalse([self tabHasIndicator]);
+}
+
+- (void)testApply_invisibleIndicatorIsNotAdded {
     DotIndicatorOptions *options = [DotIndicatorOptions new];
     options.visible = [[Bool alloc] initWithBOOL:NO];
     [[self uut] apply:self.child :options];
@@ -71,6 +79,20 @@
     NSUInteger childCountAfterApplyingIndicatorTwice = [[_bottomTabs getTabView:0] subviews].count;
     XCTAssertEqual([[self getIndicator] backgroundColor], [UIColor greenColor]);
     XCTAssertEqual(childCountAfterApplyingIndicatorOnce, childCountAfterApplyingIndicatorTwice);
+}
+
+- (void)testApply_itRemovesPreviousIndicator {
+    DotIndicatorOptions *options = [DotIndicatorOptions new];
+    options.visible = [[Bool alloc] initWithBOOL:YES];
+    options.color = [[Color alloc] initWithValue:[UIColor redColor]];
+    options.size = [[Number alloc] initWithValue:[[NSNumber alloc] initWithInt:8]];
+
+    [[self uut] apply:self.child :options];
+    XCTAssertTrue([self tabHasIndicator]);
+
+    options.visible = [[Bool alloc] initWithBOOL:NO];
+    [[self uut] apply:self.child :options];
+    XCTAssertFalse([self tabHasIndicator]);
 }
 
 - (void)applyIndicator {

--- a/lib/ios/ReactNativeNavigationTests/RNNDotIndicatorPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNDotIndicatorPresenterTest.m
@@ -145,7 +145,7 @@
     id img = [OCMockObject partialMockForObject:[UIImage new]];
 
     options.bottomTab.icon = [[Image alloc] initWithValue:img];
-    return [OCMockObject partialMockForObject:[[RNNRootViewController alloc] initWithLayoutInfo:nil rootViewCreator:nil eventEmitter:nil presenter:[RNNViewControllerPresenter new] options:options defaultOptions:nil]];
+    return [[RNNRootViewController alloc] initWithLayoutInfo:nil rootViewCreator:nil eventEmitter:nil presenter:[RNNViewControllerPresenter new] options:options defaultOptions:nil];
 }
 
 - (BOOL)tabHasIndicator {

--- a/lib/ios/ReactNativeNavigationTests/RNNDotIndicatorPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNDotIndicatorPresenterTest.m
@@ -24,6 +24,11 @@
     [self setupTopLevelUI:self.bottomTabs];
 }
 
+- (void)tearDown {
+    [self tearDownTopLevelUI:_bottomTabs];
+    [super tearDown];
+}
+
 - (void)testApply_doesNothingIfDoesNotHaveValue {
     DotIndicatorOptions *empty = [DotIndicatorOptions new];
     [[self uut] apply:self.child :empty];
@@ -93,6 +98,34 @@
     options.visible = [[Bool alloc] initWithBOOL:NO];
     [[self uut] apply:self.child :options];
     XCTAssertFalse([self tabHasIndicator]);
+}
+
+- (void)testApply_indicatorIsAlignedToTopRightOfIcon {
+    DotIndicatorOptions *options = [DotIndicatorOptions new];
+    options.visible = [[Bool alloc] initWithBOOL:YES];
+    options.size = [[Number alloc] initWithValue:[[NSNumber alloc] initWithInt:8]];
+    [[self uut] apply:self.child :options];
+    UIView *indicator = [self getIndicator];
+    UIView * icon = [_bottomTabs getTabIcon:0];
+
+    NSArray<NSLayoutConstraint *> *alignmentConstraints = [_bottomTabs getTabView:0].constraints;
+    XCTAssertEqual([alignmentConstraints count], 2);
+    XCTAssertEqual([alignmentConstraints[0] constant], -4);
+    XCTAssertEqual([alignmentConstraints[0] firstItem], indicator);
+    XCTAssertEqual([alignmentConstraints[0] secondItem], icon);
+    XCTAssertEqual([alignmentConstraints[0] firstAttribute], NSLayoutAttributeLeft);
+    XCTAssertEqual([alignmentConstraints[0] secondAttribute], NSLayoutAttributeRight);
+
+    XCTAssertEqual([alignmentConstraints[1] constant], -4);
+    XCTAssertEqual([alignmentConstraints[1] firstItem], indicator);
+    XCTAssertEqual([alignmentConstraints[1] secondItem], icon);
+    XCTAssertEqual([alignmentConstraints[1] firstAttribute], NSLayoutAttributeTop);
+    XCTAssertEqual([alignmentConstraints[1] secondAttribute], NSLayoutAttributeTop);
+
+    NSArray *sizeConstraints = indicator.constraints;
+    XCTAssertEqual([sizeConstraints count], 2);
+    XCTAssertEqual([sizeConstraints[0] constant], 8);
+    XCTAssertEqual([sizeConstraints[1] constant], 8);
 }
 
 - (void)applyIndicator {

--- a/lib/ios/ReactNativeNavigationTests/RNNNavigationControllerPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNNavigationControllerPresenterTest.m
@@ -47,14 +47,14 @@
 	_options.topBar.largeTitle.visible = [[Bool alloc] initWithBOOL:YES];
 	
 	[self.uut applyOptionsBeforePopping:self.options];
-	XCTAssertTrue([[self.uut.bindedViewController navigationBar] prefersLargeTitles]);
+	XCTAssertTrue([[self.uut.boundViewController navigationBar] prefersLargeTitles]);
 }
 
 - (void)testApplyOptionsBeforePoppingShouldSetDefaultLargeTitleFalseForPoppingViewController {
 	_options.topBar.largeTitle.visible = nil;
 	
 	[self.uut applyOptionsBeforePopping:self.options];
-	XCTAssertFalse([[self.uut.bindedViewController navigationBar] prefersLargeTitles]);
+	XCTAssertFalse([[self.uut.boundViewController navigationBar] prefersLargeTitles]);
 }
 
 @end

--- a/lib/ios/ReactNativeNavigationTests/RNNTabBarControllerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNTabBarControllerTest.m
@@ -76,7 +76,7 @@
 }
 
 - (void)testWillMoveToParent_shouldNotInvokePresenterApplyOptionsOnWillMoveToNilParent {
-    [[self.mockTabBarPresenter reject] applyOptionsOnWillMoveToParentViewController:[(RNNTabBarController *) self.uut options]];
+    [[self.mockTabBarPresenter reject] applyOptionsOnWillMoveToParentViewController:[self.uut options]];
     [self.uut willMoveToParentViewController:nil];
     [self.mockTabBarPresenter verify];
 }
@@ -90,8 +90,8 @@
 - (void)testMergeOptions_shouldInvokePresenterMergeOptions {
     RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initWithDict:@{}];
 
-    [(RNNTabBarPresenter *) [self.mockTabBarPresenter expect] mergeOptions:options currentOptions:[(RNNTabBarController *) self.uut options] defaultOptions:nil];
-    [(RNNTabBarController *) self.uut mergeOptions:options];
+    [(RNNTabBarPresenter *) [self.mockTabBarPresenter expect] mergeOptions:options currentOptions:[self.uut options] defaultOptions:nil];
+    [self.uut mergeOptions:options];
     [self.mockTabBarPresenter verify];
 }
 
@@ -101,7 +101,7 @@
 
     OCMStub([self.uut parentViewController]).andReturn(parentMock);
     [((RNNRootViewController *) [parentMock expect]) mergeOptions:options];
-    [(RNNTabBarController *) self.uut mergeOptions:options];
+    [self.uut mergeOptions:options];
     [parentMock verify];
 }
 

--- a/lib/ios/ReactNativeNavigationTests/RNNTabBarControllerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNTabBarControllerTest.m
@@ -1,166 +1,164 @@
 #import <XCTest/XCTest.h>
 #import "RNNTabBarController.h"
-#import "RNNNavigationOptions.h"
-#import "RNNTabBarPresenter.h"
 #import "RNNRootViewController.h"
 #import "RNNNavigationController.h"
 #import <OCMock/OCMock.h>
 
 @interface RNNTabBarControllerTest : XCTestCase
 
-@property (nonatomic, strong) id mockUut;
-@property (nonatomic, strong) id mockChildViewController;
-@property (nonatomic, strong) id mockEventEmmiter;
-@property (nonatomic, strong) id mockTabBarPresenter;
+@property(nonatomic, strong) id mockUut;
+@property(nonatomic, strong) id mockChildViewController;
+@property(nonatomic, strong) id mockEventEmitter;
+@property(nonatomic, strong) id mockTabBarPresenter;
 
 @end
 
 @implementation RNNTabBarControllerTest
 
 - (void)setUp {
-	[super setUp];
-	
-	id tabBarClassMock = OCMClassMock([RNNTabBarController class]);
-	OCMStub([tabBarClassMock parentViewController]).andReturn([OCMockObject partialMockForObject:[RNNTabBarController new]]);
+    [super setUp];
 
-	self.mockTabBarPresenter = [OCMockObject partialMockForObject:[[RNNTabBarPresenter alloc] init]];
-	self.mockChildViewController = [OCMockObject partialMockForObject:[RNNRootViewController new]];
-	self.mockEventEmmiter = [OCMockObject partialMockForObject:[RNNEventEmitter new]];
-	self.mockUut = [OCMockObject partialMockForObject:[[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:self.mockTabBarPresenter eventEmitter:self.mockEventEmmiter childViewControllers:@[[[UIViewController alloc] init]]]];
-	OCMStub([self.mockUut selectedViewController]).andReturn(self.mockChildViewController);
+    id tabBarClassMock = OCMClassMock([RNNTabBarController class]);
+    OCMStub([tabBarClassMock parentViewController]).andReturn([OCMockObject partialMockForObject:[RNNTabBarController new]]);
+
+    self.mockTabBarPresenter = [OCMockObject partialMockForObject:[[RNNTabBarPresenter alloc] init]];
+    self.mockChildViewController = [OCMockObject partialMockForObject:[RNNRootViewController new]];
+    self.mockEventEmitter = [OCMockObject partialMockForObject:[RNNEventEmitter new]];
+    self.mockUut = [OCMockObject partialMockForObject:[[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:self.mockTabBarPresenter eventEmitter:self.mockEventEmitter childViewControllers:@[[[UIViewController alloc] init]]]];
+    OCMStub([self.mockUut selectedViewController]).andReturn(self.mockChildViewController);
 }
 
 - (void)testInitWithLayoutInfo_shouldBindPresenter {
-	XCTAssertNotNil([self.mockUut presenter]);
+    XCTAssertNotNil([self.mockUut presenter]);
 }
 
 - (void)testInitWithLayoutInfo_shouldSetMultipleViewControllers {
-	UIViewController* vc1 = [[UIViewController alloc] init];
-	UIViewController* vc2 = [[UIViewController alloc] init];
-	
-	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:[[RNNViewControllerPresenter alloc] init] eventEmitter:nil childViewControllers:@[vc1, vc2]];
-	XCTAssertTrue(uut.viewControllers.count == 2);
+    UIViewController *vc1 = [[UIViewController alloc] init];
+    UIViewController *vc2 = [[UIViewController alloc] init];
+
+    RNNTabBarController *uut = [[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:[[RNNViewControllerPresenter alloc] init] eventEmitter:nil childViewControllers:@[vc1, vc2]];
+    XCTAssertTrue(uut.viewControllers.count == 2);
 }
 
 - (void)testInitWithLayoutInfo_shouldInitializeDependencies {
-	RNNLayoutInfo* layoutInfo = [RNNLayoutInfo new];
-	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:@{}];
-	RNNTabBarPresenter* presenter = [[RNNTabBarPresenter alloc] init];
-	NSArray* childViewControllers = @[[UIViewController new]];
-	
-	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:layoutInfo creator:nil options:options defaultOptions:nil presenter:presenter eventEmitter:nil childViewControllers:childViewControllers];
-	XCTAssertTrue(uut.layoutInfo == layoutInfo);
-	XCTAssertTrue(uut.options == options);
-	XCTAssertTrue(uut.presenter == presenter);
-	XCTAssertTrue(uut.childViewControllers.count == childViewControllers.count);
+    RNNLayoutInfo *layoutInfo = [RNNLayoutInfo new];
+    RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initWithDict:@{}];
+    RNNTabBarPresenter *presenter = [[RNNTabBarPresenter alloc] init];
+    NSArray *childViewControllers = @[[UIViewController new]];
+
+    RNNTabBarController *uut = [[RNNTabBarController alloc] initWithLayoutInfo:layoutInfo creator:nil options:options defaultOptions:nil presenter:presenter eventEmitter:nil childViewControllers:childViewControllers];
+    XCTAssertTrue(uut.layoutInfo == layoutInfo);
+    XCTAssertTrue(uut.options == options);
+    XCTAssertTrue(uut.presenter == presenter);
+    XCTAssertTrue(uut.childViewControllers.count == childViewControllers.count);
 }
 
 - (void)testInitWithEventEmmiter_shouldInitializeDependencies {
-	RNNLayoutInfo* layoutInfo = [RNNLayoutInfo new];
-	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:@{}];
-	RNNTabBarPresenter* presenter = [[RNNTabBarPresenter alloc] init];
-	RNNEventEmitter* eventEmmiter = [RNNEventEmitter new];
+    RNNLayoutInfo *layoutInfo = [RNNLayoutInfo new];
+    RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initWithDict:@{}];
+    RNNTabBarPresenter *presenter = [[RNNTabBarPresenter alloc] init];
+    RNNEventEmitter *eventEmmiter = [RNNEventEmitter new];
 
-	NSArray* childViewControllers = @[[UIViewController new]];
-	
-	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:layoutInfo creator:nil options:options defaultOptions:nil presenter:presenter eventEmitter:eventEmmiter childViewControllers:childViewControllers];
-	XCTAssertTrue(uut.layoutInfo == layoutInfo);
-	XCTAssertTrue(uut.options == options);
-	XCTAssertTrue(uut.presenter == presenter);
-	XCTAssertTrue(uut.childViewControllers.count == childViewControllers.count);
-	XCTAssertTrue(uut.eventEmitter == eventEmmiter);
+    NSArray *childViewControllers = @[[UIViewController new]];
+
+    RNNTabBarController *uut = [[RNNTabBarController alloc] initWithLayoutInfo:layoutInfo creator:nil options:options defaultOptions:nil presenter:presenter eventEmitter:eventEmmiter childViewControllers:childViewControllers];
+    XCTAssertTrue(uut.layoutInfo == layoutInfo);
+    XCTAssertTrue(uut.options == options);
+    XCTAssertTrue(uut.presenter == presenter);
+    XCTAssertTrue(uut.childViewControllers.count == childViewControllers.count);
+    XCTAssertTrue(uut.eventEmitter == eventEmmiter);
 }
 
 - (void)testInitWithLayoutInfo_shouldSetDelegate {
-	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:[[RNNBasePresenter alloc] init] eventEmitter:nil childViewControllers:nil];
-	
-	XCTAssertTrue(uut.delegate == uut);
+    RNNTabBarController *uut = [[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:[[RNNBasePresenter alloc] init] eventEmitter:nil childViewControllers:nil];
+
+    XCTAssertTrue(uut.delegate == uut);
 }
 
 - (void)testWillMoveToParent_shouldNotInvokePresenterApplyOptionsOnWillMoveToNilParent {
-	[[self.mockTabBarPresenter reject] applyOptionsOnWillMoveToParentViewController:[(RNNTabBarController *)self.mockUut options]];
-	[self.mockUut willMoveToParentViewController:nil];
-	[self.mockTabBarPresenter verify];
+    [[self.mockTabBarPresenter reject] applyOptionsOnWillMoveToParentViewController:[(RNNTabBarController *) self.mockUut options]];
+    [self.mockUut willMoveToParentViewController:nil];
+    [self.mockTabBarPresenter verify];
 }
 
 - (void)testOnChildAppear_shouldInvokePresenterApplyOptionsWithResolvedOptions {
-	[[self.mockTabBarPresenter expect] applyOptions:[OCMArg any]];
-	[self.mockUut onChildWillAppear];
-	[self.mockTabBarPresenter verify];
+    [[self.mockTabBarPresenter expect] applyOptions:[OCMArg any]];
+    [self.mockUut onChildWillAppear];
+    [self.mockTabBarPresenter verify];
 }
 
 - (void)testMergeOptions_shouldInvokePresenterMergeOptions {
-	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:@{}];
-	
-	[(RNNTabBarPresenter *)[self.mockTabBarPresenter expect] mergeOptions:options currentOptions:[(RNNTabBarController *)self.mockUut options] defaultOptions:nil];
-	[(RNNTabBarController *)self.mockUut mergeOptions:options];
-	[self.mockTabBarPresenter verify];
+    RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initWithDict:@{}];
+
+    [(RNNTabBarPresenter *) [self.mockTabBarPresenter expect] mergeOptions:options currentOptions:[(RNNTabBarController *) self.mockUut options] defaultOptions:nil];
+    [(RNNTabBarController *) self.mockUut mergeOptions:options];
+    [self.mockTabBarPresenter verify];
 }
 
 - (void)testMergeOptions_shouldInvokeParentMergeOptions {
-	id parentMock = [OCMockObject partialMockForObject:[RNNRootViewController new]];
-	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:@{}];
+    id parentMock = [OCMockObject partialMockForObject:[RNNRootViewController new]];
+    RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initWithDict:@{}];
 
-	OCMStub([self.mockUut parentViewController]).andReturn(parentMock);
-	[((RNNRootViewController *)[parentMock expect]) mergeOptions:options];
-	[(RNNTabBarController *)self.mockUut mergeOptions:options];
-	[parentMock verify];
+    OCMStub([self.mockUut parentViewController]).andReturn(parentMock);
+    [((RNNRootViewController *) [parentMock expect]) mergeOptions:options];
+    [(RNNTabBarController *) self.mockUut mergeOptions:options];
+    [parentMock verify];
 }
 
 - (void)testOnChildAppear_shouldInvokeParentOnChildAppear {
-	id parentMock = [OCMockObject partialMockForObject:[RNNNavigationController new]];
+    id parentMock = [OCMockObject partialMockForObject:[RNNNavigationController new]];
 
-	OCMStub([self.mockUut parentViewController]).andReturn(parentMock);
-	
-	[[parentMock expect] onChildWillAppear];
-	[self.mockUut onChildWillAppear];
-	[parentMock verify];
+    OCMStub([self.mockUut parentViewController]).andReturn(parentMock);
+
+    [[parentMock expect] onChildWillAppear];
+    [self.mockUut onChildWillAppear];
+    [parentMock verify];
 }
 
 - (void)testGetCurrentChild_shouldReturnSelectedViewController {
-	XCTAssertEqual([self.mockUut getCurrentChild], [(RNNTabBarController *)self.mockUut selectedViewController]);
+    XCTAssertEqual([self.mockUut getCurrentChild], [(RNNTabBarController *) self.mockUut selectedViewController]);
 }
 
 - (void)testPreferredStatusBarStyle_shouldInvokeSelectedViewControllerPreferredStatusBarStyle {
-	[[self.mockChildViewController expect] preferredStatusBarStyle];
-	[self.mockUut preferredStatusBarStyle];
-	[self.mockChildViewController verify];
+    [[self.mockChildViewController expect] preferredStatusBarStyle];
+    [self.mockUut preferredStatusBarStyle];
+    [self.mockChildViewController verify];
 }
 
 - (void)testPreferredStatusBarStyle_shouldInvokeOnSelectedViewController {
-	[[self.mockChildViewController expect] preferredStatusBarStyle];
-	[self.mockUut preferredStatusBarStyle];
-	[self.mockChildViewController verify];
+    [[self.mockChildViewController expect] preferredStatusBarStyle];
+    [self.mockUut preferredStatusBarStyle];
+    [self.mockChildViewController verify];
 }
 
 - (void)testTabBarControllerDidSelectViewControllerDelegate_shouldInvokeSendBottomTabSelectedEvent {
-	NSUInteger selectedIndex = 2;
-	OCMStub([self.mockUut selectedIndex]).andReturn(selectedIndex);
+    NSUInteger selectedIndex = 2;
+    OCMStub([self.mockUut selectedIndex]).andReturn(selectedIndex);
 
-	[[self.mockEventEmmiter expect] sendBottomTabSelected:@(selectedIndex) unselected:@(0)];
-	[self.mockUut tabBarController:self.mockUut didSelectViewController:[UIViewController new]];
-	[self.mockEventEmmiter verify];
+    [[self.mockEventEmitter expect] sendBottomTabSelected:@(selectedIndex) unselected:@(0)];
+    [self.mockUut tabBarController:self.mockUut didSelectViewController:[UIViewController new]];
+    [self.mockEventEmitter verify];
 }
 
 - (void)testSetSelectedIndexByComponentID_ShouldSetSelectedIndexWithCorrectIndex {
-	RNNLayoutInfo* layoutInfo = [RNNLayoutInfo new];
-	layoutInfo.componentId = @"componentId";
-	
-	RNNRootViewController* vc = [[RNNRootViewController alloc] initWithLayoutInfo:layoutInfo rootViewCreator:nil eventEmitter:nil presenter:nil options:nil defaultOptions:nil];
-	
-	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:nil defaultOptions:nil presenter:[RNNTabBarPresenter new] eventEmitter:nil childViewControllers:@[[UIViewController new], vc]];
-	[uut setSelectedIndexByComponentID:@"componentId"];
-	XCTAssertTrue(uut.selectedIndex == 1);
+    RNNLayoutInfo *layoutInfo = [RNNLayoutInfo new];
+    layoutInfo.componentId = @"componentId";
+
+    RNNRootViewController *vc = [[RNNRootViewController alloc] initWithLayoutInfo:layoutInfo rootViewCreator:nil eventEmitter:nil presenter:nil options:nil defaultOptions:nil];
+
+    RNNTabBarController *uut = [[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:nil defaultOptions:nil presenter:[RNNTabBarPresenter new] eventEmitter:nil childViewControllers:@[[UIViewController new], vc]];
+    [uut setSelectedIndexByComponentID:@"componentId"];
+    XCTAssertTrue(uut.selectedIndex == 1);
 }
 
 - (void)testSetSelectedIndex_ShouldSetSelectedIndexWithCurrentTabIndex {
-	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initEmptyOptions];
-	options.bottomTabs.currentTabIndex = [[IntNumber alloc] initWithValue:@(1)];
+    RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initEmptyOptions];
+    options.bottomTabs.currentTabIndex = [[IntNumber alloc] initWithValue:@(1)];
 
-	RNNRootViewController* vc = [[RNNRootViewController alloc] initWithLayoutInfo:nil rootViewCreator:nil eventEmitter:nil presenter:nil options:nil defaultOptions:nil];
-	RNNTabBarController* uut = [[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:options defaultOptions:nil presenter:[RNNTabBarPresenter new] eventEmitter:nil childViewControllers:@[[UIViewController new], vc]];
-	
-	XCTAssertTrue(uut.selectedIndex == 1);
+    RNNRootViewController *vc = [[RNNRootViewController alloc] initWithLayoutInfo:nil rootViewCreator:nil eventEmitter:nil presenter:nil options:nil defaultOptions:nil];
+    RNNTabBarController *uut = [[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:options defaultOptions:nil presenter:[RNNTabBarPresenter new] eventEmitter:nil childViewControllers:@[[UIViewController new], vc]];
+
+    XCTAssertTrue(uut.selectedIndex == 1);
 }
 
 @end

--- a/lib/ios/ReactNativeNavigationTests/RNNTabBarControllerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNTabBarControllerTest.m
@@ -6,7 +6,7 @@
 
 @interface RNNTabBarControllerTest : XCTestCase
 
-@property(nonatomic, strong) id mockUut;
+@property(nonatomic, strong) RNNTabBarController * uut;
 @property(nonatomic, strong) id mockChildViewController;
 @property(nonatomic, strong) id mockEventEmitter;
 @property(nonatomic, strong) id mockTabBarPresenter;
@@ -24,12 +24,12 @@
     self.mockTabBarPresenter = [OCMockObject partialMockForObject:[[RNNTabBarPresenter alloc] init]];
     self.mockChildViewController = [OCMockObject partialMockForObject:[RNNRootViewController new]];
     self.mockEventEmitter = [OCMockObject partialMockForObject:[RNNEventEmitter new]];
-    self.mockUut = [OCMockObject partialMockForObject:[[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:self.mockTabBarPresenter eventEmitter:self.mockEventEmitter childViewControllers:@[[[UIViewController alloc] init]]]];
-    OCMStub([self.mockUut selectedViewController]).andReturn(self.mockChildViewController);
+    self.uut = [OCMockObject partialMockForObject:[[RNNTabBarController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:self.mockTabBarPresenter eventEmitter:self.mockEventEmitter childViewControllers:@[[[UIViewController alloc] init]]]];
+    OCMStub([self.uut selectedViewController]).andReturn(self.mockChildViewController);
 }
 
 - (void)testInitWithLayoutInfo_shouldBindPresenter {
-    XCTAssertNotNil([self.mockUut presenter]);
+    XCTAssertNotNil([self.uut presenter]);
 }
 
 - (void)testInitWithLayoutInfo_shouldSetMultipleViewControllers {
@@ -76,22 +76,22 @@
 }
 
 - (void)testWillMoveToParent_shouldNotInvokePresenterApplyOptionsOnWillMoveToNilParent {
-    [[self.mockTabBarPresenter reject] applyOptionsOnWillMoveToParentViewController:[(RNNTabBarController *) self.mockUut options]];
-    [self.mockUut willMoveToParentViewController:nil];
+    [[self.mockTabBarPresenter reject] applyOptionsOnWillMoveToParentViewController:[(RNNTabBarController *) self.uut options]];
+    [self.uut willMoveToParentViewController:nil];
     [self.mockTabBarPresenter verify];
 }
 
 - (void)testOnChildAppear_shouldInvokePresenterApplyOptionsWithResolvedOptions {
     [[self.mockTabBarPresenter expect] applyOptions:[OCMArg any]];
-    [self.mockUut onChildWillAppear];
+    [self.uut onChildWillAppear];
     [self.mockTabBarPresenter verify];
 }
 
 - (void)testMergeOptions_shouldInvokePresenterMergeOptions {
     RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initWithDict:@{}];
 
-    [(RNNTabBarPresenter *) [self.mockTabBarPresenter expect] mergeOptions:options currentOptions:[(RNNTabBarController *) self.mockUut options] defaultOptions:nil];
-    [(RNNTabBarController *) self.mockUut mergeOptions:options];
+    [(RNNTabBarPresenter *) [self.mockTabBarPresenter expect] mergeOptions:options currentOptions:[(RNNTabBarController *) self.uut options] defaultOptions:nil];
+    [(RNNTabBarController *) self.uut mergeOptions:options];
     [self.mockTabBarPresenter verify];
 }
 
@@ -99,44 +99,50 @@
     id parentMock = [OCMockObject partialMockForObject:[RNNRootViewController new]];
     RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initWithDict:@{}];
 
-    OCMStub([self.mockUut parentViewController]).andReturn(parentMock);
+    OCMStub([self.uut parentViewController]).andReturn(parentMock);
     [((RNNRootViewController *) [parentMock expect]) mergeOptions:options];
-    [(RNNTabBarController *) self.mockUut mergeOptions:options];
+    [(RNNTabBarController *) self.uut mergeOptions:options];
     [parentMock verify];
 }
 
 - (void)testOnChildAppear_shouldInvokeParentOnChildAppear {
     id parentMock = [OCMockObject partialMockForObject:[RNNNavigationController new]];
 
-    OCMStub([self.mockUut parentViewController]).andReturn(parentMock);
+    OCMStub([self.uut parentViewController]).andReturn(parentMock);
 
     [[parentMock expect] onChildWillAppear];
-    [self.mockUut onChildWillAppear];
+    [self.uut onChildWillAppear];
     [parentMock verify];
 }
 
+- (void)testViewDidLayoutSubviews_delegateToPresenter {
+    [[[self mockTabBarPresenter] expect] viewDidLayoutSubviews];
+    [[self uut] viewDidLayoutSubviews];
+    [[self mockTabBarPresenter] verify];
+}
+
 - (void)testGetCurrentChild_shouldReturnSelectedViewController {
-    XCTAssertEqual([self.mockUut getCurrentChild], [(RNNTabBarController *) self.mockUut selectedViewController]);
+    XCTAssertEqual([self.uut getCurrentChild], [(RNNTabBarController *) self.uut selectedViewController]);
 }
 
 - (void)testPreferredStatusBarStyle_shouldInvokeSelectedViewControllerPreferredStatusBarStyle {
     [[self.mockChildViewController expect] preferredStatusBarStyle];
-    [self.mockUut preferredStatusBarStyle];
+    [self.uut preferredStatusBarStyle];
     [self.mockChildViewController verify];
 }
 
 - (void)testPreferredStatusBarStyle_shouldInvokeOnSelectedViewController {
     [[self.mockChildViewController expect] preferredStatusBarStyle];
-    [self.mockUut preferredStatusBarStyle];
+    [self.uut preferredStatusBarStyle];
     [self.mockChildViewController verify];
 }
 
 - (void)testTabBarControllerDidSelectViewControllerDelegate_shouldInvokeSendBottomTabSelectedEvent {
     NSUInteger selectedIndex = 2;
-    OCMStub([self.mockUut selectedIndex]).andReturn(selectedIndex);
+    OCMStub([self.uut selectedIndex]).andReturn(selectedIndex);
 
     [[self.mockEventEmitter expect] sendBottomTabSelected:@(selectedIndex) unselected:@(0)];
-    [self.mockUut tabBarController:self.mockUut didSelectViewController:[UIViewController new]];
+    [self.uut tabBarController:self.uut didSelectViewController:[UIViewController new]];
     [self.mockEventEmitter verify];
 }
 

--- a/lib/ios/ReactNativeNavigationTests/RNNTabBarPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNTabBarPresenterTest.m
@@ -56,23 +56,23 @@
 
 - (void)testViewDidLayoutSubviews_appliesBadgeOnNextRunLoop {
     id uut = [self uut];
-    [[uut expect] applyBadgeSize];
+    [[uut expect] applyDotIndicator];
     [uut viewDidLayoutSubviews];
     [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
     [uut verify];
 }
 
-- (void)testApplyBadgeSize_callsAppliesBadgeWithEachChild {
+- (void)testApplyDotIndicator_callsAppliesBadgeWithEachChild {
     id uut = [self uut];
     id child1 = [OCMockObject partialMockForObject:[UIViewController new]];
     id child2 = [OCMockObject partialMockForObject:[UIViewController new]];
 
-    [[uut expect] applyBadgeSize:child1];
-    [[uut expect] applyBadgeSize:child2];
+    [[uut expect] applyDotIndicator:child1];
+    [[uut expect] applyDotIndicator:child2];
     [[self boundViewController] addChildViewController:child1];
     [[self boundViewController] addChildViewController:child2];
 
-    [uut applyBadgeSize];
+    [uut applyDotIndicator];
     [uut verify];
 }
 

--- a/lib/ios/ReactNativeNavigationTests/RNNTabBarPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNTabBarPresenterTest.m
@@ -64,8 +64,8 @@
 
 - (void)testApplyDotIndicator_callsAppliesBadgeWithEachChild {
     id uut = [self uut];
-    id child1 = [OCMockObject partialMockForObject:[UIViewController new]];
-    id child2 = [OCMockObject partialMockForObject:[UIViewController new]];
+    id child1 = [UIViewController new];
+    id child2 = [UIViewController new];
 
     [[uut expect] applyDotIndicator:child1];
     [[uut expect] applyDotIndicator:child2];

--- a/lib/ios/ReactNativeNavigationTests/RNNTabBarPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNTabBarPresenterTest.m
@@ -6,9 +6,9 @@
 
 @interface RNNTabBarPresenterTest : XCTestCase
 
-@property (nonatomic, strong) RNNTabBarPresenter *uut;
-@property (nonatomic, strong) RNNNavigationOptions *options;
-@property (nonatomic, strong) id bindedViewController;
+@property(nonatomic, strong) RNNTabBarPresenter *uut;
+@property(nonatomic, strong) RNNNavigationOptions *options;
+@property(nonatomic, strong) id boundViewController;
 
 @end
 
@@ -16,43 +16,64 @@
 
 - (void)setUp {
     [super setUp];
-	self.uut = [[RNNTabBarPresenter alloc] init];
-	self.bindedViewController = [OCMockObject partialMockForObject:[RNNTabBarController new]];
-	[self.uut bindViewController:self.bindedViewController];
-	self.options = [[RNNNavigationOptions alloc] initEmptyOptions];
+    self.uut = [OCMockObject partialMockForObject:[RNNTabBarPresenter new]];
+    self.boundViewController = [OCMockObject partialMockForObject:[RNNTabBarController new]];
+    [self.uut bindViewController:self.boundViewController];
+    self.options = [[RNNNavigationOptions alloc] initEmptyOptions];
 }
 
 - (void)testApplyOptions_shouldSetDefaultEmptyOptions {
-	RNNNavigationOptions* emptyOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
-	[[self.bindedViewController expect] rnn_setTabBarTestID:nil];
-	[[self.bindedViewController expect] rnn_setTabBarBackgroundColor:nil];
-	[[self.bindedViewController expect] rnn_setTabBarTranslucent:NO];
-	[[self.bindedViewController expect] rnn_setTabBarHideShadow:NO];
-    [[self.bindedViewController expect] rnn_setTabBarStyle:UIBarStyleDefault];
-	[[self.bindedViewController expect] rnn_setTabBarVisible:YES animated:NO];
-	[self.uut applyOptions:emptyOptions];
-	[self.bindedViewController verify];
+    RNNNavigationOptions *emptyOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
+    [[self.boundViewController expect] rnn_setTabBarTestID:nil];
+    [[self.boundViewController expect] rnn_setTabBarBackgroundColor:nil];
+    [[self.boundViewController expect] rnn_setTabBarTranslucent:NO];
+    [[self.boundViewController expect] rnn_setTabBarHideShadow:NO];
+    [[self.boundViewController expect] rnn_setTabBarStyle:UIBarStyleDefault];
+    [[self.boundViewController expect] rnn_setTabBarVisible:YES animated:NO];
+    [self.uut applyOptions:emptyOptions];
+    [self.boundViewController verify];
 }
 
 - (void)testApplyOptions_shouldApplyOptions {
-	RNNNavigationOptions* initialOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
-	initialOptions.bottomTabs.testID = [[Text alloc] initWithValue:@"testID"];
-	initialOptions.bottomTabs.backgroundColor = [[Color alloc] initWithValue:[UIColor redColor]];
-	initialOptions.bottomTabs.translucent = [[Bool alloc] initWithValue:@(0)];
-	initialOptions.bottomTabs.hideShadow = [[Bool alloc] initWithValue:@(1)];
-	initialOptions.bottomTabs.visible = [[Bool alloc] initWithValue:@(0)];
-	initialOptions.bottomTabs.barStyle = [[Text alloc] initWithValue:@"black"];
-	
-	[[self.bindedViewController expect] rnn_setTabBarTestID:@"testID"];
-	[[self.bindedViewController expect] rnn_setTabBarBackgroundColor:[UIColor redColor]];
-	[[self.bindedViewController expect] rnn_setTabBarTranslucent:NO];
-	[[self.bindedViewController expect] rnn_setTabBarHideShadow:YES];
-	[[self.bindedViewController expect] rnn_setTabBarStyle:UIBarStyleBlack];
-	[[self.bindedViewController expect] rnn_setTabBarVisible:NO animated:NO];
-	
-	[self.uut applyOptions:initialOptions];
-	[self.bindedViewController verify];
+    RNNNavigationOptions *initialOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
+    initialOptions.bottomTabs.testID = [[Text alloc] initWithValue:@"testID"];
+    initialOptions.bottomTabs.backgroundColor = [[Color alloc] initWithValue:[UIColor redColor]];
+    initialOptions.bottomTabs.translucent = [[Bool alloc] initWithValue:@(0)];
+    initialOptions.bottomTabs.hideShadow = [[Bool alloc] initWithValue:@(1)];
+    initialOptions.bottomTabs.visible = [[Bool alloc] initWithValue:@(0)];
+    initialOptions.bottomTabs.barStyle = [[Text alloc] initWithValue:@"black"];
+
+    [[self.boundViewController expect] rnn_setTabBarTestID:@"testID"];
+    [[self.boundViewController expect] rnn_setTabBarBackgroundColor:[UIColor redColor]];
+    [[self.boundViewController expect] rnn_setTabBarTranslucent:NO];
+    [[self.boundViewController expect] rnn_setTabBarHideShadow:YES];
+    [[self.boundViewController expect] rnn_setTabBarStyle:UIBarStyleBlack];
+    [[self.boundViewController expect] rnn_setTabBarVisible:NO animated:NO];
+
+    [self.uut applyOptions:initialOptions];
+    [self.boundViewController verify];
 }
 
+- (void)testViewDidLayoutSubviews_appliesBadgeOnNextRunLoop {
+    id uut = [self uut];
+    [[uut expect] applyBadgeSize];
+    [uut viewDidLayoutSubviews];
+    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    [uut verify];
+}
+
+- (void)testApplyBadgeSize_callsAppliesBadgeWithEachChild {
+    id uut = [self uut];
+    id child1 = [OCMockObject partialMockForObject:[UIViewController new]];
+    id child2 = [OCMockObject partialMockForObject:[UIViewController new]];
+
+    [[uut expect] applyBadgeSize:child1];
+    [[uut expect] applyBadgeSize:child2];
+    [[self boundViewController] addChildViewController:child1];
+    [[self boundViewController] addChildViewController:child2];
+
+    [uut applyBadgeSize];
+    [uut verify];
+}
 
 @end

--- a/lib/ios/ReactNativeNavigationTests/RNNViewControllerPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNViewControllerPresenterTest.m
@@ -141,7 +141,7 @@
 	
 	self.options.topBar.title.component = [[RNNComponentOptions alloc] initWithDict:@{@"name": @"componentName"}];
 	
-	[[(id)self.componentRegistry expect] clearComponentsForParentId:self.uut.bindedComponentId];
+	[[(id)self.componentRegistry expect] clearComponentsForParentId:self.uut.boundComponentId];
 	self.uut = nil;
 	[(id)self.componentRegistry verify];
 }
@@ -153,7 +153,7 @@
 	bindViewController.layoutInfo = layoutInfo;
 	
 	[self.uut bindViewController:bindViewController];
-	XCTAssertEqual(self.uut.bindedComponentId, @"componentId");
+	XCTAssertEqual(self.uut.boundComponentId, @"componentId");
 }
 
 - (void)testRenderComponentsCreateReactViewWithBindedComponentId {
@@ -165,12 +165,12 @@
 	
 	self.options.topBar.title.component = [[RNNComponentOptions alloc] initWithDict:@{@"name": @"titleComponent"}];
 	
-	[[(id)self.componentRegistry expect] createComponentIfNotExists:self.options.topBar.title.component parentComponentId:self.uut.bindedComponentId reactViewReadyBlock:[OCMArg any]];
+	[[(id)self.componentRegistry expect] createComponentIfNotExists:self.options.topBar.title.component parentComponentId:self.uut.boundComponentId reactViewReadyBlock:[OCMArg any]];
 	[self.uut renderComponents:self.options perform:nil];
 	[(id)self.componentRegistry verify];
 	
 	
-	XCTAssertEqual(self.uut.bindedComponentId, @"componentId");
+	XCTAssertEqual(self.uut.boundComponentId, @"componentId");
 }
 
 - (void)testApplyOptionsOnWillMoveToParent_shouldSetBackButtonOnBindedViewController_withTitle {

--- a/lib/ios/ReactNativeNavigationTests/UITabBarController+RNNOptionsTest.m
+++ b/lib/ios/ReactNativeNavigationTests/UITabBarController+RNNOptionsTest.m
@@ -1,4 +1,5 @@
 #import <XCTest/XCTest.h>
+#import <OCMockObject.h>
 #import "UITabBarController+RNNOptions.h"
 
 @interface UITabBarController_RNNOptionsTest : XCTestCase
@@ -11,7 +12,7 @@
 
 - (void)setUp {
     [super setUp];
-	self.uut = [UITabBarController new];
+	self.uut = [OCMockObject partialMockForObject:[UITabBarController new]];
 }
 
 - (void)test_tabBarTranslucent_true {

--- a/lib/ios/ReactNativeNavigationTests/UIViewController+RNNOptionsTest.m
+++ b/lib/ios/ReactNativeNavigationTests/UIViewController+RNNOptionsTest.m
@@ -1,10 +1,11 @@
 #import <XCTest/XCTest.h>
 #import "UIViewController+RNNOptions.h"
 #import <OCMock/OCMock.h>
+#import "RNNBottomTabOptions.h"
 
 @interface UIViewController_RNNOptionsTest : XCTestCase
 
-@property (nonatomic, retain) id uut;
+@property(nonatomic, retain) id uut;
 
 @end
 
@@ -12,27 +13,28 @@
 
 - (void)setUp {
     [super setUp];
-	self.uut = [OCMockObject partialMockForObject:[UIViewController new]];
+    self.uut = [OCMockObject partialMockForObject:[UIViewController new]];
 }
 
 - (void)test_setTabBarItemBadge_shouldSetValidValue {
-	NSString* badgeValue = @"badge";
-	[self.uut rnn_setTabBarItemBadge:badgeValue];
-	XCTAssertEqual([self.uut tabBarItem].badgeValue, badgeValue);
+    NSDictionary *dict = @{@"badge": @"badge"};
+    RNNBottomTabOptions * options = [[RNNBottomTabOptions alloc] initWithDict:dict];
+    [self.uut rnn_setTabBarItemBadge:options];
+    XCTAssertEqual([self.uut tabBarItem].badgeValue, @"badge");
 }
 
 - (void)test_setTabBarItemBadge_shouldResetWhenValueIsEmptyString {
-	[self.uut rnn_setTabBarItemBadge:@"badge"];
-	NSString* badgeValue = @"";
-	[self.uut rnn_setTabBarItemBadge:badgeValue];
-	XCTAssertEqual([self.uut tabBarItem].badgeValue, nil);
+    [self.uut rnn_setTabBarItemBadge:[[RNNBottomTabOptions alloc] initWithDict:@{@"badge": @"badge"}]];
+
+    RNNBottomTabOptions * optionsWithEmptyBadge = [[RNNBottomTabOptions alloc] initWithDict:@{@"badge": @""}];
+    [self.uut rnn_setTabBarItemBadge:optionsWithEmptyBadge];
+    XCTAssertEqual([self.uut tabBarItem].badgeValue, nil);
 }
 
 - (void)test_setTabBarItemBadge_shouldResetWhenValueIsNullObject {
-	[self.uut rnn_setTabBarItemBadge:@"badge"];
-	NSNull* nullBadgeValue = [NSNull new];
-	[self.uut rnn_setTabBarItemBadge:nullBadgeValue];
-	XCTAssertEqual([self.uut tabBarItem].badgeValue, nil);
+    [self.uut rnn_setTabBarItemBadge:[[RNNBottomTabOptions alloc] initWithDict:@{@"badge": @"badge"}]];
+    [self.uut rnn_setTabBarItemBadge:[[RNNBottomTabOptions alloc] initWithDict:@{@"badge": [NSNull new]}]];
+    XCTAssertEqual([self.uut tabBarItem].badgeValue, nil);
 }
 
 - (void)testSetDrawBehindTopBarTrue_shouldSetExtendedLayoutTrue {
@@ -60,33 +62,33 @@
 }
 
 - (void)testSetDrawBehindTopBarFalse_shouldSetCorrectEdgesForExtendedLayout {
-	[self.uut rnn_setDrawBehindTopBar:NO];
+    [self.uut rnn_setDrawBehindTopBar:NO];
     UIRectEdge expectedRectEdge = UIRectEdgeLeft | UIRectEdgeBottom | UIRectEdgeRight;
     XCTAssertEqual([self.uut edgesForExtendedLayout], expectedRectEdge);
 }
 
 - (void)testSetDrawBehindTapBarFalse_shouldSetCorrectEdgesForExtendedLayout {
     [self.uut rnn_setDrawBehindTabBar:NO];
-	UIRectEdge expectedRectEdge = UIRectEdgeTop | UIRectEdgeLeft | UIRectEdgeRight;
-	XCTAssertEqual([self.uut edgesForExtendedLayout], expectedRectEdge);
+    UIRectEdge expectedRectEdge = UIRectEdgeTop | UIRectEdgeLeft | UIRectEdgeRight;
+    XCTAssertEqual([self.uut edgesForExtendedLayout], expectedRectEdge);
 }
 
 - (void)testSetBackgroundImageShouldNotAddViewIfImageNil {
-	NSUInteger subviewsCount = [[[self.uut view] subviews] count];
-	[self.uut rnn_setBackgroundImage:nil];
-	XCTAssertEqual([[[self.uut view] subviews] count], subviewsCount);
+    NSUInteger subviewsCount = [[[self.uut view] subviews] count];
+    [self.uut rnn_setBackgroundImage:nil];
+    XCTAssertEqual([[[self.uut view] subviews] count], subviewsCount);
 }
 
 - (void)testSetBackgroundImageShouldAddUIImageViewSubview {
-	NSUInteger subviewsCount = [[[self.uut view] subviews] count];
-	[self.uut rnn_setBackgroundImage:[UIImage new]];
-	XCTAssertEqual([[[self.uut view] subviews] count], subviewsCount+1);
+    NSUInteger subviewsCount = [[[self.uut view] subviews] count];
+    [self.uut rnn_setBackgroundImage:[UIImage new]];
+    XCTAssertEqual([[[self.uut view] subviews] count], subviewsCount + 1);
 }
 
 - (void)testSetBackgroundImageShouldAddUIImageViewSubviewWithImage {
-    UIImage* image = [UIImage new];
+    UIImage *image = [UIImage new];
     [self.uut rnn_setBackgroundImage:image];
-    UIImageView* imageView = [[[self.uut view] subviews] firstObject];
+    UIImageView *imageView = [[[self.uut view] subviews] firstObject];
     XCTAssertEqual(imageView.image, image);
 }
 

--- a/lib/ios/ReactNativeNavigationTests/utils/RNNTestBase.h
+++ b/lib/ios/ReactNativeNavigationTests/utils/RNNTestBase.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+
+@interface RNNTestBase : XCTestCase
+- (void)setupTopLevelUI:(UIViewController *)withViewController;
+
+- (void)tearDownTopLevelUI;
+@end

--- a/lib/ios/ReactNativeNavigationTests/utils/RNNTestBase.h
+++ b/lib/ios/ReactNativeNavigationTests/utils/RNNTestBase.h
@@ -5,5 +5,5 @@
 @interface RNNTestBase : XCTestCase
 - (void)setupTopLevelUI:(UIViewController *)withViewController;
 
-- (void)tearDownTopLevelUI;
+- (void)tearDownTopLevelUI:(UIViewController *)withViewController;
 @end

--- a/lib/ios/ReactNativeNavigationTests/utils/RNNTestBase.m
+++ b/lib/ios/ReactNativeNavigationTests/utils/RNNTestBase.m
@@ -1,0 +1,24 @@
+#import "RNNTestBase.h"
+
+@interface RNNTestBase ()
+@property(nonatomic, strong) UIWindow *window;
+@end
+
+@implementation RNNTestBase
+
+- (void)setupTopLevelUI:(UIViewController *)withViewController {
+    self.window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
+    _window.rootViewController = withViewController;
+    [_window setHidden:NO];
+    [withViewController viewWillAppear:NO];
+    [withViewController viewDidAppear:NO];
+}
+
+- (void)tearDownTopLevelUI {
+    [_window.rootViewController viewWillDisappear:NO];
+    [_window.rootViewController viewDidDisappear:NO];
+    [_window setHidden:YES];
+    _window.rootViewController = nil;
+    self.window = nil;
+}
+@end

--- a/lib/ios/ReactNativeNavigationTests/utils/RNNTestBase.m
+++ b/lib/ios/ReactNativeNavigationTests/utils/RNNTestBase.m
@@ -7,18 +7,13 @@
 @implementation RNNTestBase
 
 - (void)setupTopLevelUI:(UIViewController *)withViewController {
-    self.window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
-    _window.rootViewController = withViewController;
-    [_window setHidden:NO];
-    [withViewController viewWillAppear:NO];
-    [withViewController viewDidAppear:NO];
+    [withViewController viewDidLoad];
+    [withViewController viewWillAppear:YES];
+    [withViewController viewDidAppear:YES];
 }
 
-- (void)tearDownTopLevelUI {
-    [_window.rootViewController viewWillDisappear:NO];
-    [_window.rootViewController viewDidDisappear:NO];
-    [_window setHidden:YES];
-    _window.rootViewController = nil;
-    self.window = nil;
+- (void)tearDownTopLevelUI:(UIViewController *)withViewController {
+    [withViewController viewWillDisappear:YES];
+    [withViewController viewDidDisappear:YES];
 }
 @end

--- a/lib/ios/UITabBarController+RNNOptions.h
+++ b/lib/ios/UITabBarController+RNNOptions.h
@@ -18,6 +18,4 @@
 
 - (void)rnn_setTabBarVisible:(BOOL)visible animated:(BOOL)animated;
 
-- (void)rnn_forEachTabView:(void (^)(UIView *, int tabIndex))performOnTab;
-
 @end

--- a/lib/ios/UITabBarController+RNNOptions.h
+++ b/lib/ios/UITabBarController+RNNOptions.h
@@ -18,4 +18,6 @@
 
 - (void)rnn_setTabBarVisible:(BOOL)visible animated:(BOOL)animated;
 
+- (void)rnn_forEachTabView:(void (^)(UIView *, int tabIndex))performOnTab;
+
 @end

--- a/lib/ios/UITabBarController+RNNOptions.m
+++ b/lib/ios/UITabBarController+RNNOptions.m
@@ -74,4 +74,14 @@
 	}
 }
 
+- (void)rnn_forEachTabView:(void (^)(UIView *, int tabIndex))performOnTab {
+    int tabIndex = 0;
+    for (UIView * tab in self.tabBar.subviews) {
+        if ([NSStringFromClass([tab class]) isEqualToString:@"UITabBarButton"]) {
+            performOnTab(tab, tabIndex);
+            tabIndex++;
+        }
+    }
+}
+
 @end

--- a/lib/ios/UITabBarController+RNNOptions.m
+++ b/lib/ios/UITabBarController+RNNOptions.m
@@ -74,11 +74,11 @@
 	}
 }
 
-- (void)rnn_forEachTabView:(void (^)(UIView *, int tabIndex))performOnTab {
+- (void)rnn_forEachTab:(void (^)(UIView *, UIViewController * tabViewController, int tabIndex))performOnTab {
     int tabIndex = 0;
     for (UIView * tab in self.tabBar.subviews) {
         if ([NSStringFromClass([tab class]) isEqualToString:@"UITabBarButton"]) {
-            performOnTab(tab, tabIndex);
+            performOnTab(tab, [self childViewControllers][(NSUInteger) tabIndex], tabIndex);
             tabIndex++;
         }
     }

--- a/lib/ios/UIViewController+LayoutProtocol.h
+++ b/lib/ios/UIViewController+LayoutProtocol.h
@@ -14,6 +14,8 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 - (RNNNavigationOptions *)resolveOptions;
 
+- (RNNNavigationOptions *)resolveChildOptions:(UIViewController *) child;
+
 - (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions;
 
 - (void)overrideOptions:(RNNNavigationOptions *)options;

--- a/lib/ios/UIViewController+LayoutProtocol.m
+++ b/lib/ios/UIViewController+LayoutProtocol.m
@@ -33,9 +33,13 @@
 	return [(RNNNavigationOptions *)[self.options mergeInOptions:self.getCurrentChild.resolveOptions.copy] withDefault:self.defaultOptions];
 }
 
+- (RNNNavigationOptions *)resolveChildOptions:(UIViewController *) child {
+	return [(RNNNavigationOptions *)[self.options mergeInOptions:child.resolveOptions.copy] withDefault:self.defaultOptions];
+}
+
 - (void)mergeOptions:(RNNNavigationOptions *)options {
 	[self.presenter mergeOptions:options currentOptions:self.options defaultOptions:self.defaultOptions];
-	[((UIViewController *)self.parentViewController) mergeOptions:options];
+	[self.parentViewController mergeOptions:options];
 }
 
 - (void)overrideOptions:(RNNNavigationOptions *)options {

--- a/lib/ios/UIViewController+RNNOptions.h
+++ b/lib/ios/UIViewController+RNNOptions.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+@class RNNBottomTabOptions;
+
 @interface UIViewController (RNNOptions)
 
 - (void)rnn_setBackgroundImage:(UIImage *)backgroundImage;
@@ -18,7 +20,7 @@
 
 - (void)rnn_setTabBarItemBadgeColor:(UIColor *)badgeColor;
 
-- (void)rnn_setTabBarItemBadge:(NSString *)badge;
+- (void)rnn_setTabBarItemBadge:(RNNBottomTabOptions *)bottomTab;
 
 - (void)rnn_setTopBarPrefersLargeTitle:(BOOL)prefersLargeTitle;
 

--- a/lib/ios/UIViewController+RNNOptions.m
+++ b/lib/ios/UIViewController+RNNOptions.m
@@ -97,6 +97,7 @@ const NSInteger BLUR_STATUS_TAG = 78264801;
 - (void)rnn_setTabBarItemBadgeColor:(UIColor *)badgeColor {
 	if (@available(iOS 10.0, *)) {
 		self.tabBarItem.badgeColor = badgeColor;
+		[self.tabBarItem setBadgeTextAttributes:<#(nullable NSDictionary<NSAttributedStringKey, id> *)textAttributes#> forState:<#(UIControlState)state#>];
 	}
 }
 

--- a/lib/ios/UIViewController+RNNOptions.m
+++ b/lib/ios/UIViewController+RNNOptions.m
@@ -97,7 +97,6 @@ const NSInteger BLUR_STATUS_TAG = 78264801;
 - (void)rnn_setTabBarItemBadgeColor:(UIColor *)badgeColor {
 	if (@available(iOS 10.0, *)) {
 		self.tabBarItem.badgeColor = badgeColor;
-		[self.tabBarItem setBadgeTextAttributes:<#(nullable NSDictionary<NSAttributedStringKey, id> *)textAttributes#> forState:<#(UIControlState)state#>];
 	}
 }
 

--- a/lib/ios/UIViewController+RNNOptions.m
+++ b/lib/ios/UIViewController+RNNOptions.m
@@ -1,6 +1,7 @@
 #import "UIViewController+RNNOptions.h"
 #import <React/RCTRootView.h>
 #import "UIImage+tint.h"
+#import "RNNBottomTabOptions.h"
 
 #define kStatusBarAnimationDuration 0.35
 const NSInteger BLUR_STATUS_TAG = 78264801;
@@ -80,14 +81,17 @@ const NSInteger BLUR_STATUS_TAG = 78264801;
 	}
 }
 
-- (void)rnn_setTabBarItemBadge:(NSString *)badge {
-	UITabBarItem *tabBarItem = self.tabBarItem;
-	
-	if ([badge isKindOfClass:[NSNull class]] || [badge isEqualToString:@""]) {
-		tabBarItem.badgeValue = nil;
-	} else {
-		tabBarItem.badgeValue = badge;
-	}
+- (void)rnn_setTabBarItemBadge:(RNNBottomTabOptions *)bottomTab {
+    UITabBarItem *tabBarItem = self.tabBarItem;
+
+    NSString *badge = [bottomTab.badge get];
+    if ([badge isKindOfClass:[NSNull class]] || [badge isEqualToString:@""]) {
+        tabBarItem.badgeValue = nil;
+    } else {
+        tabBarItem.badgeValue = badge;
+        [[self.tabBarController.tabBar viewWithTag:tabBarItem.tag] removeFromSuperview];
+        tabBarItem.tag = -1;
+    }
 }
 
 - (void)rnn_setTabBarItemBadgeColor:(UIColor *)badgeColor {

--- a/lib/ios/Utils/UIColor+RNNUtils.h
+++ b/lib/ios/Utils/UIColor+RNNUtils.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface UIColor (RNNUtils)
+- (NSString *)toHex;
+@end

--- a/lib/ios/Utils/UIColor+RNNUtils.m
+++ b/lib/ios/Utils/UIColor+RNNUtils.m
@@ -1,0 +1,17 @@
+#import "UIColor+RNNUtils.h"
+
+@implementation UIColor (RNNUtils)
+- (NSString *)toHex {
+    const CGFloat *components = CGColorGetComponents([self CGColor]);
+
+    CGFloat r = components[0];
+    CGFloat g = components[1];
+    CGFloat b = components[2];
+
+    return [NSString stringWithFormat:@"#%02lX%02lX%02lX",
+                                      lroundf((float) (r * 255)),
+                                      lroundf((float) (g * 255)),
+                                      lroundf((float) (b * 255))];
+}
+
+@end

--- a/lib/ios/Utils/UITabBar+Utils.h
+++ b/lib/ios/Utils/UITabBar+Utils.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface UITabBar (Utils)
+- (UIView *)getTabView:(int)tabIndex;
+
+- (UIView *)getTabIcon:(int)tabIndex;
+@end

--- a/lib/ios/Utils/UITabBar+Utils.m
+++ b/lib/ios/Utils/UITabBar+Utils.m
@@ -1,0 +1,21 @@
+#import "UITabBar+Utils.h"
+#import "UIView+Utils.h"
+
+@implementation UITabBar (Utils)
+- (UIView *)getTabView:(int)tabIndex {
+    int index = 0;
+    for (UIView *view in [self subviews]) {
+        if ([NSStringFromClass([view class]) isEqualToString:@"UITabBarButton"]) {
+            if (index == tabIndex) return view;
+            index++;
+        }
+    }
+    return nil;
+}
+
+- (UIView *)getTabIcon:(int)tabIndex {
+    UIView * tab = [self getTabView:tabIndex];
+    return [tab findChildByClass:[UIImageView class]];
+}
+
+@end

--- a/lib/ios/Utils/UITabBarController+RNNUtils.h
+++ b/lib/ios/Utils/UITabBarController+RNNUtils.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-@interface UITabBar (Utils)
+@interface UITabBarController (RNNUtils)
 - (UIView *)getTabView:(int)tabIndex;
 
 - (UIView *)getTabIcon:(int)tabIndex;

--- a/lib/ios/Utils/UITabBarController+RNNUtils.m
+++ b/lib/ios/Utils/UITabBarController+RNNUtils.m
@@ -1,10 +1,11 @@
-#import "UITabBar+Utils.h"
+#import "UITabBarController+RNNUtils.h"
 #import "UIView+Utils.h"
 
-@implementation UITabBar (Utils)
+
+@implementation UITabBarController (RNNUtils)
 - (UIView *)getTabView:(int)tabIndex {
     int index = 0;
-    for (UIView *view in [self subviews]) {
+    for (UIView *view in [[self tabBar] subviews]) {
         if ([NSStringFromClass([view class]) isEqualToString:@"UITabBarButton"]) {
             if (index == tabIndex) return view;
             index++;
@@ -14,8 +15,7 @@
 }
 
 - (UIView *)getTabIcon:(int)tabIndex {
-    UIView * tab = [self getTabView:tabIndex];
+    UIView *tab = [self getTabView:tabIndex];
     return [tab findChildByClass:[UIImageView class]];
 }
-
 @end

--- a/lib/ios/Utils/UIView+Utils.h
+++ b/lib/ios/Utils/UIView+Utils.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface UIView (Utils)
+- (UIView *)findChildByClass:clazz;
+@end

--- a/lib/ios/Utils/UIView+Utils.m
+++ b/lib/ios/Utils/UIView+Utils.m
@@ -1,0 +1,12 @@
+#import "UIView+Utils.h"
+
+
+@implementation UIView (Utils)
+- (UIView *)findChildByClass:(id)clazz {
+    for (UIView *child in [self subviews]) {
+        if ([child isKindOfClass:clazz]) return child;
+    }
+    return nil;
+}
+
+@end

--- a/lib/ios/Utils/UIViewController+Utils.h
+++ b/lib/ios/Utils/UIViewController+Utils.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface UIViewController (Utils)
+- (void)forEachChild:(void (^)(UIViewController *child))perform;
+@end

--- a/lib/ios/Utils/UIViewController+Utils.m
+++ b/lib/ios/Utils/UIViewController+Utils.m
@@ -1,0 +1,10 @@
+#import "UIViewController+Utils.h"
+
+@implementation UIViewController (Utils)
+- (void)forEachChild:(void (^)(UIViewController *child))perform {
+    for (UIViewController *child in [self childViewControllers]) {
+        perform(child);
+    }
+}
+
+@end

--- a/playground/src/screens/FirstBottomTabScreen.js
+++ b/playground/src/screens/FirstBottomTabScreen.js
@@ -35,7 +35,8 @@ class FirstBottomTabScreen extends React.Component {
         <Button label='Switch Tab by Index' testID={SWITCH_TAB_BY_INDEX_BTN} onPress={this.switchTabByIndex} />
         <Button label='Switch Tab by componentId' testID={SWITCH_TAB_BY_COMPONENT_ID_BTN} onPress={this.switchTabByComponentId} />
         <Button label='Set Badge' testID={SET_BADGE_BTN} onPress={() => this.setBadge('NEW')} />
-        <Button label='Clear Badge' testID={CLEAR_BADGE_BTN} onPress={() => this.setBadge(null)} />
+        <Button label='Clear Badge' testID={CLEAR_BADGE_BTN} onPress={() => this.setBadge('')} />
+        <Button label='Set Notification Dot' onPress={this.setNotificationDot} />
         <Button label='Hide Tabs' testID={HIDE_TABS_BTN} onPress={() => this.toggleTabs(false)} />
         <Button label='Show Tabs' testID={SHOW_TABS_BTN} onPress={() => this.toggleTabs(true)} />
         <Button label='Hide Tabs on Push' testID={HIDE_TABS_PUSH_BTN} onPress={this.hideTabsOnPush} />
@@ -55,9 +56,22 @@ class FirstBottomTabScreen extends React.Component {
     }
   });
 
-  setBadge = (badge) => Navigation.mergeOptions(this, {
-    bottomTab: { badge }
-  });
+  setBadge = (badge) => {
+    this.dotVisible = false;
+    Navigation.mergeOptions(this, {
+      bottomTab: { badge }
+    });
+  }
+
+  setNotificationDot = () => {
+    this.dotVisible = !this.dotVisible;
+    Navigation.mergeOptions(this, {
+      bottomTab: {
+        badgeSize: this.dotVisible ? 8 : 0,
+        badge: ''
+      }
+    });
+  }
 
   toggleTabs = (visible) => Navigation.mergeOptions(this, {
     bottomTabs: { visible }

--- a/playground/src/screens/FirstBottomTabScreen.js
+++ b/playground/src/screens/FirstBottomTabScreen.js
@@ -49,6 +49,7 @@ class FirstBottomTabScreen extends React.Component {
         <Button label='Hide Tabs' testID={HIDE_TABS_BTN} onPress={() => this.toggleTabs(false)} />
         <Button label='Show Tabs' testID={SHOW_TABS_BTN} onPress={() => this.toggleTabs(true)} />
         <Button label='Hide Tabs on Push' testID={HIDE_TABS_PUSH_BTN} onPress={this.hideTabsOnPush} />
+        <Button label='Push' onPress={this.push} />
       </Root>
     );
   }
@@ -90,6 +91,8 @@ class FirstBottomTabScreen extends React.Component {
   hideTabsOnPush = () => Navigation.push(this, component(Screens.Pushed, {
     bottomTabs: { visible: false }
   }));
+
+  push = () => Navigation.push(this, Screens.Pushed);
 }
 
 module.exports = FirstBottomTabScreen;

--- a/playground/src/screens/FirstBottomTabScreen.js
+++ b/playground/src/screens/FirstBottomTabScreen.js
@@ -17,6 +17,9 @@ const {
 class FirstBottomTabScreen extends React.Component {
   static options() {
     return {
+      layout: {
+        orientation: ['portrait', 'landscape']
+      },
       topBar: {
         title: {
           text: 'First Tab'
@@ -24,9 +27,15 @@ class FirstBottomTabScreen extends React.Component {
       },
       bottomTab: {
         icon: require('../../img/whatshot.png'),
-        text: 'Tab 1'
+        text: 'Tab 1',
+        badgeSize: 6
       }
     };
+  }
+
+  constructor(props) {
+    super(props);
+    this.dotVisible = true;
   }
 
   render() {
@@ -57,7 +66,8 @@ class FirstBottomTabScreen extends React.Component {
   });
 
   setBadge = (badge) => {
-    this.dotVisible = false;
+    this.badgeVisible = !!badge;
+    if (this.badgeVisible) this.dotVisible = false;
     Navigation.mergeOptions(this, {
       bottomTab: { badge }
     });
@@ -65,9 +75,10 @@ class FirstBottomTabScreen extends React.Component {
 
   setNotificationDot = () => {
     this.dotVisible = !this.dotVisible;
-    Navigation.mergeOptions(this, {
+    // Navigation.mergeOptions('SecondTabBottomTabsLayoutScreen', {
+      Navigation.mergeOptions(this, {
       bottomTab: {
-        badgeSize: this.dotVisible ? 8 : 0,
+        badgeSize: this.dotVisible ? 6 : 0,
         badge: ''
       }
     });

--- a/playground/src/screens/FirstBottomTabScreen.js
+++ b/playground/src/screens/FirstBottomTabScreen.js
@@ -76,7 +76,6 @@ class FirstBottomTabScreen extends React.Component {
 
   setNotificationDot = () => {
     this.dotVisible = !this.dotVisible;
-    // Navigation.mergeOptions('SecondTabBottomTabsLayoutScreen', {
     Navigation.mergeOptions(this, {
       bottomTab: {
         dotIndicator: { visible: this.dotVisible }

--- a/playground/src/screens/FirstBottomTabScreen.js
+++ b/playground/src/screens/FirstBottomTabScreen.js
@@ -28,7 +28,7 @@ class FirstBottomTabScreen extends React.Component {
       bottomTab: {
         icon: require('../../img/whatshot.png'),
         text: 'Tab 1',
-        badgeSize: 6
+        dotIndicator: { visible: true }
       }
     };
   }
@@ -76,10 +76,9 @@ class FirstBottomTabScreen extends React.Component {
   setNotificationDot = () => {
     this.dotVisible = !this.dotVisible;
     // Navigation.mergeOptions('SecondTabBottomTabsLayoutScreen', {
-      Navigation.mergeOptions(this, {
+    Navigation.mergeOptions(this, {
       bottomTab: {
-        badgeSize: this.dotVisible ? 6 : 0,
-        badge: ''
+        dotIndicator: { visible: this.dotVisible }
       }
     });
   }

--- a/playground/src/screens/LayoutsScreen.js
+++ b/playground/src/screens/LayoutsScreen.js
@@ -42,6 +42,7 @@ class LayoutsScreen extends React.Component {
         stack(Screens.FirstBottomTabsScreen),
         stack({
           component: {
+            id: 'SecondTabBottomTabsLayoutScreen',
             name: Screens.SecondBottomTabsScreen
           }
         }, 'SecondTab'

--- a/playground/src/screens/LayoutsScreen.js
+++ b/playground/src/screens/LayoutsScreen.js
@@ -42,7 +42,6 @@ class LayoutsScreen extends React.Component {
         stack(Screens.FirstBottomTabsScreen),
         stack({
           component: {
-            id: 'SecondTabBottomTabsLayoutScreen',
             name: Screens.SecondBottomTabsScreen
           }
         }, 'SecondTab'

--- a/playground/src/screens/SecondBottomTabScreen.js
+++ b/playground/src/screens/SecondBottomTabScreen.js
@@ -22,7 +22,11 @@ class SecondBottomTabScreen extends React.Component {
       },
       bottomTab: {
         icon: require('../../img/star.png'),
-        text: 'Tab 2'
+        text: 'Tab 2',
+        dotIndicator: {
+          visible: true,
+          color: 'green'
+        }
       }
     };
   }
@@ -30,11 +34,14 @@ class SecondBottomTabScreen extends React.Component {
   render() {
     return (
       <Root componentId={this.props.componentId}>
+        <Button label='Push' onPress={this.push} />
         <Button label='Push BottomTabs' testID={PUSH_BTN} onPress={this.pushBottomTabs} />
         <Button label='SideMenu inside BottomTabs' testID={SIDE_MENU_INSIDE_BOTTOM_TABS_BTN} onPress={this.sideMenuInsideBottomTabs} />
       </Root>
     );
   }
+
+  push = () => Navigation.push(this, Screens.Pushed);
 
   pushBottomTabs = () => Navigation.push(this, {
     bottomTabs: {

--- a/scripts/test-unit.js
+++ b/scripts/test-unit.js
@@ -32,7 +32,7 @@ function runIosUnitTests() {
             -project playground.xcodeproj
             -sdk iphonesimulator
             -configuration ${conf}
-            -derivedDataPath ./DerivedData/playground
+            -derivedDataPath ./playground/ios/DerivedData/playground
             -quiet
             -UseModernBuildSystem=NO
             ONLY_ACTIVE_ARCH=YES`);
@@ -45,7 +45,7 @@ function runIosUnitTests() {
             -sdk iphonesimulator
             -configuration ${conf}
             -destination 'platform=iOS Simulator,name=iPhone X'
-            -derivedDataPath ./DerivedData/playground
+            -derivedDataPath ./playground/ios/DerivedData/playground
             ONLY_ACTIVE_ARCH=YES`);
 }
 


### PR DESCRIPTION
This pr adds support for adding a dot indicator to BottomTabs. When both textual badge and dot indicator are defined, the indicator takes precedence, both elements won't be visible at the same time.

![image](https://user-images.githubusercontent.com/12352397/61209392-4b808d80-a702-11e9-847c-983a9f9adc4f.png)

# API
```js
options: {
  bottomTab: {
    dotIndicator: {
      color: 'green', // default red
      size: 8, // default 8
      visible: true // default false
    }
  }
}
```

# Hiding the indicator
To hide the indicator, call `mergeOptions` with `visible: false`.

```js
Navigation.mergeOptions(this.props.componentId, {
      bottomTab: {
        dotIndicator: { visible: false }
      }
    });
```

Fixes #4910