### PR TITLE
Fix white topBar on pop with swipe gesture

### DIFF
--- a/lib/ios/TopBarAppearancePresenter.m
+++ b/lib/ios/TopBarAppearancePresenter.m
@@ -19,7 +19,7 @@
 }
 
 - (void)applyOptionsBeforePopping:(RNNTopBarOptions *)options {
-    [self setBackgroundColor:[options.background.color getWithDefaultValue:nil]];
+
 }
 
 - (void)setTranslucent:(BOOL)translucent {

--- a/playground/ios/NavigationTests/RNNStackPresenterTest.m
+++ b/playground/ios/NavigationTests/RNNStackPresenterTest.m
@@ -42,7 +42,7 @@
 	_options.topBar.background.color = [[Color alloc] initWithValue:[UIColor redColor]];
 	
 	[self.uut applyOptionsBeforePopping:self.options];
-	XCTAssertTrue([_boundViewController.childViewControllers.lastObject.navigationItem.standardAppearance.backgroundColor isEqual:[UIColor redColor]]);
+	XCTAssertFalse([_boundViewController.childViewControllers.lastObject.navigationItem.standardAppearance.backgroundColor isEqual:[UIColor redColor]]);
 }
 
 - (void)testApplyOptionsShouldSetLargeTitleVisible {


### PR DESCRIPTION
This commit fix topBar background wrong color when swiping pop gesture on iOS 13 and above.

Addresses #6055 