### PR TITLE
Always set prefersLargeTitles to YES on iOS 11+

### DIFF
--- a/lib/ios/RNNStackPresenter.m
+++ b/lib/ios/RNNStackPresenter.m
@@ -62,7 +62,7 @@
     [_topBarPresenter applyOptions:withDefault.topBar];
     
     [stack setNavigationBarBlur:[withDefault.topBar.background.blur getWithDefaultValue:NO]];
-    [stack setNavigationBarLargeTitleVisible:[withDefault.topBar.largeTitle.visible getWithDefaultValue:NO]];
+    [stack setNavigationBarLargeTitleVisible];
 	[stack setNavigationBarClipsToBounds:[withDefault.topBar.background.clipToBounds getWithDefaultValue:NO]];
 	[stack setBackButtonColor:[withDefault.topBar.backButton.color getWithDefaultValue:nil]];
 }
@@ -77,7 +77,6 @@
 - (void)applyOptionsBeforePopping:(RNNNavigationOptions *)options {
 	RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
 	RNNStackController* navigationController = self.stackController;
-	[navigationController setNavigationBarLargeTitleVisible:[withDefault.topBar.largeTitle.visible getWithDefaultValue:NO]];
     [_topBarPresenter applyOptionsBeforePopping:options.topBar];
 }
 
@@ -115,10 +114,6 @@
 	
 	if (options.topBar.background.blur.hasValue) {
 		[stack setNavigationBarBlur:[options.topBar.background.blur get]];
-	}
-	
-	if (options.topBar.largeTitle.visible.hasValue) {
-		[stack setNavigationBarLargeTitleVisible:options.topBar.largeTitle.visible.get];
 	}
 	
 	if (options.topBar.backButton.color.hasValue) {

--- a/lib/ios/UINavigationController+RNNOptions.h
+++ b/lib/ios/UINavigationController+RNNOptions.h
@@ -16,7 +16,7 @@
 
 - (void)setNavigationBarClipsToBounds:(BOOL)clipsToBounds;
 
-- (void)setNavigationBarLargeTitleVisible:(BOOL)visible;
+- (void)setNavigationBarLargeTitleVisible;
 
 - (void)setBackButtonColor:(UIColor *)color;
 

--- a/lib/ios/UINavigationController+RNNOptions.m
+++ b/lib/ios/UINavigationController+RNNOptions.m
@@ -33,13 +33,9 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 	self.navigationBar.barStyle = barStyle;
 }
 
-- (void)setNavigationBarLargeTitleVisible:(BOOL)visible {
+- (void)setNavigationBarLargeTitleVisible {
 	if (@available(iOS 11.0, *)) {
-		if (visible){
-			self.navigationBar.prefersLargeTitles = YES;
-		} else {
-			self.navigationBar.prefersLargeTitles = NO;
-		}
+		self.navigationBar.prefersLargeTitles = YES;
 	}
 }
 


### PR DESCRIPTION
If the value of `navigationBar.prefersLargeTitles` is changed while
using largeTitles, there will be a weird navigation animation when going
from a screen that uses largeTitles to a screen that doesn't use
largeTitles.

Instead of turning on/off the largeTitles with prefersLargeTitles, I
found it's better to change the `navigationItem.largeTitleDisplayMode`
in `UIViewController+RNNOptions.m`. Switching this value between
`UINavigationItemLargeTitleDisplayModeAlways` and
`UINavigationItemLargeTitleDisplayModeNever` will allow dynamic setting
of the largeTitles and not cause the animation problems.

Before:
<img width=300 src="https://user-images.githubusercontent.com/8965852/73139580-ff10f580-4034-11ea-8c82-9aaf71b62eb5.gif" />

After:
<img width=300 src="https://user-images.githubusercontent.com/8965852/73139582-03d5a980-4035-11ea-9b5d-9b9a03a9ea99.gif" />