### PR TITLE
Implement startDelay + fix image scale transition

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/Animator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/Animator.kt
@@ -2,7 +2,6 @@ package com.reactnativenavigation.utils
 
 import android.animation.Animator
 import android.animation.TimeInterpolator
-import android.view.animation.Interpolator
 
 fun Animator.withStartDelay(delay: Long): Animator {
     startDelay = delay

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/BackgroundColorAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/BackgroundColorAnimator.kt
@@ -10,10 +10,7 @@ import androidx.core.animation.doOnStart
 import com.facebook.react.views.text.ReactTextView
 import com.facebook.react.views.view.ReactViewBackgroundDrawable
 import com.reactnativenavigation.parse.SharedElementTransitionOptions
-import com.reactnativenavigation.utils.ColorUtils
-import com.reactnativenavigation.utils.ViewUtils
-import com.reactnativenavigation.utils.withInterpolator
-import com.reactnativenavigation.utils.withStartDelay
+import com.reactnativenavigation.utils.*
 
 class BackgroundColorAnimator(from: View, to: View) : PropertyAnimatorCreator<ViewGroup>(from, to) {
     override fun shouldAnimateProperty(fromChild: ViewGroup, toChild: ViewGroup): Boolean {
@@ -35,7 +32,7 @@ class BackgroundColorAnimator(from: View, to: View) : PropertyAnimatorCreator<Vi
                         fromColor,
                         toColor
                 )
-                .setDuration(options.getDuration())
+                .withDuration(options.getDuration())
                 .withStartDelay(options.getStartDelay())
                 .withInterpolator(options.interpolation.interpolator)
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/ClipBoundsAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/ClipBoundsAnimator.kt
@@ -24,7 +24,7 @@ class ClipBoundsAnimator(from: View, to: View) : PropertyAnimatorCreator<ReactIm
                 startDrawingRect,
                 endDrawingRect
         )
-                .setDuration(options.getDuration())
+                .withDuration(options.getDuration())
                 .withStartDelay(options.getStartDelay())
                 .withInterpolator(options.interpolation.interpolator)
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/MatrixAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/MatrixAnimator.kt
@@ -1,13 +1,10 @@
 package com.reactnativenavigation.views.element.animators
 
 import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
 import android.animation.ObjectAnimator
 import android.animation.TypeEvaluator
 import android.graphics.Rect
 import android.view.View
-import androidx.core.animation.addListener
-import androidx.core.animation.doOnStart
 import com.facebook.drawee.drawable.ScalingUtils.InterpolatingScaleType
 import com.facebook.react.views.image.ReactImageView
 import com.reactnativenavigation.parse.SharedElementTransitionOptions
@@ -38,7 +35,7 @@ class MatrixAnimator(from: View, to: View) : PropertyAnimatorCreator<ReactImageV
                         }
                         null
                     }, 0, 1)
-                    .setDuration(options.getDuration())
+                    .withDuration(options.getDuration())
                     .withStartDelay(options.getStartDelay())
                     .withInterpolator(options.interpolation.interpolator)
         }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/ScaleXAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/ScaleXAnimator.kt
@@ -23,7 +23,7 @@ class ScaleXAnimator(from: View, to: View) : PropertyAnimatorCreator<ViewGroup>(
         to.scaleX = from.width.toFloat() / to.width
         return ObjectAnimator
                 .ofFloat(to, View.SCALE_X, from.width.toFloat() / to.width, 1f)
-                .setDuration(options.getDuration())
+                .withDuration(options.getDuration())
                 .withStartDelay(options.getStartDelay())
                 .withInterpolator(options.interpolation.interpolator)
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/ScaleYAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/ScaleYAnimator.kt
@@ -4,8 +4,6 @@ import android.animation.Animator
 import android.animation.ObjectAnimator
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.animation.addListener
-import androidx.core.animation.doOnStart
 import com.facebook.react.views.text.ReactTextView
 import com.reactnativenavigation.parse.SharedElementTransitionOptions
 import com.reactnativenavigation.utils.withDuration
@@ -23,7 +21,7 @@ class ScaleYAnimator(from: View, to: View) : PropertyAnimatorCreator<ViewGroup>(
         to.scaleY = from.height.toFloat() / to.height
         return ObjectAnimator
                 .ofFloat(to, View.SCALE_Y, from.height.toFloat() / to.height, 1f)
-                .setDuration(options.getDuration())
+                .withDuration(options.getDuration())
                 .withStartDelay(options.getStartDelay())
                 .withInterpolator(options.interpolation.interpolator)
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/XAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/XAnimator.kt
@@ -10,6 +10,7 @@ import androidx.core.animation.doOnStart
 import com.facebook.react.views.text.ReactTextView
 import com.reactnativenavigation.parse.SharedElementTransitionOptions
 import com.reactnativenavigation.utils.ViewUtils
+import com.reactnativenavigation.utils.withDuration
 import com.reactnativenavigation.utils.withInterpolator
 import com.reactnativenavigation.utils.withStartDelay
 
@@ -31,7 +32,7 @@ class XAnimator(from: View, to: View) : PropertyAnimatorCreator<View>(from, to) 
         to.translationX = dx.toFloat()
         return ObjectAnimator
                 .ofFloat(to, TRANSLATION_X, dx.toFloat(), 0f)
-                .setDuration(options.getDuration())
+                .withDuration(options.getDuration())
                 .withStartDelay(options.getStartDelay())
                 .withInterpolator(options.interpolation.interpolator)
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/YAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/YAnimator.kt
@@ -1,16 +1,15 @@
 package com.reactnativenavigation.views.element.animators
 
 import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
 import android.animation.ObjectAnimator
 import android.view.View
 import android.view.View.TRANSLATION_Y
 import android.view.ViewGroup
-import androidx.core.animation.addListener
-import androidx.core.animation.doOnStart
 import com.facebook.react.views.text.ReactTextView
 import com.reactnativenavigation.parse.SharedElementTransitionOptions
 import com.reactnativenavigation.utils.ViewUtils
+import com.reactnativenavigation.utils.withDuration
+
 import com.reactnativenavigation.utils.withInterpolator
 import com.reactnativenavigation.utils.withStartDelay
 
@@ -32,7 +31,7 @@ class YAnimator(from: View, to: View) : PropertyAnimatorCreator<View>(from, to) 
         to.translationY = dy.toFloat()
         return ObjectAnimator
                 .ofFloat(to, TRANSLATION_Y, dy.toFloat(), 0f)
-                .setDuration(options.getDuration())
+                .withDuration(options.getDuration())
                 .withStartDelay(options.getStartDelay())
                 .withInterpolator(options.interpolation.interpolator)
     }


### PR DESCRIPTION
This commit adds support to the startDelay option in shared element transitions on Android. It also fixes image scale transition which only animated the image's scale type, but not its bounds.