### PR TITLE
Fixed syntax error in bottomTabs example

### DIFF
--- a/website/docs/docs-bottomTabs.mdx
+++ b/website/docs/docs-bottomTabs.mdx
@@ -27,7 +27,7 @@ bottomTabs: {
         children: [
           {
             component: {
-              id: 'HOME_SCREEN'
+              id: 'HOME_SCREEN',
               name: 'HomeScreen'
             }
           }


### PR DESCRIPTION
a missed comma (,) added in the bottom-tabs example