### PR TITLE
Fix wrong usage of setStackRoot command in playground app

### DIFF
--- a/playground/src/screens/StackScreen.js
+++ b/playground/src/screens/StackScreen.js
@@ -71,10 +71,10 @@ class StackScreen extends React.Component {
 
   search = () => Navigation.push(this, Screens.Search);
 
-  setStackRoot = () => Navigation.setStackRoot(this, stack([
+  setStackRoot = () => Navigation.setStackRoot(this, [
     component(Screens.Pushed, { topBar: { title: { text: 'Screen A' } } }),
     component(Screens.Pushed, { topBar: { title: { text: 'Screen B' } } }),
-  ]));
+  ]);
 
   setStackRootWithId = () => Navigation.setStackRoot(this,
     {


### PR DESCRIPTION
For some reason the stack root was set to another stack instead of the children 😕 