### PR TITLE
Always merge options with parent controller

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ChildController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ChildController.java
@@ -1,9 +1,6 @@
 package com.reactnativenavigation.viewcontrollers;
 
 import android.app.Activity;
-import androidx.annotation.CallSuper;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -12,6 +9,10 @@ import com.reactnativenavigation.presentation.Presenter;
 import com.reactnativenavigation.utils.StatusBarUtils;
 import com.reactnativenavigation.viewcontrollers.navigator.Navigator;
 import com.reactnativenavigation.views.Component;
+
+import androidx.annotation.CallSuper;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 public abstract class ChildController<T extends ViewGroup> extends ViewController<T>  {
     private final Presenter presenter;
@@ -70,6 +71,7 @@ public abstract class ChildController<T extends ViewGroup> extends ViewControlle
     public void mergeOptions(Options options) {
         if (options == Options.EMPTY) return;
         if (isViewShown()) presenter.mergeOptions(getView(), options);
+        performOnParentController(parentController -> parentController.mergeChildOptions(options, this));
         super.mergeOptions(options);
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ComponentViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ComponentViewController.java
@@ -87,7 +87,6 @@ public class ComponentViewController extends ChildController<ComponentLayout> {
         if (options == Options.EMPTY) return;
         presenter.mergeOptions(getView(), options);
         super.mergeOptions(options);
-        performOnParentController(parentController -> parentController.mergeChildOptions(options, this));
     }
 
     @Override

--- a/lib/android/app/src/test/java/com/reactnativenavigation/mocks/SimpleViewController.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/mocks/SimpleViewController.java
@@ -2,7 +2,6 @@ package com.reactnativenavigation.mocks;
 
 import android.app.Activity;
 import android.content.Context;
-import androidx.annotation.NonNull;
 import android.view.MotionEvent;
 
 import com.facebook.react.ReactInstanceManager;
@@ -15,6 +14,8 @@ import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
 import com.reactnativenavigation.views.ReactComponent;
 
 import org.mockito.Mockito;
+
+import androidx.annotation.NonNull;
 
 import static com.reactnativenavigation.utils.ObjectUtils.perform;
 
@@ -49,12 +50,6 @@ public class SimpleViewController extends ChildController<SimpleViewController.S
     @Override
     public String toString() {
         return "SimpleViewController " + getId();
-    }
-
-    @Override
-    public void mergeOptions(Options options) {
-        performOnParentController(parentController -> parentController.mergeChildOptions(options, this));
-        super.mergeOptions(options);
     }
 
     @Override

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/child/ChildControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/child/ChildControllerTest.java
@@ -6,6 +6,7 @@ import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.presentation.Presenter;
 import com.reactnativenavigation.viewcontrollers.ChildController;
 import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
+import com.reactnativenavigation.viewcontrollers.ParentController;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -17,6 +18,7 @@ import static org.mockito.Mockito.verify;
 
 public class ChildControllerTest extends BaseTest {
 
+    private ParentController parent;
     private ChildController uut;
     private ChildControllersRegistry childRegistry;
     private Presenter presenter;
@@ -32,6 +34,8 @@ public class ChildControllerTest extends BaseTest {
                 return resolvedOptions;
             }
         };
+        parent = Mockito.mock(ParentController.class);
+        uut.setParentController(parent);
     }
 
     @Test
@@ -61,6 +65,13 @@ public class ChildControllerTest extends BaseTest {
     public void mergeOptions_emptyOptionsAreIgnored() {
         uut.mergeOptions(Options.EMPTY);
         verify(presenter, times(0)).mergeOptions(any(), any());
+    }
+
+    @Test
+    public void mergeOptions_mergeWithParentViewController() {
+        Options options = new Options();
+        uut.mergeOptions(options);
+        verify(uut.getParentController()).mergeChildOptions(options, uut);
     }
 
     @Test

--- a/playground/android/build.gradle
+++ b/playground/android/build.gradle
@@ -29,7 +29,7 @@ allprojects {
             url "$rootDir/../../node_modules/react-native/android"
         }
         maven { url "$rootDir/../../node_modules/detox/Detox-android" }
-        maven { url 'https://jitpack.io' }
+        maven { url 'https://www.jitpack.io' }
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
         maven { url "$rootDir/../../node_modules/jsc-android/dist" }
     }

--- a/playground/src/screens/FirstBottomTabScreen.js
+++ b/playground/src/screens/FirstBottomTabScreen.js
@@ -60,7 +60,7 @@ class FirstBottomTabScreen extends React.Component {
     }
   });
 
-  switchTabByComponentId = () => Navigation.mergeOptions(this, {
+  switchTabByComponentId = () => Navigation.mergeOptions('SecondTab', {
     bottomTabs: {
       currentTabId: 'SecondTab'
     }


### PR DESCRIPTION
Until now, mergeOptions would merge with parent controller only if mergeOptions was called with
a componentId. This commit fixes the issue and makes options merge correctly even when called with a layoutId.