### PR TITLE
[V3, Android] Catch rare RuntimeException in setRoot when waitForRender = true

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/RootPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/RootPresenter.java
@@ -42,11 +42,9 @@ public class RootPresenter {
         if (options.animations.setRoot.waitForRender.isTrue()) {
             root.getView().setAlpha(0);
             root.addOnAppearedListener(() -> {
-                try {
+                if (!root.isDestroyed()) {
                     root.getView().setAlpha(1);
                     animateSetRootAndReportSuccess(root, listener, options);
-                } catch (RuntimeException e) {
-                    listener.onError(e.getMessage());
                 }
             });
         } else {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/RootPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/RootPresenter.java
@@ -42,7 +42,9 @@ public class RootPresenter {
         if (options.animations.setRoot.waitForRender.isTrue()) {
             root.getView().setAlpha(0);
             root.addOnAppearedListener(() -> {
-                if (!root.isDestroyed()) {
+                if (root.isDestroyed()) {
+                    listener.onError("Could not set root - Waited for the view to become visible but it was destroyed");
+                } else {
                     root.getView().setAlpha(1);
                     animateSetRootAndReportSuccess(root, listener, options);
                 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/RootPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/RootPresenter.java
@@ -42,8 +42,12 @@ public class RootPresenter {
         if (options.animations.setRoot.waitForRender.isTrue()) {
             root.getView().setAlpha(0);
             root.addOnAppearedListener(() -> {
-                root.getView().setAlpha(1);
-                animateSetRootAndReportSuccess(root, listener, options);
+                try {
+                    root.getView().setAlpha(1);
+                    animateSetRootAndReportSuccess(root, listener, options);
+                } catch (RuntimeException e) {
+                    listener.onError(e.getMessage());
+                }
             });
         } else {
             animateSetRootAndReportSuccess(root, listener, options);


### PR DESCRIPTION
I've seen the following crash in production. It's rare, but it appears there's some kind of race condition in `setRoot`'s `addOnAppearedListener` that results in `getView` throwing. Here's the stack trace:

```
java.lang.RuntimeException: Tried to create view after it has already been destroyed
    at com.reactnativenavigation.viewcontrollers.ViewController.getView(ViewController.java:165)
    at com.reactnativenavigation.viewcontrollers.ParentController.getView(ParentController.java:60)
    at com.reactnativenavigation.viewcontrollers.navigator.RootPresenter.lambda$setRoot$0(RootPresenter.java:41)
    at com.reactnativenavigation.viewcontrollers.navigator.-$$Lambda$RootPresenter$T5cjGG24h93OrmgUBwpekHEXTtY.run(lambda)
    at com.reactnativenavigation.viewcontrollers.-$$Lambda$P7xe27l85RASi5iJcSC7JIxgcA8.on(lambda)
    at com.reactnativenavigation.utils.CollectionUtils.forEach(CollectionUtils.java:89)
    at com.reactnativenavigation.utils.CollectionUtils.forEach(CollectionUtils.java:83)
    at com.reactnativenavigation.viewcontrollers.ViewController.lambda$onViewAppeared$1(ViewController.java:216)
    at com.reactnativenavigation.viewcontrollers.-$$Lambda$ViewController$TwzQHRxayGsTFM7gYujgloHVhEE.run(lambda)
    at android.os.Handler.handleCallback(Handler.java:751)
    at android.os.Handler.dispatchMessage(Handler.java:95)
    at android.os.Looper.loop(Looper.java:154)
    at android.app.ActivityThread.main(ActivityThread.java:6823)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1557)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1445)
```

Instead of swallowing the exception here, I've decided to pass it to JS so it can be caught by wrapping `await setRoot()` in a try/catch. Interested to see if others agree with this approach, or whether it should just be swallowed.

Importantly, I've observed this with RN 0.59.8 and RNN 2.22.3 as that's what I'm in production with, but I'm opening this PR against V3 so it has a chance of helping someone. Maybe someone with more knowledge of the Android view lifecycles in this library could comment on whether this is still necessary.

Thanks for the awesome library!