### PR TITLE
Hide back button in mergeOptions

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/BackButton.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/BackButton.java
@@ -65,4 +65,9 @@ public class BackButton extends Button {
         visible = new Bool(true);
         hasValue = true;
     }
+
+    public void setHidden() {
+        visible = new Bool(false);
+        hasValue = true;
+    }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutFactory.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/LayoutFactory.java
@@ -20,6 +20,7 @@ import com.reactnativenavigation.viewcontrollers.ComponentViewController;
 import com.reactnativenavigation.viewcontrollers.ViewController;
 import com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabsAttacher;
 import com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabsController;
+import com.reactnativenavigation.viewcontrollers.button.NavigationIconResolver;
 import com.reactnativenavigation.viewcontrollers.externalcomponent.ExternalComponentCreator;
 import com.reactnativenavigation.viewcontrollers.externalcomponent.ExternalComponentViewController;
 import com.reactnativenavigation.viewcontrollers.sidemenu.SideMenuController;
@@ -186,7 +187,7 @@ public class LayoutFactory {
                         new TitleBarReactViewCreator(reactInstanceManager),
                         new TopBarBackgroundViewCreator(reactInstanceManager),
                         new TitleBarButtonCreator(reactInstanceManager),
-                        new ImageLoader(),
+                        new NavigationIconResolver(activity, new ImageLoader()),
                         new RenderChecker(),
                         defaultOptions
                 ))

--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/StackPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/StackPresenter.java
@@ -21,7 +21,6 @@ import com.reactnativenavigation.parse.params.Button;
 import com.reactnativenavigation.parse.params.Colour;
 import com.reactnativenavigation.utils.ButtonPresenter;
 import com.reactnativenavigation.utils.CollectionUtils;
-import com.reactnativenavigation.utils.ImageLoader;
 import com.reactnativenavigation.utils.ObjectUtils;
 import com.reactnativenavigation.utils.StatusBarUtils;
 import com.reactnativenavigation.utils.UiUtils;
@@ -65,7 +64,6 @@ public class StackPresenter {
     private TopBarController topBarController;
     private final TitleBarReactViewCreator titleViewCreator;
     private TitleBarButtonController.OnClickListener onClickListener;
-    private final ImageLoader imageLoader;
     private final RenderChecker renderChecker;
     private final TopBarBackgroundViewCreator topBarBackgroundViewCreator;
     private final ReactViewCreator buttonCreator;
@@ -76,19 +74,20 @@ public class StackPresenter {
     private Map<View, TopBarBackgroundViewController> backgroundControllers = new HashMap();
     private Map<View, Map<String, TitleBarButtonController>> componentRightButtons = new HashMap();
     private Map<View, Map<String, TitleBarButtonController>> componentLeftButtons = new HashMap();
+    private NavigationIconResolver iconResolver;
 
     public StackPresenter(Activity activity,
                           TitleBarReactViewCreator titleViewCreator,
                           TopBarBackgroundViewCreator topBarBackgroundViewCreator,
                           ReactViewCreator buttonCreator,
-                          ImageLoader imageLoader,
+                          NavigationIconResolver iconResolver,
                           RenderChecker renderChecker,
                           Options defaultOptions) {
         this.activity = activity;
         this.titleViewCreator = titleViewCreator;
         this.topBarBackgroundViewCreator = topBarBackgroundViewCreator;
         this.buttonCreator = buttonCreator;
-        this.imageLoader = imageLoader;
+        this.iconResolver = iconResolver;
         this.renderChecker = renderChecker;
         this.defaultOptions = defaultOptions;
         defaultTitleFontSize = UiUtils.dpToSp(activity, 18);
@@ -311,8 +310,7 @@ public class StackPresenter {
 
     private TitleBarButtonController createButtonController(Button button) {
         TitleBarButtonController controller = new TitleBarButtonController(activity,
-                new NavigationIconResolver(activity, imageLoader),
-                imageLoader,
+                iconResolver,
                 new ButtonPresenter(topBar.getTitleBar(), button),
                 button,
                 buttonCreator,
@@ -379,7 +377,13 @@ public class StackPresenter {
             }
         }
         if (buttons.left != null) topBar.setLeftButtons(leftButtonControllers);
-        if (buttons.back.hasValue()) topBar.setBackButton(createButtonController(buttons.back));
+        if (buttons.back.hasValue()) {
+            if (buttons.back.visible.isFalse()) {
+                topBar.clearLeftButtons();
+            } else {
+                topBar.setBackButton(createButtonController(buttons.back));
+            }
+        }
 
         if (options.rightButtonColor.hasValue()) topBar.setOverflowButtonColor(options.rightButtonColor.get());
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/ImageLoader.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/ImageLoader.java
@@ -1,5 +1,6 @@
 package com.reactnativenavigation.utils;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -7,9 +8,11 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.StrictMode;
+import android.view.View;
 
 import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper;
 import com.reactnativenavigation.NavigationApplication;
+import com.reactnativenavigation.R;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -20,6 +23,7 @@ import java.util.List;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 
 public class ImageLoader {
 
@@ -32,6 +36,11 @@ public class ImageLoader {
     }
 
     private static final String FILE_SCHEME = "file";
+
+    public Drawable getBackButtonIcon(Activity context) {
+        boolean isRTL = context.getWindow().getDecorView().getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+        return ContextCompat.getDrawable(context, isRTL ? R.drawable.ic_arrow_back_black_rtl_24dp : R.drawable.ic_arrow_back_black_24dp);
+    }
 
     @Nullable
     public Drawable loadIcon(Context context, @Nullable String uri) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/TitleBarButtonController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/TitleBarButtonController.java
@@ -22,7 +22,6 @@ import com.reactnativenavigation.utils.ViewUtils;
 import com.reactnativenavigation.viewcontrollers.button.NavigationIconResolver;
 import com.reactnativenavigation.views.titlebar.TitleBarReactButtonView;
 
-import java.util.Collections;
 import java.util.List;
 
 import androidx.annotation.NonNull;
@@ -36,7 +35,6 @@ public class TitleBarButtonController extends ViewController<TitleBarReactButton
     }
 
     private final NavigationIconResolver navigationIconResolver;
-    private final ImageLoader imageLoader;
     private ButtonPresenter optionsPresenter;
     private final Button button;
     private final ReactViewCreator viewCreator;
@@ -54,14 +52,12 @@ public class TitleBarButtonController extends ViewController<TitleBarReactButton
 
     public TitleBarButtonController(Activity activity,
                                     NavigationIconResolver navigationIconResolver,
-                                    ImageLoader imageLoader,
                                     ButtonPresenter optionsPresenter,
                                     Button button,
                                     ReactViewCreator viewCreator,
                                     OnClickListener onClickListener) {
         super(activity, button.id, new YellowBoxDelegate(), new Options());
         this.navigationIconResolver = navigationIconResolver;
-        this.imageLoader = imageLoader;
         this.optionsPresenter = optionsPresenter;
         this.button = button;
         this.viewCreator = viewCreator;
@@ -104,8 +100,7 @@ public class TitleBarButtonController extends ViewController<TitleBarReactButton
     }
 
     public void applyNavigationIcon(Toolbar toolbar) {
-        Integer direction = getActivity().getWindow().getDecorView().getLayoutDirection();
-        navigationIconResolver.resolve(button, direction, icon -> {
+        navigationIconResolver.resolve(button, icon -> {
             setIconColor(icon);
             toolbar.setNavigationOnClickListener(view -> onPressListener.onPress(button.id));
             toolbar.setNavigationIcon(icon);
@@ -134,8 +129,7 @@ public class TitleBarButtonController extends ViewController<TitleBarReactButton
             if (button.hasIcon()) {
                 loadIcon(new ImageLoadingListenerAdapter() {
                     @Override
-                    public void onComplete(@NonNull List<Drawable> icons) {
-                        Drawable icon = icons.get(0);
+                    public void onComplete(@NonNull Drawable icon) {
                         TitleBarButtonController.this.icon = icon;
                         setIconColor(icon);
                         menuItem.setIcon(icon);
@@ -151,7 +145,7 @@ public class TitleBarButtonController extends ViewController<TitleBarReactButton
     }
 
     private void loadIcon(ImageLoader.ImagesLoadingListener callback) {
-        imageLoader.loadIcons(getActivity(), Collections.singletonList(button.icon.get()), callback);
+        navigationIconResolver.resolve(button, callback::onComplete);
     }
 
     private void setIconColor(Drawable icon) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/button/NavigationIconResolver.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/button/NavigationIconResolver.java
@@ -1,31 +1,29 @@
 package com.reactnativenavigation.viewcontrollers.button;
 
-import android.content.Context;
+import android.app.Activity;
 import android.graphics.drawable.Drawable;
-import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
 import android.util.Log;
-import android.view.View;
 
-import com.reactnativenavigation.R;
 import com.reactnativenavigation.parse.params.Button;
 import com.reactnativenavigation.react.Constants;
 import com.reactnativenavigation.utils.Functions.Func1;
 import com.reactnativenavigation.utils.ImageLoader;
 import com.reactnativenavigation.utils.ImageLoadingListenerAdapter;
 
+import androidx.annotation.NonNull;
+
 public class NavigationIconResolver {
 
-    private Context context;
+    private Activity context;
     private ImageLoader imageLoader;
 
-    public NavigationIconResolver(Context context, ImageLoader imageLoader) {
+    public NavigationIconResolver(Activity context, ImageLoader imageLoader) {
         this.context = context;
         this.imageLoader = imageLoader;
     }
 
-    public void resolve(Button button, Integer direction, Func1<Drawable> onSuccess) {
-        if (button.icon.hasValue()) {
+    public void resolve(Button button, Func1<Drawable> onSuccess) {
+        if (button.hasIcon()) {
             imageLoader.loadIcon(context, button.icon.get(), new ImageLoadingListenerAdapter() {
                 @Override
                 public void onComplete(@NonNull Drawable icon) {
@@ -38,8 +36,7 @@ public class NavigationIconResolver {
                 }
             });
         } else if (Constants.BACK_BUTTON_ID.equals(button.id)) {
-            Boolean isRTL = direction == View.LAYOUT_DIRECTION_RTL;
-            onSuccess.run(ContextCompat.getDrawable(context, isRTL ? R.drawable.ic_arrow_back_black_rtl_24dp : R.drawable.ic_arrow_back_black_24dp));
+            onSuccess.run(imageLoader.getBackButtonIcon(context));
         } else {
             Log.w("RNN", "Left button needs to have an icon");
         }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/TestUtils.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/TestUtils.java
@@ -17,6 +17,7 @@ import com.reactnativenavigation.utils.ImageLoader;
 import com.reactnativenavigation.utils.UiUtils;
 import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
 import com.reactnativenavigation.viewcontrollers.ViewController;
+import com.reactnativenavigation.viewcontrollers.button.NavigationIconResolver;
 import com.reactnativenavigation.viewcontrollers.stack.StackControllerBuilder;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarController;
 import com.reactnativenavigation.views.StackLayout;
@@ -38,7 +39,7 @@ public class TestUtils {
                 .setId("stack")
                 .setChildRegistry(new ChildControllersRegistry())
                 .setTopBarController(topBarController)
-                .setStackPresenter(new StackPresenter(activity, new TitleBarReactViewCreatorMock(), new TopBarBackgroundViewCreatorMock(), new TopBarButtonCreatorMock(), new ImageLoader(), new RenderChecker(), new Options()))
+                .setStackPresenter(new StackPresenter(activity, new TitleBarReactViewCreatorMock(), new TopBarBackgroundViewCreatorMock(), new TopBarButtonCreatorMock(), new NavigationIconResolver(activity, new ImageLoader()), new RenderChecker(), new Options()))
                 .setInitialOptions(new Options());
     }
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/mocks/BackDrawable.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/mocks/BackDrawable.java
@@ -1,0 +1,30 @@
+package com.reactnativenavigation.mocks;
+
+import android.graphics.Canvas;
+import android.graphics.ColorFilter;
+import android.graphics.drawable.Drawable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class BackDrawable extends Drawable {
+    @Override
+    public void draw(@NonNull Canvas canvas) {
+
+    }
+
+    @Override
+    public void setAlpha(int alpha) {
+
+    }
+
+    @Override
+    public void setColorFilter(@Nullable ColorFilter colorFilter) {
+
+    }
+
+    @Override
+    public int getOpacity() {
+        return 0;
+    }
+}

--- a/lib/android/app/src/test/java/com/reactnativenavigation/mocks/ImageLoaderMock.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/mocks/ImageLoaderMock.java
@@ -3,7 +3,6 @@ package com.reactnativenavigation.mocks;
 import android.graphics.Canvas;
 import android.graphics.ColorFilter;
 import android.graphics.drawable.Drawable;
-import androidx.annotation.NonNull;
 
 import com.reactnativenavigation.utils.ImageLoader;
 
@@ -12,6 +11,8 @@ import org.mockito.Mockito;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+
+import androidx.annotation.NonNull;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -39,22 +40,23 @@ public class ImageLoaderMock {
         }
     };
 
+    private static Drawable backIcon = new BackDrawable();
+
     public static ImageLoader mock() {
         ImageLoader imageLoader = Mockito.mock(ImageLoader.class);
-        doAnswer(
-                invocation -> {
+        doAnswer(invocation -> {
                     int urlCount = ((Collection) invocation.getArguments()[1]).size();
                     List<Drawable> drawables = Collections.nCopies(urlCount, mockDrawable);
                     ((ImageLoader.ImagesLoadingListener) invocation.getArguments()[2]).onComplete(drawables);
                     return null;
                 }
         ).when(imageLoader).loadIcons(any(), any(), any());
-        doAnswer(
-                invocation -> {
+        doAnswer(invocation -> {
                     ((ImageLoader.ImagesLoadingListener) invocation.getArguments()[2]).onComplete(mockDrawable);
                     return null;
                 }
         ).when(imageLoader).loadIcon(any(), any(), any());
+        doAnswer(invocation -> backIcon).when(imageLoader).getBackButtonIcon(any());
         return imageLoader;
     }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/utils/TitleBarHelper.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/utils/TitleBarHelper.java
@@ -1,8 +1,6 @@
 package com.reactnativenavigation.utils;
 
 import android.app.Activity;
-import androidx.appcompat.view.menu.ActionMenuItemView;
-import androidx.appcompat.widget.Toolbar;
 
 import com.reactnativenavigation.mocks.ImageLoaderMock;
 import com.reactnativenavigation.mocks.TopBarButtonCreatorMock;
@@ -12,6 +10,9 @@ import com.reactnativenavigation.parse.params.Text;
 import com.reactnativenavigation.viewcontrollers.TitleBarButtonController;
 import com.reactnativenavigation.viewcontrollers.button.NavigationIconResolver;
 import com.reactnativenavigation.views.titlebar.TitleBar;
+
+import androidx.appcompat.view.menu.ActionMenuItemView;
+import androidx.appcompat.widget.Toolbar;
 
 public class TitleBarHelper {
     public static ActionMenuItemView getRightButton(Toolbar toolbar, int index) {
@@ -45,7 +46,6 @@ public class TitleBarHelper {
     public static TitleBarButtonController createButtonController(Activity activity, TitleBar titleBar, Button button) {
         return new TitleBarButtonController(activity,
                 new NavigationIconResolver(activity, ImageLoaderMock.mock()),
-                ImageLoaderMock.mock(),
                 new ButtonPresenter(titleBar, button),
                 button,
                 new TopBarButtonCreatorMock(),

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TopBarButtonControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TopBarButtonControllerTest.java
@@ -51,7 +51,7 @@ public class TopBarButtonControllerTest extends BaseTest {
         getTitleBar().layout(0, 0, 1080, 200);
 
         optionsPresenter = spy(new ButtonPresenter(getTitleBar(), button));
-        uut = new TitleBarButtonController(activity, new NavigationIconResolver(activity, ImageLoaderMock.mock()), ImageLoaderMock.mock(), optionsPresenter, button, buttonCreatorMock, (buttonId) -> {});
+        uut = new TitleBarButtonController(activity, new NavigationIconResolver(activity, ImageLoaderMock.mock()), optionsPresenter, button, buttonCreatorMock, (buttonId) -> {});
 
         stackController.ensureViewIsCreated();
     }
@@ -87,7 +87,7 @@ public class TopBarButtonControllerTest extends BaseTest {
         button.disabledColor = new Colour(Color.BLACK);
         uut.addToMenu(getTitleBar(), 0);
 
-        verify(optionsPresenter, times(1)).tint(any(), eq(Color.BLACK));
+        verify(optionsPresenter).tint(any(), eq(Color.BLACK));
     }
 
     @Test

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/button/NavigationIconResolverTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/button/NavigationIconResolverTest.java
@@ -1,11 +1,11 @@
 package com.reactnativenavigation.viewcontrollers.button;
 
-import android.content.Context;
+import android.app.Activity;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
-import android.view.View;
 
 import com.reactnativenavigation.BaseTest;
+import com.reactnativenavigation.mocks.BackDrawable;
 import com.reactnativenavigation.mocks.ImageLoaderMock;
 import com.reactnativenavigation.parse.params.Button;
 import com.reactnativenavigation.parse.params.Colour;
@@ -20,13 +20,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class NavigationIconResolverTest extends BaseTest {
     private static final String ICON_URI = "someIconUri";
     private NavigationIconResolver uut;
     private ImageLoader imageLoader;
-    private Context context;
+    private Activity context;
 
     @Override
     public void beforeEach() {
@@ -43,7 +42,7 @@ public class NavigationIconResolverTest extends BaseTest {
 
             }
         });
-        uut.resolve(iconButton(), View.LAYOUT_DIRECTION_LTR, onSuccess);
+        uut.resolve(iconButton(), onSuccess);
         verify(imageLoader).loadIcon(eq(context), eq(ICON_URI), any());
         verify(onSuccess).run(any(Drawable.class));
     }
@@ -56,9 +55,8 @@ public class NavigationIconResolverTest extends BaseTest {
 
             }
         });
-        uut.resolve(backButton(), View.LAYOUT_DIRECTION_LTR, onSuccess);
-        verifyZeroInteractions(imageLoader);
-        verify(onSuccess).run(any());
+        uut.resolve(backButton(), onSuccess);
+        verify(onSuccess).run(any(BackDrawable.class));
     }
 
     private Button iconButton() {

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
@@ -32,6 +32,7 @@ import com.reactnativenavigation.utils.ViewUtils;
 import com.reactnativenavigation.viewcontrollers.ChildControllersRegistry;
 import com.reactnativenavigation.viewcontrollers.ParentController;
 import com.reactnativenavigation.viewcontrollers.ViewController;
+import com.reactnativenavigation.viewcontrollers.button.NavigationIconResolver;
 import com.reactnativenavigation.viewcontrollers.topbar.TopBarController;
 import com.reactnativenavigation.views.StackLayout;
 import com.reactnativenavigation.views.element.ElementTransitionManager;
@@ -95,7 +96,7 @@ public class StackControllerTest extends BaseTest {
         StatusBarUtils.saveStatusBarHeight(63);
         animator = spy(new NavigationAnimator(activity, Mockito.mock(ElementTransitionManager.class)));
         childRegistry = new ChildControllersRegistry();
-        presenter = spy(new StackPresenter(activity, new TitleBarReactViewCreatorMock(), new TopBarBackgroundViewCreatorMock(), new TopBarButtonCreatorMock(), ImageLoaderMock.mock(), new RenderChecker(), new Options()));
+        presenter = spy(new StackPresenter(activity, new TitleBarReactViewCreatorMock(), new TopBarBackgroundViewCreatorMock(), new TopBarButtonCreatorMock(), new NavigationIconResolver(activity, ImageLoaderMock.mock()), new RenderChecker(), new Options()));
         child1 = spy(new SimpleViewController(activity, childRegistry, "child1", new Options()));
         child1a = spy(new SimpleViewController(activity, childRegistry, "child1", new Options()));
         child2 = spy(new SimpleViewController(activity, childRegistry, "child2", new Options()));


### PR DESCRIPTION
This commit fixes hiding the back button with `backButton.visible: false` in mergeOptions. It didn't work on Android.