### PR TITLE
Add types for children property on TopTabs

### DIFF
--- a/lib/src/commands/LayoutTreeParser.ts
+++ b/lib/src/commands/LayoutTreeParser.ts
@@ -2,7 +2,7 @@ import { LayoutType } from './LayoutType';
 import { LayoutNode } from './LayoutTreeCrawler';
 import {
   Layout,
-  TopTabs,
+  LayoutTopTabs,
   LayoutComponent,
   LayoutStack,
   LayoutBottomTabs,
@@ -36,7 +36,7 @@ export class LayoutTreeParser {
     throw new Error(`unknown LayoutType "${Object.keys(api)}"`);
   }
 
-  private topTabs(api: TopTabs): LayoutNode {
+  private topTabs(api: LayoutTopTabs): LayoutNode {
     return {
       id: api.id || this.uniqueIdProvider.generate(LayoutType.TopTabs),
       type: LayoutType.TopTabs,
@@ -103,7 +103,11 @@ export class LayoutTreeParser {
     return {
       id: api.id || this.uniqueIdProvider.generate(LayoutType.Component),
       type: LayoutType.Component,
-      data: { name: api.name.toString(), options: api.options, passProps: api.passProps },
+      data: {
+        name: api.name.toString(),
+        options: api.options,
+        passProps: api.passProps
+      },
       children: []
     };
   }
@@ -112,7 +116,11 @@ export class LayoutTreeParser {
     return {
       id: api.id || this.uniqueIdProvider.generate(LayoutType.ExternalComponent),
       type: LayoutType.ExternalComponent,
-      data: { name: api.name.toString(), options: api.options, passProps: api.passProps },
+      data: {
+        name: api.name.toString(),
+        options: api.options,
+        passProps: api.passProps
+      },
       children: []
     };
   }

--- a/lib/src/interfaces/Layout.ts
+++ b/lib/src/interfaces/Layout.ts
@@ -46,7 +46,7 @@ export interface LayoutStack {
   options?: Options;
 }
 
-export interface LayoutBottomTabsChildren {
+export interface LayoutTabsChildren {
   /**
    * Set stack
    */
@@ -70,7 +70,7 @@ export interface LayoutBottomTabs {
   /**
    * Set the children screens
    */
-  children?: LayoutBottomTabsChildren[];
+  children?: LayoutTabsChildren[];
   /**
    * Set the bottom tabs options
    */
@@ -121,7 +121,7 @@ export interface LayoutSplitView {
   options?: Options;
 }
 
-export interface TopTabs {
+export interface LayoutTopTabs {
   /**
    * Set the layout's id so Navigation.mergeOptions can be used to update options
    */
@@ -129,7 +129,7 @@ export interface TopTabs {
   /**
    * Set the children screens
    */
-  children?: any[];
+  children?: LayoutTabsChildren[];
   /**
    * Configure top tabs
    */
@@ -188,7 +188,7 @@ export interface Layout<P = {}> {
   /**
    * Set the top tabs
    */
-  topTabs?: TopTabs;
+  topTabs?: LayoutTopTabs;
   /**
    * Set the external component
    */


### PR DESCRIPTION
Fixes #5570 

Added type `LayoutTabsChildren[]` on the `children` property of `TopTabs` inside Layout (before was `any[]`. Also unified the naming of the export to be prefixed by `Layout + component name` as the other components exported from the layout.

