### PR TITLE
Fix truncated bottomTab.text with semibold fontWeight

### DIFF
--- a/lib/ios/TabBarItemAppearanceCreator.m
+++ b/lib/ios/TabBarItemAppearanceCreator.m
@@ -9,10 +9,12 @@
 }
 
 + (void)setTitleAttributes:(UITabBarItem *)tabItem titleAttributes:(NSDictionary *)titleAttributes {
+    [super setTitleAttributes:tabItem titleAttributes:titleAttributes];
     tabItem.standardAppearance.stackedLayoutAppearance.normal.titleTextAttributes = titleAttributes;
 }
 
 + (void)setSelectedTitleAttributes:(UITabBarItem *)tabItem selectedTitleAttributes:(NSDictionary *)selectedTitleAttributes {
+    [super setSelectedTitleAttributes:tabItem selectedTitleAttributes:selectedTitleAttributes];
     tabItem.standardAppearance.stackedLayoutAppearance.selected.titleTextAttributes = selectedTitleAttributes;
 }
 


### PR DESCRIPTION
There's an issue with iOS 13 bottomTab appearance where the label layout calculation is wrong when changing the font weight. Updating the titleAttributes using the old API solves this.

Closes #6005
