### PR TITLE
DrawBehind when tabs are hidden

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabsOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/BottomTabsOptions.java
@@ -79,6 +79,10 @@ public class BottomTabsOptions {
         if (!tabsAttachMode.hasValue()) tabsAttachMode = defaultOptions.tabsAttachMode;
     }
 
+    public boolean isHiddenOrDrawBehind() {
+        return visible.isFalse() || drawBehind.isTrue();
+    }
+
     public void clearOneTimeOptions() {
         currentTabId = new NullText();
         currentTabIndex = new NullNumber();

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ChildController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ChildController.java
@@ -71,8 +71,8 @@ public abstract class ChildController<T extends ViewGroup> extends ViewControlle
     public void mergeOptions(Options options) {
         if (options == Options.EMPTY) return;
         if (isViewShown()) presenter.mergeOptions(getView(), options);
-        performOnParentController(parentController -> parentController.mergeChildOptions(options, this));
         super.mergeOptions(options);
+        performOnParentController(parentController -> parentController.mergeChildOptions(options, this));
     }
 
     @Override

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -177,7 +177,7 @@ public class BottomTabsController extends ParentController<BottomTabsLayout> imp
 
     @Override
     public int getBottomInset(ViewController child) {
-        int bottomTabsInset = resolveChildOptions(child).bottomTabsOptions.drawBehind.isTrue() ? 0 : bottomTabs.getHeight();
+        int bottomTabsInset = resolveChildOptions(child).bottomTabsOptions.isHiddenOrDrawBehind() ? 0 : bottomTabs.getHeight();
         return bottomTabsInset + perform(getParentController(), 0, p -> p.getBottomInset(this));
     }
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/mocks/SimpleViewController.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/mocks/SimpleViewController.java
@@ -7,6 +7,7 @@ import android.view.MotionEvent;
 import com.facebook.react.ReactInstanceManager;
 import com.reactnativenavigation.interfaces.ScrollEventListener;
 import com.reactnativenavigation.parse.Options;
+import com.reactnativenavigation.presentation.ComponentPresenterBase;
 import com.reactnativenavigation.presentation.Presenter;
 import com.reactnativenavigation.react.ReactView;
 import com.reactnativenavigation.viewcontrollers.ChildController;
@@ -20,7 +21,7 @@ import androidx.annotation.NonNull;
 import static com.reactnativenavigation.utils.ObjectUtils.perform;
 
 public class SimpleViewController extends ChildController<SimpleViewController.SimpleView> {
-
+    private ComponentPresenterBase presenter = new ComponentPresenterBase();
 
     public SimpleViewController(Activity activity, ChildControllersRegistry childRegistry, String id, Options options) {
         this(activity, childRegistry, id, new Presenter(activity, new Options()), options);
@@ -56,6 +57,11 @@ public class SimpleViewController extends ChildController<SimpleViewController.S
     public int getTopInset() {
         int statusBarInset = resolveCurrentOptions().statusBar.drawBehind.isTrue() ? 0 : 63;
         return statusBarInset + perform(getParentController(), 0, p -> p.getTopInset(this));
+    }
+
+    @Override
+    public void applyBottomInset() {
+        if (view != null) presenter.applyBottomInset(view, getBottomInset());
     }
 
     public static class SimpleView extends ReactView implements ReactComponent {

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.java
@@ -210,17 +210,17 @@ public class BottomTabsControllerTest extends BaseTest {
 
     @Test
     public void mergeOptions_drawBehind() {
-        assertThat(uut.getBottomInset()).isEqualTo(uut.getBottomTabs().getHeight());
+        assertThat(uut.getBottomInset(child1)).isEqualTo(uut.getBottomTabs().getHeight());
 
         Options o1 = new Options();
         o1.bottomTabsOptions.drawBehind = new Bool(true);
         child1.mergeOptions(o1);
-        assertThat(uut.getBottomInset()).isEqualTo(0);
+        assertThat(uut.getBottomInset(child1)).isEqualTo(0);
 
         Options o2 = new Options();
         o2.topBar.title.text = new Text("Some text");
         child1.mergeOptions(o1);
-        assertThat(uut.getBottomInset()).isEqualTo(0);
+        assertThat(uut.getBottomInset(child1)).isEqualTo(0);
     }
 
     @Test

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.graphics.Color;
 import android.view.Gravity;
 import android.view.View;
+import android.view.ViewGroup.MarginLayoutParams;
 
 import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.TestUtils;
@@ -27,6 +28,7 @@ import com.reactnativenavigation.viewcontrollers.ParentController;
 import com.reactnativenavigation.viewcontrollers.ViewController;
 import com.reactnativenavigation.viewcontrollers.stack.StackController;
 import com.reactnativenavigation.views.BottomTabs;
+import com.reactnativenavigation.views.bottomtabs.BottomTabsLayout;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -84,7 +86,7 @@ public class BottomTabsControllerTest extends BaseTest {
         child1 = spy(new SimpleViewController(activity, childRegistry, "child1", tabOptions));
         child2 = spy(new SimpleViewController(activity, childRegistry, "child2", tabOptions));
         child3 = spy(new SimpleViewController(activity, childRegistry, "child3", tabOptions));
-        child4 = spy(createStack("someStack"));
+        child4 = spy(createStack());
         child5 = spy(new SimpleViewController(activity, childRegistry, "child5", tabOptions));
         when(child5.handleBack(any())).thenReturn(true);
         tabs = createTabs();
@@ -219,6 +221,23 @@ public class BottomTabsControllerTest extends BaseTest {
         o2.topBar.title.text = new Text("Some text");
         child1.mergeOptions(o1);
         assertThat(uut.getBottomInset()).isEqualTo(0);
+    }
+
+    @Test
+    public void mergeOptions_drawBehind_stack() {
+        uut.selectTab(3);
+
+        SimpleViewController stackChild = new SimpleViewController(activity, childRegistry, "stackChild", new Options());
+        disablePushAnimation(stackChild);
+        child4.push(stackChild, new CommandListenerAdapter());
+
+        assertThat(((MarginLayoutParams) stackChild.getView().getLayoutParams()).bottomMargin).isEqualTo(bottomTabs.getHeight());
+
+        Options o1 = new Options();
+        o1.bottomTabsOptions.drawBehind = new Bool(true);
+        stackChild.mergeOptions(o1);
+
+        assertThat(((MarginLayoutParams) stackChild.getView().getLayoutParams()).bottomMargin).isEqualTo(0);
     }
 
     @Test
@@ -369,9 +388,9 @@ public class BottomTabsControllerTest extends BaseTest {
         return Arrays.asList(child1, child2, child3, child4, child5);
     }
 
-    private StackController createStack(String id) {
+    private StackController createStack() {
         return TestUtils.newStackController(activity)
-                .setId(id)
+                .setId("someStack")
                 .setInitialOptions(tabOptions)
                 .build();
     }
@@ -399,6 +418,14 @@ public class BottomTabsControllerTest extends BaseTest {
             public void ensureViewIsCreated() {
                 super.ensureViewIsCreated();
                 uut.getView().layout(0, 0, 1000, 1000);
+            }
+
+            @NonNull
+            @Override
+            protected BottomTabsLayout createView() {
+                BottomTabsLayout view = super.createView();
+                bottomTabs.getLayoutParams().height = 100;
+                return view;
             }
 
             @NonNull


### PR DESCRIPTION
When BottomTabs are hidden, draw components behind the tabs even if drawBehind isn't set to true explicitly.