### PR TITLE
Configure scrollEdgeAppearance with opaque background

### DIFF
--- a/lib/ios/TopBarAppearancePresenter.m
+++ b/lib/ios/TopBarAppearancePresenter.m
@@ -32,20 +32,17 @@
 }
 
 - (void)updateBackgroundAppearance {
-    if (@available(iOS 13.0, *)) {
+    if (self.transparent) {
+        [self.getAppearance configureWithTransparentBackground];
+        [self.getScrollEdgeAppearance configureWithTransparentBackground];
+    } else if (self.backgroundColor) {
         [self.getAppearance configureWithOpaqueBackground];
         [self.getScrollEdgeAppearance configureWithOpaqueBackground];
-
-        if (self.transparent) {
-            [self.getAppearance configureWithTransparentBackground];
-            [self.getScrollEdgeAppearance configureWithTransparentBackground];
-        } else if (self.backgroundColor) {
-            [self.getAppearance setBackgroundColor:self.backgroundColor];
-            [self.getScrollEdgeAppearance setBackgroundColor:self.backgroundColor];
-        } else if (self.translucent) {
-            [self.getAppearance configureWithDefaultBackground];
-            [self.getScrollEdgeAppearance configureWithDefaultBackground];
-        }
+        [self.getAppearance setBackgroundColor:self.backgroundColor];
+        [self.getScrollEdgeAppearance setBackgroundColor:self.backgroundColor];
+    } else if (self.translucent) {
+        [self.getAppearance configureWithDefaultBackground];
+        [self.getScrollEdgeAppearance configureWithDefaultBackground];
     }
 }
 

--- a/lib/ios/TopBarAppearancePresenter.m
+++ b/lib/ios/TopBarAppearancePresenter.m
@@ -32,18 +32,20 @@
 }
 
 - (void)updateBackgroundAppearance {
-    if (self.transparent) {
-        [self.getAppearance configureWithTransparentBackground];
-        [self.getScrollEdgeAppearance configureWithTransparentBackground];
-    } else if (self.backgroundColor) {
-        [self.getAppearance setBackgroundColor:self.backgroundColor];
-        [self.getScrollEdgeAppearance setBackgroundColor:self.backgroundColor];
-    } else if (self.translucent) {
-        [self.getAppearance configureWithDefaultBackground];
-        [self.getScrollEdgeAppearance configureWithDefaultBackground];
-    } else {
+    if (@available(iOS 13.0, *)) {
         [self.getAppearance configureWithOpaqueBackground];
         [self.getScrollEdgeAppearance configureWithOpaqueBackground];
+
+        if (self.transparent) {
+            [self.getAppearance configureWithTransparentBackground];
+            [self.getScrollEdgeAppearance configureWithTransparentBackground];
+        } else if (self.backgroundColor) {
+            [self.getAppearance setBackgroundColor:self.backgroundColor];
+            [self.getScrollEdgeAppearance setBackgroundColor:self.backgroundColor];
+        } else if (self.translucent) {
+            [self.getAppearance configureWithDefaultBackground];
+            [self.getScrollEdgeAppearance configureWithDefaultBackground];
+        }
     }
 }
 

--- a/lib/ios/TopBarAppearancePresenter.m
+++ b/lib/ios/TopBarAppearancePresenter.m
@@ -43,6 +43,9 @@
     } else if (self.translucent) {
         [self.getAppearance configureWithDefaultBackground];
         [self.getScrollEdgeAppearance configureWithDefaultBackground];
+    }  else {
+        [self.getAppearance configureWithOpaqueBackground];
+        [self.getScrollEdgeAppearance configureWithOpaqueBackground];
     }
 }
 


### PR DESCRIPTION
I noticed there is now an animation that occurs when pushing the first
view on a stack. This will happen with both:

`largeTitle: { visible: true }`
and
`largeTitle: { visible: false }`

It seems caused by the setting of the `scrollEdgeAppearance` background
without first configuring it using `configureWithOpaqueBackground`.

I also added checks for iOS 13 since these APIs require iOS 13.

I used this StackOverflow answer for reference: https://stackoverflow.com/a/57152709