### PR TITLE
Fix status bar visibility on iOS 13

### DIFF
--- a/lib/ios/RNNBasePresenter.h
+++ b/lib/ios/RNNBasePresenter.h
@@ -43,5 +43,6 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 - (UIInterfaceOrientationMask)getOrientation:(RNNNavigationOptions *)options;
 
-- (BOOL)isStatusBarVisibility:(UINavigationController *)stack resolvedOptions:(RNNNavigationOptions *)resolvedOptions;
+- (BOOL)statusBarVisibile:(UINavigationController *)stack resolvedOptions:(RNNNavigationOptions *)resolvedOptions;
+
 @end

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -102,8 +102,8 @@
     return [options withDefault:[self defaultOptions]].layout.supportedOrientations;
 }
 
-- (BOOL)isStatusBarVisibility:(UINavigationController *)stack resolvedOptions:(RNNNavigationOptions *)resolvedOptions {
-    RNNNavigationOptions *withDefault = [resolvedOptions withDefault:[self defaultOptions]];
+- (BOOL)statusBarVisibile:(UINavigationController *)stack resolvedOptions:(RNNNavigationOptions *)resolvedOptions {
+    RNNNavigationOptions *withDefault = [resolvedOptions withDefault:self.defaultOptions];
     if (withDefault.statusBar.visible.hasValue) {
         return ![withDefault.statusBar.visible get];
     } else if ([withDefault.statusBar.hideWithTopBar getWithDefaultValue:NO]) {

--- a/lib/ios/RNNBottomTabsController.m
+++ b/lib/ios/RNNBottomTabsController.m
@@ -91,6 +91,10 @@
 	return [[self presenter] getStatusBarStyle:self.resolveOptions];
 }
 
+- (BOOL)prefersStatusBarHidden {
+    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+}
+
 #pragma mark UITabBarControllerDelegate
 
 - (void)tabBarController:(UITabBarController *)tabBarController didSelectViewController:(UIViewController *)viewController {

--- a/lib/ios/RNNComponentViewController.m
+++ b/lib/ios/RNNComponentViewController.m
@@ -83,6 +83,10 @@
 	return [_presenter getStatusBarStyle:[self resolveOptions]];
 }
 
+- (BOOL)prefersStatusBarHidden {
+    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+}
+
 - (UIViewController *)previewingContext:(id<UIViewControllerPreviewing>)previewingContext viewControllerForLocation:(CGPoint)location{
 	return self.previewController;
 }

--- a/lib/ios/RNNSideMenuController.m
+++ b/lib/ios/RNNSideMenuController.m
@@ -134,6 +134,10 @@
 	return self.openedViewController.preferredStatusBarStyle;
 }
 
+- (BOOL)prefersStatusBarHidden {
+    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+}
+
 - (UIViewController<RNNLayoutProtocol> *)getCurrentChild {
 	return self.openedViewController;
 }

--- a/lib/ios/RNNStackController.m
+++ b/lib/ios/RNNStackController.m
@@ -39,6 +39,10 @@
 	return [_presenter getStatusBarStyle:self.resolveOptions];
 }
 
+- (BOOL)prefersStatusBarHidden {
+    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+}
+
 - (UIViewController *)popViewControllerAnimated:(BOOL)animated {
     [self prepareForPop];
 	return [super popViewControllerAnimated:animated];

--- a/lib/ios/UIViewController+LayoutProtocol.m
+++ b/lib/ios/UIViewController+LayoutProtocol.m
@@ -60,10 +60,6 @@
 	return interfaceOrientationMask;
 }
 
-- (BOOL)prefersStatusBarHidden {
-    return [self.presenter isStatusBarVisibility:self.navigationController resolvedOptions:self.resolveOptions];
-}
-
 - (UINavigationController *)stack {
     if ([self isKindOfClass:UINavigationController.class]) {
         return (UINavigationController *)self;

--- a/playground/ios/NavigationTests/BottomTabsControllerTest.m
+++ b/playground/ios/NavigationTests/BottomTabsControllerTest.m
@@ -5,8 +5,9 @@
 #import <OCMock/OCMock.h>
 #import <ReactNativeNavigation/BottomTabPresenterCreator.h>
 #import "RNNBottomTabsController+Helpers.h"
+#import "RNNComponentViewController+Utils.h"
 
-@interface RNNTabBarControllerTest : XCTestCase
+@interface BottomTabsControllerTest : XCTestCase
 
 @property(nonatomic, strong) RNNBottomTabsController * originalUut;
 @property(nonatomic, strong) RNNBottomTabsController * uut;
@@ -16,16 +17,17 @@
 
 @end
 
-@implementation RNNTabBarControllerTest
+@implementation BottomTabsControllerTest
 
 - (void)setUp {
     [super setUp];
 
     id tabBarClassMock = OCMClassMock([RNNBottomTabsController class]);
     OCMStub([tabBarClassMock parentViewController]).andReturn([OCMockObject partialMockForObject:[RNNBottomTabsController new]]);
-	NSArray* children = @[[[UIViewController alloc] init]];
+	UIViewController* childViewController = [RNNComponentViewController createWithComponentId:@"componentId" initialOptions:[RNNNavigationOptions emptyOptions]];
+	NSArray* children = @[childViewController];
     self.mockTabBarPresenter = [OCMockObject partialMockForObject:[[RNNBottomTabsPresenter alloc] init]];
-    self.mockChildViewController = [OCMockObject partialMockForObject:[RNNComponentViewController new]];
+    self.mockChildViewController = [OCMockObject partialMockForObject:childViewController];
     self.mockEventEmitter = [OCMockObject partialMockForObject:[RNNEventEmitter new]];
 	self.originalUut = [[RNNBottomTabsController alloc] initWithLayoutInfo:nil creator:nil options:[[RNNNavigationOptions alloc] initWithDict:@{}] defaultOptions:nil presenter:self.mockTabBarPresenter bottomTabPresenter:[BottomTabPresenterCreator createWithDefaultOptions:nil] dotIndicatorPresenter:[[RNNDotIndicatorPresenter alloc] initWithDefaultOptions:nil] eventEmitter:self.mockEventEmitter childViewControllers:children bottomTabsAttacher:nil];
     self.uut = [OCMockObject partialMockForObject:self.originalUut];
@@ -101,7 +103,7 @@
 - (void)testMergeOptions_shouldInvokePresenterMergeOptions {
     RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initWithDict:@{}];
 
-    [(RNNBottomTabsPresenter *) [self.mockTabBarPresenter expect] mergeOptions:options resolvedOptions:[self.uut options]];
+    [(RNNBottomTabsPresenter *) [self.mockTabBarPresenter expect] mergeOptions:options resolvedOptions:[OCMArg any]];
     [self.uut mergeOptions:options];
     [self.mockTabBarPresenter verify];
 }
@@ -140,6 +142,26 @@
     [[self.mockTabBarPresenter expect] getStatusBarStyle:[OCMArg any]];
     [self.uut preferredStatusBarStyle];
     [self.mockTabBarPresenter verify];
+}
+
+- (void)testPreferredStatusHidden_shouldResolveChildStatusBarVisibleTrue {
+	self.uut.getCurrentChild.options.statusBar.visible = [Bool withValue:@(1)];
+	XCTAssertFalse(self.uut.prefersStatusBarHidden);
+}
+
+- (void)testPreferredStatusHidden_shouldResolveChildStatusBarVisibleFalse {
+	self.uut.getCurrentChild.options.statusBar.visible = [Bool withValue:@(0)];
+	XCTAssertTrue(self.uut.prefersStatusBarHidden);
+}
+
+- (void)testPreferredStatusHidden_shouldHideStatusBar {
+	self.uut.options.statusBar.visible = [Bool withValue:@(1)];
+	XCTAssertFalse(self.uut.prefersStatusBarHidden);
+}
+
+- (void)testPreferredStatusHidden_shouldShowStatusBar {
+	self.uut.options.statusBar.visible = [Bool withValue:@(0)];
+	XCTAssertTrue(self.uut.prefersStatusBarHidden);
 }
 
 - (void)testTabBarControllerDidSelectViewControllerDelegate_shouldInvokeSendBottomTabSelectedEvent {

--- a/playground/ios/NavigationTests/RNNSideMenuControllerTest.m
+++ b/playground/ios/NavigationTests/RNNSideMenuControllerTest.m
@@ -16,10 +16,10 @@
 - (void)setUp {
     [super setUp];
 	_creator = [[RNNTestRootViewCreator alloc] init];
-	_leftVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil creator:nil options:nil defaultOptions:nil presenter:nil eventEmitter:nil childViewController:self.generateComponent type:RNNSideMenuChildTypeLeft];
-	_rightVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil creator:nil options:nil defaultOptions:nil presenter:nil eventEmitter:nil childViewController:self.generateComponent type:RNNSideMenuChildTypeRight];
-	_centerVC =[[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil creator:nil options:nil defaultOptions:nil presenter:nil eventEmitter:nil childViewController:self.generateComponent type:RNNSideMenuChildTypeCenter];
-	self.uut = [[RNNSideMenuController alloc] initWithLayoutInfo:nil creator:nil childViewControllers:@[_leftVC, _centerVC, _rightVC] options:[[RNNNavigationOptions alloc] initEmptyOptions] defaultOptions:nil presenter:nil eventEmitter:nil];
+	_leftVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil creator:nil options:[RNNNavigationOptions emptyOptions] defaultOptions:nil presenter:nil eventEmitter:nil childViewController:self.generateComponent type:RNNSideMenuChildTypeLeft];
+	_rightVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil creator:nil options:[RNNNavigationOptions emptyOptions] defaultOptions:nil presenter:nil eventEmitter:nil childViewController:self.generateComponent type:RNNSideMenuChildTypeRight];
+	_centerVC =[[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil creator:nil options:[RNNNavigationOptions emptyOptions] defaultOptions:nil presenter:nil eventEmitter:nil childViewController:self.generateComponent type:RNNSideMenuChildTypeCenter];
+	self.uut = [[RNNSideMenuController alloc] initWithLayoutInfo:nil creator:nil childViewControllers:@[_leftVC, _centerVC, _rightVC] options:[RNNNavigationOptions emptyOptions] defaultOptions:nil presenter:[[RNNSideMenuPresenter alloc] initWithDefaultOptions:nil] eventEmitter:nil];
 }
 
 - (RNNComponentViewController *)generateComponent {
@@ -68,6 +68,26 @@
     }];
 
     [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testPreferredStatusHidden_shouldResolveChildStatusBarVisibleTrue {
+	self.uut.getCurrentChild.options.statusBar.visible = [Bool withValue:@(1)];
+	XCTAssertFalse(self.uut.prefersStatusBarHidden);
+}
+
+- (void)testPreferredStatusHidden_shouldResolveChildStatusBarVisibleFalse {
+	self.uut.getCurrentChild.options.statusBar.visible = [Bool withValue:@(0)];
+	XCTAssertTrue(self.uut.prefersStatusBarHidden);
+}
+
+- (void)testPreferredStatusHidden_shouldHideStatusBar {
+	self.uut.options.statusBar.visible = [Bool withValue:@(1)];
+	XCTAssertFalse(self.uut.prefersStatusBarHidden);
+}
+
+- (void)testPreferredStatusHidden_shouldShowStatusBar {
+	self.uut.options.statusBar.visible = [Bool withValue:@(0)];
+	XCTAssertTrue(self.uut.prefersStatusBarHidden);
 }
 
 @end

--- a/playground/ios/NavigationTests/RNNStackControllerTest.m
+++ b/playground/ios/NavigationTests/RNNStackControllerTest.m
@@ -70,6 +70,26 @@
 	XCTAssertTrue(self.uut.preferredStatusBarStyle == self.uut.getCurrentChild.preferredStatusBarStyle);
 }
 
+- (void)testPreferredStatusHidden_shouldResolveChildStatusBarVisibleTrue {
+	self.uut.getCurrentChild.options.statusBar.visible = [Bool withValue:@(1)];
+	XCTAssertFalse(self.uut.prefersStatusBarHidden);
+}
+
+- (void)testPreferredStatusHidden_shouldResolveChildStatusBarVisibleFalse {
+	self.uut.getCurrentChild.options.statusBar.visible = [Bool withValue:@(0)];
+	XCTAssertTrue(self.uut.prefersStatusBarHidden);
+}
+
+- (void)testPreferredStatusHidden_shouldHideStatusBar {
+	self.uut.options.statusBar.visible = [Bool withValue:@(1)];
+	XCTAssertFalse(self.uut.prefersStatusBarHidden);
+}
+
+- (void)testPreferredStatusHidden_shouldShowStatusBar {
+	self.uut.options.statusBar.visible = [Bool withValue:@(0)];
+	XCTAssertTrue(self.uut.prefersStatusBarHidden);
+}
+
 - (void)testPopGestureEnabled_false {
 	NSNumber* popGestureEnabled = @(0);
 	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initEmptyOptions];

--- a/playground/ios/playground.xcodeproj/project.pbxproj
+++ b/playground/ios/playground.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		E58D26472385888C003F36BA /* RNNRootViewControllerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E58D26262385888B003F36BA /* RNNRootViewControllerTest.m */; };
 		E58D26482385888C003F36BA /* RNNDotIndicatorPresenterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E58D26272385888B003F36BA /* RNNDotIndicatorPresenterTest.m */; };
 		E58D26492385888C003F36BA /* RNNFontAttributesCreatorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E58D26282385888B003F36BA /* RNNFontAttributesCreatorTest.m */; };
-		E58D264A2385888C003F36BA /* RNNTabBarControllerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E58D26292385888B003F36BA /* RNNTabBarControllerTest.m */; };
+		E58D264A2385888C003F36BA /* BottomTabsControllerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E58D26292385888B003F36BA /* BottomTabsControllerTest.m */; };
 		E58D264B2385888C003F36BA /* RNNLayoutManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E58D262A2385888B003F36BA /* RNNLayoutManagerTest.m */; };
 		E58D264C2385888C003F36BA /* RNNSideMenuParserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E58D262B2385888B003F36BA /* RNNSideMenuParserTest.m */; };
 		E58D264D2385888C003F36BA /* RNNOverlayManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E58D262D2385888B003F36BA /* RNNOverlayManagerTest.m */; };
@@ -114,7 +114,7 @@
 		E58D26262385888B003F36BA /* RNNRootViewControllerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNRootViewControllerTest.m; sourceTree = "<group>"; };
 		E58D26272385888B003F36BA /* RNNDotIndicatorPresenterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNDotIndicatorPresenterTest.m; sourceTree = "<group>"; };
 		E58D26282385888B003F36BA /* RNNFontAttributesCreatorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNFontAttributesCreatorTest.m; sourceTree = "<group>"; };
-		E58D26292385888B003F36BA /* RNNTabBarControllerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNTabBarControllerTest.m; sourceTree = "<group>"; };
+		E58D26292385888B003F36BA /* BottomTabsControllerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BottomTabsControllerTest.m; sourceTree = "<group>"; };
 		E58D262A2385888B003F36BA /* RNNLayoutManagerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNLayoutManagerTest.m; sourceTree = "<group>"; };
 		E58D262B2385888B003F36BA /* RNNSideMenuParserTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNSideMenuParserTest.m; sourceTree = "<group>"; };
 		E58D262C2385888B003F36BA /* RNNOptionsTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNOptionsTest.h; sourceTree = "<group>"; };
@@ -260,6 +260,7 @@
 			isa = PBXGroup;
 			children = (
 				E58D26442385888C003F36BA /* Options */,
+				E58D262E2385888B003F36BA /* utils */,
 				E58D26422385888C003F36BA /* RNNBasePresenterTest.m */,
 				500E9FE62406A4E200C61231 /* BottomTabPresenterTest.m */,
 				50BCB27523F1A26600D6C8E5 /* TopBarAppearancePresenterTest.m */,
@@ -281,7 +282,7 @@
 				E58D262B2385888B003F36BA /* RNNSideMenuParserTest.m */,
 				E58D26362385888B003F36BA /* RNNSideMenuPresenterTest.m */,
 				E58D26312385888B003F36BA /* RNNStackPresenterTest.m */,
-				E58D26292385888B003F36BA /* RNNTabBarControllerTest.m */,
+				E58D26292385888B003F36BA /* BottomTabsControllerTest.m */,
 				5022EDCB240551EE00852BA6 /* RNNBottomTabsAppearancePresenterTest.m */,
 				E58D26342385888B003F36BA /* RNNTestRootViewCreator.h */,
 				E58D263D2385888C003F36BA /* RNNTestRootViewCreator.m */,
@@ -292,7 +293,6 @@
 				50CF233B240695B10098042D /* RNNBottomTabsController+Helpers.h */,
 				50CF233C240695B10098042D /* RNNBottomTabsController+Helpers.m */,
 				50647FE223E3196800B92025 /* RNNExternalViewControllerTests.m */,
-				E58D262E2385888B003F36BA /* utils */,
 				E58D261F238587F4003F36BA /* Info.plist */,
 			);
 			path = NavigationTests;
@@ -770,7 +770,7 @@
 				501C86B9239FE9C400E0B631 /* UIImage+Utils.m in Sources */,
 				E58D265F2385888C003F36BA /* RNNBasePresenterTest.m in Sources */,
 				E58D26542385888C003F36BA /* RNNSideMenuControllerTest.m in Sources */,
-				E58D264A2385888C003F36BA /* RNNTabBarControllerTest.m in Sources */,
+				E58D264A2385888C003F36BA /* BottomTabsControllerTest.m in Sources */,
 				E58D26472385888C003F36BA /* RNNRootViewControllerTest.m in Sources */,
 				E58D26582385888C003F36BA /* UITabBarController+RNNOptionsTest.m in Sources */,
 				E58D265A2385888C003F36BA /* RNNTestRootViewCreator.m in Sources */,


### PR DESCRIPTION
This PR fixes `statusBar.visible` option which stopped working on iOS 13.