### PR TITLE
Font weight option support for iOS

### DIFF
--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -82,6 +82,7 @@ Navigation.mergeOptions(this.props.componentId, {
       fontSize: 14,
       color: 'red',
       fontFamily: 'Helvetica',
+      fontWeight: 'regular', // Available on iOS only, will ignore fontFamily style and use the iOS system fonts instead. Supported weights are: 'regular', 'bold', 'thin', 'ultraLight', 'light', 'medium', 'semibold', 'heavy' and 'black'.
       component: {
         name: 'example.CustomTopBarTitle',
         alignment: 'center'
@@ -92,6 +93,7 @@ Navigation.mergeOptions(this.props.componentId, {
       fontSize: 14,
       color: 'red',
       fontFamily: 'Helvetica',
+      fontWeight: 'regular', // Available on iOS only, will ignore fontFamily style and use the iOS system fonts instead. Supported weights are: 'regular', 'bold', 'thin', 'ultraLight', 'light', 'medium', 'semibold', 'heavy' and 'black'.
       alignment: 'center'
     },
     backButton: {
@@ -130,6 +132,7 @@ Navigation.mergeOptions(this.props.componentId, {
     textColor: 'red',
     selectedTextColor: 'blue',
     fontFamily: 'Helvetica',
+    fontWeight: 'regular', // Available on iOS only, will ignore fontFamily style and use the iOS system fonts instead. Supported weights are: 'regular', 'bold', 'thin', 'ultraLight', 'light', 'medium', 'semibold', 'heavy' and 'black'.
     fontSize: 10
   },
   sideMenu: {
@@ -216,7 +219,8 @@ Navigation.mergeOptions(this.props.componentId, {
       visible: true,
       fontSize: 30,
       color: 'red',
-      fontFamily: 'Helvetica'
+      fontFamily: 'Helvetica',
+      fontWeight: 'regular' // Available on iOS only, will ignore fontFamily style and use the iOS system fonts instead. Supported weights are: 'regular', 'bold', 'thin', 'ultraLight', 'light', 'medium', 'semibold', 'heavy' and 'black'.
     },
   },
   sideMenu: {

--- a/docs/docs/topBar-buttons.md
+++ b/docs/docs/topBar-buttons.md
@@ -15,6 +15,9 @@ The following options can be used to customise buttons.
   color: 'red',
   disabledColor: 'black',
   testID: 'buttonOneTestID',
+  fontFamily: 'Helvetica',
+  fontSize: 10
+  fontWeight: 'regular', // Available on iOS only, will ignore fontFamily style and use the iOS system fonts instead. Supported weights are: 'regular', 'bold', 'thin', 'ultraLight', 'light', 'medium', 'semibold', 'heavy' and 'black'.
   // Android only
   showAsAction: 'ifRoom', // See below for details.
   // iOS only

--- a/lib/ios/RCTConvert+UIFontWeight.h
+++ b/lib/ios/RCTConvert+UIFontWeight.h
@@ -1,0 +1,21 @@
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (UIFontWeight)
+
+@end
+
+@implementation RCTConvert (UIFontWeight)
+
+RCT_ENUM_CONVERTER(UIFontWeight,
+				   (@{@"ultraLight": @(UIFontWeightUltraLight),
+					  @"thin": @(UIFontWeightThin),
+					  @"light": @(UIFontWeightLight),
+					  @"regular": @(UIFontWeightRegular),
+					  @"medium": @(UIFontWeightMedium),
+					  @"semibold": @(UIFontWeightSemibold),
+					  @"bold": @(UIFontWeightBold),
+					  @"heavy": @(UIFontWeightHeavy),
+					  @"black": @(UIFontWeightBlack)
+					  }), UIFontWeightRegular, floatValue)
+
+@end

--- a/lib/ios/RNNBottomTabOptions.h
+++ b/lib/ios/RNNBottomTabOptions.h
@@ -10,6 +10,7 @@
 @property(nonatomic, strong) Color *badgeColor;
 @property(nonatomic, strong) DotIndicatorOptions *dotIndicator;
 @property(nonatomic, strong) Text *fontFamily;
+@property(nonatomic, strong) Text *fontWeight;
 @property(nonatomic, strong) Text *testID;
 @property(nonatomic, strong) Image *icon;
 @property(nonatomic, strong) Image *selectedIcon;

--- a/lib/ios/RNNBottomTabOptions.m
+++ b/lib/ios/RNNBottomTabOptions.m
@@ -12,6 +12,7 @@
     self.badge = [TextParser parse:dict key:@"badge"];
     self.badgeColor = [ColorParser parse:dict key:@"badgeColor"];
     self.fontFamily = [TextParser parse:dict key:@"fontFamily"];
+	self.fontWeight = [TextParser parse:dict key:@"fontWeight"];
     self.testID = [TextParser parse:dict key:@"testID"];
 
     self.dotIndicator = [DotIndicatorParser parse:dict];

--- a/lib/ios/RNNFontAttributesCreator.h
+++ b/lib/ios/RNNFontAttributesCreator.h
@@ -3,6 +3,10 @@
 
 @interface RNNFontAttributesCreator : NSObject
 
-+ (NSDictionary *)createFontAttributesWithFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize color:(UIColor *)color;
++ (NSDictionary *)createWithFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize defaultFontSize:(NSNumber *)defaultFontSize fontWeight:(NSString *)fontWeight color:(UIColor *)color defaultColor:(UIColor *)defaultColor;
+
++ (NSDictionary *)createWithFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize fontWeight:(NSString *)fontWeight color:(UIColor *)color;
+
++ (NSDictionary *)createWithDictionary:(NSDictionary *)attributesDictionary fontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize defaultFontSize:(NSNumber *)defaultFontSize fontWeight:(NSString *)fontWeight color:(UIColor *)color defaultColor:(UIColor *)defaultColor;
 
 @end

--- a/lib/ios/RNNFontAttributesCreator.m
+++ b/lib/ios/RNNFontAttributesCreator.m
@@ -1,21 +1,35 @@
 #import "RNNFontAttributesCreator.h"
+#import "RCTConvert+UIFontWeight.h"
 
 @implementation RNNFontAttributesCreator
 
-+ (NSDictionary *)createFontAttributesWithFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize color:(UIColor *)color {
++ (NSDictionary *)createWithFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize defaultFontSize:(NSNumber *)defaultFontSize fontWeight:(NSString *)fontWeight color:(UIColor *)color defaultColor:(UIColor *)defaultColor {
 	NSMutableDictionary* titleTextAttributes = [NSMutableDictionary new];
-	if (fontFamily || fontSize || color) {
+	return [self createWithDictionary:titleTextAttributes fontFamily:fontFamily fontSize:fontSize fontWeight:fontWeight color:color];
+}
+
++ (NSDictionary *)createWithFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize fontWeight:(NSString *)fontWeight color:(UIColor *)color {
+	NSMutableDictionary* titleTextAttributes = [NSMutableDictionary new];
+	[self createWithDictionary:titleTextAttributes fontFamily:fontFamily fontSize:fontSize fontWeight:fontWeight color:color];
+	
+	return titleTextAttributes;
+}
+
++ (NSDictionary *)createWithDictionary:(NSDictionary *)attributesDictionary fontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize defaultFontSize:(NSNumber *)defaultFontSize fontWeight:(NSString *)fontWeight color:(UIColor *)color defaultColor:(UIColor *)defaultColor {
+	return [self createWithDictionary:attributesDictionary fontFamily:fontFamily fontSize:fontSize ?: defaultFontSize fontWeight:fontWeight color:color ?: defaultColor];
+}
+
++ (NSDictionary *)createWithDictionary:(NSDictionary *)attributesDictionary fontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize fontWeight:(NSString *)fontWeight color:(UIColor *)color {
+	NSMutableDictionary* titleTextAttributes = [NSMutableDictionary dictionaryWithDictionary:attributesDictionary];
+	if (fontFamily || fontSize || color || fontWeight) {
+		CGFloat resolvedFontSize = fontSize ? fontSize.floatValue : 17;
 		if (color) {
 			titleTextAttributes[NSForegroundColorAttributeName] = color;
 		}
-		if (fontFamily){
-			if (fontSize) {
-				titleTextAttributes[NSFontAttributeName] = [UIFont fontWithName:fontFamily size:[fontSize floatValue]];
-			} else {
-				titleTextAttributes[NSFontAttributeName] = [UIFont fontWithName:fontFamily size:17];
-			}
-		} else if (fontSize) {
-			titleTextAttributes[NSFontAttributeName] = [UIFont systemFontOfSize:[fontSize floatValue]];
+		if (fontWeight) {
+			titleTextAttributes[NSFontAttributeName] = [UIFont systemFontOfSize:resolvedFontSize weight:[RCTConvert UIFontWeight:fontWeight]];
+		} else if (fontFamily){
+			titleTextAttributes[NSFontAttributeName] = [UIFont fontWithName:fontFamily size:resolvedFontSize];
 		}
 	}
 	

--- a/lib/ios/RNNFontAttributesCreator.m
+++ b/lib/ios/RNNFontAttributesCreator.m
@@ -28,6 +28,8 @@
 			titleTextAttributes[NSFontAttributeName] = [UIFont systemFontOfSize:resolvedFontSize weight:[RCTConvert UIFontWeight:fontWeight]];
 		} else if (fontFamily){
 			titleTextAttributes[NSFontAttributeName] = [UIFont fontWithName:fontFamily size:resolvedFontSize];
+		} else {
+			titleTextAttributes[NSFontAttributeName] = [UIFont systemFontOfSize:resolvedFontSize];
 		}
 	}
 	

--- a/lib/ios/RNNFontAttributesCreator.m
+++ b/lib/ios/RNNFontAttributesCreator.m
@@ -5,14 +5,12 @@
 
 + (NSDictionary *)createWithFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize defaultFontSize:(NSNumber *)defaultFontSize fontWeight:(NSString *)fontWeight color:(UIColor *)color defaultColor:(UIColor *)defaultColor {
 	NSMutableDictionary* titleTextAttributes = [NSMutableDictionary new];
-	return [self createWithDictionary:titleTextAttributes fontFamily:fontFamily fontSize:fontSize fontWeight:fontWeight color:color];
+	return [self createWithDictionary:titleTextAttributes fontFamily:fontFamily fontSize:fontSize defaultFontSize:defaultFontSize fontWeight:fontWeight color:color defaultColor:defaultColor];
 }
 
 + (NSDictionary *)createWithFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize fontWeight:(NSString *)fontWeight color:(UIColor *)color {
 	NSMutableDictionary* titleTextAttributes = [NSMutableDictionary new];
-	[self createWithDictionary:titleTextAttributes fontFamily:fontFamily fontSize:fontSize fontWeight:fontWeight color:color];
-	
-	return titleTextAttributes;
+	return [self createWithDictionary:titleTextAttributes fontFamily:fontFamily fontSize:fontSize fontWeight:fontWeight color:color];
 }
 
 + (NSDictionary *)createWithDictionary:(NSDictionary *)attributesDictionary fontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize defaultFontSize:(NSNumber *)defaultFontSize fontWeight:(NSString *)fontWeight color:(UIColor *)color defaultColor:(UIColor *)defaultColor {

--- a/lib/ios/RNNLargeTitleOptions.h
+++ b/lib/ios/RNNLargeTitleOptions.h
@@ -7,5 +7,6 @@
 @property (nonatomic, strong) Bool* visible;
 @property (nonatomic, strong) Color* color;
 @property (nonatomic, strong) Text* fontFamily;
+@property (nonatomic, strong) Text* fontWeight;
 
 @end

--- a/lib/ios/RNNLargeTitleOptions.m
+++ b/lib/ios/RNNLargeTitleOptions.m
@@ -9,6 +9,7 @@
 	self.visible = [BoolParser parse:dict key:@"visible"];
 	self.color = [ColorParser parse:dict key:@"color"];
 	self.fontFamily = [TextParser parse:dict key:@"fontFamily"];
+	self.fontWeight = [TextParser parse:dict key:@"fontWeight"];
 	
 	return self;
 }

--- a/lib/ios/RNNNavigationButtons.m
+++ b/lib/ios/RNNNavigationButtons.m
@@ -6,6 +6,7 @@
 #import "RNNComponentViewController.h"
 #import "UIImage+insets.h"
 #import "UIViewController+LayoutProtocol.h"
+#import "RNNFontAttributesCreator.h"
 
 @interface RNNNavigationButtons()
 
@@ -126,8 +127,8 @@
 	BOOL enabledBool = enabled ? [enabled boolValue] : YES;
 	[barButtonItem setEnabled:enabledBool];
 	
-	NSMutableDictionary* textAttributes = [[NSMutableDictionary alloc] init];
-	NSMutableDictionary* disabledTextAttributes = [[NSMutableDictionary alloc] init];
+	NSMutableDictionary* textAttributes = [NSMutableDictionary dictionaryWithDictionary:[RNNFontAttributesCreator createWithFontFamily:dictionary[@"fontFamily"] ?: [defaultStyle.fontFamily getWithDefaultValue:nil] fontSize:dictionary[@"fontSize"] defaultFontSize:[defaultStyle.fontSize getWithDefaultValue:@(17)] fontWeight:dictionary[@"fontWeight"] color:nil defaultColor:nil]];
+	NSMutableDictionary* disabledTextAttributes = [NSMutableDictionary dictionaryWithDictionary:[RNNFontAttributesCreator createWithFontFamily:dictionary[@"fontFamily"] ?: [defaultStyle.fontFamily getWithDefaultValue:nil] fontSize:dictionary[@"fontSize"] defaultFontSize:[defaultStyle.fontSize getWithDefaultValue:@(17)] fontWeight:dictionary[@"fontWeight"] color:nil defaultColor:nil]];
 	
 	if (!enabledBool && disabledColor) {
 		color = disabledColor;
@@ -139,18 +140,7 @@
 		[barButtonItem setImage:[[iconImage withTintColor:color] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal]];
 		barButtonItem.tintColor = color;
 	}
-	
-	NSNumber* fontSize = [self fontSize:dictionary[@"fontSize"] defaultFontSize:[defaultStyle.fontSize getWithDefaultValue:nil]];
-	NSString* fontFamily = [self fontFamily:dictionary[@"fontFamily"] defaultFontFamily:[defaultStyle.fontFamily getWithDefaultValue:nil]];
-	UIFont *font = nil;
-	if (fontFamily) {
-		font = [UIFont fontWithName:fontFamily size:[fontSize floatValue]];
-	} else {
-		font = [UIFont systemFontOfSize:[fontSize floatValue]];
-	}
-	[textAttributes setObject:font forKey:NSFontAttributeName];
-	[disabledTextAttributes setObject:font forKey:NSFontAttributeName];
-	
+
 	[barButtonItem setTitleTextAttributes:textAttributes forState:UIControlStateNormal];
 	[barButtonItem setTitleTextAttributes:textAttributes forState:UIControlStateHighlighted];
 	[barButtonItem setTitleTextAttributes:disabledTextAttributes forState:UIControlStateDisabled];
@@ -172,24 +162,6 @@
 	}
 	
 	return nil;
-}
-
-- (NSNumber *)fontSize:(NSNumber *)fontSize defaultFontSize:(NSNumber *)defaultFontSize {
-	if (fontSize) {
-		return fontSize;
-	} else if (defaultFontSize) {
-		return defaultFontSize;
-	}
-	
-	return @(17);
-}
-
-- (NSString *)fontFamily:(NSString *)fontFamily defaultFontFamily:(NSString *)defaultFontFamily {
-	if (fontFamily) {
-		return fontFamily;
-	} else {
-		return defaultFontFamily;
-	}
 }
 
 - (id)getValue:(id)value withDefault:(id)defaultValue {

--- a/lib/ios/RNNStackPresenter.m
+++ b/lib/ios/RNNStackPresenter.m
@@ -41,8 +41,8 @@
 	[stack setNavigationBarBlur:[withDefault.topBar.background.blur getWithDefaultValue:NO]];
 	[stack setTopBarBackgroundColor:[withDefault.topBar.background.color getWithDefaultValue:nil]];
 	[stack setNavigationBarLargeTitleVisible:[withDefault.topBar.largeTitle.visible getWithDefaultValue:NO]];
-	[stack setNavigationBarLargeTitleFontFamily:[withDefault.topBar.largeTitle.fontFamily getWithDefaultValue:nil] fontSize:[withDefault.topBar.largeTitle.fontSize getWithDefaultValue:nil] color:[withDefault.topBar.largeTitle.color getWithDefaultValue:nil]];
-	[stack setNavigationBarFontFamily:[withDefault.topBar.title.fontFamily getWithDefaultValue:nil] fontSize:[withDefault.topBar.title.fontSize getWithDefaultValue:nil] color:[withDefault.topBar.title.color getWithDefaultValue:nil]];
+	[stack setNavigationBarLargeTitleFontFamily:[withDefault.topBar.largeTitle.fontFamily getWithDefaultValue:nil] fontSize:[withDefault.topBar.largeTitle.fontSize getWithDefaultValue:nil] fontWeight:[withDefault.topBar.largeTitle.fontWeight getWithDefaultValue:nil] color:[withDefault.topBar.largeTitle.color getWithDefaultValue:nil]];
+	[stack setNavigationBarFontFamily:[withDefault.topBar.title.fontFamily getWithDefaultValue:nil] fontSize:[withDefault.topBar.title.fontSize getWithDefaultValue:nil] fontWeight:[withDefault.topBar.title.fontWeight getWithDefaultValue:nil] color:[withDefault.topBar.title.color getWithDefaultValue:nil]];
 	[stack setBackButtonColor:[withDefault.topBar.backButton.color getWithDefaultValue:nil]];
 }
 
@@ -57,7 +57,7 @@
 	RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
 	RNNStackController* navigationController = self.boundViewController;
 	[navigationController setTopBarBackgroundColor:[withDefault.topBar.background.color getWithDefaultValue:nil]];
-	[navigationController setNavigationBarFontFamily:[withDefault.topBar.title.fontFamily getWithDefaultValue:nil] fontSize:[withDefault.topBar.title.fontSize getWithDefaultValue:nil] color:[withDefault.topBar.title.color getWithDefaultValue:[UIColor blackColor]]];
+	[navigationController setNavigationBarFontFamily:[withDefault.topBar.title.fontFamily getWithDefaultValue:nil] fontSize:[withDefault.topBar.title.fontSize getWithDefaultValue:nil] fontWeight:[withDefault.topBar.title.fontWeight getWithDefaultValue:nil] color:[withDefault.topBar.title.color getWithDefaultValue:[UIColor blackColor]]];
 	[navigationController setNavigationBarLargeTitleVisible:[withDefault.topBar.largeTitle.visible getWithDefaultValue:NO]];
 }
 
@@ -119,12 +119,13 @@
 
 	RNNLargeTitleOptions *largeTitleOptions = options.topBar.largeTitle;
 	if (largeTitleOptions.color.hasValue || largeTitleOptions.fontSize.hasValue || largeTitleOptions.fontFamily.hasValue) {
-		[stack setNavigationBarLargeTitleFontFamily:[options.topBar.largeTitle.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.largeTitle.fontSize getWithDefaultValue:nil] color:[options.topBar.largeTitle.color getWithDefaultValue:nil]];
+		[stack setNavigationBarLargeTitleFontFamily:[options.topBar.largeTitle.fontFamily getWithDefaultValue:nil] fontSize:[options.topBar.largeTitle.fontSize getWithDefaultValue:nil] fontWeight:[options.topBar.largeTitle.fontWeight getWithDefaultValue:nil] color:[options.topBar.largeTitle.color getWithDefaultValue:nil]];
 	}
 
 	RNNNavigationOptions * withDefault = (RNNNavigationOptions *) [[options mergeInOptions:resolvedOptions] withDefault:[self defaultOptions]];
 	[stack setNavigationBarFontFamily:[withDefault.topBar.title.fontFamily getWithDefaultValue:nil]
 							 fontSize:[withDefault.topBar.title.fontSize getWithDefaultValue:nil]
+						   fontWeight:[withDefault.topBar.title.fontWeight getWithDefaultValue:nil]
 								color:[withDefault.topBar.title.color getWithDefaultValue:nil]];
 	
 	if (options.topBar.component.name.hasValue) {

--- a/lib/ios/RNNSubtitleOptions.h
+++ b/lib/ios/RNNSubtitleOptions.h
@@ -6,6 +6,7 @@
 @property (nonatomic, strong) Number* fontSize;
 @property (nonatomic, strong) Color* color;
 @property (nonatomic, strong) Text* fontFamily;
+@property (nonatomic, strong) Text* fontWeight;
 @property (nonatomic, strong) Text* alignment;
 
 @end

--- a/lib/ios/RNNSubtitleOptions.m
+++ b/lib/ios/RNNSubtitleOptions.m
@@ -9,6 +9,7 @@
 	self.alignment = [TextParser parse:dict key:@"alignment"];
 	self.fontFamily = [TextParser parse:dict key:@"fontFamily"];
 	self.fontSize = [NumberParser parse:dict key:@"fontSize"];
+	self.fontWeight = [TextParser parse:dict key:@"fontWeight"];
 	self.color = [ColorParser parse:dict key:@"color"];
 	
 	return self;

--- a/lib/ios/RNNTabBarItemCreator.m
+++ b/lib/ios/RNNTabBarItemCreator.m
@@ -1,5 +1,6 @@
 #import "RNNTabBarItemCreator.h"
 #import "UIImage+tint.h"
+#import "RNNFontAttributesCreator.h"
 
 @implementation RNNTabBarItemCreator
 
@@ -32,7 +33,7 @@
 	
 	
 	
-	[self appendTitleAttributes:tabItem textColor:[bottomTabOptions.textColor getWithDefaultValue:nil] selectedTextColor:[bottomTabOptions.selectedTextColor getWithDefaultValue:nil] fontFamily:[bottomTabOptions.fontFamily getWithDefaultValue:nil] fontSize:[bottomTabOptions.fontSize getWithDefaultValue:nil]];
+	[self appendTitleAttributes:tabItem textColor:[bottomTabOptions.textColor getWithDefaultValue:nil] selectedTextColor:[bottomTabOptions.selectedTextColor getWithDefaultValue:nil] fontFamily:[bottomTabOptions.fontFamily getWithDefaultValue:nil] fontSize:[bottomTabOptions.fontSize getWithDefaultValue:nil] fontWeight:[bottomTabOptions.fontWeight getWithDefaultValue:nil]];
 	
 	return tabItem;
 }
@@ -61,43 +62,13 @@
 	return nil;
 }
 
-+ (void)appendTitleAttributes:(UITabBarItem *)tabItem textColor:(UIColor *)textColor selectedTextColor:(UIColor *)selectedTextColor fontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize {
-	NSMutableDictionary* selectedAttributes = [NSMutableDictionary dictionaryWithDictionary:[tabItem titleTextAttributesForState:UIControlStateNormal]];
-	if (selectedTextColor) {
-		selectedAttributes[NSForegroundColorAttributeName] = selectedTextColor;
-	} else {
-		selectedAttributes[NSForegroundColorAttributeName] = [UIColor blackColor];
-	}
-	
-	selectedAttributes[NSFontAttributeName] = [self tabBarTextFont:fontFamily fontSize:fontSize];
++ (void)appendTitleAttributes:(UITabBarItem *)tabItem textColor:(UIColor *)textColor selectedTextColor:(UIColor *)selectedTextColor fontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize fontWeight:(NSString *)fontWeight {
+	NSDictionary* selectedAttributes = [RNNFontAttributesCreator createWithDictionary:[tabItem titleTextAttributesForState:UIControlStateSelected] fontFamily:fontFamily fontSize:fontSize defaultFontSize:@(10) fontWeight:fontWeight color:selectedTextColor defaultColor:[UIColor blackColor]];
 	[tabItem setTitleTextAttributes:selectedAttributes forState:UIControlStateSelected];
 	
 	
-	NSMutableDictionary* normalAttributes = [NSMutableDictionary dictionaryWithDictionary:[tabItem titleTextAttributesForState:UIControlStateNormal]];
-	if (textColor) {
-		normalAttributes[NSForegroundColorAttributeName] = textColor;
-	} else {
-		normalAttributes[NSForegroundColorAttributeName] = [UIColor blackColor];
-	}
-	
-	normalAttributes[NSFontAttributeName] = [self tabBarTextFont:fontFamily fontSize:fontSize];
+	NSDictionary* normalAttributes = [RNNFontAttributesCreator createWithDictionary:[tabItem titleTextAttributesForState:UIControlStateNormal] fontFamily:fontFamily fontSize:fontSize defaultFontSize:@(10) fontWeight:fontWeight color:textColor defaultColor:[UIColor blackColor]];
 	[tabItem setTitleTextAttributes:normalAttributes forState:UIControlStateNormal];
-}
-
-+(UIFont *)tabBarTextFont:(NSString *)fontFamily fontSize:(NSNumber *)fontSize {
-	if (fontFamily) {
-		return [UIFont fontWithName:fontFamily size:[self fontSize:fontSize]];
-	}
-	else if (fontSize) {
-		return [UIFont systemFontOfSize:[self fontSize:fontSize]];
-	}
-	else {
-		return nil;
-	}
-}
-
-+ (CGFloat)fontSize:(NSNumber *)fontSize {
-	return fontSize ? [fontSize floatValue] : 10;
 }
 
 @end

--- a/lib/ios/RNNTitleOptions.h
+++ b/lib/ios/RNNTitleOptions.h
@@ -8,6 +8,7 @@
 @property (nonatomic, strong) Number* fontSize;
 @property (nonatomic, strong) Color* color;
 @property (nonatomic, strong) Text* fontFamily;
+@property (nonatomic, strong) Text* fontWeight;
 
 @property (nonatomic, strong) RNNComponentOptions* component;
 @property (nonatomic, strong) Text* componentAlignment;

--- a/lib/ios/RNNTitleOptions.m
+++ b/lib/ios/RNNTitleOptions.m
@@ -8,6 +8,7 @@
 	self.text = [TextParser parse:dict key:@"text"];
 	self.fontFamily = [TextParser parse:dict key:@"fontFamily"];
 	self.fontSize = [NumberParser parse:dict key:@"fontSize"];
+	self.fontWeight = [TextParser parse:dict key:@"fontWeight"];
 	self.color = [ColorParser parse:dict key:@"color"];
 	
 	self.component = [[RNNComponentOptions alloc] initWithDict:dict[@"component"]];

--- a/lib/ios/RNNTitleViewHelper.m
+++ b/lib/ios/RNNTitleViewHelper.m
@@ -96,7 +96,7 @@
 	subtitleLabel.backgroundColor = [UIColor clearColor];
 	subtitleLabel.autoresizingMask = self.titleView.autoresizingMask;
 	
-	NSDictionary* fontAttributes = [RNNFontAttributesCreator createFontAttributesWithFontFamily:[_subtitleOptions.fontFamily getWithDefaultValue:nil] fontSize:[_subtitleOptions.fontSize getWithDefaultValue:nil] color:[_subtitleOptions.color getWithDefaultValue:nil]];
+	NSDictionary* fontAttributes = [RNNFontAttributesCreator createWithFontFamily:[_subtitleOptions.fontFamily getWithDefaultValue:nil] fontSize:[_subtitleOptions.fontSize getWithDefaultValue:nil] fontWeight:[_subtitleOptions.fontWeight getWithDefaultValue:nil] color:[_subtitleOptions.color getWithDefaultValue:nil]];
 	[subtitleLabel setAttributedText:[[NSAttributedString alloc] initWithString:self.subtitle attributes:fontAttributes]];
 	
 	
@@ -128,7 +128,7 @@
 	
 	titleLabel.autoresizingMask = self.titleView.autoresizingMask;
 	
-	NSDictionary* fontAttributes = [RNNFontAttributesCreator createFontAttributesWithFontFamily:[_titleOptions.fontFamily getWithDefaultValue:nil] fontSize:[_titleOptions.fontSize getWithDefaultValue:nil] color:[_subtitleOptions.color getWithDefaultValue:nil]];
+	NSDictionary* fontAttributes = [RNNFontAttributesCreator createWithFontFamily:[_titleOptions.fontFamily getWithDefaultValue:nil] fontSize:[_titleOptions.fontSize getWithDefaultValue:nil] fontWeight:[_titleOptions.fontWeight getWithDefaultValue:nil] color:[_subtitleOptions.color getWithDefaultValue:nil]];
 	[titleLabel setAttributedText:[[NSAttributedString alloc] initWithString:self.title attributes:fontAttributes]];
 	
 	CGSize labelSize = [titleLabel.text sizeWithAttributes:fontAttributes];

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		50887CA920F26BFE00D06111 /* RNNOverlayWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = 50887CA720F26BFD00D06111 /* RNNOverlayWindow.m */; };
 		50887CAA20F26BFE00D06111 /* RNNOverlayWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = 50887CA820F26BFE00D06111 /* RNNOverlayWindow.h */; };
 		508EBDBD2278746400BEC144 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 508EBDBA2278742700BEC144 /* JavaScriptCore.framework */; };
+		50967F5B232FC2C200BEEA92 /* RNNFontAttributesCreatorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 50967F5A232FC2C200BEEA92 /* RNNFontAttributesCreatorTest.m */; };
 		509B2480217873FF00C83C23 /* UINavigationController+RNNOptionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 509B247F217873FF00C83C23 /* UINavigationController+RNNOptionsTest.m */; };
 		509B258F2178BE7A00C83C23 /* RNNStackPresenterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 509B258E2178BE7A00C83C23 /* RNNStackPresenterTest.m */; };
 		50A00C37200F84D6000F01A6 /* RNNOverlayOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 50A00C35200F84D6000F01A6 /* RNNOverlayOptions.h */; };
@@ -549,6 +550,7 @@
 		50887CA720F26BFD00D06111 /* RNNOverlayWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNOverlayWindow.m; sourceTree = "<group>"; };
 		50887CA820F26BFE00D06111 /* RNNOverlayWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNOverlayWindow.h; sourceTree = "<group>"; };
 		508EBDBA2278742700BEC144 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		50967F5A232FC2C200BEEA92 /* RNNFontAttributesCreatorTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNFontAttributesCreatorTest.m; sourceTree = "<group>"; };
 		509B247F217873FF00C83C23 /* UINavigationController+RNNOptionsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UINavigationController+RNNOptionsTest.m"; sourceTree = "<group>"; };
 		509B258E2178BE7A00C83C23 /* RNNStackPresenterTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNStackPresenterTest.m; sourceTree = "<group>"; };
 		50A00C35200F84D6000F01A6 /* RNNOverlayOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNOverlayOptions.h; sourceTree = "<group>"; };
@@ -1036,6 +1038,7 @@
 			children = (
 				E5F6C3BC22DB51E00093C2CE /* utils */,
 				7B49FEC61E95098500DEB3EA /* RNNControllerFactoryTest.m */,
+				50967F5A232FC2C200BEEA92 /* RNNFontAttributesCreatorTest.m */,
 				7B49FEC71E95098500DEB3EA /* RNNExternalComponentStoreTest.m */,
 				7B49FEC81E95098500DEB3EA /* RNNModalManagerTest.m */,
 				7B49FEC91E95098500DEB3EA /* RNNCommandsHandlerTest.m */,
@@ -1477,6 +1480,7 @@
 				506F630D216A599300AD0D0A /* RNNTabBarControllerTest.m in Sources */,
 				7B49FECB1E95098500DEB3EA /* RNNControllerFactoryTest.m in Sources */,
 				50206A6D21AFE75400B7BB1A /* RNNSideMenuParserTest.m in Sources */,
+				50967F5B232FC2C200BEEA92 /* RNNFontAttributesCreatorTest.m in Sources */,
 				509B258F2178BE7A00C83C23 /* RNNStackPresenterTest.m in Sources */,
 				7B49FECD1E95098500DEB3EA /* RNNModalManagerTest.m in Sources */,
 				5085DD2D21DCF75A0032E64B /* RNNSideMenuControllerTest.m in Sources */,

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -565,6 +565,7 @@
 		50CE8502217C6C9B00084EBF /* RNNSideMenuPresenterTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNSideMenuPresenterTest.m; sourceTree = "<group>"; };
 		50D031322005149000386B3D /* RNNOverlayManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNOverlayManager.h; sourceTree = "<group>"; };
 		50D031332005149000386B3D /* RNNOverlayManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNOverlayManager.m; sourceTree = "<group>"; };
+		50DA74CF232F80FE004A00C1 /* RCTConvert+UIFontWeight.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+UIFontWeight.h"; sourceTree = "<group>"; };
 		50E02BD521A6E54B00A43942 /* RCTConvert+SideMenuOpenGestureMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+SideMenuOpenGestureMode.h"; sourceTree = "<group>"; };
 		50E02BD621A6EE0F00A43942 /* SideMenuOpenMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SideMenuOpenMode.h; sourceTree = "<group>"; };
 		50E02BD721A6EE0F00A43942 /* SideMenuOpenMode.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SideMenuOpenMode.m; sourceTree = "<group>"; };
@@ -735,6 +736,7 @@
 				5038A3BF216E1E66009280BC /* RNNFontAttributesCreator.h */,
 				5038A3C0216E1E66009280BC /* RNNFontAttributesCreator.m */,
 				505EDD48214FDA800071C7DE /* RCTConvert+Modal.h */,
+				50DA74CF232F80FE004A00C1 /* RCTConvert+UIFontWeight.h */,
 				50E02BD521A6E54B00A43942 /* RCTConvert+SideMenuOpenGestureMode.h */,
 				7365070F21E4B16F004E020F /* RCTConvert+UIBarButtonSystemItem.h */,
 				7365071021E4B16F004E020F /* RCTConvert+UIBarButtonSystemItem.m */,

--- a/lib/ios/ReactNativeNavigationTests/RNNFontAttributesCreatorTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNFontAttributesCreatorTest.m
@@ -1,0 +1,72 @@
+#import <XCTest/XCTest.h>
+#import "RNNFontAttributesCreator.h"
+
+@interface RNNFontAttributesCreatorTest : XCTestCase
+
+@end
+
+@implementation RNNFontAttributesCreatorTest
+
+- (void)testCreateWithFontFamily_shouldCreateAttributes {
+	NSString* familyName = @"Helvetica";
+	NSNumber* fontSize = @(20);
+	UIColor* fontColor = UIColor.blueColor;
+	
+	NSDictionary* attributes = [RNNFontAttributesCreator createWithFontFamily:familyName fontSize:fontSize fontWeight:nil color:fontColor];
+	UIFont* font = attributes[NSFontAttributeName];
+	XCTAssertEqual(attributes[NSForegroundColorAttributeName], fontColor);
+    XCTAssertTrue([familyName isEqualToString:font.familyName]);
+	XCTAssertEqual(font.pointSize, fontSize.floatValue);
+}
+
+- (void)testCreateWithFontFamily_shouldIgnoreFontFamilyWhenFontWeightIsNotNil {
+	NSString* familyName = @"Helvetica";
+	NSString* fontWeight = @"bold";
+	NSNumber* fontSize = @(20);
+	UIColor* fontColor = UIColor.blueColor;
+	
+	NSDictionary* attributes = [RNNFontAttributesCreator createWithFontFamily:familyName fontSize:fontSize fontWeight:fontWeight color:fontColor];
+	UIFont* font = attributes[NSFontAttributeName];
+	XCTAssertEqual(attributes[NSForegroundColorAttributeName], fontColor);
+    XCTAssertFalse([familyName isEqualToString:font.familyName]);
+	XCTAssertEqual(font.pointSize, fontSize.floatValue);
+}
+
+- (void)testCreateWithFontFamilyWithDefault_shouldCreateDefaultAttributes {
+	NSString* familyName = @"Helvetica";
+	NSNumber* defaultFontSize = @(20);
+	UIColor* defaultFontColor = UIColor.blueColor;
+	
+	NSDictionary* attributes = [RNNFontAttributesCreator createWithFontFamily:familyName fontSize:nil defaultFontSize:defaultFontSize fontWeight:nil color:nil defaultColor:defaultFontColor];
+	UIFont* font = attributes[NSFontAttributeName];
+	XCTAssertEqual(attributes[NSForegroundColorAttributeName], defaultFontColor);
+    XCTAssertTrue([familyName isEqualToString:font.familyName]);
+	XCTAssertEqual(font.pointSize, defaultFontSize.floatValue);
+}
+
+- (void)testCreateWithDictionary_shouldCreateAttributes {
+	NSString* familyName = @"Helvetica";
+	NSNumber* fontSize = @(20);
+	UIColor* fontColor = UIColor.blueColor;
+	
+	NSDictionary* attributes = [RNNFontAttributesCreator createWithDictionary:@{} fontFamily:familyName fontSize:fontSize defaultFontSize:nil fontWeight:nil color:fontColor defaultColor:nil];
+	UIFont* font = attributes[NSFontAttributeName];
+	XCTAssertEqual(attributes[NSForegroundColorAttributeName], fontColor);
+    XCTAssertTrue([familyName isEqualToString:font.familyName]);
+	XCTAssertEqual(font.pointSize, fontSize.floatValue);
+}
+
+- (void)testCreateWithDictionary_shouldMergeWithDictionary {
+	NSString* familyName = @"Helvetica";
+	NSNumber* fontSize = @(20);
+	NSDictionary* dictionary = @{NSForegroundColorAttributeName: UIColor.redColor};
+	
+	NSDictionary* attributes = [RNNFontAttributesCreator createWithDictionary:dictionary fontFamily:familyName fontSize:fontSize defaultFontSize:nil fontWeight:nil color:nil defaultColor:nil];
+	UIFont* font = attributes[NSFontAttributeName];
+	XCTAssertEqual(attributes[NSForegroundColorAttributeName], UIColor.redColor);
+    XCTAssertTrue([familyName isEqualToString:font.familyName]);
+	XCTAssertEqual(font.pointSize, fontSize.floatValue);
+}
+
+
+@end

--- a/lib/ios/ReactNativeNavigationTests/RNNFontAttributesCreatorTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNFontAttributesCreatorTest.m
@@ -68,5 +68,15 @@
 	XCTAssertEqual(font.pointSize, fontSize.floatValue);
 }
 
+- (void)testCreateWithFontFamily_shouldCreateSystemFontWhenOnlySizeAvailable {
+	NSNumber* fontSize = @(20);
+	
+	NSDictionary* attributes = [RNNFontAttributesCreator createWithFontFamily:nil fontSize:fontSize fontWeight:nil color:nil];
+	UIFont* font = attributes[NSFontAttributeName];
+	NSString* systemFontFamilyName = [[UIFont systemFontOfSize:20] familyName];
+	XCTAssertEqual(font.pointSize, fontSize.floatValue);
+	XCTAssertTrue([font.familyName isEqualToString:systemFontFamilyName]);
+}
+
 
 @end

--- a/lib/ios/UINavigationController+RNNOptions.h
+++ b/lib/ios/UINavigationController+RNNOptions.h
@@ -16,7 +16,7 @@
 
 - (void)setBarStyle:(UIBarStyle)barStyle;
 
-- (void)setNavigationBarFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize color:(UIColor *)color;
+- (void)setNavigationBarFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize fontWeight:(NSString *)fontWeight color:(UIColor *)color;
 
 - (void)setNavigationBarTranslucent:(BOOL)translucent;
 
@@ -26,7 +26,7 @@
 
 - (void)setNavigationBarLargeTitleVisible:(BOOL)visible;
 
-- (void)setNavigationBarLargeTitleFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize color:(UIColor *)color;
+- (void)setNavigationBarLargeTitleFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize fontWeight:(NSString *)fontWeight color:(UIColor *)color;
 
 - (void)setBackButtonColor:(UIColor *)color;
 

--- a/lib/ios/UINavigationController+RNNOptions.m
+++ b/lib/ios/UINavigationController+RNNOptions.m
@@ -45,8 +45,8 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 	self.navigationBar.barStyle = barStyle;
 }
 
-- (void)setNavigationBarFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize color:(UIColor *)color {
-	NSDictionary* fontAttributes = [RNNFontAttributesCreator createFontAttributesWithFontFamily:fontFamily fontSize:fontSize color:color];
+- (void)setNavigationBarFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize fontWeight:(NSString *)fontWeight color:(UIColor *)color {
+	NSDictionary* fontAttributes = [RNNFontAttributesCreator createWithFontFamily:fontFamily fontSize:fontSize fontWeight:fontWeight color:color];
 	
 	if (fontAttributes.allKeys.count > 0) {
 		self.navigationBar.titleTextAttributes = fontAttributes;
@@ -63,9 +63,9 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 	}
 }
 
-- (void)setNavigationBarLargeTitleFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize color:(UIColor *)color {
+- (void)setNavigationBarLargeTitleFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize fontWeight:(NSString *)fontWeight color:(UIColor *)color {
 	if (@available(iOS 11.0, *)) {
-		NSDictionary* fontAttributes = [RNNFontAttributesCreator createFontAttributesWithFontFamily:fontFamily fontSize:fontSize color:color];
+		NSDictionary* fontAttributes = [RNNFontAttributesCreator createWithFontFamily:fontFamily fontSize:fontSize fontWeight:fontWeight color:color];
 		self.navigationBar.largeTitleTextAttributes = fontAttributes;
 	}
 }

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -3,6 +3,7 @@ import { ImageRequireSource, Insets } from 'react-native';
 
 type Color = string;
 type FontFamily = string;
+type FontWeight = 'regular' | 'bold' | 'thin' | 'ultraLight' | 'light' | 'medium' | 'semibold' | 'heavy' | 'black';
 type LayoutOrientation = 'portrait' | 'landscape';
 type AndroidDensityNumber = number;
 type SystemItemIcon = 'done' | 'cancel' | 'edit'
@@ -119,6 +120,11 @@ export interface OptionsTopBarLargeTitle {
    * Set the font family of large title's text
    */
   fontFamily?: FontFamily;
+  /**
+   * Set the font weight, ignore fontFamily and use the iOS system fonts instead
+   * #### (iOS specific)
+   */
+  fontWeight?: FontWeight;
 }
 
 export interface OptionsTopBarTitle {
@@ -140,6 +146,11 @@ export interface OptionsTopBarTitle {
    * Make sure that the font is available
    */
   fontFamily?: FontFamily;
+  /**
+   * Set the font weight, ignore fontFamily and use the iOS system fonts instead
+   * #### (iOS specific)
+   */
+  fontWeight?: FontWeight;
   /**
    * Custom component as the title view
    */
@@ -190,6 +201,11 @@ export interface OptionsTopBarSubtitle {
    * Set subtitle font family
    */
   fontFamily?: FontFamily;
+  /**
+   * Set the font weight, ignore fontFamily and use the iOS system fonts instead
+   * #### (iOS specific)
+   */
+  fontWeight?: FontWeight;
   /**
    * Set subtitle alignment
    */
@@ -289,6 +305,11 @@ export interface OptionsTopBarButton {
    * Set the button font family
    */
   fontFamily?: string;
+  /**
+   * Set the font weight, ignore fontFamily and use the iOS system fonts instead
+   * #### (iOS specific)
+   */
+  fontWeight?: FontWeight;
   /**
    * Set the button enabled or disabled
    * @default true
@@ -565,6 +586,11 @@ export interface OptionsBottomTab {
    * Set the text font family
    */
   fontFamily?: FontFamily;
+    /**
+   * Set the font weight, ignore fontFamily and use the iOS system fonts instead
+   * #### (iOS specific)
+   */
+  fontWeight?: FontWeight;
   /**
    * Set the text font size
    */


### PR DESCRIPTION
This feature allow using the iOS native system font weights. Providing system font names as `.SFUIText-Heavy` are no longer supported in iOS 13.

• Add `fontWeight` support for:
  • `topBar.title` option
  • `topBar.largeTitle` option
  • `topBar.subtitle` option
  • `bottomTab` option
  • `topBar.leftButtons` and `topBar.rightButtons` options

• Move all font creation to `RNNFontAttributesCreator`