### PR TITLE
Added shouldStretchDrawer property to SideMenuSide interface

### DIFF
--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -639,6 +639,12 @@ export interface SideMenuSide {
    * Set the height of the side menu
    */
   height?: number;
+  /**
+   * Stretch sideMenu contents when opened past the width
+   * #### (iOS specific)
+   * @default true
+   */
+  shouldStretchDrawer?: boolean;
 }
 
 export interface OptionsSideMenu {


### PR DESCRIPTION
Looking at the docs (https://github.com/wix/react-native-navigation/blob/1581780d2ca66acebdb149751afa1bb4afc1c59e/docs/docs/styling.md) and code it's possible to use the shouldStretchDrawer property on sideMenu. This property was however missing in the TS interface.
https://github.com/wix/react-native-navigation/blob/1581780d2ca66acebdb149751afa1bb4afc1c59e/lib/ios/RNNSideMenuSideOptions.m#L11