### PR TITLE
Add docs for bottomTab requiring icon on Android

### DIFF
--- a/docs/docs/layout-types.md
+++ b/docs/docs/layout-types.md
@@ -148,6 +148,8 @@ const bottomTabs = {
 }
 ```
 
+!> Note! On Android an `icon` is required when using `bottomTabs`.
+
 ### Selecting tabs programmatically
 
 The selected index is a style property which can be updated using the `mergeOptions` command. In order to update the BottomTabs options, Pass the BottomTabs `componentId` or the `componentId` of one of its children.

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -564,9 +564,8 @@ export interface OptionsBottomTab {
   testID?: string;
   /**
    * Set the tab icon
-   * Note: On Android `icon` is required
    */
-  icon?: ImageRequireSource;
+  icon: ImageRequireSource;
   /**
    * Set the icon tint
    */

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -564,6 +564,7 @@ export interface OptionsBottomTab {
   testID?: string;
   /**
    * Set the tab icon
+   * Note: On Android `icon` is required
    */
   icon?: ImageRequireSource;
   /**


### PR DESCRIPTION
When creating a new project using this library with TypeScript I noticed that the definition for `icon` with `bottomTab` was optional, but I ran into a crash on Android when I omitted it.

It appears this issue has come up several times before:
https://github.com/wix/react-native-navigation/issues/4534
https://github.com/wix/react-native-navigation/issues/4684
https://github.com/wix/react-native-navigation/issues/4990
https://github.com/wix/react-native-navigation/issues/5331
https://github.com/wix/react-native-navigation/issues/5435
https://github.com/wix/react-native-navigation/issues/5492

From what I can tell when I investigated, this library is used on Android for bottom tabs: https://github.com/aurelhubert/ahbottomnavigation

I didn't see a way to create a bottom tab without an icon in that library and the icon is actually optional on iOS. Because of that it didn't seem like it made sense to update the TS definition.