### PR TITLE
Stop recursive double setting of default options

### DIFF
--- a/lib/ios/RNNDefaultOptionsHelper.m
+++ b/lib/ios/RNNDefaultOptionsHelper.m
@@ -3,14 +3,11 @@
 @implementation RNNDefaultOptionsHelper
 
 + (void)recrusivelySetDefaultOptions:(RNNNavigationOptions *)defaultOptions onRootViewController:(UIViewController *)rootViewController {
-	if ([rootViewController conformsToProtocol:@protocol(RNNLayoutProtocol)])
+	if ([rootViewController conformsToProtocol:@protocol(RNNLayoutProtocol)]) {
 		[((UIViewController<RNNLayoutProtocol> *)rootViewController) setDefaultOptions:defaultOptions];
+	}
 	
 	for (UIViewController<RNNLayoutProtocol>* childViewController in rootViewController.childViewControllers) {
-		if ([childViewController conformsToProtocol:@protocol(RNNLayoutProtocol)]) {
-			[childViewController setDefaultOptions:defaultOptions];
-		}
-		
 		[self recrusivelySetDefaultOptions:defaultOptions onRootViewController:childViewController];
 	}
 }


### PR DESCRIPTION
There is no need to call `setDefaultOptions` on the `childViewController` while iterating the `childViewControllers` as those will be passed recursively as `rootViewController` anyway and thus calling `setDefaultOptions` in the nested recursive call.