### PR TITLE
feat: native UIToolbar in iOS

### DIFF
--- a/lib/ios/RNNNavigationButtons.h
+++ b/lib/ios/RNNNavigationButtons.h
@@ -10,6 +10,8 @@
 
 -(void)applyLeftButtons:(NSArray*)leftButtons rightButtons:(NSArray*)rightButtons defaultLeftButtonStyle:(RNNButtonOptions *)defaultLeftButtonStyle defaultRightButtonStyle:(RNNButtonOptions *)defaultRightButtonStyle;
 
+-(void)applyToolbarButtons:(NSArray*)buttons defaultToolbarButtonStyle:(RNNButtonOptions *)defaultToolbarButtonStyle;
+
 @end
 
 

--- a/lib/ios/RNNNavigationButtons.m
+++ b/lib/ios/RNNNavigationButtons.m
@@ -12,6 +12,7 @@
 @property (weak, nonatomic) UIViewController<RNNLayoutProtocol>* viewController;
 @property (strong, nonatomic) RNNButtonOptions* defaultLeftButtonStyle;
 @property (strong, nonatomic) RNNButtonOptions* defaultRightButtonStyle;
+@property (strong, nonatomic) RNNButtonOptions* defaultToolbarButtonStyle;
 @property (strong, nonatomic) RNNReactComponentRegistry* componentRegistry;
 @end
 
@@ -38,6 +39,13 @@
 	}
 }
 
+- (void) applyToolbarButtons:(NSArray *)toolbarButtons defaultToolbarButtonStyle:(RNNButtonOptions *)defaultToolbarButtonStyle {
+    _defaultToolbarButtonStyle = defaultToolbarButtonStyle;
+    if (toolbarButtons) {
+        [self setButtons:toolbarButtons side:@"toolbar" animated:NO defaultStyle:_defaultToolbarButtonStyle insets:[self toolbarButtonInsets:_defaultToolbarButtonStyle.iconInsets]];
+    }
+}
+
 -(void)setButtons:(NSArray*)buttons side:(NSString*)side animated:(BOOL)animated defaultStyle:(RNNButtonOptions *)defaultStyle insets:(UIEdgeInsets)insets {
 	NSMutableArray *barButtonItems = [NSMutableArray new];
 	NSArray* resolvedButtons = [self resolveButtons:buttons];
@@ -59,6 +67,10 @@
 	if ([side isEqualToString:@"right"]) {
 		[self.viewController.navigationItem setRightBarButtonItems:barButtonItems animated:animated];
 	}
+	
+	if ([side isEqualToString:@"toolbar"]) {
+    [self.viewController setToolbarItems:barButtonItems animated:animated];
+  }
 }
 
 - (NSArray *)resolveButtons:(id)buttons {
@@ -206,6 +218,13 @@
 - (UIEdgeInsets)rightButtonInsets:(RNNInsetsOptions *)defaultInsets {
 	return UIEdgeInsetsMake([defaultInsets.top getWithDefaultValue:0],
 					 [defaultInsets.left getWithDefaultValue:15],
+					 [defaultInsets.bottom getWithDefaultValue:0],
+					 [defaultInsets.right getWithDefaultValue:0]);
+}
+
+- (UIEdgeInsets)toolbarButtonInsets:(RNNInsetsOptions *)defaultInsets {
+  return UIEdgeInsetsMake([defaultInsets.top getWithDefaultValue:0],
+					 [defaultInsets.left getWithDefaultValue:0],
 					 [defaultInsets.bottom getWithDefaultValue:0],
 					 [defaultInsets.right getWithDefaultValue:0]);
 }

--- a/lib/ios/RNNNavigationOptions.h
+++ b/lib/ios/RNNNavigationOptions.h
@@ -11,6 +11,7 @@
 #import "RNNPreviewOptions.h"
 #import "RNNLayoutOptions.h"
 #import "RNNSplitViewOptions.h"
+#import "RNNToolbarOptions.h"
 
 extern const NSInteger BLUR_TOPBAR_TAG;
 extern const NSInteger TOP_BAR_TRANSPARENT_TAG;
@@ -30,6 +31,7 @@ extern const NSInteger TOP_BAR_TRANSPARENT_TAG;
 @property (nonatomic, strong) RNNPreviewOptions* preview;
 @property (nonatomic, strong) RNNLayoutOptions* layout;
 @property (nonatomic, strong) RNNSplitViewOptions* splitView;
+@property (nonatomic, strong) RNNToolbarOptions* toolbar;
 
 @property (nonatomic, strong) Bool* popGesture;
 @property (nonatomic, strong) Image* backgroundImage;

--- a/lib/ios/RNNNavigationOptions.m
+++ b/lib/ios/RNNNavigationOptions.m
@@ -8,6 +8,7 @@
 #import "RNNSplitViewController.h"
 #import "RNNNavigationButtons.h"
 #import "RNNSplitViewOptions.h"
+#import "RNNToolbarOptions.h"
 #import "UIViewController+RNNOptions.h"
 #import "UINavigationController+RNNOptions.h"
 
@@ -29,6 +30,7 @@
 	self.statusBar = [[RNNStatusBarOptions alloc] initWithDict:dict[@"statusBar"]];
 	self.preview = [[RNNPreviewOptions alloc] initWithDict:dict[@"preview"]];
 	self.layout = [[RNNLayoutOptions alloc] initWithDict:dict[@"layout"]];
+	self.toolbar = [[RNNToolbarOptions alloc] initWithDict:dict[@"toolbar"]];
 	
 	self.popGesture = [[Bool alloc] initWithValue:dict[@"popGesture"]];
 	

--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -42,12 +42,17 @@
 	[_presenter applyOptions:self.resolveOptions];
 	[_presenter renderComponents:self.resolveOptions perform:nil];
 	
+  if (self.options.toolbar.buttons) {
+    [self.navigationController setToolbarHidden:NO animated:NO];
+  }
+
 	[self.parentViewController onChildWillAppear];
 }
 
 -(void)viewDidAppear:(BOOL)animated {
 	[super viewDidAppear:animated];
 	[self.eventEmitter sendComponentDidAppear:self.layoutInfo.componentId componentName:self.layoutInfo.name];
+	[self.navigationController setToolbarHidden:YES animated:NO];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/lib/ios/RNNToolbarOptions.h
+++ b/lib/ios/RNNToolbarOptions.h
@@ -1,0 +1,9 @@
+#import "RNNOptions.h"
+#import "RNNButtonOptions.h"
+
+@interface RNNToolbarOptions : RNNOptions
+
+@property (nonatomic, strong) NSArray* buttons;
+@property (nonatomic, strong) RNNButtonOptions* buttonStyle;
+
+@end

--- a/lib/ios/RNNToolbarOptions.m
+++ b/lib/ios/RNNToolbarOptions.m
@@ -1,0 +1,18 @@
+#import "RNNToolbarOptions.h"
+#import "RNNButtonOptions.h"
+#import "UIViewController+RNNOptions.h"
+
+@interface RNNToolbarOptions ()
+
+@end
+
+@implementation RNNToolbarOptions
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+    self = [super init];
+    self.buttons = dict[@"buttons"];
+    self.buttonStyle = [[RNNButtonOptions alloc] initWithDict:dict[@"buttonStyle"]];
+    return self;
+}
+
+@end

--- a/lib/ios/RNNViewControllerPresenter.m
+++ b/lib/ios/RNNViewControllerPresenter.m
@@ -74,6 +74,10 @@
 	if ((options.topBar.leftButtons || options.topBar.rightButtons)) {
 		[_navigationButtons applyLeftButtons:options.topBar.leftButtons rightButtons:options.topBar.rightButtons defaultLeftButtonStyle:options.topBar.leftButtonStyle defaultRightButtonStyle:options.topBar.rightButtonStyle];
 	}
+	
+  if (options.toolbar.buttons) {
+    [_navigationButtons applyToolbarButtons:options.toolbar.buttons defaultToolbarButtonStyle:options.toolbar.buttonStyle];
+  }
 }
 
 - (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions {
@@ -145,6 +149,10 @@
 		RNNNavigationOptions* buttonsResolvedOptions = [(RNNNavigationOptions *)[currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
 		[_navigationButtons applyLeftButtons:newOptions.topBar.leftButtons rightButtons:newOptions.topBar.rightButtons defaultLeftButtonStyle:buttonsResolvedOptions.topBar.leftButtonStyle defaultRightButtonStyle:buttonsResolvedOptions.topBar.rightButtonStyle];
 	}
+
+  if (newOptions.toolbar.buttons) {
+    [_navigationButtons applyToolbarButtons:newOptions.toolbar.buttons defaultToolbarButtonStyle:newOptions.toolbar.buttonStyle];
+  }
 	
 	if (newOptions.overlay.interceptTouchOutside.hasValue) {
 		RCTRootView* rootView = (RCTRootView*)viewController.view;

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -862,6 +862,10 @@ export interface OptionsCustomTransitionAnimation {
   duration?: number;
 }
 
+export interface ToolbarOptions {
+  buttons: OptionsTopBarButton[];
+}
+
 export interface Options {
   /**
    * Configure the status bar
@@ -906,6 +910,10 @@ export interface Options {
    * Configure the overlay
    */
   overlay?: OverlayOptions;
+  /**
+   * Configure the bottom toolbar (iOS)
+   */
+  toolbar?: ToolbarOptions;
   /**
    * Animation used for navigation commands that modify the layout
    * hierarchy can be controlled in options.


### PR DESCRIPTION
Adds native UIToolbar for iOS's UINavigationController

```js
{
  toolbar: {
    buttons: [{
     id: 'test',
     systemIcon: 'play',
   }],
}
```

![image](https://user-images.githubusercontent.com/180773/61638803-aaf21680-ac89-11e9-99b1-83de0c6901e1.png)
