### PR TITLE
Add NavigationFunctionComponent interface

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -13,3 +13,4 @@ export * from './interfaces/Options';
 export * from './interfaces/NavigationComponent';
 export * from './interfaces/NavigationComponentProps';
 export * from './interfaces/NavigationComponentListener';
+export * from './interfaces/NavigationFunctionComponent';

--- a/lib/src/interfaces/NavigationFunctionComponent.ts
+++ b/lib/src/interfaces/NavigationFunctionComponent.ts
@@ -1,0 +1,8 @@
+import React from 'react';
+import { NavigationComponentProps } from './NavigationComponentProps';
+import { Options } from './Options';
+
+export interface NavigationFunctionComponent<Props = {}>
+  extends React.FunctionComponent<Props & NavigationComponentProps> {
+    options?: Options;
+}

--- a/lib/src/interfaces/NavigationFunctionComponent.ts
+++ b/lib/src/interfaces/NavigationFunctionComponent.ts
@@ -4,5 +4,5 @@ import { Options } from './Options';
 
 export interface NavigationFunctionComponent<Props = {}>
   extends React.FunctionComponent<Props & NavigationComponentProps> {
-    options?: Options;
+    options?: ((props: Props) => Options) | Options;
 }


### PR DESCRIPTION
- Added NavigationFunctionComponent interface

This interface can be used instead of React.FunctionComponent, fixing Typescript `Property 'options' does not exist on type 'FunctionComponent<{}>'` error when trying to declare static options on a functional component.