### PR TITLE
Fix pageSheet modals causing memory leak when swiped

### DIFF
--- a/lib/ios/RNNModalManager.h
+++ b/lib/ios/RNNModalManager.h
@@ -12,7 +12,7 @@ typedef void (^RNNTransitionRejectionBlock)(NSString *code, NSString *message, N
 
 @end
 
-@interface RNNModalManager : NSObject
+@interface RNNModalManager : NSObject <UIAdaptivePresentationControllerDelegate>
 
 @property (nonatomic, weak) id<RNNModalManagerDelegate> delegate;
 

--- a/lib/ios/RNNModalManager.m
+++ b/lib/ios/RNNModalManager.m
@@ -29,6 +29,10 @@
 	UIViewController* topVC = [self topPresentedVC];
 	topVC.definesPresentationContext = YES;
 	
+	if (viewController.presentationController) {
+		viewController.presentationController.delegate = self;
+	}
+	
 	RNNAnimationsTransitionDelegate* tr = [[RNNAnimationsTransitionDelegate alloc] initWithScreenTransition:viewController.resolveOptions.animations.showModal isDismiss:NO];
 	if (hasCustomAnimation) {
 		viewController.transitioningDelegate = tr;
@@ -103,6 +107,10 @@
 - (void)dismissedModal:(UIViewController *)viewController {
 	[_presentedModals removeObject:viewController.navigationController ? viewController.navigationController : viewController];
 	[_delegate dismissedModal:viewController];
+}
+
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
+	[_presentedModals removeObject:presentationController.presentedViewController];
 }
 
 -(UIViewController*)topPresentedVC {


### PR DESCRIPTION
On iOS 13, when a `pageSheet` modal is dismissed with a swipe, the react view was not unmounted properly caused `componentWillUnmount` to never called.
This PR listen to this event and detach it from memory.

Closes #5370