### PR TITLE
fix: disable swipe gestures when sidemenu is close

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/SideMenu.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/SideMenu.java
@@ -2,6 +2,8 @@ package com.reactnativenavigation.views;
 
 import android.content.Context;
 import android.util.Log;
+import android.view.MotionEvent;
+import android.view.Gravity;
 
 import androidx.annotation.NonNull;
 import androidx.drawerlayout.widget.DrawerLayout;
@@ -24,5 +26,21 @@ public class SideMenu extends DrawerLayout {
     public void setDrawerLockMode(int lockMode, int edgeGravity) {
         int currentLockMode = getDrawerLockMode(edgeGravity);
         if (currentLockMode != lockMode) super.setDrawerLockMode(lockMode, edgeGravity);
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev) {
+        if (!isDrawerVisible(Gravity.START)) {
+            return false;
+        }
+        return super.onInterceptTouchEvent(ev);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent ev) {
+        if (!isDrawerVisible(Gravity.START)) {
+            return false;
+        }
+        return super.onTouchEvent(ev);
     }
 }


### PR DESCRIPTION
# Summary

When the side menu is close, either leftSide or rightSide, the user is still able to open the menu with a **swipe gesture**, intercepting the touch event looking if **isDrawerVisible** fixes the issue.

When the drawer is visible we're not going to affect the normal behavior of the gestures.

Already tested for android and working as it suppose to.

| OS      | Implemented |
| ------- | :---------: |
| iOS     |   ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ x] I have tested this on a device and a simulator