### PR TITLE
Fixes unnecessary rendering of the last viewController in setStackRoot

### DIFF
--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -173,7 +173,9 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	
 	NSArray<UIViewController *> *childViewControllers = [_controllerFactory createChildrenLayout:children];
 	for (UIViewController<RNNLayoutProtocol>* viewController in childViewControllers) {
-		[viewController renderTreeAndWait:NO perform:nil];
+		if (![viewController isEqual:childViewControllers.lastObject]) {
+			[viewController renderTreeAndWait:NO perform:nil];
+		}
 	}
 	UIViewController *newVC = childViewControllers.lastObject;
 	UIViewController *fromVC = [RNNLayoutManager findComponentForId:componentId];


### PR DESCRIPTION
Last component in `setStackRoot` layout should consider `waitForRender` option, the other components should not be rendered because they shouldn't be presented yet and this can cause performance issues.

Closes #5355