### PR TITLE
Create react host after SoLoader.init

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
@@ -1,8 +1,6 @@
 package com.reactnativenavigation;
 
 import android.app.Application;
-import androidx.annotation.Nullable;
-import androidx.annotation.NonNull;
 
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
@@ -14,6 +12,9 @@ import com.reactnativenavigation.viewcontrollers.externalcomponent.ExternalCompo
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public abstract class NavigationApplication extends Application implements ReactApplication {
 
@@ -38,7 +39,7 @@ public abstract class NavigationApplication extends Application implements React
      * @return a singleton {@link ReactGateway}
      */
 	protected ReactGateway createReactGateway() {
-	    return new ReactGateway(this, isDebug(), createReactNativeHost());
+	    return new ReactGateway(this, isDebug(), this::createReactNativeHost);
     }
 
     protected ReactNativeHost createReactNativeHost() {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/ReactGateway.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/ReactGateway.java
@@ -8,6 +8,7 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
 import com.reactnativenavigation.NavigationActivity;
+import com.reactnativenavigation.utils.Functions.FuncR;
 
 import java.util.List;
 
@@ -22,15 +23,20 @@ public class ReactGateway {
 		this(application, isDebug, new NavigationReactNativeHost(application, isDebug, additionalReactPackages));
 	}
 
-	public ReactGateway(final Application application, final boolean isDebug, final ReactNativeHost host) {
+    @SuppressWarnings("WeakerAccess")
+    public ReactGateway(final Application application, final boolean isDebug, final ReactNativeHost host) {
+        this(application, isDebug, () -> host);
+    }
+
+    public ReactGateway(final Application application, final boolean isDebug, FuncR<ReactNativeHost> hostCreator) {
         SoLoader.init(application, false);
-		this.host = host;
-		initializer = new NavigationReactInitializer(host.getReactInstanceManager(), isDebug);
-		jsDevReloadHandler = new JsDevReloadHandler(host.getReactInstanceManager().getDevSupportManager());
+        this.host = hostCreator.run();
+        initializer = new NavigationReactInitializer(host.getReactInstanceManager(), isDebug);
+        jsDevReloadHandler = new JsDevReloadHandler(host.getReactInstanceManager().getDevSupportManager());
         if (host instanceof BundleDownloadListenerProvider) {
             ((BundleDownloadListenerProvider) host).setBundleLoaderListener(jsDevReloadHandler);
         }
-	}
+    }
 
 	public ReactNativeHost getReactNativeHost() {
 		return host;

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/Functions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/Functions.java
@@ -13,6 +13,10 @@ public class Functions {
         void run(T param);
     }
 
+    public interface FuncR<T> {
+        T run();
+    }
+
     public interface FuncR1<T, S> {
         S run(T param);
     }


### PR DESCRIPTION
Under certain configurations, creating ReactNativeHost before SoLoader.init throws an exception.
This commit changes the behaviour of the main ReactGateway constructor to ensures host is created after SoLoader.init.