### PR TITLE
Propagate new defaultOptions to presenters

### DIFF
--- a/e2e/Options.test.js
+++ b/e2e/Options.test.js
@@ -56,9 +56,9 @@ describe('Options', () => {
     await elementById(TestIDs.HIDE_TOPBAR_DEFAULT_OPTIONS).tap();
     await expect(elementById(TestIDs.TOP_BAR)).toBeVisible();
     await elementById(TestIDs.PUSH_BTN).tap();
-    await expect(elementById(TestIDs.TOP_BAR)).toBeNotVisible();
+    await expect(elementById(TestIDs.PUSHED_SCREEN_HEADER)).toBeNotVisible();
     await elementById(TestIDs.PUSH_BTN).tap();
-    await expect(elementById(TestIDs.TOP_BAR)).toBeNotVisible();
+    await expect(elementById(TestIDs.PUSHED_SCREEN_HEADER)).toBeNotVisible();
   });
 
   it('default options should not override static options', async () => {

--- a/lib/ios/RNNBasePresenter.h
+++ b/lib/ios/RNNBasePresenter.h
@@ -8,9 +8,13 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 @property(nonatomic, strong) NSString *boundComponentId;
 
+@property(nonatomic, strong) RNNNavigationOptions * defaultOptions;
+
 - (instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions;
 
 - (void)bindViewController:(UIViewController *)boundViewController;
+
+- (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions;
 
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)initialOptions;
 

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -8,7 +8,6 @@
 
 @interface RNNBasePresenter ()
 @property(nonatomic, strong) RNNDotIndicatorPresenter* dotIndicatorPresenter;
-@property(nonatomic, strong) RNNNavigationOptions* defaultOptions;
 @end
 @implementation RNNBasePresenter
 
@@ -22,6 +21,10 @@
 - (void)bindViewController:(UIViewController <RNNLayoutProtocol> *)boundViewController {
     self.boundComponentId = boundViewController.layoutInfo.componentId;
     _boundViewController = boundViewController;
+}
+
+- (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions {
+    _defaultOptions = defaultOptions;
 }
 
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)initialOptions {

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -1,15 +1,12 @@
 #import "RNNCommandsHandler.h"
-#import "RNNNavigationOptions.h"
 #import "RNNRootViewController.h"
-#import "RNNSplitViewController.h"
-#import "RNNElementFinder.h"
-#import "React/RCTUIManager.h"
 #import "RNNErrorHandler.h"
 #import "RNNDefaultOptionsHelper.h"
 #import "UIViewController+RNNOptions.h"
 #import "React/RCTI18nUtil.h"
 #import "UIViewController+LayoutProtocol.h"
 #import "RNNLayoutManager.h"
+#import "UIViewController+Utils.h"
 
 static NSString* const setRoot	= @"setRoot";
 static NSString* const setStackRoot	= @"setStackRoot";
@@ -86,7 +83,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 - (void)mergeOptions:(NSString*)componentId options:(NSDictionary*)mergeOptions completion:(RNNTransitionCompletionBlock)completion {
 	[self assertReady];
 	
-	UIViewController<RNNLayoutProtocol>* vc = (UIViewController<RNNLayoutProtocol>*)[RNNLayoutManager findComponentForId:componentId];
+	UIViewController<RNNLayoutProtocol>* vc = [RNNLayoutManager findComponentForId:componentId];
 	RNNNavigationOptions* newOptions = [[RNNNavigationOptions alloc] initWithDict:mergeOptions];
 	if ([vc conformsToProtocol:@protocol(RNNLayoutProtocol)] || [vc isKindOfClass:[RNNRootViewController class]]) {
 		[CATransaction begin];
@@ -106,7 +103,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	
 	UIViewController *rootViewController = UIApplication.sharedApplication.delegate.window.rootViewController;
 	[RNNDefaultOptionsHelper recrusivelySetDefaultOptions:defaultOptions onRootViewController:rootViewController];
-	
+
 	completion();
 }
 

--- a/lib/ios/RNNNavigationController.m
+++ b/lib/ios/RNNNavigationController.m
@@ -1,10 +1,14 @@
 #import "RNNNavigationController.h"
 #import "RNNRootViewController.h"
-#import "InteractivePopGestureDelegate.h"
 
 const NSInteger TOP_BAR_TRANSPARENT_TAG = 78264803;
 
 @implementation RNNNavigationController
+
+-(void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions {
+	[super setDefaultOptions:defaultOptions];
+	[self.presenter setDefaultOptions:defaultOptions];
+}
 
 - (void)viewDidLayoutSubviews {
 	[super viewDidLayoutSubviews];

--- a/lib/ios/RNNNavigationControllerPresenter.m
+++ b/lib/ios/RNNNavigationControllerPresenter.m
@@ -1,9 +1,7 @@
 #import "RNNNavigationControllerPresenter.h"
 #import "UINavigationController+RNNOptions.h"
 #import "RNNNavigationController.h"
-#import <React/RCTConvert.h>
 #import "RNNCustomTitleView.h"
-#import "UIViewController+LayoutProtocol.h"
 
 @interface RNNNavigationControllerPresenter() {
 	RNNReactComponentRegistry* _componentRegistry;
@@ -25,44 +23,43 @@
 	[super applyOptions:options];
 	
 	RNNNavigationController* navigationController = self.boundViewController;
+	RNNNavigationOptions * withDefault = [options withDefault:[self defaultOptions]];
 	
 	self.interactivePopGestureDelegate = [InteractivePopGestureDelegate new];
 	self.interactivePopGestureDelegate.navigationController = navigationController;
 	self.interactivePopGestureDelegate.originalDelegate = navigationController.interactivePopGestureRecognizer.delegate;
 	navigationController.interactivePopGestureRecognizer.delegate = self.interactivePopGestureDelegate;
 	
-	[navigationController rnn_setInteractivePopGestureEnabled:[options.popGesture getWithDefaultValue:YES]];
-	[navigationController rnn_setRootBackgroundImage:[options.rootBackgroundImage getWithDefaultValue:nil]];
-	[navigationController rnn_setNavigationBarTestID:[options.topBar.testID getWithDefaultValue:nil]];
-	[navigationController rnn_setNavigationBarVisible:[options.topBar.visible getWithDefaultValue:YES] animated:[options.topBar.animate getWithDefaultValue:YES]];
-	[navigationController rnn_hideBarsOnScroll:[options.topBar.hideOnScroll getWithDefaultValue:NO]];
-	[navigationController rnn_setNavigationBarNoBorder:[options.topBar.noBorder getWithDefaultValue:NO]];
-	[navigationController rnn_setBarStyle:[RCTConvert UIBarStyle:[options.topBar.barStyle getWithDefaultValue:@"default"]]];
-	[navigationController rnn_setNavigationBarTranslucent:[options.topBar.background.translucent getWithDefaultValue:NO]];
-	[navigationController rnn_setNavigationBarClipsToBounds:[options.topBar.background.clipToBounds getWithDefaultValue:NO]];
-	[navigationController rnn_setNavigationBarBlur:[options.topBar.background.blur getWithDefaultValue:NO]];
-	[navigationController setTopBarBackgroundColor:[options.topBar.background.color getWithDefaultValue:nil]];
-	[navigationController rnn_setNavigationBarLargeTitleVisible:[options.topBar.largeTitle.visible getWithDefaultValue:NO]];
-	[navigationController rnn_setNavigationBarLargeTitleFontFamily:[options.topBar.largeTitle.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.largeTitle.fontSize getWithDefaultValue:nil] color:[options.topBar.largeTitle.color getWithDefaultValue:nil]];
-	[navigationController rnn_setNavigationBarFontFamily:[options.topBar.title.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.title.fontSize getWithDefaultValue:nil] color:[options.topBar.title.color getWithDefaultValue:nil]];
-	[navigationController rnn_setBackButtonColor:[options.topBar.backButton.color getWithDefaultValue:nil]];
-}
-
-- (void)applyOptionsOnWillMoveToParentViewController:(RNNNavigationOptions *)options {
-	[super applyOptionsOnWillMoveToParentViewController:options];
+	[navigationController rnn_setInteractivePopGestureEnabled:[withDefault.popGesture getWithDefaultValue:YES]];
+	[navigationController rnn_setRootBackgroundImage:[withDefault.rootBackgroundImage getWithDefaultValue:nil]];
+	[navigationController rnn_setNavigationBarTestID:[withDefault.topBar.testID getWithDefaultValue:nil]];
+	[navigationController rnn_setNavigationBarVisible:[withDefault.topBar.visible getWithDefaultValue:YES] animated:[withDefault.topBar.animate getWithDefaultValue:YES]];
+	[navigationController rnn_hideBarsOnScroll:[withDefault.topBar.hideOnScroll getWithDefaultValue:NO]];
+	[navigationController rnn_setNavigationBarNoBorder:[withDefault.topBar.noBorder getWithDefaultValue:NO]];
+	[navigationController rnn_setBarStyle:[RCTConvert UIBarStyle:[withDefault.topBar.barStyle getWithDefaultValue:@"default"]]];
+	[navigationController rnn_setNavigationBarTranslucent:[withDefault.topBar.background.translucent getWithDefaultValue:NO]];
+	[navigationController rnn_setNavigationBarClipsToBounds:[withDefault.topBar.background.clipToBounds getWithDefaultValue:NO]];
+	[navigationController rnn_setNavigationBarBlur:[withDefault.topBar.background.blur getWithDefaultValue:NO]];
+	[navigationController setTopBarBackgroundColor:[withDefault.topBar.background.color getWithDefaultValue:nil]];
+	[navigationController rnn_setNavigationBarLargeTitleVisible:[withDefault.topBar.largeTitle.visible getWithDefaultValue:NO]];
+	[navigationController rnn_setNavigationBarLargeTitleFontFamily:[withDefault.topBar.largeTitle.fontFamily getWithDefaultValue:nil] fontSize:[withDefault.topBar.largeTitle.fontSize getWithDefaultValue:nil] color:[withDefault.topBar.largeTitle.color getWithDefaultValue:nil]];
+	[navigationController rnn_setNavigationBarFontFamily:[withDefault.topBar.title.fontFamily getWithDefaultValue:nil] fontSize:[withDefault.topBar.title.fontSize getWithDefaultValue:nil] color:[withDefault.topBar.title.color getWithDefaultValue:nil]];
+	[navigationController rnn_setBackButtonColor:[withDefault.topBar.backButton.color getWithDefaultValue:nil]];
 }
 
 - (void)applyOptionsOnViewDidLayoutSubviews:(RNNNavigationOptions *)options {
-	if (options.topBar.background.component.name.hasValue) {
+	RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
+	if (withDefault.topBar.background.component.name.hasValue) {
 		[self presentBackgroundComponent];
 	}
 }
 
 - (void)applyOptionsBeforePopping:(RNNNavigationOptions *)options {
+	RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
 	RNNNavigationController* navigationController = self.boundViewController;
-	[navigationController setTopBarBackgroundColor:[options.topBar.background.color getWithDefaultValue:nil]];
-	[navigationController rnn_setNavigationBarFontFamily:[options.topBar.title.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.title.fontSize getWithDefaultValue:nil] color:[options.topBar.title.color getWithDefaultValue:[UIColor blackColor]]];
-	[navigationController rnn_setNavigationBarLargeTitleVisible:[options.topBar.largeTitle.visible getWithDefaultValue:NO]];
+	[navigationController setTopBarBackgroundColor:[withDefault.topBar.background.color getWithDefaultValue:nil]];
+	[navigationController rnn_setNavigationBarFontFamily:[withDefault.topBar.title.fontFamily getWithDefaultValue:nil] fontSize:[withDefault.topBar.title.fontSize getWithDefaultValue:nil] color:[withDefault.topBar.title.color getWithDefaultValue:[UIColor blackColor]]];
+	[navigationController rnn_setNavigationBarLargeTitleVisible:[withDefault.topBar.largeTitle.visible getWithDefaultValue:NO]];
 }
 
 - (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions {

--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -27,6 +27,10 @@
 	[viewController didMoveToParentViewController:self];
 }
 
+- (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions {
+	[_presenter setDefaultOptions:defaultOptions];
+}
+
 - (void)mergeOptions:(RNNNavigationOptions *)options {
 	[_presenter mergeOptions:options currentOptions:self.options];
 	[self.parentViewController mergeOptions:options];

--- a/lib/ios/RNNSideMenuController.m
+++ b/lib/ios/RNNSideMenuController.m
@@ -34,6 +34,10 @@
 	return self;
 }
 
+- (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions {
+	[self.presenter setDefaultOptions:defaultOptions];
+}
+
 - (void)setAnimationType:(NSString *)animationType {
 	MMDrawerControllerDrawerVisualStateBlock animationTypeStateBlock = nil;
 	if ([animationType isEqualToString:@"door"]) animationTypeStateBlock = [MMDrawerVisualState swingingDoorVisualStateBlock];

--- a/lib/ios/RNNSideMenuPresenter.m
+++ b/lib/ios/RNNSideMenuPresenter.m
@@ -10,52 +10,53 @@
 
 - (void)applyOptions:(RNNNavigationOptions *)options {
 	[super applyOptions:options];
-		
+	RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
 	RNNSideMenuController* sideMenuController = self.boundViewController;
+
+	[sideMenuController side:MMDrawerSideLeft enabled:[withDefault.sideMenu.left.enabled getWithDefaultValue:YES]];
+	[sideMenuController side:MMDrawerSideRight enabled:[withDefault.sideMenu.right.enabled getWithDefaultValue:YES]];
 	
-	[sideMenuController side:MMDrawerSideLeft enabled:[options.sideMenu.left.enabled getWithDefaultValue:YES]];
-	[sideMenuController side:MMDrawerSideRight enabled:[options.sideMenu.right.enabled getWithDefaultValue:YES]];
+	[sideMenuController setShouldStretchLeftDrawer:[withDefault.sideMenu.left.shouldStretchDrawer getWithDefaultValue:YES]];
+	[sideMenuController setShouldStretchRightDrawer:[withDefault.sideMenu.right.shouldStretchDrawer getWithDefaultValue:YES]];
 	
-	[sideMenuController setShouldStretchLeftDrawer:[options.sideMenu.left.shouldStretchDrawer getWithDefaultValue:YES]];
-	[sideMenuController setShouldStretchRightDrawer:[options.sideMenu.right.shouldStretchDrawer getWithDefaultValue:YES]];
+	[sideMenuController setAnimationVelocityLeft:[withDefault.sideMenu.left.animationVelocity getWithDefaultValue:840.0f]];
+	[sideMenuController setAnimationVelocityRight:[withDefault.sideMenu.right.animationVelocity getWithDefaultValue:840.0f]];
 	
-	[sideMenuController setAnimationVelocityLeft:[options.sideMenu.left.animationVelocity getWithDefaultValue:840.0f]];
-	[sideMenuController setAnimationVelocityRight:[options.sideMenu.right.animationVelocity getWithDefaultValue:840.0f]];
+	[sideMenuController setAnimationType:[withDefault.sideMenu.animationType getWithDefaultValue:nil]];
 	
-	[sideMenuController setAnimationType:[options.sideMenu.animationType getWithDefaultValue:nil]];
-	
-	if (options.sideMenu.left.width.hasValue) {
-		[sideMenuController side:MMDrawerSideLeft width:options.sideMenu.left.width.get];
+	if (withDefault.sideMenu.left.width.hasValue) {
+		[sideMenuController side:MMDrawerSideLeft width:withDefault.sideMenu.left.width.get];
 	}
 	
-	if (options.sideMenu.right.width.hasValue) {
-		[sideMenuController side:MMDrawerSideRight width:options.sideMenu.right.width.get];
+	if (withDefault.sideMenu.right.width.hasValue) {
+		[sideMenuController side:MMDrawerSideRight width:withDefault.sideMenu.right.width.get];
 	}
 	
-	if (options.sideMenu.left.visible.hasValue) {
-		[sideMenuController side:MMDrawerSideLeft visible:options.sideMenu.left.visible.get];
-		[options.sideMenu.left.visible consume];
+	if (withDefault.sideMenu.left.visible.hasValue) {
+		[sideMenuController side:MMDrawerSideLeft visible:withDefault.sideMenu.left.visible.get];
+		[withDefault.sideMenu.left.visible consume];
 	}
 	
-	if (options.sideMenu.right.visible.hasValue) {
-		[sideMenuController side:MMDrawerSideRight visible:options.sideMenu.right.visible.get];
-		[options.sideMenu.right.visible consume];
+	if (withDefault.sideMenu.right.visible.hasValue) {
+		[sideMenuController side:MMDrawerSideRight visible:withDefault.sideMenu.right.visible.get];
+		[withDefault.sideMenu.right.visible consume];
 	}
 }
 
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)initialOptions {
 	[super applyOptionsOnInit:initialOptions];
-	
+
+	RNNNavigationOptions *withDefault = [initialOptions withDefault:[self defaultOptions]];
 	RNNSideMenuController* sideMenuController = self.boundViewController;
-	if (initialOptions.sideMenu.left.width.hasValue) {
-		[sideMenuController side:MMDrawerSideLeft width:initialOptions.sideMenu.left.width.get];
+	if (withDefault.sideMenu.left.width.hasValue) {
+		[sideMenuController side:MMDrawerSideLeft width:withDefault.sideMenu.left.width.get];
 	}
 	
-	if (initialOptions.sideMenu.right.width.hasValue) {
-		[sideMenuController side:MMDrawerSideRight width:initialOptions.sideMenu.right.width.get];
+	if (withDefault.sideMenu.right.width.hasValue) {
+		[sideMenuController side:MMDrawerSideRight width:withDefault.sideMenu.right.width.get];
 	}
 
-		[sideMenuController setOpenDrawerGestureModeMask:[[initialOptions.sideMenu.openGestureMode getWithDefaultValue:@(MMOpenDrawerGestureModeAll)] integerValue]];
+		[sideMenuController setOpenDrawerGestureModeMask:[[withDefault.sideMenu.openGestureMode getWithDefaultValue:@(MMOpenDrawerGestureModeAll)] integerValue]];
 }
 
 - (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions {

--- a/lib/ios/RNNTabBarPresenter.m
+++ b/lib/ios/RNNTabBarPresenter.m
@@ -5,25 +5,22 @@
 
 @implementation RNNTabBarPresenter
 
--(instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions {
-    self = [super initWithDefaultOptions:defaultOptions];
-    return self;
-}
-
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)options {
     UITabBarController *tabBarController = self.boundViewController;
-    [tabBarController rnn_setCurrentTabIndex:[options.bottomTabs.currentTabIndex getWithDefaultValue:0]];
+    RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
+    [tabBarController rnn_setCurrentTabIndex:[withDefault.bottomTabs.currentTabIndex getWithDefaultValue:0]];
 }
 
 - (void)applyOptions:(RNNNavigationOptions *)options {
     UITabBarController *tabBarController = self.boundViewController;
+    RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
 
-    [tabBarController rnn_setTabBarTestID:[options.bottomTabs.testID getWithDefaultValue:nil]];
-    [tabBarController rnn_setTabBarBackgroundColor:[options.bottomTabs.backgroundColor getWithDefaultValue:nil]];
-    [tabBarController rnn_setTabBarTranslucent:[options.bottomTabs.translucent getWithDefaultValue:NO]];
-    [tabBarController rnn_setTabBarHideShadow:[options.bottomTabs.hideShadow getWithDefaultValue:NO]];
-    [tabBarController rnn_setTabBarStyle:[RCTConvert UIBarStyle:[options.bottomTabs.barStyle getWithDefaultValue:@"default"]]];
-    [tabBarController rnn_setTabBarVisible:[options.bottomTabs.visible getWithDefaultValue:YES] animated:[options.bottomTabs.animate getWithDefaultValue:NO]];
+    [tabBarController rnn_setTabBarTestID:[withDefault.bottomTabs.testID getWithDefaultValue:nil]];
+    [tabBarController rnn_setTabBarBackgroundColor:[withDefault.bottomTabs.backgroundColor getWithDefaultValue:nil]];
+    [tabBarController rnn_setTabBarTranslucent:[withDefault.bottomTabs.translucent getWithDefaultValue:NO]];
+    [tabBarController rnn_setTabBarHideShadow:[withDefault.bottomTabs.hideShadow getWithDefaultValue:NO]];
+    [tabBarController rnn_setTabBarStyle:[RCTConvert UIBarStyle:[withDefault.bottomTabs.barStyle getWithDefaultValue:@"default"]]];
+    [tabBarController rnn_setTabBarVisible:[withDefault.bottomTabs.visible getWithDefaultValue:YES] animated:[withDefault.bottomTabs.animate getWithDefaultValue:NO]];
 }
 
 - (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions {

--- a/lib/ios/RNNViewControllerPresenter.m
+++ b/lib/ios/RNNViewControllerPresenter.m
@@ -2,8 +2,6 @@
 #import "UIViewController+RNNOptions.h"
 #import "UITabBarController+RNNOptions.h"
 #import "RCTConvert+Modal.h"
-#import "RNNReactView.h"
-#import "RNNCustomTitleView.h"
 #import "RNNTitleViewHelper.h"
 #import "UIViewController+LayoutProtocol.h"
 
@@ -31,48 +29,51 @@
 - (void)applyOptionsOnWillMoveToParentViewController:(RNNNavigationOptions *)options {
 	[super applyOptionsOnWillMoveToParentViewController:options];
 	UIViewController* viewController = self.boundViewController;
-	[viewController rnn_setBackButtonIcon:[options.topBar.backButton.icon getWithDefaultValue:nil] withColor:[options.topBar.backButton.color getWithDefaultValue:nil] title:[options.topBar.backButton.showTitle getWithDefaultValue:YES] ? [options.topBar.backButton.title getWithDefaultValue:nil] : @""];
+	RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
+	[viewController rnn_setBackButtonIcon:[withDefault.topBar.backButton.icon getWithDefaultValue:nil] withColor:[withDefault.topBar.backButton.color getWithDefaultValue:nil] title:[withDefault.topBar.backButton.showTitle getWithDefaultValue:YES] ? [withDefault.topBar.backButton.title getWithDefaultValue:nil] : @""];
 }
 
 - (void)applyOptions:(RNNNavigationOptions *)options {
 	[super applyOptions:options];
 	
 	UIViewController* viewController = self.boundViewController;
-	[viewController rnn_setBackgroundImage:[options.backgroundImage getWithDefaultValue:nil]];
-	[viewController rnn_setNavigationItemTitle:[options.topBar.title.text getWithDefaultValue:nil]];
-	[viewController rnn_setTopBarPrefersLargeTitle:[options.topBar.largeTitle.visible getWithDefaultValue:NO]];
-	[viewController rnn_setTabBarItemBadgeColor:[options.bottomTab.badgeColor getWithDefaultValue:nil]];
-	[viewController rnn_setStatusBarBlur:[options.statusBar.blur getWithDefaultValue:NO]];
-	[viewController rnn_setStatusBarStyle:[options.statusBar.style getWithDefaultValue:@"default"] animated:[options.statusBar.animate getWithDefaultValue:YES]];
-	[viewController rnn_setBackButtonVisible:[options.topBar.backButton.visible getWithDefaultValue:YES]];
-	[viewController rnn_setInterceptTouchOutside:[options.overlay.interceptTouchOutside getWithDefaultValue:YES]];
+	RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
+	[viewController rnn_setBackgroundImage:[withDefault.backgroundImage getWithDefaultValue:nil]];
+	[viewController rnn_setNavigationItemTitle:[withDefault.topBar.title.text getWithDefaultValue:nil]];
+	[viewController rnn_setTopBarPrefersLargeTitle:[withDefault.topBar.largeTitle.visible getWithDefaultValue:NO]];
+	[viewController rnn_setTabBarItemBadgeColor:[withDefault.bottomTab.badgeColor getWithDefaultValue:nil]];
+	[viewController rnn_setStatusBarBlur:[withDefault.statusBar.blur getWithDefaultValue:NO]];
+	[viewController rnn_setStatusBarStyle:[withDefault.statusBar.style getWithDefaultValue:@"default"] animated:[withDefault.statusBar.animate getWithDefaultValue:YES]];
+	[viewController rnn_setBackButtonVisible:[withDefault.topBar.backButton.visible getWithDefaultValue:YES]];
+	[viewController rnn_setInterceptTouchOutside:[withDefault.overlay.interceptTouchOutside getWithDefaultValue:YES]];
 	
-	if (options.layout.backgroundColor.hasValue) {
-		[viewController rnn_setBackgroundColor:options.layout.backgroundColor.get];
+	if (withDefault.layout.backgroundColor.hasValue) {
+		[viewController rnn_setBackgroundColor:withDefault.layout.backgroundColor.get];
 	}
 	
-	if (options.topBar.searchBar.hasValue) {
+	if (withDefault.topBar.searchBar.hasValue) {
 		BOOL hideNavBarOnFocusSearchBar = YES;
-		if (options.topBar.hideNavBarOnFocusSearchBar.hasValue) {
-			hideNavBarOnFocusSearchBar = options.topBar.hideNavBarOnFocusSearchBar.get;
+		if (withDefault.topBar.hideNavBarOnFocusSearchBar.hasValue) {
+			hideNavBarOnFocusSearchBar = withDefault.topBar.hideNavBarOnFocusSearchBar.get;
 		}
-		[viewController rnn_setSearchBarWithPlaceholder:[options.topBar.searchBarPlaceholder getWithDefaultValue:@""] hideNavBarOnFocusSearchBar: hideNavBarOnFocusSearchBar];
+		[viewController rnn_setSearchBarWithPlaceholder:[withDefault.topBar.searchBarPlaceholder getWithDefaultValue:@""] hideNavBarOnFocusSearchBar: hideNavBarOnFocusSearchBar];
 	}
 	
-	[self setTitleViewWithSubtitle:options];
+	[self setTitleViewWithSubtitle:withDefault];
 }
 
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)options {
 	[super applyOptionsOnInit:options];
 	
 	UIViewController* viewController = self.boundViewController;
-	[viewController rnn_setModalPresentationStyle:[RCTConvert UIModalPresentationStyle:[options.modalPresentationStyle getWithDefaultValue:@"fullScreen"]]];
-	[viewController rnn_setModalTransitionStyle:[RCTConvert UIModalTransitionStyle:[options.modalTransitionStyle getWithDefaultValue:@"coverVertical"]]];
-	[viewController rnn_setDrawBehindTopBar:[options.topBar.drawBehind getWithDefaultValue:NO]];
-	[viewController rnn_setDrawBehindTabBar:[options.bottomTabs.drawBehind getWithDefaultValue:NO] || ![options.bottomTabs.visible getWithDefaultValue:YES]];
+	RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
+	[viewController rnn_setModalPresentationStyle:[RCTConvert UIModalPresentationStyle:[withDefault.modalPresentationStyle getWithDefaultValue:@"fullScreen"]]];
+	[viewController rnn_setModalTransitionStyle:[RCTConvert UIModalTransitionStyle:[withDefault.modalTransitionStyle getWithDefaultValue:@"coverVertical"]]];
+	[viewController rnn_setDrawBehindTopBar:[withDefault.topBar.drawBehind getWithDefaultValue:NO]];
+	[viewController rnn_setDrawBehindTabBar:[withDefault.bottomTabs.drawBehind getWithDefaultValue:NO] || ![withDefault.bottomTabs.visible getWithDefaultValue:YES]];
 	
-	if ((options.topBar.leftButtons || options.topBar.rightButtons)) {
-		[_navigationButtons applyLeftButtons:options.topBar.leftButtons rightButtons:options.topBar.rightButtons defaultLeftButtonStyle:options.topBar.leftButtonStyle defaultRightButtonStyle:options.topBar.rightButtonStyle];
+	if ((withDefault.topBar.leftButtons || withDefault.topBar.rightButtons)) {
+		[_navigationButtons applyLeftButtons:withDefault.topBar.leftButtons rightButtons:withDefault.topBar.rightButtons defaultLeftButtonStyle:withDefault.topBar.leftButtonStyle defaultRightButtonStyle:withDefault.topBar.rightButtonStyle];
 	}
 }
 

--- a/lib/ios/UIViewController+RNNOptions.h
+++ b/lib/ios/UIViewController+RNNOptions.h
@@ -1,8 +1,11 @@
 #import <UIKit/UIKit.h>
 
 @class RNNBottomTabOptions;
+@class RNNNavigationOptions;
 
 @interface UIViewController (RNNOptions)
+
+- (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions;
 
 - (void)rnn_setBackgroundImage:(UIImage *)backgroundImage;
 

--- a/lib/ios/UIViewController+RNNOptions.m
+++ b/lib/ios/UIViewController+RNNOptions.m
@@ -2,11 +2,16 @@
 #import <React/RCTRootView.h>
 #import "UIImage+tint.h"
 #import "RNNBottomTabOptions.h"
+#import "RNNNavigationOptions.h"
 
 #define kStatusBarAnimationDuration 0.35
 const NSInteger BLUR_STATUS_TAG = 78264801;
 
 @implementation UIViewController (RNNOptions)
+
+- (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions {
+
+}
 
 - (void)rnn_setBackgroundImage:(UIImage *)backgroundImage {
 	if (backgroundImage) {

--- a/playground/src/screens/StatusBarOptionsScreen.js
+++ b/playground/src/screens/StatusBarOptionsScreen.js
@@ -31,18 +31,20 @@ class StatusBarOptions extends React.Component {
 
   render() {
     return (
-      <Root componentId={this.props.componentId} style={style.root}>
+      <View style={style.container}>
         <Image
-          style={style.image}
-          source={require('../../img/city.png')}
-          fadeDuration={0}
-        />
-        <Button label='Full Screen Modal' onPress={this.fullScreenModal} />
-        <Button label='Push' onPress={this.push} />
-        <Button label='BottomTabs' onPress={this.bottomTabs} />
-        <Button label='Open Left' onPress={() => this.open('left')} />
-        <Button label='Open Right' onPress={() => this.open('right')} />
-      </Root>
+            style={style.image}
+            source={require('../../img/city.png')}
+            fadeDuration={0}
+          />
+        <Root componentId={this.props.componentId} style={style.root}>
+          <Button label='Full Screen Modal' onPress={this.fullScreenModal} />
+          <Button label='Push' onPress={this.push} />
+          <Button label='BottomTabs' onPress={this.bottomTabs} />
+          <Button label='Open Left' onPress={() => this.open('left')} />
+          <Button label='Open Right' onPress={() => this.open('right')} />
+        </Root>
+      </View>
     );
   }
 
@@ -61,6 +63,10 @@ const style = StyleSheet.create({
   root: {
     paddingTop: 0,
     paddingHorizontal: 0
+  },
+  container: {
+    flex: 1,
+    flexDirection: 'column'
   },
   image: {
     height: 250,


### PR DESCRIPTION
When defaultOptions are set after setRoot has been called presenters need to receive the default options as well,
otherwise the outdated default options are regarded.
Fixes #5395