### PR TITLE
Fix rare race condition when applying bottomTabs.drawBehind

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsPresenter.java
@@ -10,7 +10,6 @@ import com.reactnativenavigation.anim.BottomTabsAnimator;
 import com.reactnativenavigation.parse.AnimationsOptions;
 import com.reactnativenavigation.parse.BottomTabsOptions;
 import com.reactnativenavigation.parse.Options;
-import com.reactnativenavigation.utils.UiUtils;
 import com.reactnativenavigation.viewcontrollers.ViewController;
 import com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabFinder;
 import com.reactnativenavigation.viewcontrollers.bottomtabs.TabSelector;
@@ -18,6 +17,8 @@ import com.reactnativenavigation.views.BottomTabs;
 import com.reactnativenavigation.views.Component;
 
 import java.util.List;
+
+import static com.reactnativenavigation.utils.ViewUtils.getHeight;
 
 public class BottomTabsPresenter {
     private final BottomTabFinder bottomTabFinder;
@@ -111,13 +112,8 @@ public class BottomTabsPresenter {
         MarginLayoutParams lp = (MarginLayoutParams) tab.getLayoutParams();
         if (options.drawBehind.isTrue()) {
             lp.bottomMargin = 0;
-        }
-        if (options.visible.isTrueOrUndefined() && options.drawBehind.isFalseOrUndefined()) {
-            if (bottomTabs.getHeight() == 0) {
-                UiUtils.runOnPreDrawOnce(bottomTabs, () -> lp.bottomMargin = bottomTabs.getHeight());
-            } else {
-                lp.bottomMargin = bottomTabs.getHeight();
-            }
+        } else if (options.visible.isTrueOrUndefined()) {
+            lp.bottomMargin = getHeight(bottomTabs);
         }
     }
 
@@ -126,13 +122,8 @@ public class BottomTabsPresenter {
         MarginLayoutParams lp = (MarginLayoutParams) tab.getLayoutParams();
         if (options.drawBehind.isTrue()) {
             lp.bottomMargin = 0;
-        }
-        if (options.visible.isTrue() && options.drawBehind.isFalse()) {
-            if (bottomTabs.getHeight() == 0) {
-                UiUtils.runOnPreDrawOnce(bottomTabs, () -> lp.bottomMargin = bottomTabs.getHeight());
-            } else {
-                lp.bottomMargin = bottomTabs.getHeight();
-            }
+        } else if (options.visible.isTrue() && options.drawBehind.isFalse()) {
+            lp.bottomMargin = getHeight(bottomTabs);
         }
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -27,10 +27,10 @@ import java.util.Collection;
 import java.util.List;
 
 import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
-import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 import static android.widget.RelativeLayout.ALIGN_PARENT_BOTTOM;
-import static com.reactnativenavigation.utils.CollectionUtils.forEach;
-import static com.reactnativenavigation.utils.CollectionUtils.map;
+import static com.reactnativenavigation.react.Constants.BOTTOM_TABS_HEIGHT;
+import static com.reactnativenavigation.utils.CollectionUtils.*;
+import static com.reactnativenavigation.utils.UiUtils.dpToPx;
 
 public class BottomTabsController extends ParentController implements AHBottomNavigation.OnTabSelectedListener, TabSelector {
 
@@ -69,7 +69,7 @@ public class BottomTabsController extends ParentController implements AHBottomNa
         presenter.bindView(bottomTabs, this);
         tabPresenter.bindView(bottomTabs);
         bottomTabs.setOnTabSelectedListener(this);
-		RelativeLayout.LayoutParams lp = new RelativeLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT);
+		RelativeLayout.LayoutParams lp = new RelativeLayout.LayoutParams(MATCH_PARENT, dpToPx(getActivity(), BOTTOM_TABS_HEIGHT));
 		lp.addRule(ALIGN_PARENT_BOTTOM);
 		root.addView(bottomTabs, lp);
 		bottomTabs.addItems(createTabs());

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.java
@@ -402,7 +402,6 @@ public class BottomTabsControllerTest extends BaseTest {
             public void ensureViewIsCreated() {
                 super.ensureViewIsCreated();
                 uut.getView().layout(0, 0, 1000, 1000);
-                uut.getBottomTabs().layout(0, 0, 1000, 100);
             }
 
             @NonNull


### PR DESCRIPTION
When setting BottomTabs root, if one of the children was a stack with multiple children
and the top child in the stack had `drawBehind: true` while the bottom child had `drawBehind: false`, sometimes the tabs' bottomMargin would be wrong since it was applied in onPreDraw.