### PR TITLE
make dotIndicator to respect visible value

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
@@ -103,6 +103,7 @@ public class BottomTabPresenter {
     }
 
     private void applyDotIndicator(int tabIndex, DotIndicatorOptions dotIndicator) {
+        if(dotIndicator.visible.isFalse()) return;
         AHNotification.Builder builder = new AHNotification.Builder()
                 .setText("")
                 .setBackgroundColor(dotIndicator.color.get(null))


### PR DESCRIPTION
In Android dotIndicator with initial value of visible: false is not respected and the dot appears in any case.