### PR TITLE
Add bottomTabs.preferLargeIcons option

### DIFF
--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.material:material:1.1.0-alpha08'
 
-    implementation 'com.github.wix-playground:ahbottomnavigation:3.0.5'
+    implementation 'com.github.wix-playground:ahbottomnavigation:3.0.8'
     implementation 'com.github.wix-playground:reflow-animator:1.0.4'
     implementation 'com.github.clans:fab:1.6.4'
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabsOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabsOptions.java
@@ -30,6 +30,7 @@ public class BottomTabsOptions {
 		options.currentTabIndex = NumberParser.parse(json,"currentTabIndex");
 		options.visible = BoolParser.parse(json,"visible");
         options.drawBehind = BoolParser.parse(json, "drawBehind");
+        options.preferLargeIcons = BoolParser.parse(json, "preferLargeIcons");
 		options.animate = BoolParser.parse(json,"animate");
         options.elevation = FractionParser.parse(json, "elevation");
         options.testId = TextParser.parse(json, "testID");
@@ -43,6 +44,7 @@ public class BottomTabsOptions {
 	public Bool visible = new NullBool();
     public Bool drawBehind = new NullBool();
 	public Bool animate = new NullBool();
+    public Bool preferLargeIcons = new NullBool();
 	public Number currentTabIndex = new NullNumber();
 	public Fraction elevation = new NullFraction();
 	public Text currentTabId = new NullText();
@@ -56,6 +58,7 @@ public class BottomTabsOptions {
 		if (other.visible.hasValue()) visible = other.visible;
         if (other.drawBehind.hasValue()) drawBehind = other.drawBehind;
 		if (other.animate.hasValue()) animate = other.animate;
+        if (other.preferLargeIcons.hasValue()) preferLargeIcons = other.preferLargeIcons;
         if (other.elevation.hasValue()) elevation = other.elevation;
         if (other.backgroundColor.hasValue()) backgroundColor = other.backgroundColor;
         if (other.testId.hasValue()) testId = other.testId;
@@ -69,6 +72,7 @@ public class BottomTabsOptions {
         if (!visible.hasValue()) visible = defaultOptions.visible;
         if (!drawBehind.hasValue()) drawBehind = defaultOptions.drawBehind;
         if (!animate.hasValue()) animate = defaultOptions.animate;
+        if (!preferLargeIcons.hasValue()) preferLargeIcons = defaultOptions.preferLargeIcons;
         if (!elevation.hasValue()) elevation = defaultOptions.elevation;
         if (!backgroundColor.hasValue()) backgroundColor = defaultOptions.backgroundColor;
         if (!titleDisplayMode.hasValue()) titleDisplayMode = defaultOptions.titleDisplayMode;

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsPresenter.java
@@ -68,6 +68,7 @@ public class BottomTabsPresenter {
         AnimationsOptions animations = options.animations;
 
         if (options.layout.direction.hasValue()) bottomTabs.setLayoutDirection(options.layout.direction);
+        if (bottomTabsOptions.preferLargeIcons.hasValue()) bottomTabs.setPreferLargeIcons(bottomTabsOptions.preferLargeIcons.get());
         if (bottomTabsOptions.titleDisplayMode.hasValue()) {
             bottomTabs.setTitleState(bottomTabsOptions.titleDisplayMode.toState());
         }
@@ -114,6 +115,7 @@ public class BottomTabsPresenter {
         AnimationsOptions animationsOptions = options.animations;
 
         bottomTabs.setLayoutDirection(options.layout.direction);
+        bottomTabs.setPreferLargeIcons(options.bottomTabsOptions.preferLargeIcons.get(false));
         bottomTabs.setTitleState(bottomTabsOptions.titleDisplayMode.get(TitleState.SHOW_WHEN_ACTIVE));
         bottomTabs.setBackgroundColor(bottomTabsOptions.backgroundColor.get(Color.WHITE));
         if (bottomTabsOptions.currentTabIndex.hasValue()) {

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -481,6 +481,12 @@ export interface OptionsBottomTabs {
    */
   animate?: boolean;
   /**
+   * Use large icons when possible, even when three tabs without titles are displayed
+   * #### (android specific)
+   * @default false
+   */
+  preferLargeIcons?: boolean;
+  /**
    * Switch to another screen within the bottom tabs via index (starting from 0)
    */
   currentTabIndex?: number;


### PR DESCRIPTION
This option is used to force large icons to be displayed when only three icons, without titles, are present on the screen.