### PR TITLE
Fix Bottom Inset when view is in fullscreen mode

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/NavigationBarUtils.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/NavigationBarUtils.java
@@ -17,7 +17,7 @@ public class NavigationBarUtils {
         final Resources resources = context.getResources();
         final int orientation = resources.getConfiguration().orientation;
         final int resourceId = resources.getIdentifier(orientation == Configuration.ORIENTATION_PORTRAIT ? "navigation_bar_height" : "navigation_bar_height_landscape", "dimen", "android");
-        if(resourceId > 0) {
+        if (resourceId > 0) {
             navigationBarHeight = resources.getDimensionPixelSize(resourceId);
         }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/NavigationBarUtils.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/NavigationBarUtils.java
@@ -1,0 +1,27 @@
+package com.reactnativenavigation.utils;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+
+public class NavigationBarUtils {
+    private static int navigationBarHeight = -1;
+    public static void saveNavigationBarHeight(int height) {
+        navigationBarHeight = height;
+    }
+
+    public static int getNavigationBarHeight(Context context) {
+        if (navigationBarHeight > 0) {
+            return navigationBarHeight;
+        }
+        final Resources resources = context.getResources();
+        final int orientation = resources.getConfiguration().orientation;
+        final int resourceId = resources.getIdentifier(orientation == Configuration.ORIENTATION_PORTRAIT ? "navigation_bar_height" : "navigation_bar_height_landscape", "dimen", "android");
+        if(resourceId > 0) {
+            navigationBarHeight = resources.getDimensionPixelSize(resourceId);
+        }
+
+        return navigationBarHeight;
+    }
+
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ChildController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ChildController.java
@@ -6,6 +6,7 @@ import android.view.ViewGroup;
 
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.presentation.Presenter;
+import com.reactnativenavigation.utils.NavigationBarUtils;
 import com.reactnativenavigation.utils.StatusBarUtils;
 import com.reactnativenavigation.viewcontrollers.navigator.Navigator;
 import com.reactnativenavigation.views.Component;
@@ -92,6 +93,7 @@ public abstract class ChildController<T extends ViewGroup> extends ViewControlle
 
     private WindowInsetsCompat onApplyWindowInsets(View view, WindowInsetsCompat insets) {
         StatusBarUtils.saveStatusBarHeight(insets.getSystemWindowInsetTop());
+        NavigationBarUtils.saveNavigationBarHeight(insets.getSystemWindowInsetBottom());
         return applyWindowInsets(findController(view), insets);
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ComponentViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ComponentViewController.java
@@ -7,6 +7,7 @@ import com.reactnativenavigation.interfaces.ScrollEventListener;
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.presentation.ComponentPresenter;
 import com.reactnativenavigation.presentation.Presenter;
+import com.reactnativenavigation.utils.NavigationBarUtils;
 import com.reactnativenavigation.utils.StatusBarUtils;
 import com.reactnativenavigation.views.ComponentLayout;
 import com.reactnativenavigation.views.ReactComponent;
@@ -104,6 +105,14 @@ public class ComponentViewController extends ChildController<ComponentLayout> {
     public int getTopInset() {
         int statusBarInset = resolveCurrentOptions().statusBar.isHiddenOrDrawBehind() ? 0 : StatusBarUtils.getStatusBarHeight(getActivity());
         return statusBarInset + perform(getParentController(), 0, p -> p.getTopInset(this));
+    }
+
+    @Override
+    public int getBottomInset() {
+        int navigationBarInset = resolveCurrentOptions().statusBar.isHiddenOrDrawBehind()
+                ? 0
+                : NavigationBarUtils.getNavigationBarHeight(getActivity());
+        return navigationBarInset + perform(getParentController(), 0, p -> p.getBottomInset(this));
     }
 
     @Override

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/ComponentViewControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/ComponentViewControllerTest.java
@@ -10,6 +10,7 @@ import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.parse.params.Bool;
 import com.reactnativenavigation.presentation.ComponentPresenter;
 import com.reactnativenavigation.presentation.Presenter;
+import com.reactnativenavigation.utils.NavigationBarUtils;
 import com.reactnativenavigation.utils.StatusBarUtils;
 import com.reactnativenavigation.viewcontrollers.stack.StackController;
 import com.reactnativenavigation.views.ComponentLayout;
@@ -36,6 +37,7 @@ public class ComponentViewControllerTest extends BaseTest {
         super.beforeEach();
         activity = newActivity();
         StatusBarUtils.saveStatusBarHeight(63);
+        NavigationBarUtils.saveNavigationBarHeight(186);
         view = spy(new TestComponentLayout(activity, new TestReactView(activity)));
         parent = TestUtils.newStackController(activity).build();
         Presenter presenter = new Presenter(activity, new Options());
@@ -147,6 +149,38 @@ public class ComponentViewControllerTest extends BaseTest {
         uut.options.statusBar.drawBehind = new Bool(true);
         uut.options.topBar.drawBehind = new Bool(true);
         assertThat(uut.getTopInset()).isEqualTo(0);
+    }
+
+    @Test
+    public void getBottomInset_resolveWithParent() {
+        assertThat(uut.getBottomInset()).isEqualTo(NavigationBarUtils.getNavigationBarHeight(activity) + parent.getBottomInset(uut));
+    }
+
+    @Test
+    public void getBottomInset_returnsStatusBarHeight() {
+        //noinspection ConstantConditions
+        uut.setParentController(null);
+        assertThat(uut.getBottomInset()).isEqualTo(NavigationBarUtils.getNavigationBarHeight(activity));
+    }
+
+    @Test
+    public void getBottomInset_drawBehind() {
+        uut.options.statusBar.drawBehind = new Bool(true);
+        uut.options.topBar.drawBehind = new Bool(true);
+        assertThat(uut.getBottomInset()).isEqualTo(0);
+    }
+
+    @Test
+    public void getBottomInset_invisibleStatusBar() {
+        uut.options.statusBar.visible = new Bool(false);
+        uut.options.statusBar.drawBehind = new Bool(true);
+        assertThat(uut.getBottomInset()).isEqualTo(0);
+    }
+
+    @Test
+    public void getBottomInset_visibleStatusBar() {
+        uut.options.statusBar.visible = new Bool(true);
+        assertThat(uut.getBottomInset()).isEqualTo(NavigationBarUtils.getNavigationBarHeight(activity));
     }
 
     @Test


### PR DESCRIPTION
Currently when the status bar is hidden , the view mode is set to `View.SYSTEM_UI_FLAG_FULLSCREEN`. And the topInset is calculate to allow for the top section of the view to be immersive. 

According to google's documentation when the status bar is hidden we should also hide the navigation bar. (https://developer.android.com/training/system-ui/navigation)

This PR sorts to calculate the bottom inset to apply this rule to allow for the fullscreen mode to be fully immersive, rather than just take into account the top inset.

