### PR TITLE
[Android] Fix/Avoid issue with sidemenuoptions.xxxx.enabled flag being clobbered.

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/SideMenuRootOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/SideMenuRootOptions.java
@@ -21,7 +21,8 @@ public class SideMenuRootOptions {
         right.mergeWith(other.right);
     }
 
-    public void mergeWithDefault(SideMenuRootOptions sideMenuRootOptions) {
-
+    public void mergeWithDefault(SideMenuRootOptions defaultOptions) {
+        left.mergeWithDefault(defaultOptions.left);
+        right.mergeWithDefault(defaultOptions.right);
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/sidemenu/SideMenuController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/sidemenu/SideMenuController.java
@@ -6,6 +6,7 @@ import android.view.View;
 
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.parse.params.Bool;
+import com.reactnativenavigation.parse.params.NullBool;
 import com.reactnativenavigation.presentation.Presenter;
 import com.reactnativenavigation.presentation.SideMenuPresenter;
 import com.reactnativenavigation.utils.CommandListener;
@@ -106,6 +107,10 @@ public class SideMenuController extends ParentController<SideMenuRoot> implement
     public void mergeOptions(Options options) {
         super.mergeOptions(options);
         presenter.mergeOptions(options.sideMenuRootOptions);
+        this.options.sideMenuRootOptions.left.visible = new NullBool();
+        this.options.sideMenuRootOptions.right.visible = new NullBool();
+        this.initialOptions.sideMenuRootOptions.left.visible = new NullBool();
+        this.initialOptions.sideMenuRootOptions.right.visible = new NullBool();
     }
 
     @Override


### PR DESCRIPTION
Fixes #5444 by copying the "parents" side menu options into the "childrens" before the "childrens" are use by applyChildOptions.

But this `mergeWithDefault` is used in a few places so we need to cleanup theses "One Time Options" after we use them in the side menu controller.

See https://github.com/wix/react-native-navigation/issues/5444#issuecomment-528727738 for more information on the context.