### PR TITLE
Remove Shared Element Screen from Options screen

### DIFF
--- a/playground/src/screens/OptionsScreen.js
+++ b/playground/src/screens/OptionsScreen.js
@@ -14,7 +14,6 @@ const {
   SHOW_YELLOW_BOX_BTN,
   SET_REACT_TITLE_VIEW,
   GOTO_BUTTONS_SCREEN,
-  GOTO_SHARED_ELEMENT_SCREEN
 } = require('../testIDs');
 
 class Options extends Component {
@@ -42,7 +41,6 @@ class Options extends Component {
         <Button label='Show Yellow Box' testID={SHOW_YELLOW_BOX_BTN} onPress={() => console.warn('Yellow Box')} />
         <Button label='StatusBar' onPress={this.statusBarScreen} />
         <Button label='Buttons Screen' testID={GOTO_BUTTONS_SCREEN} onPress={this.goToButtonsScreen} />
-        <Button label='Shared element' testID={GOTO_SHARED_ELEMENT_SCREEN} onPress={this.goToSharedElementScreen} />
       </Root>
     );
   }
@@ -104,8 +102,6 @@ class Options extends Component {
   statusBarScreen = () => Navigation.showModal(Screens.StatusBar);
 
   goToButtonsScreen = () => Navigation.push(this, Screens.Buttons);
-
-  goToSharedElementScreen = () => Navigation.push(this, Screens.SharedElement);
 }
 
 module.exports = Options;


### PR DESCRIPTION
This is probably leftover from the previous Shared Element implementation which was refactored in v5