### PR TITLE
feat: Ability to control `prefersHomeIndicatorAutoHidden` flag on iOS

### DIFF
--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -28,7 +28,10 @@
 }
 
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)initialOptions {
-
+	UIViewController *viewController = self.boundViewController;
+	if (initialOptions.layout.showHomeIndicator.hasValue) {
+		[viewController rnn_setShowHomeIndicator:[initialOptions.layout.showHomeIndicator get]];
+	}
 }
 
 - (void)applyOptionsOnViewDidLayoutSubviews:(RNNNavigationOptions *)options {
@@ -78,6 +81,10 @@
         UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:withDefault.bottomTab];
         viewController.tabBarItem = tabItem;
     }
+	
+	if (withDefault.layout.showHomeIndicator.hasValue) {
+		[viewController rnn_setShowHomeIndicator:[withDefault.layout.showHomeIndicator get]];
+	}
 }
 
 - (void)applyOptions:(RNNNavigationOptions *)options {
@@ -91,6 +98,10 @@
     if (withDefault.bottomTab.badgeColor.hasValue && [viewController.parentViewController isKindOfClass:[UITabBarController class]]) {
         [viewController rnn_setTabBarItemBadgeColor:withDefault.bottomTab.badgeColor.get];
     }
+	
+	if (withDefault.layout.showHomeIndicator.hasValue) {
+		[viewController rnn_setShowHomeIndicator:[withDefault.layout.showHomeIndicator get]];
+	}
 }
 
 - (void)mergeOptions:(RNNNavigationOptions *)newOptions currentOptions:(RNNNavigationOptions *)currentOptions {
@@ -148,6 +159,10 @@
         UITabBarItem *tabItem = [RNNTabBarItemCreator updateTabBarItem:viewController.tabBarItem bottomTabOptions:buttonsResolvedOptions.bottomTab];
         viewController.tabBarItem = tabItem;
     }
+	
+	if (newOptions.layout.showHomeIndicator.hasValue) {
+		[viewController rnn_setShowHomeIndicator:[newOptions.layout.showHomeIndicator get]];
+	}
 }
 
 - (void)renderComponents:(RNNNavigationOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock {

--- a/lib/ios/RNNLayoutOptions.h
+++ b/lib/ios/RNNLayoutOptions.h
@@ -5,6 +5,7 @@
 @property (nonatomic, strong) Color* backgroundColor;
 @property (nonatomic, strong) Text* direction;
 @property (nonatomic, strong) id orientation;
+@property (nonatomic, strong) Bool* showHomeIndicator;
 
 - (UIInterfaceOrientationMask)supportedOrientations;
 

--- a/lib/ios/RNNLayoutOptions.m
+++ b/lib/ios/RNNLayoutOptions.m
@@ -10,7 +10,8 @@
 	self.backgroundColor = [ColorParser parse:dict key:@"backgroundColor"];
 	self.direction = [TextParser parse:dict key:@"direction"];
 	self.orientation = dict[@"orientation"];
-
+	self.showHomeIndicator = [BoolParser parse:dict key:@"showHomeIndicator"];
+	
 	return self;
 }
 

--- a/lib/ios/ReactNativeNavigationTests/RNNBasePresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNBasePresenterTest.m
@@ -89,5 +89,31 @@
     XCTAssertEqual([_uut getStatusBarStyle:options], UIStatusBarStyleLightContent);
 }
 
+- (void)testSetShowHomeIndicator_preferHomeIndicatorVisible {
+	RNNNavigationOptions * homeIndicatorOptions = [[RNNNavigationOptions alloc] initWithDict:@{@"layout":@{@"showHomeIndicator":@1}}];
+	XCTAssertNotNil(homeIndicatorOptions.layout.showHomeIndicator);
+	XCTAssertEqual([homeIndicatorOptions.layout.showHomeIndicator get], YES);
+	
+	[_uut applyOptions:homeIndicatorOptions];
+	if (@available(iOS 11.0, *)) {
+		XCTAssertEqual([_boundViewController prefersHomeIndicatorAutoHidden], NO);
+	} else {
+		// Fallback on earlier versions
+	}
+}
+
+- (void)testSetShowHomeIndicator_preferHomeIndicatorHidden {
+	RNNNavigationOptions * homeIndicatorOptions = [[RNNNavigationOptions alloc] initWithDict:@{@"layout":@{@"showHomeIndicator":@0}}];
+	XCTAssertNotNil(homeIndicatorOptions.layout.showHomeIndicator);
+	XCTAssertEqual([homeIndicatorOptions.layout.showHomeIndicator get], NO);
+	
+	[_uut applyOptions:homeIndicatorOptions];
+	if (@available(iOS 11.0, *)) {
+		XCTAssertEqual([_boundViewController prefersHomeIndicatorAutoHidden], YES);
+	} else {
+		// Fallback on earlier versions
+	}
+}
+
 
 @end

--- a/lib/ios/UINavigationController+RNNOptions.h
+++ b/lib/ios/UINavigationController+RNNOptions.h
@@ -1,6 +1,10 @@
 #import <UIKit/UIKit.h>
 
+@class Bool;
+
 @interface UINavigationController (RNNOptions)
+
+@property (nonatomic, strong) Bool* showHomeIndicator;
 
 - (void)rnn_setInteractivePopGestureEnabled:(BOOL)enabled;
 
@@ -29,5 +33,7 @@
 - (void)rnn_setNavigationBarLargeTitleFontFamily:(NSString *)fontFamily fontSize:(NSNumber *)fontSize fontWeight:(NSString *)fontWeight color:(UIColor *)color;
 
 - (void)rnn_setBackButtonColor:(UIColor *)color;
+
+- (void)rnn_setShowHomeIndicator:(BOOL)showHomeIndicator;
 
 @end

--- a/lib/ios/UINavigationController+RNNOptions.m
+++ b/lib/ios/UINavigationController+RNNOptions.m
@@ -1,9 +1,20 @@
+#import <objc/runtime.h>
 #import "UINavigationController+RNNOptions.h"
 #import "RNNFontAttributesCreator.h"
+#import "Bool.h"
 
 const NSInteger BLUR_TOPBAR_TAG = 78264802;
+static void * RNNOptionsPropertyKey = &RNNOptionsPropertyKey;
 
 @implementation UINavigationController (RNNOptions)
+
+- (Bool*) showHomeIndicator {
+	return objc_getAssociatedObject(self, RNNOptionsPropertyKey);
+}
+
+- (void) setShowHomeIndicator:(Bool*)homeIndicator {
+	objc_setAssociatedObject(self, RNNOptionsPropertyKey, homeIndicator, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
 
 - (void)rnn_setInteractivePopGestureEnabled:(BOOL)enabled {
 	self.interactivePopGestureRecognizer.enabled = enabled;
@@ -101,6 +112,22 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 
 - (void)rnn_setNavigationBarClipsToBounds:(BOOL)clipsToBounds {
 	self.navigationBar.clipsToBounds = clipsToBounds;
+}
+
+- (void)rnn_setShowHomeIndicator:(BOOL)showHomeIndicator {
+	self.showHomeIndicator = [[Bool alloc] initWithBOOL:showHomeIndicator];
+	if (@available(iOS 11.0, *)) {
+		 [self setNeedsUpdateOfHomeIndicatorAutoHidden];
+	}
+	
+}
+
+- (BOOL)prefersHomeIndicatorAutoHidden {
+   if ([self respondsToSelector:@selector(showHomeIndicator)]) {
+	   return [self.showHomeIndicator isFalse];
+   } else {
+	   return NO;
+   }
 }
 
 @end

--- a/lib/ios/UIViewController+RNNOptions.h
+++ b/lib/ios/UIViewController+RNNOptions.h
@@ -1,10 +1,13 @@
 #import <UIKit/UIKit.h>
 
+@class Bool;
 @class RNNBottomTabOptions;
 @class RNNNavigationOptions;
 @class RNNBackButtonOptions;
 
 @interface UIViewController (RNNOptions)
+
+@property (nonatomic, strong) Bool* showHomeIndicator;
 
 - (void)rnn_setBackgroundImage:(UIImage *)backgroundImage;
 
@@ -39,6 +42,8 @@
 - (void)rnn_setInterceptTouchOutside:(BOOL)interceptTouchOutside;
 
 - (void)rnn_setBackButtonIcon:(UIImage *)icon withColor:(UIColor *)color title:(NSString *)title;
+
+- (void)rnn_setShowHomeIndicator:(BOOL)showHomeIndicator;
 
 - (void)applyBackButton:(RNNBackButtonOptions *)backButton;
 

--- a/lib/ios/UIViewController+RNNOptions.m
+++ b/lib/ios/UIViewController+RNNOptions.m
@@ -1,5 +1,6 @@
 #import "UIViewController+RNNOptions.h"
 #import <React/RCTRootView.h>
+#import <objc/runtime.h>
 #import "UIImage+tint.h"
 #import "RNNBottomTabOptions.h"
 #import "RNNNavigationOptions.h"
@@ -7,8 +8,18 @@
 
 #define kStatusBarAnimationDuration 0.35
 const NSInteger BLUR_STATUS_TAG = 78264801;
+static void * RNNOptionsPropertyKey = &RNNOptionsPropertyKey;
 
 @implementation UIViewController (RNNOptions)
+
+- (Bool*) showHomeIndicator {
+	return objc_getAssociatedObject(self, RNNOptionsPropertyKey);
+}
+
+- (void) setShowHomeIndicator:(Bool*)homeIndicator {
+	objc_setAssociatedObject(self, RNNOptionsPropertyKey, homeIndicator, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 
 - (void)rnn_setBackgroundImage:(UIImage *)backgroundImage {
 	if (backgroundImage) {
@@ -187,6 +198,14 @@ const NSInteger BLUR_STATUS_TAG = 78264801;
 	lastViewControllerInStack.navigationItem.backBarButtonItem = backItem;
 }
 
+- (void)rnn_setShowHomeIndicator:(BOOL)showHomeIndicator {
+	self.showHomeIndicator = [[Bool alloc] initWithBOOL:showHomeIndicator];
+	if (@available(iOS 11.0, *)) {
+		 [self setNeedsUpdateOfHomeIndicatorAutoHidden];
+	}
+	
+}
+
 - (void)applyBackButton:(RNNBackButtonOptions *)backButton {
 	UIBarButtonItem *backItem = [UIBarButtonItem new];
 	if (backButton.icon.hasValue) {
@@ -202,6 +221,14 @@ const NSInteger BLUR_STATUS_TAG = 78264801;
 	if ([backButton.showTitle getWithDefaultValue:YES]) backItem.title = [backButton.title getWithDefaultValue:nil];
 	if (backButton.color.hasValue) backItem.tintColor = [backButton.color get];
 	self.navigationItem.backBarButtonItem = backItem;
+}
+
+- (BOOL)prefersHomeIndicatorAutoHidden {
+	if ([self respondsToSelector:@selector(showHomeIndicator)]) {
+		return [self.showHomeIndicator isFalse];
+	} else {
+		return NO;
+	}
 }
 
 @end

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -82,6 +82,12 @@ export interface OptionsLayout {
    * only works with DefaultOptions
    */
   direction?: 'rtl' | 'ltr';
+
+  /**
+   * When set to false will cause home indicator bar on iOS fade-out when there is no interaction with the screen.
+   * see Apple docs in regards to UIViewController prefersHomeIndicatorAutoHidden
+   */
+  showHomeIndicator?: boolean;
 }
 
 export enum OptionsModalPresentationStyle {


### PR DESCRIPTION
Ability to control `prefersHomeIndicatorAutoHidden` flag on iOS via layout option `showHomeIndicator`.
This will allow to auto-hide/keep showing the home indicator on iOS devices like iPhone X.
In our case, this feature is required to be able to hide the home indicator in the full-screen player view. 