### PR TITLE
Fix #5330 Set the correct layout background colour on iOS

### DIFF
--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -77,7 +77,12 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	UIViewController *vc = [_controllerFactory createLayout:layout[@"root"]];
 	
 	[vc renderTreeAndWait:[vc.resolveOptions.animations.setRoot.waitForRender getWithDefaultValue:NO] perform:^{
+		if(_controllerFactory.defaultOptions.layout.backgroundColor.hasValue) {
+			[vc rnn_setBackgroundColor:_controllerFactory.defaultOptions.layout.backgroundColor.get];
+		}
+
 		_mainWindow.rootViewController = vc;
+
 		[_eventEmitter sendOnNavigationCommandCompletion:setRoot commandId:commandId params:@{@"layout": layout}];
 		completion() ;
 	}];


### PR DESCRIPTION
This is a fix for #5330 and it sets the correct layout background colour on iOS when setting the root view.

I'm a complete newb when it comes to Objective-C, therefore, I wasn't able to successfully add a unit test for this piece of code.

Is anyone kind enough to help? The test should assert the proper background colour is set when calling the `setRoot` command.