### PR TITLE
Fix issue with previous iOS version

### DIFF
--- a/lib/ios/RNNStackController.m
+++ b/lib/ios/RNNStackController.m
@@ -12,7 +12,9 @@
     self = [super initWithLayoutInfo:layoutInfo creator:creator options:options defaultOptions:defaultOptions presenter:presenter eventEmitter:eventEmitter childViewControllers:childViewControllers];
     _stackDelegate = [[StackControllerDelegate alloc] initWithEventEmitter:self.eventEmitter];
     self.delegate = _stackDelegate;
-    self.navigationBar.prefersLargeTitles = YES;
+    if (@available(iOS 11.0, *)) {
+        self.navigationBar.prefersLargeTitles = YES;
+    }
     return self;
 }
 


### PR DESCRIPTION
Check if prefersLargeTitles is supported to avoid a crash on iOS < 11.0