### PR TITLE
Remove component if title is defined in mergeOptions

### DIFF
--- a/lib/ios/RNNBasePresenter.h
+++ b/lib/ios/RNNBasePresenter.h
@@ -12,7 +12,7 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 - (instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions;
 
-- (void)bindViewController:(UIViewController *)boundViewController;
+- (void)boundViewController:(UIViewController *)boundViewController;
 
 - (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions;
 

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -18,7 +18,7 @@
     return self;
 }
 
-- (void)bindViewController:(UIViewController <RNNLayoutProtocol> *)boundViewController {
+- (void)boundViewController:(UIViewController *)boundViewController {
     self.boundComponentId = boundViewController.layoutInfo.componentId;
     _boundViewController = boundViewController;
 }

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -89,7 +89,6 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 		[CATransaction begin];
 		[CATransaction setCompletionBlock:completion];
 		
-		[vc overrideOptions:newOptions];
 		[vc mergeOptions:newOptions];
 		
 		[CATransaction commit];

--- a/lib/ios/RNNComponentOptions.h
+++ b/lib/ios/RNNComponentOptions.h
@@ -7,4 +7,6 @@
 @property (nonatomic, strong) Text* alignment;
 @property (nonatomic, strong) Bool* waitForRender;
 
+- (BOOL)hasValue;
+
 @end

--- a/lib/ios/RNNComponentOptions.m
+++ b/lib/ios/RNNComponentOptions.m
@@ -13,4 +13,8 @@
 	return self;
 }
 
+- (BOOL)hasValue {
+	return _name.hasValue;
+}
+
 @end

--- a/lib/ios/RNNComponentPresenter.m
+++ b/lib/ios/RNNComponentPresenter.m
@@ -21,8 +21,8 @@
 	return self;
 }
 
-- (void)bindViewController:(UIViewController<RNNLayoutProtocol> *)bindedViewController {
-	[super bindViewController:bindedViewController];
+- (void)boundViewController:(UIViewController *)boundViewController {
+	[super boundViewController:boundViewController];
 	_navigationButtons = [[RNNNavigationButtons alloc] initWithViewController:self.boundViewController componentRegistry:_componentRegistry];
 }
 
@@ -80,9 +80,9 @@
 - (void)mergeOptions:(RNNNavigationOptions *)options resolvedOptions:(RNNNavigationOptions *)currentOptions {
     [super mergeOptions:options resolvedOptions:currentOptions];
 	RNNNavigationOptions * withDefault	= (RNNNavigationOptions *) [[currentOptions overrideOptions:options] withDefault:[self defaultOptions]];
-
 	UIViewController* viewController = self.boundViewController;
-	
+	[self removeTitleComponentIfNeeded:options];
+
 	if (options.backgroundImage.hasValue) {
 		[viewController setBackgroundImage:options.backgroundImage.get];
 	}
@@ -155,9 +155,6 @@
 
 	if (options.topBar.title.component.name.hasValue) {
 		[self setCustomNavigationTitleView:options perform:nil];
-	} else {
-		[_customTitleView removeFromSuperview];
-		_customTitleView = nil;
 	}
 
 	[self setTitleViewWithSubtitle:withDefault];
@@ -166,6 +163,13 @@
 		UIViewController *lastViewControllerInStack = viewController.navigationController.viewControllers.count > 1 ? viewController.navigationController.viewControllers[viewController.navigationController.viewControllers.count - 2] : viewController.navigationController.topViewController;
 	    RNNNavigationOptions * resolvedOptions	= (RNNNavigationOptions *) [[currentOptions overrideOptions:options] withDefault:[self defaultOptions]];
 		[lastViewControllerInStack applyBackButton:resolvedOptions.topBar.backButton];
+	}
+}
+
+- (void)removeTitleComponentIfNeeded:(RNNNavigationOptions *)options {
+	if (options.topBar.title.text.hasValue && !options.topBar.component.hasValue) {
+		[_customTitleView removeFromSuperview];
+		_customTitleView = nil;
 	}
 }
 

--- a/lib/ios/RNNSideMenuController.m
+++ b/lib/ios/RNNSideMenuController.m
@@ -16,7 +16,7 @@
 	self = [super initWithCenterViewController:self.center leftDrawerViewController:self.left rightDrawerViewController:self.right];
 	
 	self.presenter = presenter;
-	[self.presenter bindViewController:self];
+    [self.presenter boundViewController:self];
 	
 	self.defaultOptions = defaultOptions;
 	self.options = options;

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -183,7 +183,7 @@
 		506A2B1420973DFD00F43A95 /* RNNErrorHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 506A2B1220973DFD00F43A95 /* RNNErrorHandler.h */; };
 		506A2B1520973DFD00F43A95 /* RNNErrorHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 506A2B1320973DFD00F43A95 /* RNNErrorHandler.m */; };
 		506F630D216A599300AD0D0A /* RNNTabBarControllerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 506F630C216A599300AD0D0A /* RNNTabBarControllerTest.m */; };
-		506F630F216A5AD700AD0D0A /* RNNViewControllerPresenterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 506F630E216A5AD700AD0D0A /* RNNViewControllerPresenterTest.m */; };
+		506F630F216A5AD700AD0D0A /* RNNComponentPresenterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 506F630E216A5AD700AD0D0A /* RNNComponentPresenterTest.m */; };
 		50706E6D20CE7CA5003345C3 /* UIImage+tint.h in Headers */ = {isa = PBXBuildFile; fileRef = 50706E6B20CE7CA5003345C3 /* UIImage+tint.h */; };
 		50706E6E20CE7CA5003345C3 /* UIImage+tint.m in Sources */ = {isa = PBXBuildFile; fileRef = 50706E6C20CE7CA5003345C3 /* UIImage+tint.m */; };
 		507E7D57201DDD3000444E6C /* RNNSharedElementAnimationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 507E7D55201DDD3000444E6C /* RNNSharedElementAnimationOptions.h */; };
@@ -531,7 +531,7 @@
 		506A2B1220973DFD00F43A95 /* RNNErrorHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNErrorHandler.h; sourceTree = "<group>"; };
 		506A2B1320973DFD00F43A95 /* RNNErrorHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNErrorHandler.m; sourceTree = "<group>"; };
 		506F630C216A599300AD0D0A /* RNNTabBarControllerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNTabBarControllerTest.m; sourceTree = "<group>"; };
-		506F630E216A5AD700AD0D0A /* RNNViewControllerPresenterTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNViewControllerPresenterTest.m; sourceTree = "<group>"; };
+		506F630E216A5AD700AD0D0A /* RNNComponentPresenterTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNComponentPresenterTest.m; sourceTree = "<group>"; };
 		50706E6B20CE7CA5003345C3 /* UIImage+tint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+tint.h"; sourceTree = "<group>"; };
 		50706E6C20CE7CA5003345C3 /* UIImage+tint.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+tint.m"; sourceTree = "<group>"; };
 		507E7D55201DDD3000444E6C /* RNNSharedElementAnimationOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNSharedElementAnimationOptions.h; sourceTree = "<group>"; };
@@ -1054,7 +1054,7 @@
 				504753772109C13C00FFFBE6 /* RNNOverlayManagerTest.m */,
 				505EDD31214E4BE80071C7DE /* RNNNavigationControllerTest.m */,
 				506F630C216A599300AD0D0A /* RNNTabBarControllerTest.m */,
-				506F630E216A5AD700AD0D0A /* RNNViewControllerPresenterTest.m */,
+				506F630E216A5AD700AD0D0A /* RNNComponentPresenterTest.m */,
 				509B258E2178BE7A00C83C23 /* RNNStackPresenterTest.m */,
 				502F0E172179C39900367CC3 /* RNNTabBarPresenterTest.m */,
 				50CE8502217C6C9B00084EBF /* RNNSideMenuPresenterTest.m */,
@@ -1474,7 +1474,7 @@
 				502F0E162178D09600367CC3 /* RNNBasePresenterTest.m in Sources */,
 				504753782109C13C00FFFBE6 /* RNNOverlayManagerTest.m in Sources */,
 				502F0E182179C39900367CC3 /* RNNTabBarPresenterTest.m in Sources */,
-				506F630F216A5AD700AD0D0A /* RNNViewControllerPresenterTest.m in Sources */,
+				506F630F216A5AD700AD0D0A /* RNNComponentPresenterTest.m in Sources */,
 				505963F722676A0000EBB63C /* RNNLayoutManagerTest.m in Sources */,
 				7B49FECE1E95098500DEB3EA /* RNNCommandsHandlerTest.m in Sources */,
 				E5F6C3AB22DB4D0F0093C2CE /* UIColor+RNNUtils.m in Sources */,

--- a/lib/ios/ReactNativeNavigationTests/RNNBasePresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNBasePresenterTest.m
@@ -20,7 +20,7 @@
     self.uut = [[RNNBasePresenter alloc] init];
     self.boundViewController = [RNNComponentViewController new];
     self.mockBoundViewController = [OCMockObject partialMockForObject:self.boundViewController];
-    [self.uut bindViewController:self.mockBoundViewController];
+    [self.uut boundViewController:self.mockBoundViewController];
     self.options = [[RNNNavigationOptions alloc] initEmptyOptions];
 }
 
@@ -45,7 +45,7 @@
 }
 
 - (void)testApplyOptions_setTabBarItemBadgeShouldNotCalledOnUITabBarController {
-    [self.uut bindViewController:self.mockBoundViewController];
+    [self.uut boundViewController:self.mockBoundViewController];
     self.options.bottomTab.badge = [[Text alloc] initWithValue:@"badge"];
     [[self.mockBoundViewController reject] setTabBarItemBadge:[[RNNBottomTabOptions alloc] initWithDict:@{@"badge": @"badge"}]];
     [self.uut applyOptions:self.options];
@@ -53,7 +53,7 @@
 }
 
 - (void)testApplyOptions_setTabBarItemBadgeShouldWhenNoValue {
-    [self.uut bindViewController:self.mockBoundViewController];
+    [self.uut boundViewController:self.mockBoundViewController];
     self.options.bottomTab.badge = nil;
     [[self.mockBoundViewController reject] setTabBarItemBadge:[OCMArg any]];
     [self.uut applyOptions:self.options];

--- a/lib/ios/ReactNativeNavigationTests/RNNSideMenuPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNSideMenuPresenterTest.m
@@ -17,7 +17,7 @@
     [super setUp];
 	self.uut = [[RNNSideMenuPresenter alloc] init];
 	self.bindedViewController = [OCMockObject partialMockForObject:[RNNSideMenuController new]];
-	[self.uut bindViewController:self.bindedViewController];
+    [self.uut boundViewController:self.bindedViewController];
 	self.options = [[RNNNavigationOptions alloc] initEmptyOptions];
 }
 

--- a/lib/ios/ReactNativeNavigationTests/RNNStackPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNStackPresenterTest.m
@@ -18,7 +18,7 @@
 	[super setUp];
 	self.uut = [[RNNStackPresenter alloc] init];
 	self.boundViewController = [OCMockObject partialMockForObject:[RNNStackController new]];
-	[self.uut bindViewController:self.boundViewController];
+    [self.uut boundViewController:self.boundViewController];
 	self.options = [[RNNNavigationOptions alloc] initEmptyOptions];
 }
 

--- a/lib/ios/ReactNativeNavigationTests/RNNTabBarPresenterTest.m
+++ b/lib/ios/ReactNativeNavigationTests/RNNTabBarPresenterTest.m
@@ -18,7 +18,7 @@
     [super setUp];
     self.uut = [OCMockObject partialMockForObject:[RNNBottomTabsPresenter new]];
     self.boundViewController = [OCMockObject partialMockForObject:[RNNBottomTabsController new]];
-    [self.uut bindViewController:self.boundViewController];
+    [self.uut boundViewController:self.boundViewController];
     self.options = [[RNNNavigationOptions alloc] initEmptyOptions];
 }
 

--- a/lib/ios/UIViewController+LayoutProtocol.m
+++ b/lib/ios/UIViewController+LayoutProtocol.m
@@ -22,7 +22,7 @@
 		[self performSelector:@selector(setViewControllers:) withObject:childViewControllers];
 	}
 	self.presenter = presenter;
-	[self.presenter bindViewController:self];
+    [self.presenter boundViewController:self];
 	[self.presenter applyOptionsOnInit:self.resolveOptions];
 
 	return self;


### PR DESCRIPTION
When mergeOptions was called without a title component, existing component was undesirably removed.
This commit changes how component is removed when mergeOptions is called. It will now be removed if a component is not defined and title is defined in mergeOptions.
Fixes #5628