### PR TITLE
Initial support for null as color 

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/params/DontApplyColour.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/params/DontApplyColour.java
@@ -4,8 +4,8 @@ import android.graphics.Color;
 
 import javax.annotation.Nonnull;
 
-public class IgnoreColour extends Colour {
-    public IgnoreColour() {
+public class DontApplyColour extends Colour {
+    public DontApplyColour() {
         super(Color.TRANSPARENT);
     }
 
@@ -15,8 +15,8 @@ public class IgnoreColour extends Colour {
     }
 
     @Override
-    public boolean ignore() {
-        return true;
+    public boolean canApplyValue() {
+        return false;
     }
 
     @Nonnull

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/params/IgnoreColour.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/params/IgnoreColour.java
@@ -4,23 +4,18 @@ import android.graphics.Color;
 
 import javax.annotation.Nonnull;
 
-public class NoColour extends Colour {
-    public NoColour() {
+public class IgnoreColour extends Colour {
+    public IgnoreColour() {
         super(Color.TRANSPARENT);
     }
 
     @Override
-    public Integer get() {
-        return null;
-    }
-
-    @Override
-    public Integer get(Integer defaultValue) {
-        return null;
-    }
-
-    @Override
     public boolean hasValue() {
+        return true;
+    }
+
+    @Override
+    public boolean ignore() {
         return true;
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/params/NoColour.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/params/NoColour.java
@@ -1,0 +1,32 @@
+package com.reactnativenavigation.parse.params;
+
+import android.graphics.Color;
+
+import javax.annotation.Nonnull;
+
+public class NoColour extends Colour {
+    public NoColour() {
+        super(Color.TRANSPARENT);
+    }
+
+    @Override
+    public Integer get() {
+        return null;
+    }
+
+    @Override
+    public Integer get(Integer defaultValue) {
+        return null;
+    }
+
+    @Override
+    public boolean hasValue() {
+        return true;
+    }
+
+    @Nonnull
+    @Override
+    public String toString() {
+        return "NoColor";
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/params/Param.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/params/Param.java
@@ -24,8 +24,8 @@ public abstract class Param<T> {
         return value != null;
     }
 
-    public boolean ignore() {
-        return false;
+    public boolean canApplyValue() {
+        return true;
     }
 
     public boolean equals(Param other) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/params/Param.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/params/Param.java
@@ -24,6 +24,10 @@ public abstract class Param<T> {
         return value != null;
     }
 
+    public boolean ignore() {
+        return false;
+    }
+
     public boolean equals(Param other) {
         return value == other.value || equalsNotNull(value, other.value);
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/parsers/ColorParser.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/parsers/ColorParser.java
@@ -1,7 +1,7 @@
 package com.reactnativenavigation.parse.parsers;
 
 import com.reactnativenavigation.parse.params.Colour;
-import com.reactnativenavigation.parse.params.NoColour;
+import com.reactnativenavigation.parse.params.IgnoreColour;
 import com.reactnativenavigation.parse.params.NullColor;
 
 import org.json.JSONObject;
@@ -9,7 +9,7 @@ import org.json.JSONObject;
 public class ColorParser {
     public static Colour parse(JSONObject json, String color) {
         if (json.has(color)) {
-            return json.opt(color) instanceof Integer ? new Colour(json.optInt(color)) : new NoColour();
+            return json.opt(color) instanceof Integer ? new Colour(json.optInt(color)) : new IgnoreColour();
         }
         return new NullColor();
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/parsers/ColorParser.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/parsers/ColorParser.java
@@ -1,12 +1,16 @@
 package com.reactnativenavigation.parse.parsers;
 
 import com.reactnativenavigation.parse.params.Colour;
+import com.reactnativenavigation.parse.params.NoColour;
 import com.reactnativenavigation.parse.params.NullColor;
 
 import org.json.JSONObject;
 
 public class ColorParser {
     public static Colour parse(JSONObject json, String color) {
-        return json.has(color) ? new Colour(json.optInt(color)) : new NullColor();
+        if (json.has(color)) {
+            return json.opt(color) instanceof Integer ? new Colour(json.optInt(color)) : new NoColour();
+        }
+        return new NullColor();
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/parsers/ColorParser.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/parsers/ColorParser.java
@@ -1,7 +1,7 @@
 package com.reactnativenavigation.parse.parsers;
 
 import com.reactnativenavigation.parse.params.Colour;
-import com.reactnativenavigation.parse.params.IgnoreColour;
+import com.reactnativenavigation.parse.params.DontApplyColour;
 import com.reactnativenavigation.parse.params.NullColor;
 
 import org.json.JSONObject;
@@ -9,7 +9,7 @@ import org.json.JSONObject;
 public class ColorParser {
     public static Colour parse(JSONObject json, String color) {
         if (json.has(color)) {
-            return json.opt(color) instanceof Integer ? new Colour(json.optInt(color)) : new IgnoreColour();
+            return json.opt(color) instanceof Integer ? new Colour(json.optInt(color)) : new DontApplyColour();
         }
         return new NullColor();
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
@@ -52,8 +52,8 @@ public class BottomTabPresenter {
             for (int i = 0; i < tabs.size(); i++) {
                 BottomTabOptions tab = tabs.get(i).resolveCurrentOptions(defaultOptions).bottomTabOptions;
                 bottomTabs.setTitleTypeface(i, tab.fontFamily);
-                if (!tab.selectedIconColor.ignore()) bottomTabs.setIconActiveColor(i, tab.selectedIconColor.get(null));
-                if (!tab.iconColor.ignore()) bottomTabs.setIconInactiveColor(i, tab.iconColor.get(null));
+                if (tab.selectedIconColor.canApplyValue()) bottomTabs.setIconActiveColor(i, tab.selectedIconColor.get(null));
+                if (tab.iconColor.canApplyValue()) bottomTabs.setIconInactiveColor(i, tab.iconColor.get(null));
                 bottomTabs.setTitleActiveColor(i, tab.selectedTextColor.get(null));
                 bottomTabs.setTitleInactiveColor(i, tab.textColor.get(null));
                 bottomTabs.setTitleInactiveTextSizeInSp(i, tab.fontSize.hasValue() ? Float.valueOf(tab.fontSize.get()) : null);

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
@@ -52,8 +52,8 @@ public class BottomTabPresenter {
             for (int i = 0; i < tabs.size(); i++) {
                 BottomTabOptions tab = tabs.get(i).resolveCurrentOptions(defaultOptions).bottomTabOptions;
                 bottomTabs.setTitleTypeface(i, tab.fontFamily);
-                bottomTabs.setIconActiveColor(i, tab.selectedIconColor.get(null));
-                bottomTabs.setIconInactiveColor(i, tab.iconColor.get(null));
+                if (!tab.selectedIconColor.ignore()) bottomTabs.setIconActiveColor(i, tab.selectedIconColor.get(null));
+                if (!tab.iconColor.ignore()) bottomTabs.setIconInactiveColor(i, tab.iconColor.get(null));
                 bottomTabs.setTitleActiveColor(i, tab.selectedTextColor.get(null));
                 bottomTabs.setTitleInactiveColor(i, tab.textColor.get(null));
                 bottomTabs.setTitleInactiveTextSizeInSp(i, tab.fontSize.hasValue() ? Float.valueOf(tab.fontSize.get()) : null);

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/Presenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/Presenter.java
@@ -111,7 +111,7 @@ public class Presenter {
     }
 
     private void setStatusBarBackgroundColor(StatusBarOptions statusBar) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && !statusBar.backgroundColor.ignore()) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && statusBar.backgroundColor.canApplyValue()) {
             int defaultColor = statusBar.visible.isTrueOrUndefined() ? Color.BLACK : Color.TRANSPARENT;
             activity.getWindow().setStatusBarColor(statusBar.backgroundColor.get(defaultColor));
         }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/Presenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/Presenter.java
@@ -111,7 +111,7 @@ public class Presenter {
     }
 
     private void setStatusBarBackgroundColor(StatusBarOptions statusBar) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && !statusBar.backgroundColor.ignore()) {
             int defaultColor = statusBar.visible.isTrueOrUndefined() ? Color.BLACK : Color.TRANSPARENT;
             activity.getWindow().setStatusBarColor(statusBar.backgroundColor.get(defaultColor));
         }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/parse/parsers/ColorParseTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/parse/parsers/ColorParseTest.java
@@ -1,7 +1,7 @@
 package com.reactnativenavigation.parse.parsers;
 
 import com.reactnativenavigation.BaseTest;
-import com.reactnativenavigation.parse.params.NoColour;
+import com.reactnativenavigation.parse.params.IgnoreColour;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -15,6 +15,6 @@ public class ColorParseTest extends BaseTest {
     public void nullIsParsedAsNoColor() throws JSONException {
         JSONObject json = new JSONObject();
         json.put("color", "NoColor");
-        assertThat(ColorParser.parse(json, "color")).isInstanceOf(NoColour.class);
+        assertThat(ColorParser.parse(json, "color")).isInstanceOf(IgnoreColour.class);
     }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/parse/parsers/ColorParseTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/parse/parsers/ColorParseTest.java
@@ -1,0 +1,20 @@
+package com.reactnativenavigation.parse.parsers;
+
+import com.reactnativenavigation.BaseTest;
+import com.reactnativenavigation.parse.params.NoColour;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class ColorParseTest extends BaseTest {
+
+    @Test
+    public void nullIsParsedAsNoColor() throws JSONException {
+        JSONObject json = new JSONObject();
+        json.put("color", "NoColor");
+        assertThat(ColorParser.parse(json, "color")).isInstanceOf(NoColour.class);
+    }
+}

--- a/lib/android/app/src/test/java/com/reactnativenavigation/parse/parsers/ColorParseTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/parse/parsers/ColorParseTest.java
@@ -1,7 +1,7 @@
 package com.reactnativenavigation.parse.parsers;
 
 import com.reactnativenavigation.BaseTest;
-import com.reactnativenavigation.parse.params.IgnoreColour;
+import com.reactnativenavigation.parse.params.DontApplyColour;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -15,6 +15,6 @@ public class ColorParseTest extends BaseTest {
     public void nullIsParsedAsNoColor() throws JSONException {
         JSONObject json = new JSONObject();
         json.put("color", "NoColor");
-        assertThat(ColorParser.parse(json, "color")).isInstanceOf(IgnoreColour.class);
+        assertThat(ColorParser.parse(json, "color")).isInstanceOf(DontApplyColour.class);
     }
 }

--- a/lib/ios/Color.m
+++ b/lib/ios/Color.m
@@ -20,4 +20,21 @@
 	return [super getWithDefaultValue:defaultValue];
 }
 
+-(NSString *)description {
+	return [self hexStringFromColor:[self getWithDefaultValue:nil]];
+}
+
+- (NSString *)hexStringFromColor:(UIColor *)color {
+    const CGFloat *components = CGColorGetComponents(color.CGColor);
+
+    CGFloat r = components[0];
+    CGFloat g = components[1];
+    CGFloat b = components[2];
+
+    return [NSString stringWithFormat:@"#%02lX%02lX%02lX",
+                                      lroundf(r * 255),
+                                      lroundf(g * 255),
+                                      lroundf(b * 255)];
+}
+
 @end

--- a/lib/ios/ColorParser.m
+++ b/lib/ios/ColorParser.m
@@ -1,11 +1,15 @@
 #import "ColorParser.h"
 #import "NullColor.h"
+#import "NoColor.h"
 #import <React/RCTConvert.h>
 
 @implementation ColorParser
 
 + (Color *)parse:(NSDictionary *)json key:(NSString *)key {
-	return json[key] ? [[Color alloc] initWithValue:[RCTConvert UIColor:json[key]]] : [NullColor new];
+	if (json[key]) {
+		return [json[key] isKindOfClass:[NSNumber class]] ? [[Color alloc] initWithValue:[RCTConvert UIColor:json[key]]] : [NoColor new];
+	}
+	return [NullColor new];
 }
 
 @end

--- a/lib/ios/NoColor.h
+++ b/lib/ios/NoColor.h
@@ -1,0 +1,5 @@
+#import "Color.h"
+
+@interface NoColor : Color
+
+@end

--- a/lib/ios/NoColor.m
+++ b/lib/ios/NoColor.m
@@ -1,0 +1,22 @@
+#import "NoColor.h"
+#import "Color.h"
+
+
+@implementation NoColor
+
+- (BOOL)hasValue {
+    return YES;
+}
+
+- (UIColor *)get {
+//    return nil;
+    return UIColor.cyanColor;
+}
+
+- (UIColor *)getWithDefaultValue:(id)defaultValue {
+    return UIColor.cyanColor;
+//    return nil;
+}
+
+
+@end

--- a/lib/ios/RNNBasePresenter.h
+++ b/lib/ios/RNNBasePresenter.h
@@ -8,6 +8,8 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 @property(nonatomic, strong) NSString *boundComponentId;
 
+- (instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions;
+
 - (void)bindViewController:(UIViewController *)boundViewController;
 
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)initialOptions;
@@ -20,7 +22,7 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 - (void)applyDotIndicator:(UIViewController *)child;
 
-- (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions;
+- (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions;
 
 - (void)renderComponents:(RNNNavigationOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock;
 

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -8,13 +8,14 @@
 
 @interface RNNBasePresenter ()
 @property(nonatomic, strong) RNNDotIndicatorPresenter* dotIndicatorPresenter;
+@property(nonatomic, strong) RNNNavigationOptions* defaultOptions;
 @end
-
 @implementation RNNBasePresenter
 
--(instancetype)init {
+-(instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions {
     self = [super init];
-    self.dotIndicatorPresenter = [RNNDotIndicatorPresenter new];
+    _defaultOptions = defaultOptions;
+    self.dotIndicatorPresenter = [[RNNDotIndicatorPresenter alloc] initWithDefaultOptions:_defaultOptions];
     return self;
 }
 
@@ -33,64 +34,66 @@
 
 - (void)applyOptionsOnWillMoveToParentViewController:(RNNNavigationOptions *)options {
     UIViewController *viewController = self.boundViewController;
+    RNNNavigationOptions * withDefault = [options withDefault:_defaultOptions];
 
-    if (options.bottomTab.text.hasValue) {
-        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+    if (withDefault.bottomTab.text.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:withDefault.bottomTab];
         viewController.tabBarItem = tabItem;
     }
 
-    if (options.bottomTab.icon.hasValue) {
-        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+    if (withDefault.bottomTab.icon.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:withDefault.bottomTab];
         viewController.tabBarItem = tabItem;
     }
 
-    if (options.bottomTab.selectedIcon.hasValue) {
-        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+    if (withDefault.bottomTab.selectedIcon.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:withDefault.bottomTab];
         viewController.tabBarItem = tabItem;
     }
 
-    if (options.bottomTab.badgeColor.hasValue) {
-        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+    if (withDefault.bottomTab.badgeColor.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:withDefault.bottomTab];
         viewController.tabBarItem = tabItem;
     }
 
-    if (options.bottomTab.textColor.hasValue) {
-        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+    if (withDefault.bottomTab.textColor.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:withDefault.bottomTab];
         viewController.tabBarItem = tabItem;
     }
 
-    if (options.bottomTab.iconColor.hasValue) {
-        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+    if (withDefault.bottomTab.iconColor.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:withDefault.bottomTab];
         viewController.tabBarItem = tabItem;
     }
 
-    if (options.bottomTab.selectedTextColor.hasValue) {
-        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+    if (withDefault.bottomTab.selectedTextColor.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:withDefault.bottomTab];
         viewController.tabBarItem = tabItem;
     }
 
-    if (options.bottomTab.selectedIconColor.hasValue) {
-        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:options.bottomTab];
+    if (withDefault.bottomTab.selectedIconColor.hasValue) {
+        UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:withDefault.bottomTab];
         viewController.tabBarItem = tabItem;
     }
 }
 
 - (void)applyOptions:(RNNNavigationOptions *)options {
     UIViewController *viewController = self.boundViewController;
+    RNNNavigationOptions * withDefault = [options withDefault:_defaultOptions];
 
-    if (options.bottomTab.badge.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
-        [viewController rnn_setTabBarItemBadge:options.bottomTab];
+    if (withDefault.bottomTab.badge.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
+        [viewController rnn_setTabBarItemBadge:withDefault.bottomTab.badge.get];
     }
 
-    if (options.bottomTab.badgeColor.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
-        [viewController rnn_setTabBarItemBadgeColor:options.bottomTab.badgeColor.get];
+    if (withDefault.bottomTab.badgeColor.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
+        [viewController rnn_setTabBarItemBadgeColor:withDefault.bottomTab.badgeColor.get];
     }
 }
 
-- (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions {
+- (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions {
     UIViewController *viewController = self.boundViewController;
     if (newOptions.bottomTab.badge.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
-        [viewController rnn_setTabBarItemBadge:newOptions.bottomTab];
+        [viewController rnn_setTabBarItemBadge:newOptions.bottomTab.badge.get];
     }
 
     if (newOptions.bottomTab.badgeColor.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
@@ -102,43 +105,43 @@
     }
 
     if (newOptions.bottomTab.text.hasValue) {
-        RNNNavigationOptions *buttonsResolvedOptions = [(RNNNavigationOptions *) [currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+        RNNNavigationOptions *buttonsResolvedOptions = (RNNNavigationOptions *) [currentOptions overrideOptions:newOptions];
         UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
         viewController.tabBarItem = tabItem;
     }
 
     if (newOptions.bottomTab.icon.hasValue) {
-        RNNNavigationOptions *buttonsResolvedOptions = [(RNNNavigationOptions *) [currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+        RNNNavigationOptions *buttonsResolvedOptions = (RNNNavigationOptions *) [currentOptions overrideOptions:newOptions];
         UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
         viewController.tabBarItem = tabItem;
     }
 
     if (newOptions.bottomTab.selectedIcon.hasValue) {
-        RNNNavigationOptions *buttonsResolvedOptions = [(RNNNavigationOptions *) [currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+        RNNNavigationOptions *buttonsResolvedOptions = (RNNNavigationOptions *) [currentOptions overrideOptions:newOptions];
         UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
         viewController.tabBarItem = tabItem;
     }
 
     if (newOptions.bottomTab.textColor.hasValue) {
-        RNNNavigationOptions *buttonsResolvedOptions = [(RNNNavigationOptions *) [currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+        RNNNavigationOptions *buttonsResolvedOptions = (RNNNavigationOptions *) [currentOptions overrideOptions:newOptions];
         UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
         viewController.tabBarItem = tabItem;
     }
 
     if (newOptions.bottomTab.selectedTextColor.hasValue) {
-        RNNNavigationOptions *buttonsResolvedOptions = [(RNNNavigationOptions *) [currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+        RNNNavigationOptions *buttonsResolvedOptions = (RNNNavigationOptions *) [currentOptions overrideOptions:newOptions];
         UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
         viewController.tabBarItem = tabItem;
     }
 
     if (newOptions.bottomTab.iconColor.hasValue) {
-        RNNNavigationOptions *buttonsResolvedOptions = [(RNNNavigationOptions *) [currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+        RNNNavigationOptions *buttonsResolvedOptions = (RNNNavigationOptions *) [currentOptions overrideOptions:newOptions];
         UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
         viewController.tabBarItem = tabItem;
     }
 
     if (newOptions.bottomTab.selectedIconColor.hasValue) {
-        RNNNavigationOptions *buttonsResolvedOptions = [(RNNNavigationOptions *) [currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+        RNNNavigationOptions *buttonsResolvedOptions = (RNNNavigationOptions *) [currentOptions overrideOptions:newOptions];
         UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
         viewController.tabBarItem = tabItem;
     }

--- a/lib/ios/RNNControllerFactory.m
+++ b/lib/ios/RNNControllerFactory.m
@@ -29,7 +29,7 @@
 	_bridge = bridge;
 	_store = store;
 	_componentRegistry = componentRegistry;
-	
+
 	return self;
 }
 
@@ -103,7 +103,7 @@
 - (UIViewController *)createComponent:(RNNLayoutNode*)node {
 	RNNLayoutInfo* layoutInfo = [[RNNLayoutInfo alloc] initWithNode:node];
 	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];;
-	RNNViewControllerPresenter* presenter = [[RNNViewControllerPresenter alloc] initWithComponentRegistry:_componentRegistry];
+	RNNViewControllerPresenter* presenter = [[RNNViewControllerPresenter alloc] initWithComponentRegistry:_componentRegistry:_defaultOptions];
 	
 	RNNRootViewController* component = [[RNNRootViewController alloc] initWithLayoutInfo:layoutInfo rootViewCreator:_creator eventEmitter:_eventEmitter presenter:presenter options:options defaultOptions:_defaultOptions];
 	
@@ -112,8 +112,8 @@
 
 - (UIViewController *)createExternalComponent:(RNNLayoutNode*)node {
 	RNNLayoutInfo* layoutInfo = [[RNNLayoutInfo alloc] initWithNode:node];
-	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];;
-	RNNViewControllerPresenter* presenter = [[RNNViewControllerPresenter alloc] init];
+	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];
+	RNNViewControllerPresenter* presenter = [[RNNViewControllerPresenter alloc] initWithDefaultOptions:_defaultOptions];
 	
 	UIViewController* externalVC = [_store getExternalComponent:layoutInfo bridge:_bridge];
 	
@@ -123,11 +123,10 @@
 	return component;
 }
 
-
 - (UIViewController *)createStack:(RNNLayoutNode*)node {
-	RNNNavigationControllerPresenter* presenter = [[RNNNavigationControllerPresenter alloc] initWithComponentRegistry:_componentRegistry];
+	RNNNavigationControllerPresenter* presenter = [[RNNNavigationControllerPresenter alloc] initWithComponentRegistry:_componentRegistry :_defaultOptions];
 	RNNLayoutInfo* layoutInfo = [[RNNLayoutInfo alloc] initWithNode:node];
-	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];;
+	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];
 	
 	NSArray *childViewControllers = [self extractChildrenViewControllersFromNode:node];
 	
@@ -138,8 +137,8 @@
 
 -(UIViewController *)createBottomTabs:(RNNLayoutNode*)node {
 	RNNLayoutInfo* layoutInfo = [[RNNLayoutInfo alloc] initWithNode:node];
-	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];;
-	RNNTabBarPresenter* presenter = [RNNTabBarPresenter new];
+	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];
+	RNNTabBarPresenter* presenter = [[RNNTabBarPresenter alloc] initWithDefaultOptions:_defaultOptions];
 
 	NSArray *childViewControllers = [self extractChildrenViewControllersFromNode:node];
 	
@@ -157,8 +156,8 @@
 
 - (UIViewController *)createTopTabs:(RNNLayoutNode*)node {
 	RNNLayoutInfo* layoutInfo = [[RNNLayoutInfo alloc] initWithNode:node];
-	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];;
-	RNNViewControllerPresenter* presenter = [[RNNViewControllerPresenter alloc] init];
+	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];
+	RNNViewControllerPresenter* presenter = [[RNNViewControllerPresenter alloc] initWithDefaultOptions :_defaultOptions];
 
 	NSArray *childViewControllers = [self extractChildrenViewControllersFromNode:node];
 	
@@ -169,8 +168,8 @@
 
 - (UIViewController *)createSideMenu:(RNNLayoutNode*)node {
 	RNNLayoutInfo* layoutInfo = [[RNNLayoutInfo alloc] initWithNode:node];
-	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];;
-	RNNSideMenuPresenter* presenter = [[RNNSideMenuPresenter alloc] init];
+	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];
+	RNNSideMenuPresenter* presenter = [[RNNSideMenuPresenter alloc] initWithDefaultOptions:_defaultOptions];
 
 	NSArray *childViewControllers = [self extractChildrenViewControllersFromNode:node];
 	
@@ -183,17 +182,17 @@
 - (UIViewController *)createSideMenuChild:(RNNLayoutNode*)node type:(RNNSideMenuChildType)type {
 	UIViewController* childVc = [self fromTree:node.children[0]];
 	RNNLayoutInfo* layoutInfo = [[RNNLayoutInfo alloc] initWithNode:node];
-	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];;
+	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];
 
-	RNNSideMenuChildVC *sideMenuChild = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:layoutInfo creator:_creator options:options defaultOptions:_defaultOptions presenter:[[RNNViewControllerPresenter alloc] initWithComponentRegistry:_componentRegistry] eventEmitter:_eventEmitter childViewController:childVc type:type];
+	RNNSideMenuChildVC *sideMenuChild = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:layoutInfo creator:_creator options:options defaultOptions:_defaultOptions presenter:[[RNNViewControllerPresenter alloc] initWithComponentRegistry:_componentRegistry:_defaultOptions] eventEmitter:_eventEmitter childViewController:childVc type:type];
 	
 	return sideMenuChild;
 }
 
 - (UIViewController *)createSplitView:(RNNLayoutNode*)node {
 	RNNLayoutInfo* layoutInfo = [[RNNLayoutInfo alloc] initWithNode:node];
-	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];;
-	RNNSplitViewControllerPresenter* presenter = [[RNNSplitViewControllerPresenter alloc] init];
+	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];
+	RNNSplitViewControllerPresenter* presenter = [[RNNSplitViewControllerPresenter alloc] initWithDefaultOptions:_defaultOptions];
 
 	NSArray *childViewControllers = [self extractChildrenViewControllersFromNode:node];
 

--- a/lib/ios/RNNDotIndicatorPresenter.h
+++ b/lib/ios/RNNDotIndicatorPresenter.h
@@ -1,9 +1,11 @@
 #import <Foundation/Foundation.h>
-
-@class UIViewController;
-@class DotIndicatorOptions;
-
+#import "DotIndicatorOptions.h"
+#import "RNNNavigationOptions.h"
 
 @interface RNNDotIndicatorPresenter : NSObject
+@property(nonatomic, strong) RNNNavigationOptions* defaultOptions;
+
+- (instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions;
+
 - (void)apply:(UIViewController *)child :(DotIndicatorOptions *)options;
 @end

--- a/lib/ios/RNNDotIndicatorPresenter.m
+++ b/lib/ios/RNNDotIndicatorPresenter.m
@@ -3,8 +3,15 @@
 #import "UIViewController+LayoutProtocol.h"
 #import "DotIndicatorOptions.h"
 #import "UITabBarController+RNNUtils.h"
+#import "RNNNavigationOptions.h"
 
 @implementation RNNDotIndicatorPresenter
+
+-(instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions {
+    self = [super init];
+    _defaultOptions = defaultOptions;
+    return self;
+}
 
 - (void)apply:(UIViewController *)child :(DotIndicatorOptions *)options {
     if (![options hasValue]) return;

--- a/lib/ios/RNNNavigationControllerPresenter.h
+++ b/lib/ios/RNNNavigationControllerPresenter.h
@@ -5,9 +5,9 @@
 
 @interface RNNNavigationControllerPresenter : RNNBasePresenter
 
-@property (nonatomic, strong) InteractivePopGestureDelegate *interactivePopGestureDelegate;
+@property(nonatomic, strong) InteractivePopGestureDelegate *interactivePopGestureDelegate;
 
-- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry;
+- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry :(RNNNavigationOptions *)defaultOptions;
 
 - (void)applyOptionsBeforePopping:(RNNNavigationOptions *)options;
 

--- a/lib/ios/RNNNavigationControllerPresenter.m
+++ b/lib/ios/RNNNavigationControllerPresenter.m
@@ -15,8 +15,8 @@
 @end
 @implementation RNNNavigationControllerPresenter
 
-- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry {
-	self = [super init];
+- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry:(RNNNavigationOptions *)defaultOptions {
+	self = [super initWithDefaultOptions:defaultOptions];
 	_componentRegistry = componentRegistry;
 	return self;
 }
@@ -65,8 +65,8 @@
 	[navigationController rnn_setNavigationBarLargeTitleVisible:[options.topBar.largeTitle.visible getWithDefaultValue:NO]];
 }
 
-- (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions {
-	[super mergeOptions:newOptions currentOptions:currentOptions defaultOptions:defaultOptions];
+- (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions {
+	[super mergeOptions:newOptions currentOptions:currentOptions];
 	
 	RNNNavigationController* navigationController = self.boundViewController;
 	

--- a/lib/ios/RNNNavigationOptions.m
+++ b/lib/ios/RNNNavigationOptions.m
@@ -45,7 +45,7 @@
 	return self;
 }
 
-- (RNNOptions *)copy {
+- (RNNNavigationOptions *)copy {
 	RNNNavigationOptions* newOptions = [[RNNNavigationOptions alloc] initWithDict:@{}];
 	[newOptions overrideOptions:self];
 	

--- a/lib/ios/RNNOptions.m
+++ b/lib/ios/RNNOptions.m
@@ -46,7 +46,7 @@
 	RNNOptions* newOptions = [[[self class] alloc] initWithDict:@{}];
 	[newOptions mergeOptions:defaultOptions overrideOptions:YES];
 	[newOptions mergeOptions:self overrideOptions:YES];
-	
+
 	return newOptions;
 }
 

--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -28,7 +28,7 @@
 }
 
 - (void)mergeOptions:(RNNNavigationOptions *)options {
-	[_presenter mergeOptions:options currentOptions:self.options defaultOptions:self.defaultOptions];
+	[_presenter mergeOptions:options currentOptions:self.options];
 	[self.parentViewController mergeOptions:options];
 }
 

--- a/lib/ios/RNNSideMenuPresenter.m
+++ b/lib/ios/RNNSideMenuPresenter.m
@@ -3,6 +3,11 @@
 
 @implementation RNNSideMenuPresenter
 
+-(instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions {
+	self = [super initWithDefaultOptions:defaultOptions];
+	return self;
+}
+
 - (void)applyOptions:(RNNNavigationOptions *)options {
 	[super applyOptions:options];
 		
@@ -53,8 +58,8 @@
 		[sideMenuController setOpenDrawerGestureModeMask:[[initialOptions.sideMenu.openGestureMode getWithDefaultValue:@(MMOpenDrawerGestureModeAll)] integerValue]];
 }
 
-- (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions {
-	[super mergeOptions:newOptions currentOptions:currentOptions defaultOptions:defaultOptions];
+- (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions {
+	[super mergeOptions:newOptions currentOptions:currentOptions];
 	
 	RNNSideMenuController* sideMenuController = self.boundViewController;
 	

--- a/lib/ios/RNNSplitViewControllerPresenter.m
+++ b/lib/ios/RNNSplitViewControllerPresenter.m
@@ -5,6 +5,11 @@
 
 @implementation RNNSplitViewControllerPresenter
 
+-(instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions {
+	self = [super initWithDefaultOptions:defaultOptions];
+	return self;
+}
+
 - (void)applyOptions:(RNNNavigationOptions *)options {
 	[super applyOptions:options];
 	
@@ -26,8 +31,8 @@
 	[splitViewController rnn_setMaxWidth:initialOptions.splitView.maxWidth];
 }
 
-- (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions {
-	[super mergeOptions:newOptions currentOptions:currentOptions defaultOptions:defaultOptions];
+- (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions {
+	[super mergeOptions:newOptions currentOptions:currentOptions];
 	
 	UISplitViewController* splitViewController = self.boundViewController;
 

--- a/lib/ios/RNNTabBarPresenter.m
+++ b/lib/ios/RNNTabBarPresenter.m
@@ -5,6 +5,11 @@
 
 @implementation RNNTabBarPresenter
 
+-(instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions {
+    self = [super initWithDefaultOptions:defaultOptions];
+    return self;
+}
+
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)options {
     UITabBarController *tabBarController = self.boundViewController;
     [tabBarController rnn_setCurrentTabIndex:[options.bottomTabs.currentTabIndex getWithDefaultValue:0]];
@@ -21,8 +26,8 @@
     [tabBarController rnn_setTabBarVisible:[options.bottomTabs.visible getWithDefaultValue:YES] animated:[options.bottomTabs.animate getWithDefaultValue:NO]];
 }
 
-- (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions {
-    [super mergeOptions:newOptions currentOptions:currentOptions defaultOptions:defaultOptions];
+- (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions {
+    [super mergeOptions:newOptions currentOptions:currentOptions];
 
     UITabBarController *tabBarController = self.boundViewController;
 

--- a/lib/ios/RNNViewControllerPresenter.h
+++ b/lib/ios/RNNViewControllerPresenter.h
@@ -4,7 +4,7 @@
 
 @interface RNNViewControllerPresenter : RNNBasePresenter
 
-- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry;
+- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry:(RNNNavigationOptions *)defaultOptions;
 
 - (void)renderComponents:(RNNNavigationOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock;
 

--- a/lib/ios/RNNViewControllerPresenter.m
+++ b/lib/ios/RNNViewControllerPresenter.m
@@ -17,8 +17,8 @@
 
 @implementation RNNViewControllerPresenter
 
-- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry {
-	self = [self init];
+- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry:(RNNNavigationOptions *)defaultOptions {
+	self = [self initWithDefaultOptions:defaultOptions];
 	_componentRegistry = componentRegistry;
 	return self;
 }
@@ -76,8 +76,8 @@
 	}
 }
 
-- (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions defaultOptions:(RNNNavigationOptions *)defaultOptions {
-	[super mergeOptions:newOptions currentOptions:currentOptions defaultOptions:defaultOptions];
+- (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions {
+	[super mergeOptions:newOptions currentOptions:currentOptions];
 	
 	UIViewController* viewController = self.boundViewController;
 	
@@ -142,7 +142,7 @@
 	}
 	
 	if (newOptions.topBar.leftButtons || newOptions.topBar.rightButtons) {
-		RNNNavigationOptions* buttonsResolvedOptions = [(RNNNavigationOptions *)[currentOptions overrideOptions:newOptions] withDefault:defaultOptions];
+		RNNNavigationOptions* buttonsResolvedOptions = (RNNNavigationOptions *)[currentOptions overrideOptions:newOptions];
 		[_navigationButtons applyLeftButtons:newOptions.topBar.leftButtons rightButtons:newOptions.topBar.rightButtons defaultLeftButtonStyle:buttonsResolvedOptions.topBar.leftButtonStyle defaultRightButtonStyle:buttonsResolvedOptions.topBar.rightButtonStyle];
 	}
 	
@@ -151,7 +151,7 @@
 		rootView.passThroughTouches = !newOptions.overlay.interceptTouchOutside.get;
 	}
 	
-	[self setTitleViewWithSubtitle:(RNNNavigationOptions *)[[currentOptions overrideOptions:newOptions] mergeOptions:defaultOptions]];
+	[self setTitleViewWithSubtitle:(RNNNavigationOptions *)[currentOptions overrideOptions:newOptions]];
 	
 	if (newOptions.topBar.title.component.name.hasValue) {
 		[self setCustomNavigationTitleView:newOptions perform:nil];

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -34,11 +34,13 @@
 		26916C991E4B9E7700D13680 /* RNNReactRootViewCreator.m in Sources */ = {isa = PBXBuildFile; fileRef = 26916C971E4B9E7700D13680 /* RNNReactRootViewCreator.m */; };
 		2DCD9195200014A900EDC75D /* RNNBridgeManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DCD9193200014A900EDC75D /* RNNBridgeManager.h */; };
 		2DCD9196200014A900EDC75D /* RNNBridgeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DCD9194200014A900EDC75D /* RNNBridgeManager.m */; };
+		3098702E6833E5CC16D91CE3 /* NoColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 309874C5B132A51A03DAA3BF /* NoColor.h */; };
 		3098730BC3B4DE41104D9CC4 /* RNNDotIndicatorPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 309878B02F15ECDD1A286722 /* RNNDotIndicatorPresenter.h */; };
 		309874B40D202C9718F15CBD /* UIView+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 309877F25920CFE113FADEE0 /* UIView+Utils.h */; };
 		30987680135A8C78E62D5B8E /* DotIndicatorOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987122507D8CBF16624F93 /* DotIndicatorOptions.h */; };
 		309877B0B5AAA7788F56F3D9 /* UIViewController+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */; };
 		309877F473AECC05FB3B9362 /* UITabBarController+RNNUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 30987FED6F982D322416CAF2 /* UITabBarController+RNNUtils.h */; };
+		309878CC9D33CE1CF991EBD1 /* NoColor.m in Sources */ = {isa = PBXBuildFile; fileRef = 309877ADF638DF25FF0DA8A1 /* NoColor.m */; };
 		30987AB5137F264FA06DA289 /* DotIndicatorOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 309876223177761614786DCC /* DotIndicatorOptions.m */; };
 		30987B23F288EB3A78B7F27C /* RNNDotIndicatorPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 30987E66AA7AB38E7370F8C8 /* RNNDotIndicatorPresenter.m */; };
 		30987CA5048A48D6CE76B06C /* DotIndicatorParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 309871FBA64AD937CEF3E191 /* DotIndicatorParser.h */; };
@@ -378,9 +380,11 @@
 		30987122507D8CBF16624F93 /* DotIndicatorOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DotIndicatorOptions.h; sourceTree = "<group>"; };
 		309871FBA64AD937CEF3E191 /* DotIndicatorParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DotIndicatorParser.h; sourceTree = "<group>"; };
 		3098727A36771B4902A14FEA /* RNNTestBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNTestBase.m; sourceTree = "<group>"; };
+		309874C5B132A51A03DAA3BF /* NoColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NoColor.h; sourceTree = "<group>"; };
 		309874E37C7E9764C7B694E5 /* DotIndicatorParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DotIndicatorParser.m; sourceTree = "<group>"; };
 		309876223177761614786DCC /* DotIndicatorOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DotIndicatorOptions.m; sourceTree = "<group>"; };
 		30987758777622B7D6CCD695 /* RNNDotIndicatorPresenterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNDotIndicatorPresenterTest.m; sourceTree = "<group>"; };
+		309877ADF638DF25FF0DA8A1 /* NoColor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NoColor.m; sourceTree = "<group>"; };
 		309877F25920CFE113FADEE0 /* UIView+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+Utils.h"; sourceTree = "<group>"; };
 		309878B02F15ECDD1A286722 /* RNNDotIndicatorPresenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNDotIndicatorPresenter.h; sourceTree = "<group>"; };
 		30987CF6993B89E85C0BCEE4 /* UIViewController+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Utils.h"; sourceTree = "<group>"; };
@@ -840,6 +844,8 @@
 				5039558E217482FE00B0A663 /* NullIntNumber.m */,
 				503955952174864E00B0A663 /* NullDouble.h */,
 				503955962174864E00B0A663 /* NullDouble.m */,
+				309877ADF638DF25FF0DA8A1 /* NoColor.m */,
+				309874C5B132A51A03DAA3BF /* NoColor.h */,
 			);
 			name = Params;
 			sourceTree = "<group>";
@@ -1352,6 +1358,7 @@
 				30987CA5048A48D6CE76B06C /* DotIndicatorParser.h in Headers */,
 				3098730BC3B4DE41104D9CC4 /* RNNDotIndicatorPresenter.h in Headers */,
 				309877F473AECC05FB3B9362 /* UITabBarController+RNNUtils.h in Headers */,
+				3098702E6833E5CC16D91CE3 /* NoColor.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1618,6 +1625,7 @@
 				30987AB5137F264FA06DA289 /* DotIndicatorOptions.m in Sources */,
 				30987D71FB4FEEAC8D8978E8 /* DotIndicatorParser.m in Sources */,
 				30987B23F288EB3A78B7F27C /* RNNDotIndicatorPresenter.m in Sources */,
+				309878CC9D33CE1CF991EBD1 /* NoColor.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/lib/ios/ReactNativeNavigationTests/RNNBasePresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNBasePresenterTest.m
@@ -8,8 +8,8 @@
 
 @property(nonatomic, strong) RNNBasePresenter *uut;
 @property(nonatomic, strong) RNNNavigationOptions *options;
-@property(nonatomic, strong) RNNRootViewController *bindedViewController;
-@property(nonatomic, strong) id mockBindedViewController;
+@property(nonatomic, strong) RNNRootViewController *boundViewController;
+@property(nonatomic, strong) id mockBoundViewController;
 
 @end
 
@@ -18,46 +18,46 @@
 - (void)setUp {
     [super setUp];
     self.uut = [[RNNBasePresenter alloc] init];
-    self.bindedViewController = [RNNRootViewController new];
-    self.mockBindedViewController = [OCMockObject partialMockForObject:self.bindedViewController];
-    [self.uut bindViewController:self.mockBindedViewController];
+    self.boundViewController = [RNNRootViewController new];
+    self.mockBoundViewController = [OCMockObject partialMockForObject:self.boundViewController];
+    [self.uut bindViewController:self.mockBoundViewController];
     self.options = [[RNNNavigationOptions alloc] initEmptyOptions];
 }
 
 - (void)tearDown {
     [super tearDown];
-    [self.mockBindedViewController stopMocking];
-    self.bindedViewController = nil;
+    [self.mockBoundViewController stopMocking];
+    self.boundViewController = nil;
 }
 
 - (void)testApplyOptions_shouldSetTabBarItemBadgeOnlyWhenParentIsUITabBarController {
-    [[self.mockBindedViewController reject] rnn_setTabBarItemBadge:[OCMArg any]];
+    [[self.mockBoundViewController reject] rnn_setTabBarItemBadge:[OCMArg any]];
     [self.uut applyOptions:self.options];
-    [self.mockBindedViewController verify];
+    [self.mockBoundViewController verify];
 }
 
 - (void)testApplyOptions_shouldSetTabBarItemBadgeWithValue {
-    OCMStub([self.mockBindedViewController parentViewController]).andReturn([UITabBarController new]);
+    OCMStub([self.mockBoundViewController parentViewController]).andReturn([UITabBarController new]);
     self.options.bottomTab.badge = [[Text alloc] initWithValue:@"badge"];
-    [[self.mockBindedViewController expect] rnn_setTabBarItemBadge:self.options.bottomTab];
+    [[self.mockBoundViewController expect] rnn_setTabBarItemBadge:self.options.bottomTab.badge.get];
     [self.uut applyOptions:self.options];
-    [self.mockBindedViewController verify];
+    [self.mockBoundViewController verify];
 }
 
 - (void)testApplyOptions_setTabBarItemBadgeShouldNotCalledOnUITabBarController {
-    [self.uut bindViewController:self.mockBindedViewController];
+    [self.uut bindViewController:self.mockBoundViewController];
     self.options.bottomTab.badge = [[Text alloc] initWithValue:@"badge"];
-    [[self.mockBindedViewController reject] rnn_setTabBarItemBadge:[[RNNBottomTabOptions alloc] initWithDict:@{@"badge": @"badge"}]];
+    [[self.mockBoundViewController reject] rnn_setTabBarItemBadge:[[RNNBottomTabOptions alloc] initWithDict:@{@"badge": @"badge"}]];
     [self.uut applyOptions:self.options];
-    [self.mockBindedViewController verify];
+    [self.mockBoundViewController verify];
 }
 
 - (void)testApplyOptions_setTabBarItemBadgeShouldWhenNoValue {
-    [self.uut bindViewController:self.mockBindedViewController];
+    [self.uut bindViewController:self.mockBoundViewController];
     self.options.bottomTab.badge = nil;
-    [[self.mockBindedViewController reject] rnn_setTabBarItemBadge:[OCMArg any]];
+    [[self.mockBoundViewController reject] rnn_setTabBarItemBadge:[OCMArg any]];
     [self.uut applyOptions:self.options];
-    [self.mockBindedViewController verify];
+    [self.mockBoundViewController verify];
 }
 
 @end

--- a/lib/ios/ReactNativeNavigationTests/RNNNavigationOptionsTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNNavigationOptionsTest.m
@@ -25,7 +25,7 @@
 	NSDictionary* dynamicOptionsDict = @{@"topBar": @{@"textColor" : @(0xffff00ff), @"title" : @{@"text": @"hello"}}};
 	RNNNavigationOptions* dynamicOptions = [[RNNNavigationOptions alloc] initWithDict:dynamicOptionsDict];
 	[options overrideOptions:dynamicOptions];
-	
+
 	XCTAssertTrue([options.topBar.title.text.get isEqual:@"hello"]);
 }
 
@@ -35,6 +35,31 @@
 	RNNNavigationOptions* dynamicOptions = [[RNNNavigationOptions alloc] initWithDict:dynamicOptionsDict];
 	XCTAssertNoThrow([options overrideOptions:dynamicOptions]);
 }
+
+- (void)testWithDefault {
+	RNNNavigationOptions * options = [[RNNNavigationOptions alloc] initWithDict:@{
+			@"topBar": @{
+					@"subtitle" : @{@"text": @"hey"}
+			},
+			@"bottomTab": @{
+					@"selectedIconColor": @(0xff000000)
+			}
+	}];
+	RNNNavigationOptions * defaultOptions = [[RNNNavigationOptions alloc] initWithDict:@{
+	        @"topBar": @{
+                    @"subtitle": @{@"text": @"ho"},
+                    @"title": @{@"text": @"hello"}
+            },
+			@"bottomTab": @{
+	        		@"selectedIconColor": @(0xff0000ff)
+	        }
+	}];
+
+	RNNNavigationOptions * withDefault = [options withDefault:defaultOptions];
+	XCTAssertEqual(withDefault.topBar.subtitle.text.get, @"hey");
+	XCTAssertEqual(withDefault.bottomTab.selectedIconColor.get, options.bottomTab.selectedIconColor.get);
+}
+
 //
 //- (void)test_applyDefaultOptions {
 //	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initEmptyOptions];

--- a/lib/ios/ReactNativeNavigationTests/RNNOptionsTest.h
+++ b/lib/ios/ReactNativeNavigationTests/RNNOptionsTest.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+
+@interface RNNOptionsTest : NSObject
+@end

--- a/lib/ios/ReactNativeNavigationTests/RNNRootViewControllerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNRootViewControllerTest.m
@@ -548,7 +548,7 @@
 
 - (void)testMergeOptionsShouldCallPresenterMergeOptions {
 	RNNNavigationOptions* newOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
-	[[(id)self.uut.presenter expect] mergeOptions:newOptions currentOptions:self.uut.options defaultOptions:self.uut.defaultOptions];
+	[[(id)self.uut.presenter expect] mergeOptions:newOptions currentOptions:self.uut.options];
 	[self.uut mergeOptions:newOptions];
 	[(id)self.uut.presenter verify];
 }

--- a/lib/ios/ReactNativeNavigationTests/RNNTabBarControllerTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNTabBarControllerTest.m
@@ -90,7 +90,7 @@
 - (void)testMergeOptions_shouldInvokePresenterMergeOptions {
     RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initWithDict:@{}];
 
-    [(RNNTabBarPresenter *) [self.mockTabBarPresenter expect] mergeOptions:options currentOptions:[self.uut options] defaultOptions:nil];
+    [(RNNTabBarPresenter *) [self.mockTabBarPresenter expect] mergeOptions:options currentOptions:[self.uut options]];
     [self.uut mergeOptions:options];
     [self.mockTabBarPresenter verify];
 }

--- a/lib/ios/ReactNativeNavigationTests/RNNViewControllerPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNViewControllerPresenterTest.m
@@ -2,7 +2,6 @@
 #import <OCMock/OCMock.h>
 #import "RNNViewControllerPresenter.h"
 #import "UIViewController+RNNOptions.h"
-#import "RNNReactView.h"
 #import "RNNRootViewController.h"
 
 @interface RNNViewControllerPresenterTest : XCTestCase
@@ -19,7 +18,7 @@
 - (void)setUp {
     [super setUp];
 	self.componentRegistry = [OCMockObject partialMockForObject:[RNNReactComponentRegistry new]];
-	self.uut = [[RNNViewControllerPresenter alloc] initWithComponentRegistry:self.componentRegistry];
+	self.uut = [[RNNViewControllerPresenter alloc] initWithComponentRegistry:self.componentRegistry:[[RNNNavigationOptions alloc] initEmptyOptions]];
 	self.bindedViewController = [OCMockObject partialMockForObject:[RNNRootViewController new]];
 	[self.uut bindViewController:self.bindedViewController];
 	self.options = [[RNNNavigationOptions alloc] initEmptyOptions];

--- a/lib/ios/ReactNativeNavigationTests/UIViewController+LayoutProtocolTest.m
+++ b/lib/ios/ReactNativeNavigationTests/UIViewController+LayoutProtocolTest.m
@@ -4,6 +4,8 @@
 #import "UIViewController+RNNOptions.h"
 #import "RNNViewControllerPresenter.h"
 #import "RCTConvert+Modal.h"
+#import "RNNTabBarController.h"
+#import "RNNNavigationController.h"
 
 @interface UIViewController_LayoutProtocolTest : XCTestCase
 
@@ -76,6 +78,25 @@
 	
 	[uut rnn_setBackButtonIcon:nil withColor:nil title:title];
 	XCTAssertEqual(title, uut.navigationItem.backBarButtonItem.title);
+}
+
+- (void)testResolveOptions {
+	RNNViewControllerPresenter* presenter = [[RNNViewControllerPresenter alloc] init];
+
+	RNNNavigationOptions* childOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
+	RNNNavigationOptions* parentOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
+		parentOptions.bottomTab.text =  [[Text alloc] initWithValue:@"text"];
+		parentOptions.bottomTab.selectedIconColor =  [[Color alloc] initWithValue:UIColor.redColor];
+	RNNNavigationOptions* defaultOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
+		defaultOptions.bottomTab.text = [[Text alloc] initWithValue:@"default text"];
+		defaultOptions.bottomTab.selectedIconColor = [[Color alloc] initWithValue:UIColor.blueColor];
+
+	UIViewController* child = [[UIViewController alloc] initWithLayoutInfo:nil creator:nil options:childOptions defaultOptions:defaultOptions presenter:presenter eventEmitter:nil childViewControllers:nil];
+    RNNNavigationController* parent = [[RNNNavigationController alloc] initWithLayoutInfo:nil creator:nil options:parentOptions defaultOptions:defaultOptions presenter:presenter eventEmitter:nil childViewControllers:@[child]];
+
+    XCTAssertEqual([parent getCurrentChild], child);
+	XCTAssertEqual([[parent resolveOptions].bottomTab.text get], @"text");
+	XCTAssertEqual([[parent resolveOptions].bottomTab.selectedIconColor get], UIColor.redColor);
 }
 
 @end

--- a/lib/ios/ReactNativeNavigationTests/UIViewController+RNNOptionsTest.m
+++ b/lib/ios/ReactNativeNavigationTests/UIViewController+RNNOptionsTest.m
@@ -17,23 +17,20 @@
 }
 
 - (void)test_setTabBarItemBadge_shouldSetValidValue {
-    NSDictionary *dict = @{@"badge": @"badge"};
-    RNNBottomTabOptions * options = [[RNNBottomTabOptions alloc] initWithDict:dict];
-    [self.uut rnn_setTabBarItemBadge:options];
+    [self.uut rnn_setTabBarItemBadge:@"badge"];
     XCTAssertEqual([self.uut tabBarItem].badgeValue, @"badge");
 }
 
 - (void)test_setTabBarItemBadge_shouldResetWhenValueIsEmptyString {
-    [self.uut rnn_setTabBarItemBadge:[[RNNBottomTabOptions alloc] initWithDict:@{@"badge": @"badge"}]];
+    [self.uut rnn_setTabBarItemBadge:@"badge"];
 
-    RNNBottomTabOptions * optionsWithEmptyBadge = [[RNNBottomTabOptions alloc] initWithDict:@{@"badge": @""}];
-    [self.uut rnn_setTabBarItemBadge:optionsWithEmptyBadge];
+    [self.uut rnn_setTabBarItemBadge:@""];
     XCTAssertEqual([self.uut tabBarItem].badgeValue, nil);
 }
 
 - (void)test_setTabBarItemBadge_shouldResetWhenValueIsNullObject {
-    [self.uut rnn_setTabBarItemBadge:[[RNNBottomTabOptions alloc] initWithDict:@{@"badge": @"badge"}]];
-    [self.uut rnn_setTabBarItemBadge:[[RNNBottomTabOptions alloc] initWithDict:@{@"badge": [NSNull new]}]];
+    [self.uut rnn_setTabBarItemBadge:@"badge"];
+    [self.uut rnn_setTabBarItemBadge:(id) [NSNull new]];
     XCTAssertEqual([self.uut tabBarItem].badgeValue, nil);
 }
 

--- a/lib/ios/UIViewController+LayoutProtocol.h
+++ b/lib/ios/UIViewController+LayoutProtocol.h
@@ -14,8 +14,6 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 - (RNNNavigationOptions *)resolveOptions;
 
-- (RNNNavigationOptions *)resolveChildOptions:(UIViewController *) child;
-
 - (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions;
 
 - (void)overrideOptions:(RNNNavigationOptions *)options;

--- a/lib/ios/UIViewController+LayoutProtocol.m
+++ b/lib/ios/UIViewController+LayoutProtocol.m
@@ -24,21 +24,16 @@
 	self.presenter = presenter;
 	[self.presenter bindViewController:self];
 	[self.presenter applyOptionsOnInit:self.resolveOptions];
-	
 
 	return self;
 }
 
 - (RNNNavigationOptions *)resolveOptions {
-	return [(RNNNavigationOptions *)[self.options mergeInOptions:self.getCurrentChild.resolveOptions.copy] withDefault:self.defaultOptions];
-}
-
-- (RNNNavigationOptions *)resolveChildOptions:(UIViewController *) child {
-	return [(RNNNavigationOptions *)[self.options mergeInOptions:child.resolveOptions.copy] withDefault:self.defaultOptions];
+    return (RNNNavigationOptions *) [self.options mergeInOptions:self.getCurrentChild.resolveOptions.copy];
 }
 
 - (void)mergeOptions:(RNNNavigationOptions *)options {
-	[self.presenter mergeOptions:options currentOptions:self.options defaultOptions:self.defaultOptions];
+	[self.presenter mergeOptions:options currentOptions:self.options];
 	[self.parentViewController mergeOptions:options];
 }
 

--- a/lib/ios/UIViewController+RNNOptions.h
+++ b/lib/ios/UIViewController+RNNOptions.h
@@ -20,7 +20,7 @@
 
 - (void)rnn_setTabBarItemBadgeColor:(UIColor *)badgeColor;
 
-- (void)rnn_setTabBarItemBadge:(RNNBottomTabOptions *)bottomTab;
+- (void)rnn_setTabBarItemBadge:(NSString *)badge;
 
 - (void)rnn_setTopBarPrefersLargeTitle:(BOOL)prefersLargeTitle;
 

--- a/lib/ios/UIViewController+RNNOptions.m
+++ b/lib/ios/UIViewController+RNNOptions.m
@@ -81,10 +81,9 @@ const NSInteger BLUR_STATUS_TAG = 78264801;
 	}
 }
 
-- (void)rnn_setTabBarItemBadge:(RNNBottomTabOptions *)bottomTab {
+- (void)rnn_setTabBarItemBadge:(NSString *)badge {
     UITabBarItem *tabBarItem = self.tabBarItem;
 
-    NSString *badge = [bottomTab.badge get];
     if ([badge isKindOfClass:[NSNull class]] || [badge isEqualToString:@""]) {
         tabBarItem.badgeValue = nil;
     } else {

--- a/lib/src/commands/OptionsProcessor.ts
+++ b/lib/src/commands/OptionsProcessor.ts
@@ -20,12 +20,12 @@ export class OptionsProcessor {
 
   private processObject(objectToProcess: object) {
     _.forEach(objectToProcess, (value, key) => {
+      this.processColor(key, value, objectToProcess);
       if (!value) {
         return;
       }
 
       this.processComponent(key, value, objectToProcess);
-      this.processColor(key, value, objectToProcess);
       this.processImage(key, value, objectToProcess);
       this.processButtonsPassProps(key, value);
 
@@ -37,7 +37,7 @@ export class OptionsProcessor {
 
   private processColor(key: string, value: any, options: Record<string, any>) {
     if (_.isEqual(key, 'color') || _.endsWith(key, 'Color')) {
-      options[key] = this.colorService.toNativeColor(value);
+      options[key] = value === null ? 'NoColor' : this.colorService.toNativeColor(value);
     }
   }
 

--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -48,7 +48,11 @@ function start() {
                 options: {
                   bottomTab: {
                     text: 'Layouts',
-                    icon: require('../img/layouts.png'),
+                    icon: require('../img/Icon-87.png'),
+                    selectedIconColor: 'green',
+                    iconColor: 'red',
+                    fontSize: 10,
+                    textColor: 'red',
                     testID: testIDs.LAYOUTS_TAB
                   }
                 }

--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -48,11 +48,8 @@ function start() {
                 options: {
                   bottomTab: {
                     text: 'Layouts',
-                    icon: require('../img/Icon-87.png'),
-                    selectedIconColor: 'green',
-                    iconColor: 'red',
+                    icon: require('../img/layouts.png'),
                     fontSize: 10,
-                    textColor: 'red',
                     testID: testIDs.LAYOUTS_TAB
                   }
                 }


### PR DESCRIPTION
This commit adds initial support for passing null as a valid value for color properties.
When a color property is applied, if it wasn't specified then the default color is applied. Now, when null is passed, no color will be applied
leaving the last color applied as is.

This is useful when showing an Overlay and you'd like to keep the current StatusBar color unaffected. Another usecase would be when you'd like to avoid coloring an icon in BottomTabs. 