### PR TITLE
Fix sending dismissed modal event when dismissing modal by swiping gesture

### DIFF
--- a/lib/ios/RNNModalManager.m
+++ b/lib/ios/RNNModalManager.m
@@ -124,6 +124,7 @@
 
 - (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
 	[_presentedModals removeObject:presentationController.presentedViewController];
+    [_delegate dismissedModal:presentationController.presentedViewController];
 }
 
 -(UIViewController*)topPresentedVC {

--- a/lib/src/events/ComponentEventsObserver.test.tsx
+++ b/lib/src/events/ComponentEventsObserver.test.tsx
@@ -175,9 +175,9 @@ describe('ComponentEventsObserver', () => {
     expect(navigationButtonPressedFn).toHaveBeenCalledTimes(1);
     expect(navigationButtonPressedFn).toHaveBeenCalledWith({ buttonId: 'myButtonId', componentId: 'myCompId' });
 
-    uut.notifyModalDismissed({ componentId: 'myCompId' });
+    uut.notifyModalDismissed({ componentId: 'myCompId', modalsDismissed: 1 });
     expect(modalDismissedFn).toHaveBeenCalledTimes(1);
-    expect(modalDismissedFn).toHaveBeenLastCalledWith({ componentId: 'myCompId' })
+    expect(modalDismissedFn).toHaveBeenLastCalledWith({ componentId: 'myCompId', modalsDismissed: 1 })
 
     uut.notifySearchBarUpdated({ componentId: 'myCompId', text: 'theText', isFocused: true });
     expect(searchBarUpdatedFn).toHaveBeenCalledTimes(1);

--- a/playground/ios/NavigationTests/RNNModalManagerTest.m
+++ b/playground/ios/NavigationTests/RNNModalManagerTest.m
@@ -1,4 +1,5 @@
 #import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
 #import "RNNModalManager.h"
 #import "RNNComponentViewController.h"
 
@@ -105,6 +106,27 @@
 - (void)testShowModal_CallPresentViewController {
 	[_modalManager showModal:_vc1 animated:NO completion:nil];
 	XCTAssertTrue(_modalManager.topPresentedVC.presentViewControllerCalls == 1);
+}
+
+- (void)testDismissModal_ShouldInvokeDelegateDismissedModal {
+	id mockDelegate = [OCMockObject mockForProtocol:@protocol(RNNModalManagerDelegate)];
+	_modalManager.delegate = mockDelegate;
+	[_modalManager showModal:_vc1 animated:NO completion:nil];
+	
+	[[mockDelegate expect] dismissedModal:_vc1];
+	[_modalManager dismissModal:_vc1 completion:nil];
+	[mockDelegate verify];
+}
+
+- (void)testPresentationControllerDidDismiss_ShouldInvokeDelegateDismissedModal {
+	id mockDelegate = [OCMockObject mockForProtocol:@protocol(RNNModalManagerDelegate)];
+	_modalManager.delegate = mockDelegate;
+	
+	UIPresentationController* presentationController = [[UIPresentationController alloc] initWithPresentedViewController:_vc2 presentingViewController:_vc1];
+	
+	[[mockDelegate expect] dismissedModal:_vc2];
+	[_modalManager presentationControllerDidDismiss:presentationController];
+	[mockDelegate verify];
 }
 
 #pragma mark RNNModalManagerDelegate


### PR DESCRIPTION
Closes https://github.com/wix/react-native-navigation/issues/5737

closes #5744