### PR TITLE
Fix largeTitle background color on iOS 13

### DIFF
--- a/lib/ios/RNNComponentViewController.m
+++ b/lib/ios/RNNComponentViewController.m
@@ -9,6 +9,7 @@
 	self.extendedLayoutIncludesOpaqueBars = YES;
     if (@available(iOS 13.0, *)) {
         self.navigationItem.standardAppearance = [UINavigationBarAppearance new];
+        self.navigationItem.scrollEdgeAppearance = [UINavigationBarAppearance new];
     }
 	return self;
 }

--- a/lib/ios/TopBarAppearancePresenter.m
+++ b/lib/ios/TopBarAppearancePresenter.m
@@ -34,12 +34,16 @@
 - (void)updateBackgroundAppearance {
     if (self.transparent) {
         [self.getAppearance configureWithTransparentBackground];
+        [self.getScrollEdgeAppearance configureWithTransparentBackground];
     } else if (self.backgroundColor) {
         [self.getAppearance setBackgroundColor:self.backgroundColor];
+        [self.getScrollEdgeAppearance setBackgroundColor:self.backgroundColor];
     } else if (self.translucent) {
         [self.getAppearance configureWithDefaultBackground];
+        [self.getScrollEdgeAppearance configureWithDefaultBackground];
     } else {
         [self.getAppearance configureWithOpaqueBackground];
+        [self.getScrollEdgeAppearance configureWithOpaqueBackground];
     }
 }
 
@@ -72,6 +76,10 @@
 
 - (UINavigationBarAppearance *)getAppearance {
     return self.currentNavigationItem.standardAppearance;
+}
+
+- (UINavigationBarAppearance *)getScrollEdgeAppearance {
+    return self.currentNavigationItem.scrollEdgeAppearance;
 }
 
 @end


### PR DESCRIPTION
Resolves largeTitle background color from `topBar.title.background.color`

Closes #5779 