### PR TITLE
[v2/v3][iOS9][iOS10] Fix topbar custom component buttons layout

### DIFF
--- a/lib/ios/RNNUIBarButtonItem.m
+++ b/lib/ios/RNNUIBarButtonItem.m
@@ -31,13 +31,14 @@
 
 -(instancetype)init:(NSString*)buttonId withCustomView:(RCTRootView *)reactView componentRegistry:(RNNReactComponentRegistry *)componentRegistry {
 	self = [super initWithCustomView:reactView];
-	
+
 	self.componentRegistry = componentRegistry;
 	reactView.sizeFlexibility = RCTRootViewSizeFlexibilityWidthAndHeight;
 	reactView.delegate = self;
 	reactView.backgroundColor = [UIColor clearColor];
 	reactView.hidden = YES;
-	
+	reactView.translatesAutoresizingMaskIntoConstraints = NO;
+
 	self.widthConstraint = [NSLayoutConstraint constraintWithItem:reactView
 														attribute:NSLayoutAttributeWidth
 														relatedBy:NSLayoutRelationEqual
@@ -56,7 +57,7 @@
 	self.buttonId = buttonId;
 	return self;
 }
-	
+
 - (instancetype)init:(NSString*)buttonId withSystemItem:(NSString *)systemItemName {
 	UIBarButtonSystemItem systemItem = [RCTConvert UIBarButtonSystemItem:systemItemName];
 	self = [super initWithBarButtonSystemItem:systemItem target:nil action:nil];


### PR DESCRIPTION
On iOS versions below 11, custom topbar button components are not positioned properly, as seen in the screenshot below:
<img width="439" alt="Screenshot 2019-10-02 at 16 22 24" src="https://user-images.githubusercontent.com/6169923/66049732-a2914400-e534-11e9-9821-fadc14b55573.png">
The right button is even clipped off screen. Press handlers are not fired for either of them.
When rendering buttons xcode logs report:
```
2019-10-02 16:21:55.302708+0300 App[71152:3051577] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
	(Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints) 
(
    "<NSAutoresizingMaskLayoutConstraint:0x60000028d570 h=--& v=--& RNNReactView:0x7faa860c9130.width == 0   (active)>",
    "<NSLayoutConstraint:0x60000009d010 RNNReactView:0x7faa860c9130.width == 1   (active)>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x60000009d010 RNNReactView:0x7faa860c9130.width == 1   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKit/UIView.h> may also be helpful.
```
After investigating it seems that incorrect constraints are being calculated (`width == 0`), and the proper ones broken (if `width == 1` could be considered proper). This is probably the reason they don't respond to interactions, since the view in question is of 0 width and height. Setting `translatesAutoresizingMaskIntoConstraints` for the component's `UIView` seems to alleviate the problem, the buttons become interactable and positioned alike in the new iOS versions, unfortunately only after a short delay, before which, they become visible at the top of the topbar, behind the status bar. This flickering does not look great, but at least it works.
I haven't noticed any visual or functional changes for iOS versions 11 and above.

I haven't written any tests since there are none present for old iOS versions, but the existing ones seem to pass. Feel free to close this PR if fixes for legacy iOS versions are not welcome