### PR TITLE
Fix styling options on iOS 13.4

### DIFF
--- a/lib/ios/RNNBasePresenter.h
+++ b/lib/ios/RNNBasePresenter.h
@@ -39,10 +39,12 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 - (UINavigationItem *)currentNavigationItem;
 
-- (UIStatusBarStyle)getStatusBarStyle:(RNNNavigationOptions *)resolvedOptions;
+- (void)willMoveToParentViewController:(UIViewController *)parent;
 
-- (UIInterfaceOrientationMask)getOrientation:(RNNNavigationOptions *)options;
+- (UIStatusBarStyle)getStatusBarStyle;
 
-- (BOOL)statusBarVisibile:(UINavigationController *)stack resolvedOptions:(RNNNavigationOptions *)resolvedOptions;
+- (UIInterfaceOrientationMask)getOrientation;
+
+- (BOOL)getStatusBarVisibility;
 
 @end

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -36,6 +36,13 @@
     
 }
 
+- (void)willMoveToParentViewController:(UIViewController *)parent {
+    if (parent) {
+        [self applyOptionsOnWillMoveToParentViewController:self.boundViewController.resolveOptions];
+        [self.boundViewController onChildAddToParent:self.boundViewController options:self.boundViewController.resolveOptions];
+    }
+}
+
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)initialOptions {
     UIViewController* viewController = self.boundViewController;
     RNNNavigationOptions *withDefault = [initialOptions withDefault:[self defaultOptions]];
@@ -78,8 +85,8 @@
 
 }
 
-- (UIStatusBarStyle)getStatusBarStyle:(RNNNavigationOptions *)resolvedOptions {
-    RNNNavigationOptions *withDefault = [resolvedOptions withDefault:[self defaultOptions]];
+- (UIStatusBarStyle)getStatusBarStyle {
+    RNNNavigationOptions *withDefault = [self.boundViewController.resolveOptions withDefault:[self defaultOptions]];
     NSString* statusBarStyle = [withDefault.statusBar.style getWithDefaultValue:@"default"];
     if ([statusBarStyle isEqualToString:@"light"]) {
         return UIStatusBarStyleLightContent;
@@ -98,16 +105,16 @@
     return self.boundViewController.getCurrentChild.navigationItem;
 }
 
-- (UIInterfaceOrientationMask)getOrientation:(RNNNavigationOptions *)options {
-    return [options withDefault:[self defaultOptions]].layout.supportedOrientations;
+- (UIInterfaceOrientationMask)getOrientation {
+    return [self.boundViewController.resolveOptions withDefault:self.defaultOptions].layout.supportedOrientations;
 }
 
-- (BOOL)statusBarVisibile:(UINavigationController *)stack resolvedOptions:(RNNNavigationOptions *)resolvedOptions {
-    RNNNavigationOptions *withDefault = [resolvedOptions withDefault:self.defaultOptions];
+- (BOOL)getStatusBarVisibility {
+    RNNNavigationOptions *withDefault = [self.boundViewController.resolveOptions withDefault:self.defaultOptions];
     if (withDefault.statusBar.visible.hasValue) {
         return ![withDefault.statusBar.visible get];
     } else if ([withDefault.statusBar.hideWithTopBar getWithDefaultValue:NO]) {
-        return stack.isNavigationBarHidden;
+        return self.boundViewController.stack.isNavigationBarHidden;
     }
     return NO;
 }

--- a/lib/ios/RNNBottomTabsController.m
+++ b/lib/ios/RNNBottomTabsController.m
@@ -116,22 +116,19 @@
 # pragma mark - UIViewController overrides
 
 - (void)willMoveToParentViewController:(UIViewController *)parent {
-    if (parent) {
-        [self.presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
-        [self onChildAddToParent:self options:self.resolveOptions];
-    }
+    [self.presenter willMoveToParentViewController:parent];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-    return [self.presenter getStatusBarStyle:self.resolveOptions];
+    return [self.presenter getStatusBarStyle];
 }
 
 - (BOOL)prefersStatusBarHidden {
-    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+    return [self.presenter getStatusBarVisibility];
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    return [self.presenter getOrientation:self.resolveOptions];
+    return [self.presenter getOrientation];
 }
 
 

--- a/lib/ios/RNNBottomTabsController.m
+++ b/lib/ios/RNNBottomTabsController.m
@@ -87,14 +87,6 @@
 	[super setSelectedIndex:selectedIndex];
 }
 
-- (UIStatusBarStyle)preferredStatusBarStyle {
-	return [[self presenter] getStatusBarStyle:self.resolveOptions];
-}
-
-- (BOOL)prefersStatusBarHidden {
-    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
-}
-
 #pragma mark UITabBarControllerDelegate
 
 - (void)tabBarController:(UITabBarController *)tabBarController didSelectViewController:(UIViewController *)viewController {
@@ -120,5 +112,27 @@
 
     return NO;
 }
+
+# pragma mark - UIViewController overrides
+
+- (void)willMoveToParentViewController:(UIViewController *)parent {
+    if (parent) {
+        [self.presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
+        [self onChildAddToParent:self options:self.resolveOptions];
+    }
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return [self.presenter getStatusBarStyle:self.resolveOptions];
+}
+
+- (BOOL)prefersStatusBarHidden {
+    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    return [self.presenter getOrientation:self.resolveOptions];
+}
+
 
 @end

--- a/lib/ios/RNNComponentViewController.m
+++ b/lib/ios/RNNComponentViewController.m
@@ -133,22 +133,19 @@
 # pragma mark - UIViewController overrides
 
 - (void)willMoveToParentViewController:(UIViewController *)parent {
-    if (parent) {
-        [self.presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
-        [self onChildAddToParent:self options:self.resolveOptions];
-    }
+    [self.presenter willMoveToParentViewController:parent];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-    return [self.presenter getStatusBarStyle:self.resolveOptions];
+    return [self.presenter getStatusBarStyle];
 }
 
 - (BOOL)prefersStatusBarHidden {
-    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+    return [self.presenter getStatusBarVisibility];
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    return [self.presenter getOrientation:self.resolveOptions];
+    return [self.presenter getOrientation];
 }
 
 

--- a/lib/ios/RNNComponentViewController.m
+++ b/lib/ios/RNNComponentViewController.m
@@ -6,7 +6,6 @@
 
 - (instancetype)initWithLayoutInfo:(RNNLayoutInfo *)layoutInfo rootViewCreator:(id<RNNComponentViewCreator>)creator eventEmitter:(RNNEventEmitter *)eventEmitter presenter:(RNNComponentPresenter *)presenter options:(RNNNavigationOptions *)options defaultOptions:(RNNNavigationOptions *)defaultOptions {
 	self = [super initWithLayoutInfo:layoutInfo creator:creator options:options defaultOptions:defaultOptions presenter:presenter eventEmitter:eventEmitter childViewControllers:nil];
-	self.extendedLayoutIncludesOpaqueBars = YES;
     if (@available(iOS 13.0, *)) {
         self.navigationItem.standardAppearance = [UINavigationBarAppearance new];
         self.navigationItem.scrollEdgeAppearance = [UINavigationBarAppearance new];
@@ -79,14 +78,6 @@
 	[self.eventEmitter sendOnSearchBarCancelPressed:self.layoutInfo.componentId];
 }
 
-- (UIStatusBarStyle)preferredStatusBarStyle {
-	return [_presenter getStatusBarStyle:[self resolveOptions]];
-}
-
-- (BOOL)prefersStatusBarHidden {
-    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
-}
-
 - (UIViewController *)previewingContext:(id<UIViewControllerPreviewing>)previewingContext viewControllerForLocation:(CGPoint)location{
 	return self.previewController;
 }
@@ -137,6 +128,27 @@
 
 -(void)onButtonPress:(RNNUIBarButtonItem *)barButtonItem {
 	[self.eventEmitter sendOnNavigationButtonPressed:self.layoutInfo.componentId buttonId:barButtonItem.buttonId];
+}
+
+# pragma mark - UIViewController overrides
+
+- (void)willMoveToParentViewController:(UIViewController *)parent {
+    if (parent) {
+        [self.presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
+        [self onChildAddToParent:self options:self.resolveOptions];
+    }
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return [self.presenter getStatusBarStyle:self.resolveOptions];
+}
+
+- (BOOL)prefersStatusBarHidden {
+    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    return [self.presenter getOrientation:self.resolveOptions];
 }
 
 

--- a/lib/ios/RNNExternalViewController.m
+++ b/lib/ios/RNNExternalViewController.m
@@ -33,22 +33,19 @@
 # pragma mark - UIViewController overrides
 
 - (void)willMoveToParentViewController:(UIViewController *)parent {
-    if (parent) {
-        [self.presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
-        [self onChildAddToParent:self options:self.resolveOptions];
-    }
+    [self.presenter willMoveToParentViewController:parent];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-    return [self.presenter getStatusBarStyle:self.resolveOptions];
+    return [self.presenter getStatusBarStyle];
 }
 
 - (BOOL)prefersStatusBarHidden {
-    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+    return [self.presenter getStatusBarVisibility];
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    return [self.presenter getOrientation:self.resolveOptions];
+    return [self.presenter getOrientation];
 }
 
 @end

--- a/lib/ios/RNNExternalViewController.m
+++ b/lib/ios/RNNExternalViewController.m
@@ -30,4 +30,25 @@
 	[self readyForPresentation];
 }
 
+# pragma mark - UIViewController overrides
+
+- (void)willMoveToParentViewController:(UIViewController *)parent {
+    if (parent) {
+        [self.presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
+        [self onChildAddToParent:self options:self.resolveOptions];
+    }
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return [self.presenter getStatusBarStyle:self.resolveOptions];
+}
+
+- (BOOL)prefersStatusBarHidden {
+    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    return [self.presenter getOrientation:self.resolveOptions];
+}
+
 @end

--- a/lib/ios/RNNSideMenuChildVC.m
+++ b/lib/ios/RNNSideMenuChildVC.m
@@ -39,8 +39,25 @@
 	return self.child;
 }
 
+# pragma mark - UIViewController overrides
+
+- (void)willMoveToParentViewController:(UIViewController *)parent {
+    if (parent) {
+        [self.presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
+        [self onChildAddToParent:self options:self.resolveOptions];
+    }
+}
+
 - (UIStatusBarStyle)preferredStatusBarStyle {
-	return [[self presenter] getStatusBarStyle:[self resolveOptions]];
+    return [self.presenter getStatusBarStyle:self.resolveOptions];
+}
+
+- (BOOL)prefersStatusBarHidden {
+    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    return [self.presenter getOrientation:self.resolveOptions];
 }
 
 @end

--- a/lib/ios/RNNSideMenuChildVC.m
+++ b/lib/ios/RNNSideMenuChildVC.m
@@ -42,22 +42,19 @@
 # pragma mark - UIViewController overrides
 
 - (void)willMoveToParentViewController:(UIViewController *)parent {
-    if (parent) {
-        [self.presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
-        [self onChildAddToParent:self options:self.resolveOptions];
-    }
+    [self.presenter willMoveToParentViewController:parent];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-    return [self.presenter getStatusBarStyle:self.resolveOptions];
+    return [self.presenter getStatusBarStyle];
 }
 
 - (BOOL)prefersStatusBarHidden {
-    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+    return [self.presenter getStatusBarVisibility];
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    return [self.presenter getOrientation:self.resolveOptions];
+    return [self.presenter getOrientation];
 }
 
 @end

--- a/lib/ios/RNNSideMenuController.m
+++ b/lib/ios/RNNSideMenuController.m
@@ -130,14 +130,6 @@
 	}
 }
 
-- (UIStatusBarStyle)preferredStatusBarStyle {
-	return self.openedViewController.preferredStatusBarStyle;
-}
-
-- (BOOL)prefersStatusBarHidden {
-    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
-}
-
 - (UIViewController<RNNLayoutProtocol> *)getCurrentChild {
 	return self.openedViewController;
 }
@@ -161,6 +153,27 @@
         [options.sideMenu mergeOptions:self.center.resolveOptions.sideMenu];
     }
     return options;
+}
+
+# pragma mark - UIViewController overrides
+
+- (void)willMoveToParentViewController:(UIViewController *)parent {
+    if (parent) {
+        [self.presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
+        [self onChildAddToParent:self options:self.resolveOptions];
+    }
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return self.openedViewController.preferredStatusBarStyle;
+}
+
+- (BOOL)prefersStatusBarHidden {
+    return [self.openedViewController prefersStatusBarHidden];
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    return [self.presenter getOrientation:self.resolveOptions];
 }
 
 @end

--- a/lib/ios/RNNSideMenuController.m
+++ b/lib/ios/RNNSideMenuController.m
@@ -158,22 +158,19 @@
 # pragma mark - UIViewController overrides
 
 - (void)willMoveToParentViewController:(UIViewController *)parent {
-    if (parent) {
-        [self.presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
-        [self onChildAddToParent:self options:self.resolveOptions];
-    }
+    [self.presenter willMoveToParentViewController:parent];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-    return self.openedViewController.preferredStatusBarStyle;
+    return [self.presenter getStatusBarStyle];
 }
 
 - (BOOL)prefersStatusBarHidden {
-    return [self.openedViewController prefersStatusBarHidden];
+    return [self.presenter getStatusBarVisibility];
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    return [self.presenter getOrientation:self.resolveOptions];
+    return [self.presenter getOrientation];
 }
 
 @end

--- a/lib/ios/RNNSplitViewController.m
+++ b/lib/ios/RNNSplitViewController.m
@@ -16,22 +16,19 @@
 # pragma mark - UIViewController overrides
 
 - (void)willMoveToParentViewController:(UIViewController *)parent {
-    if (parent) {
-        [self.presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
-        [self onChildAddToParent:self options:self.resolveOptions];
-    }
+    [self.presenter willMoveToParentViewController:parent];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-    return [self.presenter getStatusBarStyle:self.resolveOptions];
+    return [self.presenter getStatusBarStyle];
 }
 
 - (BOOL)prefersStatusBarHidden {
-    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+    return [self.presenter getStatusBarVisibility];
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    return [self.presenter getOrientation:self.resolveOptions];
+    return [self.presenter getOrientation];
 }
 
 @end

--- a/lib/ios/RNNSplitViewController.m
+++ b/lib/ios/RNNSplitViewController.m
@@ -9,12 +9,29 @@
     self.delegate = masterViewController;
 }
 
--(void)viewWillAppear:(BOOL)animated{
-	[super viewWillAppear:animated];
-}
-
 - (UIViewController *)getCurrentChild {
 	return self.viewControllers[0];
+}
+
+# pragma mark - UIViewController overrides
+
+- (void)willMoveToParentViewController:(UIViewController *)parent {
+    if (parent) {
+        [self.presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
+        [self onChildAddToParent:self options:self.resolveOptions];
+    }
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return [self.presenter getStatusBarStyle:self.resolveOptions];
+}
+
+- (BOOL)prefersStatusBarHidden {
+    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    return [self.presenter getOrientation:self.resolveOptions];
 }
 
 @end

--- a/lib/ios/RNNStackController.m
+++ b/lib/ios/RNNStackController.m
@@ -35,14 +35,6 @@
     [self.parentViewController mergeChildOptions:options child:child];
 }
 
-- (UIStatusBarStyle)preferredStatusBarStyle {
-	return [_presenter getStatusBarStyle:self.resolveOptions];
-}
-
-- (BOOL)prefersStatusBarHidden {
-    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
-}
-
 - (UIViewController *)popViewControllerAnimated:(BOOL)animated {
     [self prepareForPop];
 	return [super popViewControllerAnimated:animated];
@@ -60,6 +52,27 @@
 
 - (UIViewController *)childViewControllerForStatusBarStyle {
 	return self.topViewController;
+}
+
+# pragma mark - UIViewController overrides
+
+- (void)willMoveToParentViewController:(UIViewController *)parent {
+    if (parent) {
+        [self.presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
+        [self onChildAddToParent:self options:self.resolveOptions];
+    }
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return [self.presenter getStatusBarStyle:self.resolveOptions];
+}
+
+- (BOOL)prefersStatusBarHidden {
+    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    return [self.presenter getOrientation:self.resolveOptions];
 }
 
 @end

--- a/lib/ios/RNNStackController.m
+++ b/lib/ios/RNNStackController.m
@@ -57,22 +57,19 @@
 # pragma mark - UIViewController overrides
 
 - (void)willMoveToParentViewController:(UIViewController *)parent {
-    if (parent) {
-        [self.presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
-        [self onChildAddToParent:self options:self.resolveOptions];
-    }
+    [self.presenter willMoveToParentViewController:parent];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-    return [self.presenter getStatusBarStyle:self.resolveOptions];
+    return [self.presenter getStatusBarStyle];
 }
 
 - (BOOL)prefersStatusBarHidden {
-    return [self.presenter statusBarVisibile:self.navigationController resolvedOptions:self.resolveOptions];
+    return [self.presenter getStatusBarVisibility];
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    return [self.presenter getOrientation:self.resolveOptions];
+    return [self.presenter getOrientation];
 }
 
 @end

--- a/lib/ios/UIViewController+LayoutProtocol.m
+++ b/lib/ios/UIViewController+LayoutProtocol.m
@@ -20,6 +20,7 @@
     self.eventEmitter = eventEmitter;
     self.presenter = presenter;
     [self.presenter bindViewController:self];
+    self.extendedLayoutIncludesOpaqueBars = YES;
     if ([self respondsToSelector:@selector(setViewControllers:)]) {
         [self performSelector:@selector(setViewControllers:) withObject:childViewControllers];
     }
@@ -49,15 +50,6 @@
 
 - (void)overrideOptions:(RNNNavigationOptions *)options {
 	[self.options overrideOptions:options];
-}
-
-- (BOOL)extendedLayoutIncludesOpaqueBars {
-    return YES;
-}
-
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-	UIInterfaceOrientationMask interfaceOrientationMask = self.presenter ? [self.presenter getOrientation:[self resolveOptions]] : [[UIApplication sharedApplication] supportedInterfaceOrientationsForWindow:[[UIApplication sharedApplication] keyWindow]];
-	return interfaceOrientationMask;
 }
 
 - (UINavigationController *)stack {
@@ -159,13 +151,6 @@
 - (void)componentDidDisappear {
     [self.presenter componentDidDisappear];
     [self.parentViewController componentDidDisappear];
-}
-
-- (void)willMoveToParentViewController:(UIViewController *)parent {
-	if (parent) {
-		[self.presenter applyOptionsOnWillMoveToParentViewController:self.resolveOptions];
-        [self onChildAddToParent:self options:self.resolveOptions];
-	}
 }
 
 #pragma mark getters and setters to associated object

--- a/playground/ios/NavigationTests/BottomTabsControllerTest.m
+++ b/playground/ios/NavigationTests/BottomTabsControllerTest.m
@@ -139,7 +139,7 @@
 }
 
 - (void)testPreferredStatusBarStyle_shouldInvokeSelectedViewControllerPreferredStatusBarStyle {
-    [[self.mockTabBarPresenter expect] getStatusBarStyle:[OCMArg any]];
+    [[self.mockTabBarPresenter expect] getStatusBarStyle];
     [self.uut preferredStatusBarStyle];
     [self.mockTabBarPresenter verify];
 }

--- a/playground/ios/NavigationTests/RNNBasePresenterTest.m
+++ b/playground/ios/NavigationTests/RNNBasePresenterTest.m
@@ -2,7 +2,7 @@
 #import "RNNBasePresenter.h"
 #import <OCMock/OCMock.h>
 #import "UIViewController+RNNOptions.h"
-#import "RNNComponentViewController.h"
+#import "RNNComponentViewController+Utils.h"
 
 @interface RNNBasePresenterTest : XCTestCase
 
@@ -18,7 +18,7 @@
 - (void)setUp {
     [super setUp];
     self.uut = [[RNNBasePresenter alloc] initWithDefaultOptions:[[RNNNavigationOptions alloc] initEmptyOptions]];
-    self.boundViewController = [RNNComponentViewController new];
+    self.boundViewController = [RNNComponentViewController createWithComponentId:@"componentId" initialOptions:[RNNNavigationOptions emptyOptions]];
     self.mockBoundViewController = [OCMockObject partialMockForObject:self.boundViewController];
 	[self.uut bindViewController:self.mockBoundViewController];
     self.options = [[RNNNavigationOptions alloc] initEmptyOptions];
@@ -53,32 +53,28 @@
 }
 
 - (void)testGetPreferredStatusBarStyle_returnLightIfLight {
-    RNNNavigationOptions * lightOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
-    lightOptions.statusBar.style = [[Text alloc] initWithValue:@"light"];
-
-    XCTAssertEqual([_uut getStatusBarStyle:lightOptions], UIStatusBarStyleLightContent);
+	self.boundViewController.options.statusBar.style = [[Text alloc] initWithValue:@"light"];
+	
+    XCTAssertEqual([_uut getStatusBarStyle], UIStatusBarStyleLightContent);
 }
 
 - (void)testGetPreferredStatusBarStyle_returnDark {
-    RNNNavigationOptions * darkOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
-    darkOptions.statusBar.style = [[Text alloc] initWithValue:@"dark"];
+    self.boundViewController.options.statusBar.style = [[Text alloc] initWithValue:@"dark"];
 
-    XCTAssertEqual([_uut getStatusBarStyle:darkOptions], UIStatusBarStyleDarkContent);
+    XCTAssertEqual([_uut getStatusBarStyle], UIStatusBarStyleDarkContent);
 }
 
 - (void)testGetPreferredStatusBarStyle_returnDefaultIfNil {
-    RNNNavigationOptions * options = [[RNNNavigationOptions alloc] initEmptyOptions];
-
-    XCTAssertEqual([_uut getStatusBarStyle:options], UIStatusBarStyleDefault);
+	self.boundViewController.options.statusBar.style = nil;
+    XCTAssertEqual([_uut getStatusBarStyle], UIStatusBarStyleDefault);
 }
 
 - (void)testGetPreferredStatusBarStyle_considersDefaultOptions {
-    RNNNavigationOptions * options = [[RNNNavigationOptions alloc] initEmptyOptions];
     RNNNavigationOptions * lightOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
     lightOptions.statusBar.style = [[Text alloc] initWithValue:@"light"];
     [_uut setDefaultOptions:lightOptions];
 
-    XCTAssertEqual([_uut getStatusBarStyle:options], UIStatusBarStyleLightContent);
+    XCTAssertEqual([_uut getStatusBarStyle], UIStatusBarStyleLightContent);
 }
 
 - (void)testApplyOptionsOnInit_setSwipeToDismiss {

--- a/playground/ios/NavigationTests/RNNSideMenuControllerTest.m
+++ b/playground/ios/NavigationTests/RNNSideMenuControllerTest.m
@@ -16,9 +16,12 @@
 - (void)setUp {
     [super setUp];
 	_creator = [[RNNTestRootViewCreator alloc] init];
-	_leftVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil creator:nil options:[RNNNavigationOptions emptyOptions] defaultOptions:nil presenter:nil eventEmitter:nil childViewController:self.generateComponent type:RNNSideMenuChildTypeLeft];
-	_rightVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil creator:nil options:[RNNNavigationOptions emptyOptions] defaultOptions:nil presenter:nil eventEmitter:nil childViewController:self.generateComponent type:RNNSideMenuChildTypeRight];
-	_centerVC =[[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil creator:nil options:[RNNNavigationOptions emptyOptions] defaultOptions:nil presenter:nil eventEmitter:nil childViewController:self.generateComponent type:RNNSideMenuChildTypeCenter];
+	_leftVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil creator:nil options:[RNNNavigationOptions emptyOptions] defaultOptions:nil presenter:[RNNBasePresenter new] eventEmitter:nil childViewController:self.generateComponent type:RNNSideMenuChildTypeLeft];
+	[_leftVC.presenter bindViewController:_leftVC];
+	_rightVC = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil creator:nil options:[RNNNavigationOptions emptyOptions] defaultOptions:nil presenter:[RNNBasePresenter new] eventEmitter:nil childViewController:self.generateComponent type:RNNSideMenuChildTypeRight];
+	[_rightVC.presenter bindViewController:_rightVC];
+	_centerVC =[[RNNSideMenuChildVC alloc] initWithLayoutInfo:nil creator:nil options:[RNNNavigationOptions emptyOptions] defaultOptions:nil presenter:[RNNBasePresenter new] eventEmitter:nil childViewController:self.generateComponent type:RNNSideMenuChildTypeCenter];
+	[_centerVC.presenter bindViewController:_centerVC];
 	self.uut = [[RNNSideMenuController alloc] initWithLayoutInfo:nil creator:nil childViewControllers:@[_leftVC, _centerVC, _rightVC] options:[RNNNavigationOptions emptyOptions] defaultOptions:nil presenter:[[RNNSideMenuPresenter alloc] initWithDefaultOptions:nil] eventEmitter:nil];
 }
 


### PR DESCRIPTION
iOS 13.4 doesn't allow overriding UIViewController's methods in categories (and it's also discouraged by apple) which causes styles to break.
* Move UIViewController override methods from category to controllers.
* Fixes BottomTab style visibility
* Fixes `statusBar.style`

Closes #6075 