### PR TITLE
Stop overwriting enabled flag when opening flag.

### DIFF
--- a/lib/ios/RNNSideMenuPresenter.m
+++ b/lib/ios/RNNSideMenuPresenter.m
@@ -13,8 +13,12 @@
 	RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
 	RNNSideMenuController* sideMenuController = self.boundViewController;
 
-	[sideMenuController side:MMDrawerSideLeft enabled:[withDefault.sideMenu.left.enabled getWithDefaultValue:YES]];
-	[sideMenuController side:MMDrawerSideRight enabled:[withDefault.sideMenu.right.enabled getWithDefaultValue:YES]];
+	if (options.sideMenu.left.enabled.hasValue) {
+		[sideMenuController side:MMDrawerSideLeft enabled:[options.sideMenu.left.enabled getWithDefaultValue:YES]];
+	}
+	if (options.sideMenu.right.enabled.hasValue) {
+		[sideMenuController side:MMDrawerSideRight enabled:[options.sideMenu.right.enabled getWithDefaultValue:YES]];
+	}
 	
 	[sideMenuController setShouldStretchLeftDrawer:[withDefault.sideMenu.left.shouldStretchDrawer getWithDefaultValue:YES]];
 	[sideMenuController setShouldStretchRightDrawer:[withDefault.sideMenu.right.shouldStretchDrawer getWithDefaultValue:YES]];


### PR DESCRIPTION
`RNNSideMenuPresenter.applyOptions` is called when
Navigation.setRoot() is called but also when the
menu's become visible (via a pan gesture) and it set *enabled:true*
for both menu's. ( In some circumstances, see #5444 )

This means that setting enabled:false doesn't
last very long.

This possibly naive PR removes the "defaulting to true" behaviour for the `enabled` flag to remove this bug.