### PR TITLE
Fix modalpresentationstyle

### DIFF
--- a/docs/api/OptionsModalPresentationStyle.md
+++ b/docs/api/OptionsModalPresentationStyle.md
@@ -7,4 +7,4 @@
 - overCurrentContext
 - overFullScreen
 - pageSheet
-- popOver
+- popover

--- a/docs/docs/options-migration.md
+++ b/docs/docs/options-migration.md
@@ -374,11 +374,14 @@ topBar: {
 Controls the behavior of screens displayed modally. 
 
 ### Options supported on iOS
-* overCurrentContext - Content is displayed over the previous screen. Useful for **transparent modals**
+* `overCurrentContext` - Content is displayed over the previous screen. Useful for **transparent modals**
 * `formSheet` - Content is centered in the screen
 * `pageSheet` -Content partially covers the underlying content
 * `overFullScreen` - Content covers the screen, without detaching previous content.
 * `fullScreen` - Content covers the screen, previous content is detached.
+* `popover` - Content is displayed in a popover view.
+
+More information on the different styles for iOS can be found on https://developer.apple.com/documentation/uikit/uimodalpresentationstyle
 
 ### Options supported on Android
 * `overCurrentContext` - Content is displayed over the previous screen. Useful for **transparent modals**

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -119,7 +119,7 @@ export enum OptionsModalPresentationStyle {
   overFullScreen = 'overFullScreen',
   overCurrentContext = 'overCurrentContext',
   currentContext = 'currentContext',
-  popOver = 'popOver',
+  popover = 'popover',
   fullScreen = 'fullScreen',
   none = 'none'
 }


### PR DESCRIPTION
The enum `OptionsModalPresentationStyle` contained a value "popOver", which should probably be lowercase "popover" to match https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/popover. This should fix bug #6004.