### PR TITLE
Dismiss all modals before app start to ensure this use case does not break

### DIFF
--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -19,10 +19,10 @@ if (Platform.OS === 'android') {
 };
 
 function start() {
-  Navigation.dismissAllModals();
   registerScreens();
   Navigation.events().registerAppLaunchedListener(async () => {
     setDefaultOptions();
+    Navigation.dismissAllModals();
     setRoot();
   });
 }

--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -19,6 +19,7 @@ if (Platform.OS === 'android') {
 };
 
 function start() {
+  Navigation.dismissAllModals();
   registerScreens();
   Navigation.events().registerAppLaunchedListener(async () => {
     setDefaultOptions();


### PR DESCRIPTION
This commit adds a call to dismissAllModals before setRoot to ensure this use case doesn't break in the future.