### PR TITLE
Fix overlays touch interception on new iPads

### DIFF
--- a/lib/ios/RNNOverlayWindow.m
+++ b/lib/ios/RNNOverlayWindow.m
@@ -3,13 +3,13 @@
 @implementation RNNOverlayWindow
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
-	UIView *hitTestResult = [super hitTest:point withEvent:event];
-	
-	if ([hitTestResult isKindOfClass:[UIWindow class]]) {
-		return nil;
-	}
-	
-	return hitTestResult;
+    UIView *hitTestResult = [super hitTest:point withEvent:event];
+    
+    if ([hitTestResult isKindOfClass:[UIWindow class]] || [hitTestResult isMemberOfClass:UIView.class]) {
+        return nil;
+    }
+    
+    return hitTestResult;
 }
 
 @end


### PR DESCRIPTION
On new iPads, `UIWindow` content is wrapped with another `UIView`.
Fixed by propagating touch events through all `UIView` members in overlays.
Closes #5889