### PR TITLE
[Docs] Fix invalid links

### DIFF
--- a/website/api/options-stack.mdx
+++ b/website/api/options-stack.mdx
@@ -124,9 +124,9 @@ Indicates whether the navigation bar should be hidden when searching. True by de
 
 ### `leftButtons`
 
-An array of buttons to be displayed at the right-side of the TopBar. Button layout is from left to right. See the [Buttons](button-options) section for more details.
+An array of buttons to be displayed at the right-side of the TopBar. Button layout is from left to right. See the [Buttons](options-button) section for more details.
 
-:::info Android support 
+:::info Android support
 Android currently only supports a single left button and does not support custom left Buttons.
 :::
 
@@ -153,7 +153,7 @@ Disables border at the bottom of the TopBar.
 
 ### `rightButtons`
 
-An array of buttons to be displayed at the right side of the TopBar. Button layout is from right to left. See the [Buttons](button-options) section for more details.
+An array of buttons to be displayed at the right side of the TopBar. Button layout is from right to left. See the [Buttons](options-button) section for more details.
 
 | Type                       | Required | Platform |
 | -------------------------- | -------- | -------- |

--- a/website/docs/docs-bottomTabs.mdx
+++ b/website/docs/docs-bottomTabs.mdx
@@ -67,7 +67,7 @@ Once we run this code, our BottomTabs should look like this:
 ## Selecting Tabs Programmatically
 Tabs can be selected programmatically by updating the `currentTabIndex` or `currentTabId` options.
 
-We'll use the BottomTabs layout showcased [above](bottomTabs-docs#example) to demonstrate programmatic tab selection.
+We'll use the BottomTabs layout showcased [above](bottomTabs#example) to demonstrate programmatic tab selection.
 
 ### Selecting a tab by index
 The following mergeOptions command will select the second tab. We're passing the id of our BottomTabs layout, but we could also use the id of any of the child components, for example `PROFILE_TAB` or `PROFILE_SCREEN`.

--- a/website/docs/docs-playground-app.mdx
+++ b/website/docs/docs-playground-app.mdx
@@ -13,6 +13,6 @@ If you want to have a quick look around and test things out, you can run the pla
     - `npm run start` to get the packager running in the terminal, leave it open
     - **iOS**: open `./playground/ios` in Xcode and run it
     - **Android**: open `./playground/android` in Android Studio and run it
-3. You can run tests if / when you need to (list of scripts [available here](../meta-contributing#scripts)). Before
+3. You can run tests if / when you need to (list of scripts [available here](meta-contributing#scripts)). Before
 you start changing things, make sure everything works.
 	- To easily run all tests in parallel `npm run test-all`

--- a/website/docs/docs-playground-app.mdx
+++ b/website/docs/docs-playground-app.mdx
@@ -13,5 +13,6 @@ If you want to have a quick look around and test things out, you can run the pla
     - `npm run start` to get the packager running in the terminal, leave it open
     - **iOS**: open `./playground/ios` in Xcode and run it
     - **Android**: open `./playground/android` in Android Studio and run it
-3. You can run tests if / when you need to (list of scripts [available here](contributing#scripts)). Before you start changing things, make sure everything works.
+3. You can run tests if / when you need to (list of scripts [available here](../meta-contributing#scripts)). Before
+you start changing things, make sure everything works.
 	- To easily run all tests in parallel `npm run test-all`

--- a/website/docs/style-animations.mdx
+++ b/website/docs/style-animations.mdx
@@ -29,7 +29,7 @@ The following properties can be animated with our animation framework:
 ## Layout animations
 
 ### Stack animations
-When animating screens in and out of a stack, there are three elements you can work with: 
+When animating screens in and out of a stack, there are three elements you can work with:
 
 1. **content** - screen being pushed or popped
 2. **topBar** - stack's TopBar
@@ -146,7 +146,7 @@ At the moment, the transition is available on iOS for push and pop while on Andr
 
 Let's take a more in-depth look at the following example, which you can find in the playground app:
 
-> [Source screen](https://github.com/wix/react-native-navigation/blob/master/playground/src/screens/sharedElementTransition/CocktailsList.js) and the [Destination screen](https://github.com/wix/react-native-navigation/blob/master/playground/src/screens/sharedElementTransition/CocktailDetailsScreen.js)
+> [Source screen](https://github.com/wix/react-native-navigation/blob/master/playground/src/screens/sharedElementTransition/CocktailsListScreen.js) and the [Destination screen](https://github.com/wix/react-native-navigation/blob/master/playground/src/screens/sharedElementTransition/CocktailDetailsScreen.js)
 
 
 <p align="center">

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -49,7 +49,7 @@ module.exports = {
             },
             {
               label: 'Contributing',
-              to: 'docs/contributing',
+              to: 'docs/meta-contributing',
             }
           ],
         },
@@ -95,7 +95,7 @@ module.exports = {
           routeBasePath: 'docs',
           path: 'docs',
           editUrl:
-            'https://github.com/wix/react-native-navigation/edit/master/website/docs'
+            'https://github.com/wix/react-native-navigation/edit/master/website'
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
@@ -110,7 +110,7 @@ module.exports = {
           path: 'api',
           sidebarPath: require.resolve('./sidebarsApi.js'),
           editUrl:
-            'https://github.com/wix/react-native-navigation/edit/master/website/docs'
+            'https://github.com/wix/react-native-navigation/edit/master/website'
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
- All "Edit this page" links were broken
- And some links inside `.md` files

```sh
# to test run

npx broken-link-checker "https://wix.github.io/react-native-navigation/docs/before-you-start" -ro
```

(c) Mur Amur