### PR TITLE
Apply extendedLayoutIncludesOpaqueBars true on all viewControllers

### DIFF
--- a/lib/ios/UIViewController+LayoutProtocol.m
+++ b/lib/ios/UIViewController+LayoutProtocol.m
@@ -51,6 +51,10 @@
 	[self.options overrideOptions:options];
 }
 
+- (BOOL)extendedLayoutIncludesOpaqueBars {
+    return YES;
+}
+
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
 	UIInterfaceOrientationMask interfaceOrientationMask = self.presenter ? [self.presenter getOrientation:[self resolveOptions]] : [[UIApplication sharedApplication] supportedInterfaceOrientationsForWindow:[[UIApplication sharedApplication] keyWindow]];
 	return interfaceOrientationMask;

--- a/lib/ios/UIViewController+RNNOptions.m
+++ b/lib/ios/UIViewController+RNNOptions.m
@@ -58,7 +58,6 @@ const NSInteger BLUR_STATUS_TAG = 78264801;
 
 - (void)setDrawBehindTopBar:(BOOL)drawBehind {
 	if (drawBehind) {
-		[self setExtendedLayoutIncludesOpaqueBars:YES];
 		self.edgesForExtendedLayout |= UIRectEdgeTop;
 	} else {
 		self.edgesForExtendedLayout &= ~UIRectEdgeTop;
@@ -67,7 +66,6 @@ const NSInteger BLUR_STATUS_TAG = 78264801;
 
 - (void)setDrawBehindTabBar:(BOOL)drawBehindTabBar {
 	if (drawBehindTabBar) {
-		[self setExtendedLayoutIncludesOpaqueBars:YES];
 		self.edgesForExtendedLayout |= UIRectEdgeBottom;
 	} else {
 		self.edgesForExtendedLayout &= ~UIRectEdgeBottom;

--- a/playground/ios/NavigationTests/UIViewController+LayoutProtocolTest.m
+++ b/playground/ios/NavigationTests/UIViewController+LayoutProtocolTest.m
@@ -108,4 +108,14 @@
 	XCTAssertEqual(uut.resolveOptions.topBar.title.text.get, @"merged");
 }
 
+- (void)testLayout_shouldExtendedLayoutIncludesOpaqueBars {
+	UIViewController* component = [[UIViewController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initEmptyOptions] defaultOptions:nil presenter:nil eventEmitter:nil childViewControllers:nil];
+	UINavigationController* stack = [[UINavigationController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initEmptyOptions] defaultOptions:nil presenter:nil eventEmitter:nil childViewControllers:nil];
+	UITabBarController* tabBar = [[UITabBarController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initEmptyOptions] defaultOptions:nil presenter:nil eventEmitter:nil childViewControllers:nil];
+	
+	XCTAssertTrue(component.extendedLayoutIncludesOpaqueBars);
+	XCTAssertTrue(stack.extendedLayoutIncludesOpaqueBars);
+	XCTAssertTrue(tabBar.extendedLayoutIncludesOpaqueBars);
+}
+
 @end

--- a/playground/ios/NavigationTests/UIViewController+RNNOptionsTest.m
+++ b/playground/ios/NavigationTests/UIViewController+RNNOptionsTest.m
@@ -34,18 +34,6 @@
     XCTAssertEqual([self.uut tabBarItem].badgeValue, nil);
 }
 
-- (void)testSetDrawBehindTopBarTrue_shouldSetExtendedLayoutTrue {
-    [[self.uut expect] setExtendedLayoutIncludesOpaqueBars:YES];
-    [self.uut setDrawBehindTopBar:YES];
-    [self.uut verify];
-}
-
-- (void)testSetDrawBehindTabBarTrue_shouldSetExtendedLayoutTrue {
-    [[self.uut expect] setExtendedLayoutIncludesOpaqueBars:YES];
-    [self.uut setDrawBehindTabBar:YES];
-    [self.uut verify];
-}
-
 - (void)testSetDrawBehindTopBarFalse_shouldNotCallExtendedLayout {
     [[self.uut reject] setExtendedLayoutIncludesOpaqueBars:NO];
     [self.uut setDrawBehindTopBar:NO];


### PR DESCRIPTION
Fix wrong SafeAreaView margins when using `bottomTabs.drawBehind: true`.