### PR TITLE
Prefer new imageWithTintColor API when tinting an UIImage

### DIFF
--- a/lib/ios/UIImage+tint.m
+++ b/lib/ios/UIImage+tint.m
@@ -4,6 +4,11 @@
 
 - (UIImage *)withTintColor:(UIColor *)color {
 	UIImage *newImage = [self imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+	if (@available(iOS 13.0, *)) {
+		return [newImage imageWithTintColor:color];
+	}
+#endif
 	UIGraphicsBeginImageContextWithOptions(self.size, NO, newImage.scale);
 	[color set];
 	[newImage drawInRect:CGRectMake(0, 0, self.size.width, newImage.size.height)];


### PR DESCRIPTION
With this change, dynamic colors will be supported when tinting an image and the image color will change on the fly depending on the dynamic provider and traits. This will be especially useful when supporting the new dark mode in iOS 13.