### PR TITLE
Create new UITabBarItem instance on each bottomTab update

### DIFF
--- a/lib/ios/BottomTabAppearancePresenter.h
+++ b/lib/ios/BottomTabAppearancePresenter.h
@@ -3,6 +3,4 @@
 API_AVAILABLE(ios(13.0))
 @interface BottomTabAppearancePresenter : BottomTabPresenter
 
-- (instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions children:(NSArray<UIViewController *> *)children;
-
 @end

--- a/lib/ios/BottomTabAppearancePresenter.m
+++ b/lib/ios/BottomTabAppearancePresenter.m
@@ -3,16 +3,9 @@
 
 @implementation BottomTabAppearancePresenter
 
-- (instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions children:(NSArray<UIViewController *> *)children {
-    self = [super initWithDefaultOptions:defaultOptions];
-    for (UIViewController* child in children) {
-        child.tabBarItem.standardAppearance = [[UITabBarAppearance alloc] init];
-    }
-    return self;
-}
-
 - (void)createTabBarItem:(UIViewController *)child bottomTabOptions:(RNNBottomTabOptions *)bottomTabOptions {
-    child.tabBarItem = [TabBarItemAppearanceCreator updateTabBarItem:child.tabBarItem bottomTabOptions:bottomTabOptions];
+    child.tabBarItem = [TabBarItemAppearanceCreator createTabBarItem:bottomTabOptions];
+    child.tabBarItem.standardAppearance = [[UITabBarAppearance alloc] init];
 }
 
 @end

--- a/lib/ios/BottomTabPresenter.m
+++ b/lib/ios/BottomTabPresenter.m
@@ -15,21 +15,21 @@
 - (void)applyOptionsOnWillMoveToParentViewController:(RNNNavigationOptions *)options  child:(UIViewController *)child {
     RNNNavigationOptions * withDefault = [options withDefault:self.defaultOptions];
     
+    [self createTabBarItem:child bottomTabOptions:withDefault.bottomTab];
     [child setTabBarItemBadge:[withDefault.bottomTab.badge getWithDefaultValue:[NSNull null]]];
     [child setTabBarItemBadgeColor:[withDefault.bottomTab.badgeColor getWithDefaultValue:nil]];
-    [self createTabBarItem:child bottomTabOptions:withDefault.bottomTab];
 }
 
 - (void)mergeOptions:(RNNNavigationOptions *)options resolvedOptions:(RNNNavigationOptions *)resolvedOptions child:(UIViewController *)child {
     RNNNavigationOptions* withDefault = (RNNNavigationOptions *) [[resolvedOptions withDefault:self.defaultOptions] overrideOptions:options];
     
+    if (options.bottomTab.hasValue) [self createTabBarItem:child bottomTabOptions:withDefault.bottomTab];
     if (options.bottomTab.badge.hasValue) [child setTabBarItemBadge:options.bottomTab.badge.get];
     if (options.bottomTab.badgeColor.hasValue) [child setTabBarItemBadgeColor:options.bottomTab.badgeColor.get];
-    if (options.bottomTab.hasValue) [self createTabBarItem:child bottomTabOptions:withDefault.bottomTab];
 }
 
 - (void)createTabBarItem:(UIViewController *)child bottomTabOptions:(RNNBottomTabOptions *)bottomTabOptions {
-    child.tabBarItem = [RNNTabBarItemCreator updateTabBarItem:child.tabBarItem bottomTabOptions:bottomTabOptions];
+    child.tabBarItem = [RNNTabBarItemCreator createTabBarItem:bottomTabOptions];
 }
 
 @end

--- a/lib/ios/BottomTabPresenterCreator.h
+++ b/lib/ios/BottomTabPresenterCreator.h
@@ -3,6 +3,6 @@
 
 @interface BottomTabPresenterCreator : NSObject
 
-+ (BottomTabPresenter *)createWithDefaultOptions:(RNNNavigationOptions *)defaultOptions children:(NSArray<UIViewController *> *)children;
++ (BottomTabPresenter *)createWithDefaultOptions:(RNNNavigationOptions *)defaultOptions;
 
 @end

--- a/lib/ios/BottomTabPresenterCreator.m
+++ b/lib/ios/BottomTabPresenterCreator.m
@@ -3,9 +3,9 @@
 
 @implementation BottomTabPresenterCreator
 
-+ (BottomTabPresenter *)createWithDefaultOptions:(RNNNavigationOptions *)defaultOptions children:(NSArray<UIViewController *> *)children {
++ (BottomTabPresenter *)createWithDefaultOptions:(RNNNavigationOptions *)defaultOptions {
 	if (@available(iOS 13.0, *)) {
-		return [[BottomTabAppearancePresenter alloc] initWithDefaultOptions:defaultOptions children:children];
+		return [[BottomTabAppearancePresenter alloc] initWithDefaultOptions:defaultOptions];
 	} else {
 		return [[BottomTabPresenter alloc] initWithDefaultOptions:defaultOptions];
 	}

--- a/lib/ios/RNNControllerFactory.m
+++ b/lib/ios/RNNControllerFactory.m
@@ -152,7 +152,7 @@
     RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];
     RNNBottomTabsPresenter* presenter = [BottomTabsPresenterCreator createWithDefaultOptions:_defaultOptions];
     NSArray *childViewControllers = [self extractChildrenViewControllersFromNode:node];
-    BottomTabPresenter* bottomTabPresenter = [BottomTabPresenterCreator createWithDefaultOptions:_defaultOptions children:childViewControllers];;
+    BottomTabPresenter* bottomTabPresenter = [BottomTabPresenterCreator createWithDefaultOptions:_defaultOptions];
     RNNDotIndicatorPresenter* dotIndicatorPresenter = [[RNNDotIndicatorPresenter alloc] initWithDefaultOptions:_defaultOptions];
 	BottomTabsBaseAttacher* bottomTabsAttacher = [_bottomTabsAttachModeFactory fromOptions:options];
     

--- a/lib/ios/RNNTabBarItemCreator.h
+++ b/lib/ios/RNNTabBarItemCreator.h
@@ -4,7 +4,7 @@
 
 @interface RNNTabBarItemCreator : NSObject
 
-+ (UITabBarItem *)updateTabBarItem:(UITabBarItem *)tabItem bottomTabOptions:(RNNBottomTabOptions *)bottomTabOptions;
++ (UITabBarItem *)createTabBarItem:(RNNBottomTabOptions *)bottomTabOptions;
 
 + (void)setTitleAttributes:(UITabBarItem *)tabItem titleAttributes:(NSDictionary *)titleAttributes;
 

--- a/lib/ios/RNNTabBarItemCreator.m
+++ b/lib/ios/RNNTabBarItemCreator.m
@@ -4,7 +4,8 @@
 
 @implementation RNNTabBarItemCreator
 
-+ (UITabBarItem *)updateTabBarItem:(UITabBarItem *)tabItem bottomTabOptions:(RNNBottomTabOptions *)bottomTabOptions {
++ (UITabBarItem *)createTabBarItem:(RNNBottomTabOptions *)bottomTabOptions {
+    UITabBarItem* tabItem = [UITabBarItem new];
 	UIImage* icon = [bottomTabOptions.icon getWithDefaultValue:nil];
 	UIImage* selectedIcon = [bottomTabOptions.selectedIcon getWithDefaultValue:icon];
 	UIColor* iconColor = [bottomTabOptions.iconColor getWithDefaultValue:nil];

--- a/playground/ios/NavigationTests/BottomTabPresenterTest.m
+++ b/playground/ios/NavigationTests/BottomTabPresenterTest.m
@@ -52,4 +52,18 @@
 	XCTAssertEqual(self.componentViewController.tabBarItem.title, @"title");
 }
 
+- (void)testMergeOptions_shouldCreateNewTabBarItemInstance {
+	RNNNavigationOptions* defaultOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
+	defaultOptions.bottomTab.selectedIconColor = [Color withColor:UIColor.greenColor];
+	self.uut.defaultOptions = defaultOptions;
+	
+	RNNNavigationOptions* mergeOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
+	mergeOptions.bottomTab.text = [[Text alloc] initWithValue:@"title"];
+	
+	UITabBarItem* currentTabBarItem = self.componentViewController.tabBarItem;
+	[self.uut mergeOptions:mergeOptions resolvedOptions:self.options child:self.componentViewController];
+	UITabBarItem* newTabBarItem = self.componentViewController.tabBarItem;
+	XCTAssertNotEqual(currentTabBarItem, newTabBarItem);
+}
+
 @end

--- a/playground/ios/NavigationTests/RNNBottomTabsAppearancePresenterTest.m
+++ b/playground/ios/NavigationTests/RNNBottomTabsAppearancePresenterTest.m
@@ -25,7 +25,7 @@
 	self.children = @[[[RNNComponentViewController alloc] initWithLayoutInfo:nil rootViewCreator:nil eventEmitter:nil presenter:[[RNNComponentPresenter alloc] initWithDefaultOptions:nil] options:nil defaultOptions:nil]];
 	self.dotIndicatorPresenter = [OCMockObject partialMockForObject:[[RNNDotIndicatorPresenter alloc] initWithDefaultOptions:nil]];
     self.uut = [OCMockObject partialMockForObject:[BottomTabsPresenterCreator createWithDefaultOptions:nil]];
-	self.boundViewController = [OCMockObject partialMockForObject:[[RNNBottomTabsController alloc] initWithLayoutInfo:nil creator:nil options:nil defaultOptions:nil presenter:self.uut bottomTabPresenter:[BottomTabPresenterCreator createWithDefaultOptions:nil children:self.children] dotIndicatorPresenter:self.dotIndicatorPresenter eventEmitter:nil childViewControllers:self.children bottomTabsAttacher:nil]];
+	self.boundViewController = [OCMockObject partialMockForObject:[[RNNBottomTabsController alloc] initWithLayoutInfo:nil creator:nil options:nil defaultOptions:nil presenter:self.uut bottomTabPresenter:[BottomTabPresenterCreator createWithDefaultOptions:nil] dotIndicatorPresenter:self.dotIndicatorPresenter eventEmitter:nil childViewControllers:self.children bottomTabsAttacher:nil]];
     [self.uut bindViewController:self.boundViewController];
     self.options = [[RNNNavigationOptions alloc] initEmptyOptions];
 }

--- a/playground/ios/NavigationTests/RNNBottomTabsController+Helpers.m
+++ b/playground/ios/NavigationTests/RNNBottomTabsController+Helpers.m
@@ -11,7 +11,7 @@
 
 + (RNNBottomTabsController *)createWithChildren:(NSArray *)children {
 	RNNNavigationOptions* defaultOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
-	return [[RNNBottomTabsController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initEmptyOptions] defaultOptions:defaultOptions presenter:[BottomTabsPresenterCreator createWithDefaultOptions:defaultOptions] bottomTabPresenter:[BottomTabPresenterCreator createWithDefaultOptions:defaultOptions children:children] dotIndicatorPresenter:[[RNNDotIndicatorPresenter alloc] initWithDefaultOptions:defaultOptions] eventEmitter:nil childViewControllers:children bottomTabsAttacher:nil];
+	return [[RNNBottomTabsController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initEmptyOptions] defaultOptions:defaultOptions presenter:[BottomTabsPresenterCreator createWithDefaultOptions:defaultOptions] bottomTabPresenter:[BottomTabPresenterCreator createWithDefaultOptions:defaultOptions] dotIndicatorPresenter:[[RNNDotIndicatorPresenter alloc] initWithDefaultOptions:defaultOptions] eventEmitter:nil childViewControllers:children bottomTabsAttacher:nil];
 }
 
 @end

--- a/playground/ios/NavigationTests/RNNDotIndicatorPresenterTest.m
+++ b/playground/ios/NavigationTests/RNNDotIndicatorPresenterTest.m
@@ -20,7 +20,7 @@
 - (void)setUp {
     [super setUp];
 	self.child = [self createChild];
-	self.bottomTabPresenter = [BottomTabPresenterCreator createWithDefaultOptions:nil children:@[self.child]];
+	self.bottomTabPresenter = [BottomTabPresenterCreator createWithDefaultOptions:nil];
     self.uut = [OCMockObject partialMockForObject:[RNNDotIndicatorPresenter new]];
     self.bottomTabs = [OCMockObject partialMockForObject:[RNNBottomTabsController createWithChildren:@[self.child]]];
 

--- a/playground/ios/NavigationTests/RNNRootViewControllerTest.m
+++ b/playground/ios/NavigationTests/RNNRootViewControllerTest.m
@@ -180,8 +180,6 @@
 	NSString* tabBadgeInput = @"5";
 	self.options.bottomTab.badge = [[Text alloc] initWithValue:tabBadgeInput];
 	NSMutableArray* controllers = [NSMutableArray new];
-	UITabBarItem* item = [[UITabBarItem alloc] initWithTitle:@"A Tab" image:nil tag:1];
-	[self.uut setTabBarItem:item];
 	[controllers addObject:self.uut];
 	__unused RNNBottomTabsController* vc = [RNNBottomTabsController createWithChildren:controllers];
 	[self.uut willMoveToParentViewController:vc];

--- a/playground/ios/NavigationTests/RNNTabBarControllerTest.m
+++ b/playground/ios/NavigationTests/RNNTabBarControllerTest.m
@@ -28,7 +28,7 @@
     self.mockTabBarPresenter = [OCMockObject partialMockForObject:[[RNNBottomTabsPresenter alloc] init]];
     self.mockChildViewController = [OCMockObject partialMockForObject:[RNNComponentViewController new]];
     self.mockEventEmitter = [OCMockObject partialMockForObject:[RNNEventEmitter new]];
-	self.originalUut = [[RNNBottomTabsController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:self.mockTabBarPresenter bottomTabPresenter:[BottomTabPresenterCreator createWithDefaultOptions:nil children:children] dotIndicatorPresenter:[[RNNDotIndicatorPresenter alloc] initWithDefaultOptions:nil] eventEmitter:self.mockEventEmitter childViewControllers:children bottomTabsAttacher:nil];
+	self.originalUut = [[RNNBottomTabsController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:self.mockTabBarPresenter bottomTabPresenter:[BottomTabPresenterCreator createWithDefaultOptions:nil] dotIndicatorPresenter:[[RNNDotIndicatorPresenter alloc] initWithDefaultOptions:nil] eventEmitter:self.mockEventEmitter childViewControllers:children bottomTabsAttacher:nil];
     self.uut = [OCMockObject partialMockForObject:self.originalUut];
     OCMStub([self.uut selectedViewController]).andReturn(self.mockChildViewController);
 }


### PR DESCRIPTION
Fix an issue where `bottomTab.testID` doesn't get updated on `mergeOptions` unless a new UITabBarItem is created.