### PR TITLE
Resolve modal presentation and transition on showModal

### DIFF
--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -4,7 +4,6 @@
 #import "RNNReactComponentRegistry.h"
 #import "UIViewController+LayoutProtocol.h"
 #import "DotIndicatorOptions.h"
-#import "RCTConvert+Modal.h"
 
 @implementation RNNBasePresenter
 
@@ -40,8 +39,6 @@
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)initialOptions {
     UIViewController* viewController = self.boundViewController;
     RNNNavigationOptions *withDefault = [initialOptions withDefault:[self defaultOptions]];
-    [viewController setModalPresentationStyle:[RCTConvert UIModalPresentationStyle:[withDefault.modalPresentationStyle getWithDefaultValue:@"default"]]];
-    [viewController setModalTransitionStyle:[RCTConvert UIModalTransitionStyle:[withDefault.modalTransitionStyle getWithDefaultValue:@"coverVertical"]]];
     
     if (@available(iOS 13.0, *)) {
         viewController.modalInPresentation = ![withDefault.modal.swipeToDismiss getWithDefaultValue:YES];

--- a/lib/ios/RNNComponentPresenter.m
+++ b/lib/ios/RNNComponentPresenter.m
@@ -1,7 +1,6 @@
 #import "RNNComponentPresenter.h"
 #import "UIViewController+RNNOptions.h"
 #import "UITabBarController+RNNOptions.h"
-#import "RCTConvert+Modal.h"
 #import "RNNTitleViewHelper.h"
 #import "UIViewController+LayoutProtocol.h"
 #import "RNNReactTitleView.h"
@@ -98,14 +97,6 @@
 
 	if (options.backgroundImage.hasValue) {
 		[viewController setBackgroundImage:options.backgroundImage.get];
-	}
-	
-	if (options.modalPresentationStyle.hasValue) {
-		[viewController setModalPresentationStyle:[RCTConvert UIModalPresentationStyle:options.modalPresentationStyle.get]];
-	}
-	
-	if (options.modalTransitionStyle.hasValue) {
-		[viewController setModalTransitionStyle:[RCTConvert UIModalTransitionStyle:options.modalTransitionStyle.get]];
 	}
 	
 	if (options.topBar.searchBar.hasValue) {

--- a/lib/ios/RNNComponentViewController.h
+++ b/lib/ios/RNNComponentViewController.h
@@ -4,7 +4,7 @@
 #import "RNNNavigationOptions.h"
 #import "RNNUIBarButtonItem.h"
 #import "RNNLayoutInfo.h"
-#import "RNNLayoutProtocol.h"
+#import "UIViewController+LayoutProtocol.h"
 #import "RNNComponentPresenter.h"
 
 typedef void (^PreviewCallback)(UIViewController *vc);

--- a/lib/ios/RNNComponentViewController.m
+++ b/lib/ios/RNNComponentViewController.m
@@ -1,5 +1,4 @@
 #import "RNNComponentViewController.h"
-#import "UIViewController+LayoutProtocol.h"
 
 @implementation RNNComponentViewController
 

--- a/lib/ios/RNNConvert.h
+++ b/lib/ios/RNNConvert.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+#import <React/RCTConvert.h>
+
+@interface RNNConvert : NSObject
+
++ (UIModalPresentationStyle)UIModalPresentationStyle:(id)json;
+
++ (UIModalTransitionStyle)UIModalTransitionStyle:(id)json;
+
+@end

--- a/lib/ios/RNNConvert.m
+++ b/lib/ios/RNNConvert.m
@@ -1,12 +1,6 @@
-#import <React/RCTConvert.h>
+#import "RNNConvert.h"
 
-@interface RCTConvert (Modal)
-
-+ (UIModalPresentationStyle)defaultModalPresentationStyle;
-
-@end
-
-@implementation RCTConvert (Modal)
+@implementation RNNConvert
 
 + (UIModalPresentationStyle)defaultModalPresentationStyle {
     if (@available(iOS 13.0, *)) {
@@ -33,7 +27,7 @@ RCT_ENUM_CONVERTER(UIModalPresentationStyle,
                       @"overCurrentContext": @(UIModalPresentationOverCurrentContext),
                       @"popover": @(UIModalPresentationPopover),
                       @"none": @(UIModalPresentationNone),
-                      @"default": @([RCTConvert defaultModalPresentationStyle])
+                      @"default": @([RNNConvert defaultModalPresentationStyle])
                    }), UIModalPresentationFullScreen, integerValue)
-@end
 
+@end

--- a/lib/ios/RNNModalManager.m
+++ b/lib/ios/RNNModalManager.m
@@ -3,6 +3,7 @@
 #import "UIViewController+LayoutProtocol.h"
 #import "ModalTransitionDelegate.h"
 #import "ModalDismissTransitionDelegate.h"
+#import "RNNConvert.h"
 
 @interface RNNModalManager ()
 @property (nonatomic, strong) ModalTransitionDelegate* modalTransitionDelegate;
@@ -36,6 +37,9 @@
 	
 	UIViewController* topVC = [self topPresentedVC];
 	
+    viewController.modalPresentationStyle = [RNNConvert UIModalPresentationStyle:[viewController.resolveOptionsWithDefault.modalPresentationStyle getWithDefaultValue:@"default"]];
+    viewController.modalTransitionStyle = [RNNConvert UIModalTransitionStyle:[viewController.resolveOptionsWithDefault.modalTransitionStyle getWithDefaultValue:@"coverVertical"]];
+    
 	if (viewController.presentationController) {
 		viewController.presentationController.delegate = self;
 	}

--- a/lib/ios/RNNNavigationOptions.h
+++ b/lib/ios/RNNNavigationOptions.h
@@ -43,6 +43,8 @@ extern const NSInteger BLUR_TOPBAR_TAG;
 
 - (instancetype)initEmptyOptions;
 
++ (instancetype)emptyOptions;
+
 - (RNNNavigationOptions *)withDefault:(RNNNavigationOptions *)defaultOptions;
 
 - (RNNNavigationOptions *)copy;

--- a/lib/ios/RNNNavigationOptions.m
+++ b/lib/ios/RNNNavigationOptions.m
@@ -42,6 +42,10 @@
 	return self;
 }
 
++ (instancetype)emptyOptions {
+    return [[RNNNavigationOptions alloc] initEmptyOptions];
+}
+
 - (instancetype)initEmptyOptions {
 	self = [self initWithDict:@{}];
 	return self;

--- a/lib/ios/RNNSplitViewControllerPresenter.m
+++ b/lib/ios/RNNSplitViewControllerPresenter.m
@@ -1,6 +1,5 @@
 #import "RNNSplitViewControllerPresenter.h"
 #import "UISplitViewController+RNNOptions.h"
-#import "RCTConvert+Modal.h"
 #import "RNNSplitViewController.h"
 
 @implementation RNNSplitViewControllerPresenter

--- a/lib/ios/RNNStackController.m
+++ b/lib/ios/RNNStackController.m
@@ -37,10 +37,6 @@
 	return [_presenter getStatusBarStyle:self.resolveOptions];
 }
 
-- (UIModalPresentationStyle)modalPresentationStyle {
-	return self.getCurrentChild.modalPresentationStyle;
-}
-
 - (UIViewController *)popViewControllerAnimated:(BOOL)animated {
     [self prepareForPop];
 	return [super popViewControllerAnimated:animated];

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -219,7 +219,6 @@
 		505EDD34214E7B7B0071C7DE /* RNNLeafProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 505EDD33214E7A6A0071C7DE /* RNNLeafProtocol.h */; };
 		505EDD3C214FA8000071C7DE /* RNNComponentPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 505EDD3A214FA8000071C7DE /* RNNComponentPresenter.h */; };
 		505EDD3D214FA8000071C7DE /* RNNComponentPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 505EDD3B214FA8000071C7DE /* RNNComponentPresenter.m */; };
-		505EDD4A214FDA800071C7DE /* RCTConvert+Modal.h in Headers */ = {isa = PBXBuildFile; fileRef = 505EDD48214FDA800071C7DE /* RCTConvert+Modal.h */; };
 		5060DE73219DAD7E00D0C052 /* ReactNativeNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BA500731E2544B9001B9E1B /* ReactNativeNavigation.h */; };
 		5060DE74219DAD8300D0C052 /* RNNBridgeManagerDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 502CB43920CBCA140019B2FE /* RNNBridgeManagerDelegate.h */; };
 		5061B6C723D48449008B9827 /* VerticalRotationTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = 5061B6C523D48449008B9827 /* VerticalRotationTransition.h */; };
@@ -270,6 +269,8 @@
 		509416A823A11C630036092C /* EnumParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 509416A623A11C630036092C /* EnumParser.m */; };
 		509416AB23A11CB20036092C /* NullEnum.h in Headers */ = {isa = PBXBuildFile; fileRef = 509416A923A11CB20036092C /* NullEnum.h */; };
 		509416AC23A11CB20036092C /* NullEnum.m in Sources */ = {isa = PBXBuildFile; fileRef = 509416AA23A11CB20036092C /* NullEnum.m */; };
+		5095BB722416A3B900C4CD41 /* RNNConvert.h in Headers */ = {isa = PBXBuildFile; fileRef = 5095BB702416A3B900C4CD41 /* RNNConvert.h */; };
+		5095BB732416A3B900C4CD41 /* RNNConvert.m in Sources */ = {isa = PBXBuildFile; fileRef = 5095BB712416A3B900C4CD41 /* RNNConvert.m */; };
 		509670A023D4A81E002224F9 /* BaseAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 5096709E23D4A81E002224F9 /* BaseAnimator.h */; };
 		509670A123D4A81E002224F9 /* BaseAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 5096709F23D4A81E002224F9 /* BaseAnimator.m */; };
 		50967F5B232FC2C200BEEA92 /* RNNFontAttributesCreatorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 50967F5A232FC2C200BEEA92 /* RNNFontAttributesCreatorTest.m */; };
@@ -704,7 +705,6 @@
 		505EDD3A214FA8000071C7DE /* RNNComponentPresenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNComponentPresenter.h; sourceTree = "<group>"; };
 		505EDD3B214FA8000071C7DE /* RNNComponentPresenter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNComponentPresenter.m; sourceTree = "<group>"; };
 		505EDD47214FC4A60071C7DE /* RNNLayoutProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNLayoutProtocol.h; sourceTree = "<group>"; };
-		505EDD48214FDA800071C7DE /* RCTConvert+Modal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+Modal.h"; sourceTree = "<group>"; };
 		5061B6C523D48449008B9827 /* VerticalRotationTransition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VerticalRotationTransition.h; sourceTree = "<group>"; };
 		5061B6C623D48449008B9827 /* VerticalRotationTransition.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VerticalRotationTransition.m; sourceTree = "<group>"; };
 		506317A8220B547400B26FC3 /* UIImage+insets.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+insets.h"; sourceTree = "<group>"; };
@@ -753,6 +753,8 @@
 		509416A623A11C630036092C /* EnumParser.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EnumParser.m; sourceTree = "<group>"; };
 		509416A923A11CB20036092C /* NullEnum.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NullEnum.h; sourceTree = "<group>"; };
 		509416AA23A11CB20036092C /* NullEnum.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NullEnum.m; sourceTree = "<group>"; };
+		5095BB702416A3B900C4CD41 /* RNNConvert.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNConvert.h; sourceTree = "<group>"; };
+		5095BB712416A3B900C4CD41 /* RNNConvert.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNConvert.m; sourceTree = "<group>"; };
 		5096709923D49B35002224F9 /* DisplayLinkAnimatorDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DisplayLinkAnimatorDelegate.h; sourceTree = "<group>"; };
 		5096709E23D4A81E002224F9 /* BaseAnimator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BaseAnimator.h; sourceTree = "<group>"; };
 		5096709F23D4A81E002224F9 /* BaseAnimator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BaseAnimator.m; sourceTree = "<group>"; };
@@ -1007,12 +1009,13 @@
 				5038A373216CDDB6009280BC /* UIViewController+SideMenuController.m */,
 				5038A3BF216E1E66009280BC /* RNNFontAttributesCreator.h */,
 				5038A3C0216E1E66009280BC /* RNNFontAttributesCreator.m */,
-				505EDD48214FDA800071C7DE /* RCTConvert+Modal.h */,
 				50DA74CF232F80FE004A00C1 /* RCTConvert+UIFontWeight.h */,
 				50E02BD521A6E54B00A43942 /* RCTConvert+SideMenuOpenGestureMode.h */,
 				7365070F21E4B16F004E020F /* RCTConvert+UIBarButtonSystemItem.h */,
 				7365071021E4B16F004E020F /* RCTConvert+UIBarButtonSystemItem.m */,
 				5030B62823D5C9AF008F1642 /* RCTConvert+Interpolation.h */,
+				5095BB702416A3B900C4CD41 /* RNNConvert.h */,
+				5095BB712416A3B900C4CD41 /* RNNConvert.m */,
 				5038A3BB216E1490009280BC /* RNNTabBarItemCreator.h */,
 				5038A3BC216E1490009280BC /* RNNTabBarItemCreator.m */,
 				5022EDBF24053C9F00852BA6 /* TabBarItemAppearanceCreator.h */,
@@ -1671,7 +1674,6 @@
 			files = (
 				5060DE74219DAD8300D0C052 /* RNNBridgeManagerDelegate.h in Headers */,
 				5060DE73219DAD7E00D0C052 /* ReactNativeNavigation.h in Headers */,
-				261F0E6A1E6F028A00989DE2 /* RNNNavigationStackManager.h in Headers */,
 				5022EDBD2405237100852BA6 /* BottomTabPresenterCreator.h in Headers */,
 				507ACB1523F44E5200829911 /* RNNComponentRootView.h in Headers */,
 				5061B6C723D48449008B9827 /* VerticalRotationTransition.h in Headers */,
@@ -1849,7 +1851,6 @@
 				507F43F81FF525B500D9425B /* RNNSegmentedControl.h in Headers */,
 				50175CD1207A2AA1004FE91B /* RNNComponentOptions.h in Headers */,
 				5038A3B1216DF41B009280BC /* UIViewController+RNNOptions.h in Headers */,
-				505EDD4A214FDA800071C7DE /* RCTConvert+Modal.h in Headers */,
 				5049595A216F6B46006D2B81 /* NullDictionary.h in Headers */,
 				50BCB27123F1650800D6C8E5 /* SharedElementAnimator.h in Headers */,
 				50BCB27D23F2A1EE00D6C8E5 /* FloatTransition.h in Headers */,
@@ -1863,6 +1864,7 @@
 				30987680135A8C78E62D5B8E /* DotIndicatorOptions.h in Headers */,
 				30987CA5048A48D6CE76B06C /* DotIndicatorParser.h in Headers */,
 				3098730BC3B4DE41104D9CC4 /* RNNDotIndicatorPresenter.h in Headers */,
+				5095BB722416A3B900C4CD41 /* RNNConvert.h in Headers */,
 				50D3A36E23B8D6C600717F95 /* SharedElementTransitionsCreator.h in Headers */,
 				309877F473AECC05FB3B9362 /* UITabBarController+RNNUtils.h in Headers */,
 				3098702E6833E5CC16D91CE3 /* NoColor.h in Headers */,
@@ -2171,6 +2173,7 @@
 				7B4928091E70415400555040 /* RNNCommandsHandler.m in Sources */,
 				50887C1620ECC5C200D06111 /* RNNButtonOptions.m in Sources */,
 				50EA541B23AEE1C6006F881A /* AnimatedReactView.m in Sources */,
+				5095BB732416A3B900C4CD41 /* RNNConvert.m in Sources */,
 				7BC9346E1E26886E00EFA125 /* RNNControllerFactory.m in Sources */,
 				507F43F91FF525B500D9425B /* RNNSegmentedControl.m in Sources */,
 				5038A3B2216DF41B009280BC /* UIViewController+RNNOptions.m in Sources */,

--- a/playground/ios/NavigationTests/RNNComponentPresenterTest.m
+++ b/playground/ios/NavigationTests/RNNComponentPresenterTest.m
@@ -5,7 +5,6 @@
 #import "RNNComponentViewController.h"
 #import "UIViewController+LayoutProtocol.h"
 #import "RNNTitleViewHelper.h"
-#import "RCTConvert+Modal.h"
 
 @interface RNNComponentPresenterTest : XCTestCase
 
@@ -58,12 +57,12 @@
 	XCTAssertFalse(self.boundViewController.navigationItem.hidesBackButton);
 }
 
-//- (void)testApplyOptions_drawBehindTabBarTrueWhenVisibleFalse {
-//	self.options.bottomTabs.visible = [[Bool alloc] initWithValue:@(0)];
-//	[[(id) self.boundViewController expect] setDrawBehindTabBar:YES];
-//	[self.uut applyOptionsOnInit:self.options];
-//	[(id)self.boundViewController verify];
-//}
+- (void)testApplyOptions_drawBehindTabBarTrueWhenVisibleFalse {
+	self.options.bottomTabs.visible = [[Bool alloc] initWithValue:@(0)];
+	[[(id) self.boundViewController expect] setDrawBehindTabBar:YES];
+	[self.uut applyOptionsOnInit:self.options];
+	[(id)self.boundViewController verify];
+}
 
 - (void)testApplyOptions_setOverlayTouchOutsideIfHasValue {
     self.options.overlay.interceptTouchOutside = [[Bool alloc] initWithBOOL:YES];
@@ -78,63 +77,37 @@
 	XCTAssertNotNil(presenter.navigationButtons);
 }
 
-- (void)testApplyOptionsOnInit_shouldSetModalPresentationStyleWithDefault {
-    [(UIViewController *) [(id) self.boundViewController expect] setModalPresentationStyle:[RCTConvert defaultModalPresentationStyle]];
-	[self.uut applyOptionsOnInit:self.options];
-	[(id)self.boundViewController verify];
+-(void)testApplyOptionsOnInit_TopBarDrawUnder_true {
+    self.options.topBar.drawBehind = [[Bool alloc] initWithValue:@(1)];
+
+	[[(id) self.boundViewController expect] setDrawBehindTopBar:YES];
+    [self.uut applyOptionsOnInit:self.options];
+    [(id)self.boundViewController verify];
 }
 
-- (void)testApplyOptionsOnInit_shouldSetModalTransitionStyleWithDefault {
-	[(UIViewController *) [(id) self.boundViewController expect] setModalTransitionStyle:UIModalTransitionStyleCoverVertical];
-	[self.uut applyOptionsOnInit:self.options];
-	[(id)self.boundViewController verify];
+-(void)testApplyOptionsOnInit_TopBarDrawUnder_false {
+    self.options.topBar.drawBehind = [[Bool alloc] initWithValue:@(0)];
+
+	[[(id) self.boundViewController expect] setDrawBehindTopBar:NO];
+    [self.uut applyOptionsOnInit:self.options];
+    [(id)self.boundViewController verify];
 }
 
-- (void)testApplyOptionsOnInit_shouldSetModalPresentationStyleWithValue {
-	self.options.modalPresentationStyle = [[Text alloc] initWithValue:@"overCurrentContext"];
-    [(UIViewController *) [(id) self.boundViewController expect] setModalPresentationStyle:UIModalPresentationOverCurrentContext];
-	[self.uut applyOptionsOnInit:self.options];
-	[(id)self.boundViewController verify];
+-(void)testApplyOptionsOnInit_BottomTabsDrawUnder_true {
+    self.options.bottomTabs.drawBehind = [[Bool alloc] initWithValue:@(1)];
+
+	[[(id) self.boundViewController expect] setDrawBehindTabBar:YES];
+    [self.uut applyOptionsOnInit:self.options];
+    [(id)self.boundViewController verify];
 }
 
-- (void)testApplyOptionsOnInit_shouldSetModalTransitionStyleWithValue {
-	self.options.modalTransitionStyle = [[Text alloc] initWithValue:@"crossDissolve"];
-	[(UIViewController *) [(id) self.boundViewController expect] setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
-	[self.uut applyOptionsOnInit:self.options];
-	[(id)self.boundViewController verify];
-}
+-(void)testApplyOptionsOnInit_BottomTabsDrawUnder_false {
+    self.options.bottomTabs.drawBehind = [[Bool alloc] initWithValue:@(0)];
 
-//-(void)testApplyOptionsOnInit_TopBarDrawUnder_true {
-//    self.options.topBar.drawBehind = [[Bool alloc] initWithValue:@(1)];
-//
-//	[[(id) self.boundViewController expect] setDrawBehindTopBar:YES];
-//    [self.uut applyOptionsOnInit:self.options];
-//    [(id)self.boundViewController verify];
-//}
-//
-//-(void)testApplyOptionsOnInit_TopBarDrawUnder_false {
-//    self.options.topBar.drawBehind = [[Bool alloc] initWithValue:@(0)];
-//
-//	[[(id) self.boundViewController expect] setDrawBehindTopBar:NO];
-//    [self.uut applyOptionsOnInit:self.options];
-//    [(id)self.boundViewController verify];
-//}
-//
-//-(void)testApplyOptionsOnInit_BottomTabsDrawUnder_true {
-//    self.options.bottomTabs.drawBehind = [[Bool alloc] initWithValue:@(1)];
-//
-//	[[(id) self.boundViewController expect] setDrawBehindTabBar:YES];
-//    [self.uut applyOptionsOnInit:self.options];
-//    [(id)self.boundViewController verify];
-//}
-//
-//-(void)testApplyOptionsOnInit_BottomTabsDrawUnder_false {
-//    self.options.bottomTabs.drawBehind = [[Bool alloc] initWithValue:@(0)];
-//
-//	[[(id) self.boundViewController expect] setDrawBehindTabBar:NO];
-//    [self.uut applyOptionsOnInit:self.options];
-//    [(id)self.boundViewController verify];
-//}
+	[[(id) self.boundViewController expect] setDrawBehindTabBar:NO];
+    [self.uut applyOptionsOnInit:self.options];
+    [(id)self.boundViewController verify];
+}
 
 - (void)testReactViewShouldBeReleasedOnDealloc {
 	RNNComponentViewController* bindViewController = [RNNComponentViewController new];

--- a/playground/ios/NavigationTests/RNNModalManagerTest.m
+++ b/playground/ios/NavigationTests/RNNModalManagerTest.m
@@ -145,6 +145,32 @@
 	[mockDelegate verify];
 }
 
+- (void)testApplyOptionsOnInit_shouldShowModalWithDefaultPresentationStyle {
+	_vc1.options = [RNNNavigationOptions emptyOptions];
+	[_modalManager showModal:_vc1 animated:NO completion:nil];
+	XCTAssertEqual(_vc1.modalPresentationStyle, UIModalPresentationPageSheet);
+}
+
+- (void)testApplyOptionsOnInit_shouldShowModalWithDefaultTransitionStyle {
+	_vc1.options = [RNNNavigationOptions emptyOptions];
+	[_modalManager showModal:_vc1 animated:NO completion:nil];
+	XCTAssertEqual(_vc1.modalTransitionStyle, UIModalTransitionStyleCoverVertical);
+}
+
+- (void)testApplyOptionsOnInit_shouldShowModalWithPresentationStyle {
+	_vc1.options = [RNNNavigationOptions emptyOptions];
+	_vc1.options.modalPresentationStyle = [Text withValue:@"overCurrentContext"];
+	[_modalManager showModal:_vc1 animated:NO completion:nil];
+	XCTAssertEqual(_vc1.modalPresentationStyle, UIModalPresentationOverCurrentContext);
+}
+
+- (void)testApplyOptionsOnInit_shouldShowModalWithTransitionStyle {
+	_vc1.options = [RNNNavigationOptions emptyOptions];
+	_vc1.options.modalTransitionStyle = [Text withValue:@"crossDissolve"];
+	[_modalManager showModal:_vc1 animated:NO completion:nil];
+	XCTAssertEqual(_vc1.modalTransitionStyle, UIModalTransitionStyleCrossDissolve);
+}
+
 #pragma mark RNNModalManagerDelegate
 
 - (void)dismissedMultipleModals:(NSArray *)viewControllers {

--- a/playground/ios/NavigationTests/RNNTabBarControllerTest.m
+++ b/playground/ios/NavigationTests/RNNTabBarControllerTest.m
@@ -3,7 +3,6 @@
 #import <ReactNativeNavigation/RNNComponentViewController.h>
 #import "RNNStackController.h"
 #import <OCMock/OCMock.h>
-#import "RCTConvert+Modal.h"
 #import <ReactNativeNavigation/BottomTabPresenterCreator.h>
 #import "RNNBottomTabsController+Helpers.h"
 

--- a/playground/ios/NavigationTests/UIViewController+LayoutProtocolTest.m
+++ b/playground/ios/NavigationTests/UIViewController+LayoutProtocolTest.m
@@ -3,7 +3,6 @@
 #import "UIViewController+LayoutProtocol.h"
 #import "UIViewController+RNNOptions.h"
 #import "RNNComponentPresenter.h"
-#import "RCTConvert+Modal.h"
 #import "RNNBottomTabsController.h"
 #import "RNNStackController.h"
 


### PR DESCRIPTION
* Resolve `modalPresentationStyle` and `modalTransitionStyle` from layout tree on `showModal`.
* Remove merging `modalPresentationStyle` and `modalTransitionStyle` because it make no sense.
* Restore few tests that were disabled.

Closes #6003