### PR TITLE
Apply BottomTabs visibility only if child is visible

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabsPresenter.java
@@ -35,14 +35,14 @@ public class BottomTabsPresenter {
         this.defaultOptions = defaultOptions;
     }
 
-    public void bindView(BottomTabs bottomTabs, TabSelector tabSelector) {
+    public void bindView(BottomTabs bottomTabs, TabSelector tabSelector, BottomTabsAnimator animator) {
         this.bottomTabs = bottomTabs;
         this.tabSelector = tabSelector;
-        animator = new BottomTabsAnimator(bottomTabs);
+        this.animator = animator;
     }
 
-    public void mergeOptions(Options options) {
-        mergeBottomTabsOptions(options);
+    public void mergeOptions(Options options, ViewController view) {
+        mergeBottomTabsOptions(options, view);
     }
 
     public void applyOptions(Options options) {
@@ -58,12 +58,12 @@ public class BottomTabsPresenter {
     }
 
     public void mergeChildOptions(Options options, ViewController child) {
-        mergeBottomTabsOptions(options);
+        mergeBottomTabsOptions(options, child);
         int tabIndex = bottomTabFinder.findByControllerId(child.getId());
         if (tabIndex >= 0) mergeDrawBehind(tabIndex);
     }
 
-    private void mergeBottomTabsOptions(Options options) {
+    private void mergeBottomTabsOptions(Options options, ViewController view) {
         BottomTabsOptions bottomTabsOptions = options.bottomTabsOptions;
         AnimationsOptions animations = options.animations;
 
@@ -86,18 +86,20 @@ public class BottomTabsPresenter {
             int tabIndex = bottomTabFinder.findByControllerId(bottomTabsOptions.currentTabId.get());
             if (tabIndex >= 0) tabSelector.selectTab(tabIndex);
         }
-        if (bottomTabsOptions.visible.isTrue()) {
-            if (bottomTabsOptions.animate.isTrueOrUndefined()) {
-                animator.show(animations);
-            } else {
-                bottomTabs.restoreBottomNavigation(false);
+        if (view.isViewShown()) {
+            if (bottomTabsOptions.visible.isTrue()) {
+                if (bottomTabsOptions.animate.isTrueOrUndefined()) {
+                    animator.show(animations);
+                } else {
+                    bottomTabs.restoreBottomNavigation(false);
+                }
             }
-        }
-        if (bottomTabsOptions.visible.isFalse()) {
-            if (bottomTabsOptions.animate.isTrueOrUndefined()) {
-                animator.hide(animations);
-            } else {
-                bottomTabs.hideBottomNavigation(false);
+            if (bottomTabsOptions.visible.isFalse()) {
+                if (bottomTabsOptions.animate.isTrueOrUndefined()) {
+                    animator.hide(animations);
+                } else {
+                    bottomTabs.hideBottomNavigation(false);
+                }
             }
         }
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -7,6 +7,7 @@ import android.view.ViewGroup;
 
 import com.aurelhubert.ahbottomnavigation.AHBottomNavigation;
 import com.aurelhubert.ahbottomnavigation.AHBottomNavigationItem;
+import com.reactnativenavigation.anim.BottomTabsAnimator;
 import com.reactnativenavigation.parse.BottomTabOptions;
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.presentation.BottomTabPresenter;
@@ -68,7 +69,7 @@ public class BottomTabsController extends ParentController<BottomTabsLayout> imp
 
         bottomTabs = createBottomTabs();
         tabsAttacher.init(root, resolveCurrentOptions());
-        presenter.bindView(bottomTabs, this);
+        presenter.bindView(bottomTabs, this, new BottomTabsAnimator(bottomTabs));
         tabPresenter.bindView(bottomTabs);
         bottomTabs.setOnTabSelectedListener(this);
         CoordinatorLayout.LayoutParams lp = new CoordinatorLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT);
@@ -98,7 +99,7 @@ public class BottomTabsController extends ParentController<BottomTabsLayout> imp
 
     @Override
     public void mergeOptions(Options options) {
-        presenter.mergeOptions(options);
+        presenter.mergeOptions(options, this);
         tabPresenter.mergeOptions(options);
         super.mergeOptions(options);
         this.options.bottomTabsOptions.clearOneTimeOptions();


### PR DESCRIPTION
When calling mergeOptions to update BottomTabs visibility, apply the visibility only if the child is visible.