### PR TITLE
Fix disableOpenGesture assignment

### DIFF
--- a/src/deprecated/platformSpecificDeprecated.android.js
+++ b/src/deprecated/platformSpecificDeprecated.android.js
@@ -275,12 +275,7 @@ function convertDrawerParamsToSideMenuParams(drawerParams) {
       addNavigatorParams(result[key]);
       result[key] = adaptNavigationParams(result[key]);
       result[key].passProps = drawer[key].passProps;
-      if (drawer.disableOpenGesture) {
-        result[key].disableOpenGesture = parseInt(drawer.disableOpenGesture);
-      } else {
-        let fixedWidth = drawer[key].disableOpenGesture;
-        result[key].disableOpenGesture = fixedWidth ? parseInt(fixedWidth) : null;
-      }
+      result[key].disableOpenGesture = !!(drawer.disableOpenGesture || drawer[key].disableOpenGesture)
       if (drawer.fixedWidth) {
         result[key].fixedWidth = drawer.fixedWidth;
       } else {


### PR DESCRIPTION
disableOpenGesture wasn't working as expected since parseInt(boolean) is NaN.
On RN 0.59.10 this would even crash the app since passing NaN to the bridge is not allowed.

This resolves issue #5429 