### PR TITLE
Fix incorrect bottom inset when hiding BottomTabs in default options

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsPresenter.java
@@ -151,4 +151,8 @@ public class BottomTabsPresenter {
         lp.bottomMargin = bottomInset;
         bottomTabs.requestLayout();
     }
+
+    public int getBottomInset(Options resolvedOptions) {
+        return resolvedOptions.withDefaultOptions(defaultOptions).bottomTabsOptions.isHiddenOrDrawBehind() ? 0 : bottomTabs.getHeight();
+    }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -174,8 +174,7 @@ public class BottomTabsController extends ParentController<BottomTabsLayout> imp
 
     @Override
     public int getBottomInset(ViewController child) {
-        int bottomTabsInset = resolveChildOptions(child).bottomTabsOptions.isHiddenOrDrawBehind() ? 0 : bottomTabs.getHeight();
-        return bottomTabsInset + perform(getParentController(), 0, p -> p.getBottomInset(this));
+        return presenter.getBottomInset(resolveChildOptions(child)) + perform(getParentController(), 0, p -> p.getBottomInset(this));
     }
 
     @Override

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.java
@@ -378,6 +378,16 @@ public class BottomTabsControllerTest extends BaseTest {
     }
 
     @Test
+    public void getBottomInset_defaultOptionsAreTakenIntoAccount() {
+        Options defaultOptions = new Options();
+        defaultOptions.bottomTabsOptions.visible = new Bool(false);
+
+        assertThat(uut.getBottomInset(child1)).isEqualTo(bottomTabs.getHeight());
+        uut.setDefaultOptions(defaultOptions);
+        assertThat(uut.getBottomInset(child1)).isZero();
+    }
+
+    @Test
     public void destroy() {
         uut.destroy();
         verify(tabsAttacher).destroy();


### PR DESCRIPTION
Default options were not taken into account when determining bottom inset.
Closes #5738