### PR TITLE
Added TitleState showWhenActiveForce option for bottomTabs

### DIFF
--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -285,7 +285,7 @@ Navigation.mergeOptions(this.props.componentId, {
   },
   bottomTabs: {
     elevation: 8, // BottomTabs elevation in dp
-    titleDisplayMode: 'alwaysShow' | 'showWhenActive' | 'alwaysHide' // Sets the title state for each tab.
+    titleDisplayMode: 'alwaysShow' | 'showWhenActive' | 'alwaysHide' | 'showWhenActiveForce' // Sets the title state for each tab. (showWhenActiveForce to be used when showWhenActive doesn't work, e.g. with three bottom tabs)
   },
   bottomTab: {
     selectedFontSize: 19 // Selected tab font size in sp

--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.material:material:1.1.0-alpha08'
 
-    implementation 'com.github.wix-playground:ahbottomnavigation:3.0.8'
+    implementation 'com.github.wix-playground:ahbottomnavigation:3.0.9'
     implementation 'com.github.wix-playground:reflow-animator:1.0.4'
     implementation 'com.github.clans:fab:1.6.4'
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/params/TitleDisplayMode.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/params/TitleDisplayMode.java
@@ -7,7 +7,7 @@ import com.aurelhubert.ahbottomnavigation.AHBottomNavigation.TitleState;
 import javax.annotation.Nullable;
 
 public enum TitleDisplayMode {
-    ALWAYS_SHOW(TitleState.ALWAYS_SHOW), SHOW_WHEN_ACTIVE(TitleState.SHOW_WHEN_ACTIVE), ALWAYS_HIDE(TitleState.ALWAYS_HIDE), UNDEFINED(null);
+    ALWAYS_SHOW(TitleState.ALWAYS_SHOW), SHOW_WHEN_ACTIVE(TitleState.SHOW_WHEN_ACTIVE), ALWAYS_HIDE(TitleState.ALWAYS_HIDE), SHOW_WHEN_ACTIVE_FORCE(TitleState.SHOW_WHEN_ACTIVE_FORCE), UNDEFINED(null);
 
     public static TitleDisplayMode fromString(String mode) {
         switch (mode) {
@@ -17,6 +17,8 @@ public enum TitleDisplayMode {
                 return SHOW_WHEN_ACTIVE;
             case Constants.ALWAYS_HIDE:
                 return ALWAYS_HIDE;
+            case Constants.SHOW_WHEN_ACTIVE_FORCE:
+                return SHOW_WHEN_ACTIVE_FORCE;
             default:
                 return UNDEFINED;
         }
@@ -45,6 +47,7 @@ public enum TitleDisplayMode {
     private static class Constants {
         static final String ALWAYS_SHOW = "alwaysShow";
         static final String SHOW_WHEN_ACTIVE = "showWhenActive";
+        static final String SHOW_WHEN_ACTIVE_FORCE = "showWhenActiveForce";
         static final String ALWAYS_HIDE = "alwaysHide";
     }
 }

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -532,7 +532,7 @@ export interface OptionsBottomTabs {
    * Control the text display mode below the tab icon
    * #### (Android specific)
    */
-  titleDisplayMode?: 'alwaysShow' | 'showWhenActive' | 'alwaysHide';
+  titleDisplayMode?: 'alwaysShow' | 'showWhenActive' | 'alwaysHide' | 'showWhenActiveForce';
   /**
    * Set the elevation of the Bottom Tabs in dp
    * #### (Android specific)


### PR DESCRIPTION
### Android Bottom Navigation Tabs

_**Related Issue**_
Closes #5800

_**Description**_
When playing around with [AHBottomNavigation](https://github.com/aurelhubert/ahbottomnavigation) demo app, in order to only show to title of the active bottom tab when there's three tabs, the `TitleState` needs to be set to `SHOW_WHEN_ACTIVE_FORCE`. 

Adding these changes allow for this behavior in RNN, but when I'm clicking on a tab, the app dies. I only added this change to the playground app, to the bottomTabs root in `app.js`:

```
options: {
  bottomTabs: {
    titleDisplayMode: 'showWhenActiveForce'
  }
}
```

Would anyone have a pointer on how to fix this or how to figure out what's wrong?