### PR TITLE
Fix autolink script

### DIFF
--- a/autolink/postlink/gradleLinker.js
+++ b/autolink/postlink/gradleLinker.js
@@ -4,6 +4,8 @@ var fs = require('fs');
 var { warnn, errorn, logn, infon, debugn } = require('./log');
 var { insertString } = require('./stringUtils');
 var DEFAULT_KOTLIN_VERSION = '1.3.61';
+// This should be the minSdkVersion required for RNN.
+var DEFAULT_MIN_SDK_VERSION = 19
 
 class GradleLinker {
   constructor() {
@@ -16,6 +18,7 @@ class GradleLinker {
       var contents = fs.readFileSync(this.gradlePath, 'utf8');
       contents = this._setKotlinVersion(contents);
       contents = this._setKotlinPluginDependency(contents);
+      contents = this._setMinSdkVersion(contents);
       fs.writeFileSync(this.gradlePath, contents);
       infon('Root build.gradle linked successfully!\n');
     } else {
@@ -55,6 +58,22 @@ class GradleLinker {
   }
 
   /**
+   * Check the current minSdkVersion specified and if it's lower than
+   * the required version, set it to the required version otherwise leave as it is.
+   */
+  _setMinSdkVersion(contents) {
+    var minSdkVersion = this._getMinSdkVersion(contents)
+    // If user entered minSdkVersion is lower than the default, set it to default.
+    if (minSdkVersion < DEFAULT_MIN_SDK_VERSION) {
+      debugn(`   Updating minSdkVersion to ${DEFAULT_MIN_SDK_VERSION}`)
+      return contents.replace(/minSdkVersion = \d*/, `minSdkVersion = ${DEFAULT_MIN_SDK_VERSION}`)
+    } 
+
+    debugn(`   Already specified minSdkVersion ${minSdkVersion}`)
+    return contents.replace(/minSdkVersion = \d*/, `minSdkVersion = ${minSdkVersion}`)
+  }
+
+  /**
    * @param { string } contents
    */
   _getKotlinVersion(contents) {
@@ -67,6 +86,21 @@ class GradleLinker {
       return extensionVariableVersion[0].replace("$", "");
     }
     return `"${DEFAULT_KOTLIN_VERSION}"`;
+  }
+
+  /**
+   * Get the minSdkVersion value.
+   * @param { string } contents
+   */
+  _getMinSdkVersion(contents) {
+    var minSdkVersion = contents.match(/minSdkVersion = (\d*)/)
+
+    if (minSdkVersion && minSdkVersion[1]) {
+      // It'd be something like 16 for a fresh React Native project.
+      return +minSdkVersion[1] 
+    }
+
+    return DEFAULT_MIN_SDK_VERSION
   }
 
   /**

--- a/autolink/postlink/gradleLinker.js
+++ b/autolink/postlink/gradleLinker.js
@@ -66,11 +66,11 @@ class GradleLinker {
     // If user entered minSdkVersion is lower than the default, set it to default.
     if (minSdkVersion < DEFAULT_MIN_SDK_VERSION) {
       debugn(`   Updating minSdkVersion to ${DEFAULT_MIN_SDK_VERSION}`)
-      return contents.replace(/minSdkVersion = \d*/, `minSdkVersion\s=\s${DEFAULT_MIN_SDK_VERSION}`)
+      return contents.replace(/minSdkVersion\s{0,}=\s{0,}\d*/, `minSdkVersion = ${DEFAULT_MIN_SDK_VERSION}`)
     } 
 
     debugn(`   Already specified minSdkVersion ${minSdkVersion}`)
-    return contents.replace(/minSdkVersion = \d*/, `minSdkVersion = ${minSdkVersion}`)
+    return contents.replace(/minSdkVersion\s{0,}=\s{0,}\d*/, `minSdkVersion = ${minSdkVersion}`)
   }
 
   /**
@@ -93,7 +93,7 @@ class GradleLinker {
    * @param { string } contents
    */
   _getMinSdkVersion(contents) {
-    var minSdkVersion = contents.match(/minSdkVersion\s=\s(\d*)/)
+    var minSdkVersion = contents.match(/minSdkVersion\s{0,}=\s{0,}(\d*)/)
 
     if (minSdkVersion && minSdkVersion[1]) {
       // It'd be something like 16 for a fresh React Native project.

--- a/autolink/postlink/gradleLinker.js
+++ b/autolink/postlink/gradleLinker.js
@@ -66,7 +66,7 @@ class GradleLinker {
     // If user entered minSdkVersion is lower than the default, set it to default.
     if (minSdkVersion < DEFAULT_MIN_SDK_VERSION) {
       debugn(`   Updating minSdkVersion to ${DEFAULT_MIN_SDK_VERSION}`)
-      return contents.replace(/minSdkVersion = \d*/, `minSdkVersion = ${DEFAULT_MIN_SDK_VERSION}`)
+      return contents.replace(/minSdkVersion = \d*/, `minSdkVersion\s=\s${DEFAULT_MIN_SDK_VERSION}`)
     } 
 
     debugn(`   Already specified minSdkVersion ${minSdkVersion}`)
@@ -93,7 +93,7 @@ class GradleLinker {
    * @param { string } contents
    */
   _getMinSdkVersion(contents) {
-    var minSdkVersion = contents.match(/minSdkVersion = (\d*)/)
+    var minSdkVersion = contents.match(/minSdkVersion\s=\s(\d*)/)
 
     if (minSdkVersion && minSdkVersion[1]) {
       // It'd be something like 16 for a fresh React Native project.

--- a/autolink/postlink/path.js
+++ b/autolink/postlink/path.js
@@ -10,3 +10,4 @@ exports.mainApplicationJava = mainApplicationJava;
 exports.rootGradle = mainApplicationJava.replace(/android\/app\/.*\.java/, "android/build.gradle");;
 
 exports.appDelegate = glob.sync("**/AppDelegate.m", ignoreFolders)[0];
+exports.podFile = glob.sync("**/Podfile", ignoreFolders)[0]

--- a/autolink/postlink/podfileLinker.js
+++ b/autolink/postlink/podfileLinker.js
@@ -1,0 +1,39 @@
+// @ts-check
+var path = require('./path');
+var fs = require("fs");
+var {logn, debugn, infon} = require("./log");
+
+class PodfileLinker {
+  constructor() {
+    this.podfilePath = path.podFile;
+  }
+
+  link() {
+    if (this.podfilePath) {
+      logn("Updating Podfile...")
+      var podfileContent = fs.readFileSync(this.podfilePath, "utf8");
+
+      podfileContent = this._removeRNNPodLink(podfileContent);
+
+      fs.writeFileSync(this.podfilePath, podfileContent);
+      infon("Podfile updated successfully!\n")
+    }
+  }
+
+  /**
+   * Removes the RNN pod added by react-native link script. 
+   */
+  _removeRNNPodLink(contents) {
+    const rnnPodLink  = contents.match(/\s+.*pod 'ReactNativeNavigation'.+react-native-navigation'/)
+
+    if (!rnnPodLink) {
+      debugn("   RNN Pod has not been added to Podfile")
+      return contents
+    }
+
+    debugn("   Removing RNN Pod from Podfile")
+    return contents.replace(rnnPodLink, "")    
+  }
+}
+
+module.exports = PodfileLinker

--- a/autolink/postlink/postLinkIOS.js
+++ b/autolink/postlink/postLinkIOS.js
@@ -1,7 +1,9 @@
 // @ts-check
 var AppDelegateLinker = require("./appDelegateLinker");
+var PodfileLinker = require('./podfileLinker');
 
 module.exports = () => {
   console.log("Running iOS postlink script\n");
   new AppDelegateLinker().link();
+  new PodfileLinker().link();
 }


### PR DESCRIPTION
This PR fixes the autolink script including:
- Specifying the minSdkVersion for Android. Closes https://github.com/wix/react-native-navigation/issues/5983.
- Removing the RNN Pod added by the react-native link script.

@guyca  I've assumed the minSdkVersion will be 19 unless user specified higher. I've got the version from the doc, should this be updated to something higher?