### PR TITLE
Fix title bar being too wide and overlapping right buttons on Android

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBarReactView.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBarReactView.java
@@ -16,7 +16,7 @@ public class TitleBarReactView extends ReactView {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(
-                (getChildCount() > 0 && getChildAt(0).getWidth() > 0) ? MeasureSpec.makeMeasureSpec(getChildAt(0).getWidth(), MeasureSpec.EXACTLY) : widthMeasureSpec,
+                (getChildCount() > 0 && getChildAt(0).getWidth() > 0) ? MeasureSpec.makeMeasureSpec(getChildAt(0).getWidth(), MeasureSpec.UNSPECIFIED) : widthMeasureSpec,
                 heightMeasureSpec
         );
     }


### PR DESCRIPTION
This seems to fix https://github.com/wix/react-native-navigation/issues/5524