### PR TITLE
Add 'visible' option in TopBar docs

### DIFF
--- a/website/api/options-stack.mdx
+++ b/website/api/options-stack.mdx
@@ -18,6 +18,14 @@ const options = {
 };
 ```
 
+### `visible`
+
+Determines if TopBar is visible or not.
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | Both     |
+
 ### `animate`
 
 Determines if changing the TopBar visibility will be animated or not.


### PR DESCRIPTION
I think `visible` option should be under Options/Stack/TopBar. Correct me if I am wrong.