### PR TITLE
Corrected typo in options-button.mdx

### DIFF
--- a/website/api/options-button.mdx
+++ b/website/api/options-button.mdx
@@ -47,7 +47,7 @@ Button text. Ignored if an icon is specified, unless the button is displayed in 
 | --------------------------------------------- | -------- | -------- |
 | enum('always', 'never', 'withText', 'ifRoom') | No       | Android  |
 
-- **ifRooom** - Only add button to the TopBar if there is room for it, otherwise add it to the overflow menu.
+- **ifRoom** - Only add button to the TopBar if there is room for it, otherwise add it to the overflow menu.
 - **never** - Never place this button in the TopBar. Instead, list the button in the overflow menu.
 - **always** - Always place this button in the app bar.
 


### PR DESCRIPTION
Corrected typo in file options-button.mdx: `ifRooom` > `ifRoom`