### PR TITLE
Upgrade playground app's Gradle to 5.1.1 (matches version of lib)

### DIFF
--- a/playground/android/build.gradle
+++ b/playground/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/playground/android/gradle/wrapper/gradle-wrapper.properties
+++ b/playground/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Aug 11 15:52:47 IDT 2019
+#Mon Sep 16 17:06:02 IDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
Upgrade Gradle to 5.1.1 and the Android gradle-plugin to equivalent version 3.4.1 in playground app. Biggest motivation for doing this is the [HTTP retries](https://docs.gradle.org/5.0/release-notes.html#http-retries-during-dependency-resolution) feature.

Disclaimer: the feature may not be fully functional as described [in this report to gradle](https://github.com/gradle/gradle/issues/8264). I hope it'd be ok for us nevertheless.