### PR TITLE
Tag release versions only

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -99,10 +99,10 @@ function tagAndPublish(newVersion) {
     console.log(`trying to publish ${newVersion}...`);
     exec.execSync(`npm --no-git-tag-version version ${newVersion}`);
     exec.execSync(`npm publish --tag ${VERSION_TAG}`);
-    exec.execSync(`git tag -a ${newVersion} -m "${newVersion}"`);
-    exec.execSyncSilent(`git push deploy ${newVersion} || true`);
     if (isRelease) {
-      updatePackageJsonGit(newVersion);
+        exec.execSync(`git tag -a ${newVersion} -m "${newVersion}"`);
+        exec.execSyncSilent(`git push deploy ${newVersion} || true`);
+        updatePackageJsonGit(newVersion);
     }
 }
 


### PR DESCRIPTION
This PR disables snapshot tags in order to make github releases page more readable.