### PR TITLE
Fix merging back button

### DIFF
--- a/lib/ios/RNNBackButtonOptions.h
+++ b/lib/ios/RNNBackButtonOptions.h
@@ -9,4 +9,6 @@
 @property (nonatomic, strong) Bool* showTitle;
 @property (nonatomic, strong) Bool* visible;
 
+- (BOOL)hasValue;
+
 @end

--- a/lib/ios/RNNBackButtonOptions.m
+++ b/lib/ios/RNNBackButtonOptions.m
@@ -15,4 +15,12 @@
 	return self;
 }
 
+- (BOOL)hasValue {
+	return self.icon.hasValue ||
+			self.showTitle.hasValue ||
+			self.color.hasValue ||
+			self.title.hasValue;
+}
+
+
 @end

--- a/lib/ios/RNNViewControllerPresenter.m
+++ b/lib/ios/RNNViewControllerPresenter.m
@@ -158,9 +158,11 @@
 	if (newOptions.topBar.title.component.name.hasValue) {
 		[self setCustomNavigationTitleView:newOptions perform:nil];
 	}
-	
-	if (newOptions.topBar.backButton.icon.hasValue || newOptions.topBar.backButton.showTitle.hasValue || newOptions.topBar.backButton.color.hasValue || newOptions.topBar.backButton.title.hasValue) {
-		[viewController rnn_setBackButtonIcon:[newOptions.topBar.backButton.icon getWithDefaultValue:nil] withColor:[newOptions.topBar.backButton.color getWithDefaultValue:nil] title:[newOptions.topBar.backButton.showTitle getWithDefaultValue:YES] ? [newOptions.topBar.backButton.title getWithDefaultValue:nil] : @""];
+
+	if (newOptions.topBar.backButton.hasValue) {
+		UIViewController *lastViewControllerInStack = viewController.navigationController.viewControllers.count > 1 ? viewController.navigationController.viewControllers[viewController.navigationController.viewControllers.count - 2] : viewController.navigationController.topViewController;
+	    RNNNavigationOptions * resolvedOptions	= (RNNNavigationOptions *) [[currentOptions overrideOptions:newOptions] withDefault:[self defaultOptions]];
+		[lastViewControllerInStack applyBackButton:resolvedOptions.topBar.backButton];
 	}
 }
 

--- a/lib/ios/UIViewController+RNNOptions.h
+++ b/lib/ios/UIViewController+RNNOptions.h
@@ -2,6 +2,7 @@
 
 @class RNNBottomTabOptions;
 @class RNNNavigationOptions;
+@class RNNBackButtonOptions;
 
 @interface UIViewController (RNNOptions)
 
@@ -40,6 +41,8 @@
 - (void)rnn_setInterceptTouchOutside:(BOOL)interceptTouchOutside;
 
 - (void)rnn_setBackButtonIcon:(UIImage *)icon withColor:(UIColor *)color title:(NSString *)title;
+
+- (void)applyBackButton:(RNNBackButtonOptions *)backButton;
 
 - (BOOL)isModal;
 

--- a/lib/ios/UIViewController+RNNOptions.m
+++ b/lib/ios/UIViewController+RNNOptions.m
@@ -3,6 +3,7 @@
 #import "UIImage+tint.h"
 #import "RNNBottomTabOptions.h"
 #import "RNNNavigationOptions.h"
+#import "RNNBackButtonOptions.h"
 
 #define kStatusBarAnimationDuration 0.35
 const NSInteger BLUR_STATUS_TAG = 78264801;
@@ -177,17 +178,34 @@ const NSInteger BLUR_STATUS_TAG = 78264801;
 		backItem.image = color
 		? [[icon withTintColor:color] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal]
 		: icon;
-		
+
 		[self.navigationController.navigationBar setBackIndicatorImage:[UIImage new]];
 		[self.navigationController.navigationBar setBackIndicatorTransitionMaskImage:[UIImage new]];
 	}
 	
-	UIViewController *lastViewControllerInStack = self.navigationController.viewControllers.count > 1 ? [self.navigationController.viewControllers objectAtIndex:self.navigationController.viewControllers.count-2] : self.navigationController.topViewController;
+	UIViewController *lastViewControllerInStack = self.navigationController.viewControllers.count > 1 ? self.navigationController.viewControllers[self.navigationController.viewControllers.count - 2] : self.navigationController.topViewController;
 	
 	backItem.title = title ? title : lastViewControllerInStack.navigationItem.title;
 	backItem.tintColor = color;
 	
 	lastViewControllerInStack.navigationItem.backBarButtonItem = backItem;
+}
+
+- (void)applyBackButton:(RNNBackButtonOptions *)backButton {
+	UIBarButtonItem *backItem = [UIBarButtonItem new];
+	if (backButton.icon.hasValue) {
+		UIColor *color = [backButton.color getWithDefaultValue:nil];
+		backItem.image = color ?
+				[[backButton.icon.get withTintColor:color] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal] :
+				backButton.icon.get;
+
+		[self.navigationController.navigationBar setBackIndicatorImage:[UIImage new]];
+        [self.navigationController.navigationBar setBackIndicatorTransitionMaskImage:[UIImage new]];
+	}
+
+	if ([backButton.showTitle getWithDefaultValue:YES]) backItem.title = [backButton.title getWithDefaultValue:nil];
+	if (backButton.color.hasValue) backItem.tintColor = [backButton.color get];
+	self.navigationItem.backBarButtonItem = backItem;
 }
 
 @end


### PR DESCRIPTION
The backButton options are always applied. Even when one of its values has changed in mergeOptions.
This commit adds a function to apply the backButton, and should probably replace the existing rnn_setBackButtonIcon - as that function does more than just set the icon, it sets all options.