### PR TITLE
Fix bottomTabs.translucent option

### DIFF
--- a/lib/ios/BottomTabsAppearancePresenter.h
+++ b/lib/ios/BottomTabsAppearancePresenter.h
@@ -1,7 +1,7 @@
-#import "RNNBottomTabsPresenter.h"
+#import "BottomTabsBasePresenter.h"
 
 API_AVAILABLE(ios(13.0))
-@interface BottomTabsAppearancePresenter : RNNBottomTabsPresenter
+@interface BottomTabsAppearancePresenter : BottomTabsBasePresenter
 
 
 @end

--- a/lib/ios/BottomTabsAppearancePresenter.m
+++ b/lib/ios/BottomTabsAppearancePresenter.m
@@ -1,12 +1,47 @@
 #import "BottomTabsAppearancePresenter.h"
+#import "UIColor+RNNUtils.h"
 
 @implementation BottomTabsAppearancePresenter
 
+# pragma mark - public
+
+- (void)applyBackgroundColor:(UIColor *)backgroundColor translucent:(BOOL)translucent {
+    if (translucent) [self setTabBarTranslucent:YES];
+    else if (backgroundColor.isTransparent) [self setTabBarTransparentBackground];
+    else if (backgroundColor) [self setTabBarBackgroundColor:backgroundColor];
+    else [self setTabBarDefaultBackground];
+}
+
 - (void)setTabBarBackgroundColor:(UIColor *)backgroundColor {
-    UITabBarController *bottomTabs = self.tabBarController;
-    for (UIViewController* childViewController in bottomTabs.childViewControllers) {
+    [self setTabBarOpaqueBackground];
+    for (UIViewController* childViewController in self.tabBarController.childViewControllers)
         childViewController.tabBarItem.standardAppearance.backgroundColor = backgroundColor;
-    }
+}
+
+- (void)setTabBarTranslucent:(BOOL)translucent {
+    if (translucent) [self setTabBarTranslucentBackground];
+    else [self setTabBarOpaqueBackground];
+}
+
+# pragma mark - private
+
+- (void)setTabBarDefaultBackground {
+    [self setTabBarOpaqueBackground];
+}
+
+- (void)setTabBarTranslucentBackground {
+    for (UIViewController* childViewController in self.tabBarController.childViewControllers)
+        [childViewController.tabBarItem.standardAppearance configureWithDefaultBackground];
+}
+
+- (void)setTabBarTransparentBackground {
+    for (UIViewController* childViewController in self.tabBarController.childViewControllers)
+        [childViewController.tabBarItem.standardAppearance configureWithTransparentBackground];
+}
+
+- (void)setTabBarOpaqueBackground {
+    for (UIViewController* childViewController in self.tabBarController.childViewControllers)
+        [childViewController.tabBarItem.standardAppearance configureWithOpaqueBackground];
 }
 
 @end

--- a/lib/ios/BottomTabsBasePresenter.h
+++ b/lib/ios/BottomTabsBasePresenter.h
@@ -1,0 +1,20 @@
+#import <Foundation/Foundation.h>
+#import "RNNBasePresenter.h"
+#import "UITabBarController+RNNOptions.h"
+#import "UIViewController+LayoutProtocol.h"
+#import "UIViewController+Utils.h"
+#import "UIColor+RNNUtils.h"
+
+@interface BottomTabsBasePresenter : RNNBasePresenter
+
+- (void)applyBackgroundColor:(UIColor *)backgroundColor translucent:(BOOL)translucent;
+
+- (void)setTabBarBackgroundColor:(UIColor *)backgroundColor;
+
+- (void)setTabBarTranslucent:(BOOL)translucent;
+
+- (UITabBarController *)tabBarController;
+
+- (UITabBar *)tabBar;
+
+@end

--- a/lib/ios/BottomTabsBasePresenter.m
+++ b/lib/ios/BottomTabsBasePresenter.m
@@ -1,0 +1,95 @@
+#import "BottomTabsBasePresenter.h"
+
+@implementation BottomTabsBasePresenter
+
+- (void)applyOptionsOnInit:(RNNNavigationOptions *)options {
+    [super applyOptionsOnInit:options];
+    UITabBarController *bottomTabs = self.tabBarController;
+    RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
+    [bottomTabs setCurrentTabIndex:[withDefault.bottomTabs.currentTabIndex getWithDefaultValue:0]];
+    if ([[withDefault.bottomTabs.titleDisplayMode getWithDefaultValue:@"alwaysShow"] isEqualToString:@"alwaysHide"]) {
+        [bottomTabs centerTabItems];
+    }
+}
+
+- (void)applyOptions:(RNNNavigationOptions *)options {
+    UITabBarController *bottomTabs = self.tabBarController;
+    RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
+
+    [bottomTabs setTabBarTestID:[withDefault.bottomTabs.testID getWithDefaultValue:nil]];
+    [bottomTabs setTabBarVisible:[withDefault.bottomTabs.visible getWithDefaultValue:YES] animated:[withDefault.bottomTabs.animate getWithDefaultValue:NO]];
+    
+    [bottomTabs.view setBackgroundColor:[withDefault.layout.backgroundColor getWithDefaultValue:nil]];
+    [self applyBackgroundColor:[withDefault.bottomTabs.backgroundColor getWithDefaultValue:nil] translucent:[withDefault.bottomTabs.translucent getWithDefaultValue:NO]];
+    [bottomTabs setTabBarHideShadow:[withDefault.bottomTabs.hideShadow getWithDefaultValue:NO]];
+    [bottomTabs setTabBarStyle:[RCTConvert UIBarStyle:[withDefault.bottomTabs.barStyle getWithDefaultValue:@"default"]]];
+}
+
+- (void)mergeOptions:(RNNNavigationOptions *)options resolvedOptions:(RNNNavigationOptions *)currentOptions {
+    [super mergeOptions:options resolvedOptions:currentOptions];
+    UITabBarController *bottomTabs = self.tabBarController;
+
+    if (options.bottomTabs.currentTabIndex.hasValue) {
+        [bottomTabs setCurrentTabIndex:options.bottomTabs.currentTabIndex.get];
+        [options.bottomTabs.currentTabIndex consume];
+    }
+
+    if (options.bottomTabs.currentTabId.hasValue) {
+        [bottomTabs setCurrentTabID:options.bottomTabs.currentTabId.get];
+        [options.bottomTabs.currentTabId consume];
+    }
+
+    if (options.bottomTabs.testID.hasValue) {
+        [bottomTabs setTabBarTestID:options.bottomTabs.testID.get];
+    }
+
+    if (options.bottomTabs.backgroundColor.hasValue) {
+        [self setTabBarBackgroundColor:options.bottomTabs.backgroundColor.get];
+    }
+
+    if (options.bottomTabs.barStyle.hasValue) {
+        [bottomTabs setTabBarStyle:[RCTConvert UIBarStyle:options.bottomTabs.barStyle.get]];
+    }
+
+    if (options.bottomTabs.translucent.hasValue) {
+        [bottomTabs setTabBarTranslucent:options.bottomTabs.translucent.get];
+    }
+
+    if (options.bottomTabs.hideShadow.hasValue) {
+        [bottomTabs setTabBarHideShadow:options.bottomTabs.hideShadow.get];
+    }
+
+    if (options.bottomTabs.visible.hasValue) {
+        if (options.bottomTabs.animate.hasValue) {
+            [bottomTabs setTabBarVisible:options.bottomTabs.visible.get animated:[options.bottomTabs.animate getWithDefaultValue:NO]];
+        } else {
+            [bottomTabs setTabBarVisible:options.bottomTabs.visible.get animated:NO];
+        }
+    }
+    
+    if (options.layout.backgroundColor.hasValue) {
+        [bottomTabs.view setBackgroundColor:options.layout.backgroundColor.get];
+    }
+}
+
+- (UITabBarController *)tabBarController {
+    return (UITabBarController *)self.boundViewController;
+}
+
+- (UITabBar *)tabBar {
+    return self.tabBarController.tabBar;
+}
+
+- (void)applyBackgroundColor:(UIColor *)backgroundColor translucent:(BOOL)translucent {
+    
+}
+
+- (void)setTabBarBackgroundColor:(UIColor *)backgroundColor {
+    
+}
+
+- (void)setTabBarTranslucent:(BOOL)translucent {
+    
+}
+
+@end

--- a/lib/ios/RNNBottomTabsOptions.h
+++ b/lib/ios/RNNBottomTabsOptions.h
@@ -21,4 +21,6 @@
 @property (nonatomic, strong) Text* titleDisplayMode;
 @property (nonatomic, strong) BottomTabsAttachMode* tabsAttachMode;
 
+- (BOOL)shouldDrawBehind;
+
 @end

--- a/lib/ios/RNNBottomTabsOptions.m
+++ b/lib/ios/RNNBottomTabsOptions.m
@@ -25,4 +25,10 @@
 	return self;
 }
 
+- (BOOL)shouldDrawBehind {
+    return [self.drawBehind getWithDefaultValue:NO] ||
+    [self.translucent getWithDefaultValue:NO] ||
+    ![self.visible getWithDefaultValue:YES];
+}
+
 @end

--- a/lib/ios/RNNBottomTabsPresenter.h
+++ b/lib/ios/RNNBottomTabsPresenter.h
@@ -1,11 +1,5 @@
-#import "RNNBasePresenter.h"
+#import "BottomTabsBasePresenter.h"
 
-@interface RNNBottomTabsPresenter : RNNBasePresenter
-
-- (void)setTabBarBackgroundColor:(UIColor *)backgroundColor;
-
-- (UITabBarController *)tabBarController;
-
-- (UITabBar *)tabBar;
+@interface RNNBottomTabsPresenter : BottomTabsBasePresenter
 
 @end

--- a/lib/ios/RNNBottomTabsPresenter.m
+++ b/lib/ios/RNNBottomTabsPresenter.m
@@ -23,7 +23,7 @@
     [bottomTabs setTabBarVisible:[withDefault.bottomTabs.visible getWithDefaultValue:YES] animated:[withDefault.bottomTabs.animate getWithDefaultValue:NO]];
     
     [bottomTabs.view setBackgroundColor:[withDefault.layout.backgroundColor getWithDefaultValue:nil]];
-    [self setTabBarBackgroundColor:[withDefault.bottomTabs.backgroundColor getWithDefaultValue:UIColor.whiteColor]];
+    [self setTabBarBackgroundColor:[withDefault.bottomTabs.backgroundColor getWithDefaultValue:nil]];
     [bottomTabs setTabBarTranslucent:[withDefault.bottomTabs.translucent getWithDefaultValue:NO]];
     [bottomTabs setTabBarHideShadow:[withDefault.bottomTabs.hideShadow getWithDefaultValue:NO]];
     [bottomTabs setTabBarStyle:[RCTConvert UIBarStyle:[withDefault.bottomTabs.barStyle getWithDefaultValue:@"default"]]];

--- a/lib/ios/RNNBottomTabsPresenter.m
+++ b/lib/ios/RNNBottomTabsPresenter.m
@@ -1,91 +1,18 @@
 #import "RNNBottomTabsPresenter.h"
-#import "UITabBarController+RNNOptions.h"
-#import "UIViewController+LayoutProtocol.h"
-#import "UIViewController+Utils.h"
 
 @implementation RNNBottomTabsPresenter
 
-- (void)applyOptionsOnInit:(RNNNavigationOptions *)options {
-    [super applyOptionsOnInit:options];
-    UITabBarController *bottomTabs = self.tabBarController;
-    RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
-    [bottomTabs setCurrentTabIndex:[withDefault.bottomTabs.currentTabIndex getWithDefaultValue:0]];
-	if ([[withDefault.bottomTabs.titleDisplayMode getWithDefaultValue:@"alwaysShow"] isEqualToString:@"alwaysHide"]) {
-		[bottomTabs centerTabItems];
-	}
-}
-
-- (void)applyOptions:(RNNNavigationOptions *)options {
-    UITabBarController *bottomTabs = self.tabBarController;
-    RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
-
-    [bottomTabs setTabBarTestID:[withDefault.bottomTabs.testID getWithDefaultValue:nil]];
-    [bottomTabs setTabBarVisible:[withDefault.bottomTabs.visible getWithDefaultValue:YES] animated:[withDefault.bottomTabs.animate getWithDefaultValue:NO]];
-    
-    [bottomTabs.view setBackgroundColor:[withDefault.layout.backgroundColor getWithDefaultValue:nil]];
-    [self setTabBarBackgroundColor:[withDefault.bottomTabs.backgroundColor getWithDefaultValue:nil]];
-    [bottomTabs setTabBarTranslucent:[withDefault.bottomTabs.translucent getWithDefaultValue:NO]];
-    [bottomTabs setTabBarHideShadow:[withDefault.bottomTabs.hideShadow getWithDefaultValue:NO]];
-    [bottomTabs setTabBarStyle:[RCTConvert UIBarStyle:[withDefault.bottomTabs.barStyle getWithDefaultValue:@"default"]]];
-}
-
-- (void)mergeOptions:(RNNNavigationOptions *)options resolvedOptions:(RNNNavigationOptions *)currentOptions {
-    [super mergeOptions:options resolvedOptions:currentOptions];
-    UITabBarController *bottomTabs = self.tabBarController;
-
-    if (options.bottomTabs.currentTabIndex.hasValue) {
-        [bottomTabs setCurrentTabIndex:options.bottomTabs.currentTabIndex.get];
-        [options.bottomTabs.currentTabIndex consume];
-    }
-
-    if (options.bottomTabs.currentTabId.hasValue) {
-        [bottomTabs setCurrentTabID:options.bottomTabs.currentTabId.get];
-        [options.bottomTabs.currentTabId consume];
-    }
-
-    if (options.bottomTabs.testID.hasValue) {
-        [bottomTabs setTabBarTestID:options.bottomTabs.testID.get];
-    }
-
-    if (options.bottomTabs.backgroundColor.hasValue) {
-        [self setTabBarBackgroundColor:options.bottomTabs.backgroundColor.get];
-    }
-
-    if (options.bottomTabs.barStyle.hasValue) {
-        [bottomTabs setTabBarStyle:[RCTConvert UIBarStyle:options.bottomTabs.barStyle.get]];
-    }
-
-    if (options.bottomTabs.translucent.hasValue) {
-        [bottomTabs setTabBarTranslucent:options.bottomTabs.translucent.get];
-    }
-
-    if (options.bottomTabs.hideShadow.hasValue) {
-        [bottomTabs setTabBarHideShadow:options.bottomTabs.hideShadow.get];
-    }
-
-    if (options.bottomTabs.visible.hasValue) {
-        if (options.bottomTabs.animate.hasValue) {
-            [bottomTabs setTabBarVisible:options.bottomTabs.visible.get animated:[options.bottomTabs.animate getWithDefaultValue:NO]];
-        } else {
-            [bottomTabs setTabBarVisible:options.bottomTabs.visible.get animated:NO];
-        }
-    }
-    
-    if (options.layout.backgroundColor.hasValue) {
-        [bottomTabs.view setBackgroundColor:options.layout.backgroundColor.get];
-    }
+- (void)applyBackgroundColor:(UIColor *)backgroundColor translucent:(BOOL)translucent {
+    [self setTabBarTranslucent:translucent];
+    [self setTabBarBackgroundColor:backgroundColor];
 }
 
 - (void)setTabBarBackgroundColor:(UIColor *)backgroundColor {
     self.tabBar.barTintColor = backgroundColor;
 }
 
-- (UITabBarController *)tabBarController {
-    return (UITabBarController *)self.boundViewController;
-}
-
-- (UITabBar *)tabBar {
-    return self.tabBarController.tabBar;
+- (void)setTabBarTranslucent:(BOOL)translucent {
+    self.tabBar.translucent = translucent;
 }
 
 @end

--- a/lib/ios/RNNComponentPresenter.m
+++ b/lib/ios/RNNComponentPresenter.m
@@ -77,17 +77,17 @@
 }
 
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)options {
-	[super applyOptionsOnInit:options];
-	
-	UIViewController* viewController = self.boundViewController;
-	RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
+    [super applyOptionsOnInit:options];
     
-	[viewController setDrawBehindTopBar:[withDefault.topBar.drawBehind getWithDefaultValue:NO]];
-    [viewController setDrawBehindTabBar:[withDefault.bottomTabs.drawBehind getWithDefaultValue:NO] || ![withDefault.bottomTabs.visible getWithDefaultValue:YES]];
+    UIViewController* viewController = self.boundViewController;
+    RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
     
-	if ((withDefault.topBar.leftButtons || withDefault.topBar.rightButtons)) {
-		[_navigationButtons applyLeftButtons:withDefault.topBar.leftButtons rightButtons:withDefault.topBar.rightButtons defaultLeftButtonStyle:withDefault.topBar.leftButtonStyle defaultRightButtonStyle:withDefault.topBar.rightButtonStyle];
-	}
+    [viewController setDrawBehindTopBar:[withDefault.topBar shouldDrawBehind]];
+    [viewController setDrawBehindTabBar:[withDefault.bottomTabs shouldDrawBehind]];
+    
+    if ((withDefault.topBar.leftButtons || withDefault.topBar.rightButtons)) {
+        [_navigationButtons applyLeftButtons:withDefault.topBar.leftButtons rightButtons:withDefault.topBar.rightButtons defaultLeftButtonStyle:withDefault.topBar.leftButtonStyle defaultRightButtonStyle:withDefault.topBar.rightButtonStyle];
+    }
 }
 
 - (void)mergeOptions:(RNNNavigationOptions *)options resolvedOptions:(RNNNavigationOptions *)currentOptions {

--- a/lib/ios/RNNTopBarOptions.h
+++ b/lib/ios/RNNTopBarOptions.h
@@ -35,4 +35,6 @@
 @property (nonatomic, strong) RNNButtonOptions* leftButtonStyle;
 @property (nonatomic, strong) RNNButtonOptions* rightButtonStyle;
 
+- (BOOL)shouldDrawBehind;
+
 @end

--- a/lib/ios/RNNTopBarOptions.m
+++ b/lib/ios/RNNTopBarOptions.m
@@ -60,5 +60,10 @@
 	return self;
 }
 
+- (BOOL)shouldDrawBehind {
+    return [self.drawBehind getWithDefaultValue:NO] ||
+    [self.background.translucent getWithDefaultValue:NO] ||
+    ![self.visible getWithDefaultValue:YES];
+}
 
 @end

--- a/lib/ios/RNNTopBarOptions.m
+++ b/lib/ios/RNNTopBarOptions.m
@@ -63,7 +63,8 @@
 - (BOOL)shouldDrawBehind {
     return [self.drawBehind getWithDefaultValue:NO] ||
     [self.background.translucent getWithDefaultValue:NO] ||
-    ![self.visible getWithDefaultValue:YES];
+    ![self.visible getWithDefaultValue:YES] ||
+    [self.largeTitle.visible getWithDefaultValue:NO];
 }
 
 @end

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -167,6 +167,8 @@
 		503A8A2623BD04410094D1C4 /* ElementTransitionsCreator.m in Sources */ = {isa = PBXBuildFile; fileRef = 503A8A2423BD04410094D1C4 /* ElementTransitionsCreator.m */; };
 		50415CBA20553B8E00BB682E /* RNNScreenTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = 50415CB820553B8E00BB682E /* RNNScreenTransition.h */; };
 		50415CBB20553B8E00BB682E /* RNNScreenTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 50415CB920553B8E00BB682E /* RNNScreenTransition.m */; };
+		5041DC3E2417BBBA0033312F /* BottomTabsBasePresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5041DC3C2417BBBA0033312F /* BottomTabsBasePresenter.h */; };
+		5041DC3F2417BBBA0033312F /* BottomTabsBasePresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5041DC3D2417BBBA0033312F /* BottomTabsBasePresenter.m */; };
 		50451D052042DAEB00695F00 /* RNNPushAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 50451D032042DAEB00695F00 /* RNNPushAnimation.h */; };
 		50451D062042DAEB00695F00 /* RNNPushAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = 50451D042042DAEB00695F00 /* RNNPushAnimation.m */; };
 		50451D092042E20600695F00 /* RNNAnimationsOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 50451D072042E20600695F00 /* RNNAnimationsOptions.h */; };
@@ -653,6 +655,8 @@
 		503A8A2423BD04410094D1C4 /* ElementTransitionsCreator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ElementTransitionsCreator.m; sourceTree = "<group>"; };
 		50415CB820553B8E00BB682E /* RNNScreenTransition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNScreenTransition.h; sourceTree = "<group>"; };
 		50415CB920553B8E00BB682E /* RNNScreenTransition.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNScreenTransition.m; sourceTree = "<group>"; };
+		5041DC3C2417BBBA0033312F /* BottomTabsBasePresenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BottomTabsBasePresenter.h; sourceTree = "<group>"; };
+		5041DC3D2417BBBA0033312F /* BottomTabsBasePresenter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BottomTabsBasePresenter.m; sourceTree = "<group>"; };
 		50451D032042DAEB00695F00 /* RNNPushAnimation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNPushAnimation.h; sourceTree = "<group>"; };
 		50451D042042DAEB00695F00 /* RNNPushAnimation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNPushAnimation.m; sourceTree = "<group>"; };
 		50451D072042E20600695F00 /* RNNAnimationsOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNAnimationsOptions.h; sourceTree = "<group>"; };
@@ -1395,6 +1399,8 @@
 				5022EDB82405226800852BA6 /* BottomTabAppearancePresenter.m */,
 				5022EDC324054C6100852BA6 /* BottomTabsAppearancePresenter.h */,
 				5022EDC424054C6100852BA6 /* BottomTabsAppearancePresenter.m */,
+				5041DC3C2417BBBA0033312F /* BottomTabsBasePresenter.h */,
+				5041DC3D2417BBBA0033312F /* BottomTabsBasePresenter.m */,
 				5022EDBB2405237100852BA6 /* BottomTabPresenterCreator.h */,
 				5022EDBC2405237100852BA6 /* BottomTabPresenterCreator.m */,
 				5022EDC724054C8A00852BA6 /* BottomTabsPresenterCreator.h */,
@@ -1705,6 +1711,7 @@
 				50E38DDD23A7A306009817F6 /* AnimatedImageView.h in Headers */,
 				7B4928081E70415400555040 /* RNNCommandsHandler.h in Headers */,
 				50495942216F5E5D006D2B81 /* NullBool.h in Headers */,
+				5041DC3E2417BBBA0033312F /* BottomTabsBasePresenter.h in Headers */,
 				263905AE1E4C6F440023D7D3 /* MMDrawerBarButtonItem.h in Headers */,
 				5012241621736667000F5F98 /* Color.h in Headers */,
 				7365071121E4B16F004E020F /* RCTConvert+UIBarButtonSystemItem.h in Headers */,
@@ -2199,6 +2206,7 @@
 				30987D71FB4FEEAC8D8978E8 /* DotIndicatorParser.m in Sources */,
 				50CED44E239EA78700C42EE2 /* TopBarAppearancePresenter.m in Sources */,
 				30987B23F288EB3A78B7F27C /* RNNDotIndicatorPresenter.m in Sources */,
+				5041DC3F2417BBBA0033312F /* BottomTabsBasePresenter.m in Sources */,
 				5022EDC224053C9F00852BA6 /* TabBarItemAppearanceCreator.m in Sources */,
 				507ACB1223F44D1E00829911 /* RNNComponentView.m in Sources */,
 				5017D9F3239D2FCB00B74047 /* BottomTabsOnSwitchToTabAttacher.m in Sources */,

--- a/lib/ios/TopBarPresenter.m
+++ b/lib/ios/TopBarPresenter.m
@@ -1,6 +1,7 @@
 #import "TopBarPresenter.h"
 #import "UIImage+tint.h"
 #import "RNNFontAttributesCreator.h"
+#import "UIColor+RNNUtils.h"
 
 @implementation TopBarPresenter
 
@@ -148,7 +149,7 @@
 }
 
 - (BOOL)transparent {
-    return (self.backgroundColor && CGColorGetAlpha(self.backgroundColor.CGColor) == 0.0);
+    return self.backgroundColor.isTransparent;
 }
 
 @end

--- a/lib/ios/Utils/UIColor+RNNUtils.h
+++ b/lib/ios/Utils/UIColor+RNNUtils.h
@@ -2,4 +2,5 @@
 
 @interface UIColor (RNNUtils)
 - (NSString *)toHex;
+- (BOOL)isTransparent;
 @end

--- a/lib/ios/Utils/UIColor+RNNUtils.m
+++ b/lib/ios/Utils/UIColor+RNNUtils.m
@@ -8,6 +8,11 @@
 @implementation UIColor (RNNUtils)
 
 #pragma mark Public
+
+- (BOOL)isTransparent {
+    return (CGColorGetAlpha(self.CGColor) == 0.0);
+}
+
 - (NSString *)toHex {
     const CGFloat *components = CGColorGetComponents([self CGColor]);
 

--- a/playground/ios/NavigationIOS12Tests/RNNBottomTabsPresenterTest.m
+++ b/playground/ios/NavigationIOS12Tests/RNNBottomTabsPresenterTest.m
@@ -25,8 +25,7 @@
 - (void)testApplyOptions_shouldSetDefaultEmptyOptions {
     RNNNavigationOptions *emptyOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
     [[self.boundViewController expect] setTabBarTestID:nil];
-    [self.uut setTabBarBackgroundColor:nil];
-    [[self.boundViewController expect] setTabBarTranslucent:NO];
+	[[(id)self.uut expect] applyBackgroundColor:nil translucent:NO];
     [[self.boundViewController expect] setTabBarHideShadow:NO];
     [[self.boundViewController expect] setTabBarStyle:UIBarStyleDefault];
     [[self.boundViewController expect] setTabBarVisible:YES animated:NO];
@@ -44,8 +43,7 @@
     initialOptions.bottomTabs.barStyle = [[Text alloc] initWithValue:@"black"];
 
     [[self.boundViewController expect] setTabBarTestID:@"testID"];
-    [self.uut setTabBarBackgroundColor:[UIColor redColor]];
-    [[self.boundViewController expect] setTabBarTranslucent:NO];
+    [[(id)self.uut expect] applyBackgroundColor:nil translucent:[UIColor redColor]];
     [[self.boundViewController expect] setTabBarHideShadow:YES];
     [[self.boundViewController expect] setTabBarStyle:UIBarStyleBlack];
     [[self.boundViewController expect] setTabBarVisible:NO animated:NO];

--- a/playground/ios/NavigationTests/RNNBottomTabsAppearancePresenterTest.m
+++ b/playground/ios/NavigationTests/RNNBottomTabsAppearancePresenterTest.m
@@ -33,8 +33,7 @@
 - (void)testApplyOptions_shouldSetDefaultEmptyOptions {
     RNNNavigationOptions *emptyOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
     [[self.boundViewController expect] setTabBarTestID:nil];
-    [self.uut setTabBarBackgroundColor:nil];
-    [[self.boundViewController expect] setTabBarTranslucent:NO];
+    [[(id)self.uut expect] applyBackgroundColor:nil translucent:NO];
     [[self.boundViewController expect] setTabBarHideShadow:NO];
     [[self.boundViewController expect] setTabBarStyle:UIBarStyleDefault];
     [[self.boundViewController expect] setTabBarVisible:YES animated:NO];
@@ -52,8 +51,7 @@
     initialOptions.bottomTabs.barStyle = [[Text alloc] initWithValue:@"black"];
 
     [[self.boundViewController expect] setTabBarTestID:@"testID"];
-    [self.uut setTabBarBackgroundColor:[UIColor redColor]];
-    [[self.boundViewController expect] setTabBarTranslucent:NO];
+    [[(id)self.uut expect] applyBackgroundColor:nil translucent:[UIColor redColor]];
     [[self.boundViewController expect] setTabBarHideShadow:YES];
     [[self.boundViewController expect] setTabBarStyle:UIBarStyleBlack];
     [[self.boundViewController expect] setTabBarVisible:NO animated:NO];

--- a/playground/src/components/Root.js
+++ b/playground/src/components/Root.js
@@ -1,17 +1,18 @@
 const React = require('react');
 const { TextInput } = require('react-native');
-const { SafeAreaView, View, Text, StyleSheet, ScrollView, } = require('react-native');
+const { View, Text, StyleSheet, ScrollView, } = require('react-native');
 const { KeyboardAwareInsetsView } = require('react-native-keyboard-tracking-view');
 const { showTextInputToTestKeyboardInteraction } = require('../flags');
 
 module.exports = (props) =>
-  <SafeAreaView style={styles.root} testID={props.testID}>
-    <ScrollView contentContainerStyle={[styles.scrollView, props.style]}>
+  <ScrollView 
+    style={styles.root}
+    contentContainerStyle={[styles.scrollView, props.style]}
+    testID={props.testID}>
       {props.children}
       {renderFooter(props)}
-    </ScrollView>
-    {showTextInputToTestKeyboardInteraction && <KeyboardAwareInsetsView />}
-  </SafeAreaView>
+      {showTextInputToTestKeyboardInteraction && <KeyboardAwareInsetsView />}
+  </ScrollView>
 
 const renderFooter = (props) => props.componentId && <View style={styles.footer}>
   {renderInput()}

--- a/playground/src/components/Root.js
+++ b/playground/src/components/Root.js
@@ -1,18 +1,17 @@
 const React = require('react');
 const { TextInput } = require('react-native');
-const { View, Text, StyleSheet, ScrollView, } = require('react-native');
+const { SafeAreaView, View, Text, StyleSheet, ScrollView, } = require('react-native');
 const { KeyboardAwareInsetsView } = require('react-native-keyboard-tracking-view');
 const { showTextInputToTestKeyboardInteraction } = require('../flags');
 
 module.exports = (props) =>
-  <ScrollView 
-    style={styles.root}
-    contentContainerStyle={[styles.scrollView, props.style]}
-    testID={props.testID}>
+  <SafeAreaView style={styles.root} testID={props.testID}>
+    <ScrollView contentContainerStyle={[styles.scrollView, props.style]}>
       {props.children}
       {renderFooter(props)}
-      {showTextInputToTestKeyboardInteraction && <KeyboardAwareInsetsView />}
-  </ScrollView>
+    </ScrollView>
+    {showTextInputToTestKeyboardInteraction && <KeyboardAwareInsetsView />}
+  </SafeAreaView>
 
 const renderFooter = (props) => props.componentId && <View style={styles.footer}>
   {renderInput()}


### PR DESCRIPTION
* Add bottomTabsPresenter base class
* Always drawBehind `bottomTabs` and `topBar` when `translucent: true`
* Resolve `bottomTabs` background appearance in the correct order - 
  * translucent - strongest option
  * backgroundColor
* drawBehind when largeTitle is visible - fixes black large title

Closes #6006 
Closes #6014 