### PR TITLE
Add adaptive navigation bar buttons color

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/Presenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/Presenter.java
@@ -202,7 +202,27 @@ public class Presenter {
     private void setNavigationBarBackgroundColor(NavigationBarOptions navigationBar) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && navigationBar.backgroundColor.canApplyValue()) {
             int defaultColor = activity.getWindow().getNavigationBarColor();
-            activity.getWindow().setNavigationBarColor(navigationBar.backgroundColor.get(defaultColor));
+            int color = navigationBar.backgroundColor.get(defaultColor);
+            activity.getWindow().setNavigationBarColor(color);
+            setNavigationBarButtonsColor(color);
         }
+    }
+
+    private void setNavigationBarButtonsColor(int color) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            View decorView = activity.getWindow().getDecorView();
+            int flags = decorView.getSystemUiVisibility();
+            if (isColorLight(color)) {
+                flags |= View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+            } else {
+                flags &= ~View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+            }
+            decorView.setSystemUiVisibility(flags);
+        }
+    }
+
+    private boolean isColorLight(int color) {
+        double darkness = 1 - (0.299 * Color.red(color) + 0.587 * Color.green(color) + 0.114 * Color.blue(color)) / 255;
+        return darkness < 0.5;
     }
 }


### PR DESCRIPTION
Fix #5858 

Proposed changes add functionality to check applied navigation background color and apply contrast navigation bar style.

This PR does not contain tests since it seems quite impossible to test proposed changes.

Implementation is based on implementation of [react-native-navigation-bar-color](https://github.com/thebylito/react-native-navigation-bar-color/blob/8ee6a25bd2edae55e080389cd0b652097349e2fc/android/src/main/java/com/thebylito/navigationbarcolor/NavigationBarColorModule.java#L44). Color check is based on this [code snippet](https://codepen.io/WebSeed/pen/pvgqEq)