### PR TITLE
Always resolve dismissAllModals promise

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/modal/ModalStack.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/modal/ModalStack.java
@@ -84,6 +84,7 @@ public class ModalStack {
 
     public void dismissAllModals(ViewController root, Options mergeOptions, CommandListener listener) {
         if (modals.isEmpty()) {
+            listener.onSuccess(root.getId());
             return;
         }
         String topModalId = peek().getId();

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalStackTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalStackTest.java
@@ -174,7 +174,7 @@ public class ModalStackTest extends BaseTest {
     }
 
     @Test
-    public void dismissAllModals_rejectIfEmpty() {
+    public void dismissAllModals_resolveSuccessfullyIfEmpty() {
         CommandListener spy = spy(new CommandListenerAdapter());
         uut.dismissAllModals(root, Options.EMPTY, spy);
         verify(spy, times(1)).onSuccess(root.getId());

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalStackTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalStackTest.java
@@ -174,6 +174,13 @@ public class ModalStackTest extends BaseTest {
     }
 
     @Test
+    public void dismissAllModals_rejectIfEmpty() {
+        CommandListener spy = spy(new CommandListenerAdapter());
+        uut.dismissAllModals(root, Options.EMPTY, spy);
+        verify(spy, times(1)).onSuccess(root.getId());
+    }
+
+    @Test
     public void dismissAllModals_optionsAreMergedOnTopModal() {
         uut.showModal(modal1, root, new CommandListenerAdapter());
         uut.showModal(modal2, root, new CommandListenerAdapter());

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/NavigatorTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/NavigatorTest.java
@@ -596,6 +596,7 @@ public class NavigatorTest extends BaseTest {
     public void dismissAllModals_onViewAppearedInvokedOnRoot() {
         disablePushAnimation(child2);
         disableShowModalAnimation(child1);
+        uut.setRoot(child3, new CommandListenerAdapter(), reactInstanceManager);
 
         uut.dismissAllModals(Options.EMPTY, new CommandListenerAdapter());
         verify(parentVisibilityListener, times(0)).onViewAppeared(parentController.getView());


### PR DESCRIPTION
When no modals are displayed and dismissAllModals is called, resolve the promise successfully. This regression was introduced in  #5991 