### PR TITLE
Root layouts refactor

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/modal/ModalPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/modal/ModalPresenter.java
@@ -2,6 +2,7 @@ package com.reactnativenavigation.viewcontrollers.modal;
 
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
+import android.view.View;
 import android.view.ViewGroup;
 
 import com.reactnativenavigation.anim.ModalAnimator;
@@ -46,6 +47,7 @@ public class ModalPresenter {
 
         Options options = toAdd.resolveCurrentOptions(defaultOptions);
         toAdd.setWaitForRender(options.animations.showModal.waitForRender);
+        modalsLayout.setVisibility(View.VISIBLE);
         modalsLayout.addView(toAdd.getView(), matchParentLP());
 
         if (options.animations.showModal.enabled.isTrueOrUndefined()) {
@@ -107,5 +109,10 @@ public class ModalPresenter {
     private void onDismissEnd(ViewController toDismiss, CommandListener listener) {
         listener.onSuccess(toDismiss.getId());
         toDismiss.destroy();
+        if (isEmpty()) modalsLayout.setVisibility(View.GONE);
+    }
+
+    private boolean isEmpty() {
+        return modalsLayout.getChildCount() == 0;
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/navigator/Navigator.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/navigator/Navigator.java
@@ -240,4 +240,9 @@ public class Navigator extends ParentController {
     CoordinatorLayout getModalsLayout() {
         return modalsLayout;
     }
+
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    CoordinatorLayout getOverlaysLayout() {
+        return overlaysLayout;
+    }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/navigator/Navigator.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/navigator/Navigator.java
@@ -64,6 +64,7 @@ public class Navigator extends ParentController {
         this.contentLayout = contentLayout;
         contentLayout.addView(rootLayout);
         contentLayout.addView(modalsLayout);
+        contentLayout.addView(overlaysLayout);
     }
 
     public Navigator(final Activity activity, ChildControllersRegistry childRegistry, ModalStack modalStack, OverlayManager overlayManager, RootPresenter rootPresenter) {
@@ -114,7 +115,7 @@ public class Navigator extends ParentController {
 
     public void destroyViews() {
         modalStack.destroy();
-        overlayManager.destroy();
+        overlayManager.destroy(overlaysLayout);
         destroyRoot();
     }
 
@@ -198,11 +199,11 @@ public class Navigator extends ParentController {
     }
 
     public void showOverlay(ViewController overlay, CommandListener listener) {
-        overlayManager.show(contentLayout, overlaysLayout, overlay, listener);
+        overlayManager.show(overlaysLayout, overlay, listener);
     }
 
     public void dismissOverlay(final String componentId, CommandListener listener) {
-        overlayManager.dismiss(componentId, listener);
+        overlayManager.dismiss(overlaysLayout, componentId, listener);
     }
 
     @Nullable

--- a/lib/android/app/src/test/java/com/reactnativenavigation/BaseTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/BaseTest.java
@@ -121,4 +121,12 @@ public abstract class BaseTest {
         when(mock.getContext()).thenReturn(activity);
         return mock;
     }
+
+    protected void assertVisible(View view) {
+        assertThat(view.getVisibility()).isEqualTo(View.VISIBLE);
+    }
+
+    protected void assertGone(View view) {
+        assertThat(view.getVisibility()).isEqualTo(View.GONE);
+    }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalPresenterTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalPresenterTest.java
@@ -257,4 +257,20 @@ public class ModalPresenterTest extends BaseTest {
         inOrder.verify(listener).onSuccess(modal.getId());
         inOrder.verify(modal).destroy();
     }
+
+    @Test
+    public void dismissModal_modalsLayoutIfHiddenIsAllModalsAreDismissed() {
+        disableShowModalAnimation(modal1, modal2);
+        disableDismissModalAnimation(modal1, modal2);
+
+        uut.showModal(modal1, root, new CommandListenerAdapter());
+        assertVisible(modalsLayout);
+        uut.showModal(modal2, modal1, new CommandListenerAdapter());
+        assertVisible(modalsLayout);
+
+        uut.dismissModal(modal2, modal1, root, new CommandListenerAdapter());
+        assertVisible(modalsLayout);
+        uut.dismissModal(modal1, root, root, new CommandListenerAdapter());
+        assertGone(modalsLayout);
+    }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/NavigatorTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/NavigatorTest.java
@@ -155,11 +155,11 @@ public class NavigatorTest extends BaseTest {
     @Test
     public void setRoot_clearsSplashLayout() {
         FrameLayout content = activity.findViewById(android.R.id.content);
-        assertThat(content.getChildCount()).isEqualTo(3); // 2 frame layouts (root and modal containers) and the default splash layout
+        assertThat(content.getChildCount()).isEqualTo(4); // 3 frame layouts (root, modal and overlay containers) and the default splash layout
 
         uut.setRoot(child2, new CommandListenerAdapter(), reactInstanceManager);
 
-        assertThat(content.getChildCount()).isEqualTo(2);
+        assertThat(content.getChildCount()).isEqualTo(3);
     }
 
     @Test
@@ -658,7 +658,7 @@ public class NavigatorTest extends BaseTest {
     public void destroy_destroyOverlayManager() {
         uut.setRoot(parentController, new CommandListenerAdapter(), reactInstanceManager);
         activityController.destroy();
-        verify(overlayManager).destroy();
+        verify(overlayManager).destroy(uut.getOverlaysLayout());
     }
 
     @Test


### PR DESCRIPTION
This commit improves support for react-native-youtube library. This library uses the native Youtube player which requires that no visible views will be laid out on top of the player. This commit set visibility of Modal and Overlay containers to GONE when they are empty.