### PR TITLE
Handle errors in postlink scripts

### DIFF
--- a/autolink/postlink/activityLinker.js
+++ b/autolink/postlink/activityLinker.js
@@ -1,23 +1,52 @@
 // @ts-check
-var path = require('./path');
+var path = require("./path");
 var fs = require("fs");
-var { warnn, logn, infon, debugn } = require("./log");
+var { errorn, warnn, logn, infon, debugn } = require("./log");
 
 class ActivityLinker {
   constructor() {
     this.activityPath = path.mainActivityJava;
+    this.extendNavigationActivity = false;
+    this.removeGetMainComponentName = false;
   }
 
   link() {
+    if (!this.activityPath) {
+      errorn(
+        "   MainActivity not found! Does the file exist in the correct folder?\n   Please check the manual installation docs:\n   https://wix.github.io/react-native-navigation/docs/installing#2-update-mainactivityjava"
+      );
+      return;
+    }
+
     logn("Linking MainActivity...");
-    if (this.activityPath) {
-      var activityContent = fs.readFileSync(this.activityPath, "utf8");
+
+    var activityContent = fs.readFileSync(this.activityPath, "utf8");
+
+    try {
       activityContent = this._extendNavigationActivity(activityContent);
+      this.extendNavigationActivity = true;
+    } catch (e) {
+      errorn("   " + e);
+    }
+
+    try {
       activityContent = this._removeGetMainComponentName(activityContent);
-      fs.writeFileSync(this.activityPath, activityContent);
+      this.removeGetMainComponentName = true;
+    } catch (e) {
+      errorn("   " + e);
+    }
+
+    fs.writeFileSync(this.activityPath, activityContent);
+    if (this.extendNavigationActivity && this.removeGetMainComponentName) {
       infon("MainActivity linked successfully!\n");
+    } else if (!this.extendNavigationActivity && !this.removeGetMainComponentName) {
+      errorn(
+        "MainActivity was not linked. Please check the logs above for more information and proceed with manual linking of the MainActivity file in Android:\nhttps://wix.github.io/react-native-navigation/docs/installing#2-update-mainactivityjava"
+      );
     } else {
-      warnn("   MainActivity not found!");
+      warnn(
+        "MainActivity was only partially linked. Please check the logs above for more information and proceed with manual linking for the failed steps:\nhttps://wix.github.io/react-native-navigation/docs/installing#2-update-mainactivityjava"
+      );
     }
   }
 
@@ -27,22 +56,30 @@ class ActivityLinker {
       debugn("   Removing getMainComponentName function");
       return contents.replace(/\/\*\*\s*\n([^\*]|(\*(?!\/)))*\*\/\s*@Override\s*protected\s*String\s*getMainComponentName\s*\(\)\s*{\s*return.+\s*\}/, "");
     }
+    warnn("   getMainComponentName function was not found.");
     return contents;
   }
 
   _extendNavigationActivity(activityContent) {
     if (this._doesActivityExtendReactActivity(activityContent)) {
-      debugn("   Extending NavigationActivity")
+      debugn("   Extending NavigationActivity");
       return activityContent
         .replace(/extends\s+ReactActivity\s*/, "extends NavigationActivity ")
-        .replace("import com.facebook.react.ReactActivity;", "import com.reactnativenavigation.NavigationActivity;")
-    } else {
-      warnn("   MainActivity already extends NavigationActivity")
+        .replace("import com.facebook.react.ReactActivity;", "import com.reactnativenavigation.NavigationActivity;");
     }
-    return activityContent;
+    if (this._hasAlreadyExtendReactActivity) {
+      warnn("   MainActivity already extends NavigationActivity");
+      return activityContent;
+    }
+
+    throw new Error("MainActivity was not successfully replaced. Please check the documentation and proceed manually.");
   }
 
   _doesActivityExtendReactActivity(activityContent) {
+    return /public\s+class\s+MainActivity\s+extends\s+ReactActivity\s*/.test(activityContent);
+  }
+
+  _hasAlreadyExtendReactActivity(activityContent) {
     return /public\s+class\s+MainActivity\s+extends\s+ReactActivity\s*/.test(activityContent);
   }
 }

--- a/autolink/postlink/activityLinker.js
+++ b/autolink/postlink/activityLinker.js
@@ -6,8 +6,8 @@ var { errorn, warnn, logn, infon, debugn } = require("./log");
 class ActivityLinker {
   constructor() {
     this.activityPath = path.mainActivityJava;
-    this.extendNavigationActivity = false;
-    this.removeGetMainComponentName = false;
+    this.extendNavigationActivitySuccess = false;
+    this.removeGetMainComponentNameSuccess = false;
   }
 
   link() {
@@ -24,22 +24,22 @@ class ActivityLinker {
 
     try {
       activityContent = this._extendNavigationActivity(activityContent);
-      this.extendNavigationActivity = true;
+      this.extendNavigationActivitySuccess = true;
     } catch (e) {
-      errorn("   " + e);
+      errorn("   " + e.message);
     }
 
     try {
       activityContent = this._removeGetMainComponentName(activityContent);
-      this.removeGetMainComponentName = true;
+      this.removeGetMainComponentNameSuccess = true;
     } catch (e) {
-      errorn("   " + e);
+      errorn("   " + e.message);
     }
 
     fs.writeFileSync(this.activityPath, activityContent);
-    if (this.extendNavigationActivity && this.removeGetMainComponentName) {
+    if (this.extendNavigationActivitySuccess && this.removeGetMainComponentNameSuccess) {
       infon("MainActivity linked successfully!\n");
-    } else if (!this.extendNavigationActivity && !this.removeGetMainComponentName) {
+    } else if (!this.extendNavigationActivitySuccess && !this.removeGetMainComponentNameSuccess) {
       errorn(
         "MainActivity was not linked. Please check the logs above for more information and proceed with manual linking of the MainActivity file in Android:\nhttps://wix.github.io/react-native-navigation/docs/installing#2-update-mainactivityjava"
       );

--- a/autolink/postlink/appDelegateLinker.js
+++ b/autolink/postlink/appDelegateLinker.js
@@ -1,78 +1,145 @@
 // @ts-check
-var path = require('./path');
 var fs = require("fs");
-var {warnn, logn, infon, debugn} = require("./log");
+var path = require("./path");
+var { warnn, logn, infon, debugn, errorn } = require("./log");
 
-class ApplicationLinker {
+class AppDelegateLinker {
   constructor() {
     this.appDelegatePath = path.appDelegate;
+    this.removeUnneededImportsSuccess = false;
+    this.removeApplicationLaunchContentSuccess = false;
   }
 
   link() {
-    if (this.appDelegatePath) {
-      logn("Linking AppDelegate...");
-      var appDelegateContents = fs.readFileSync(this.appDelegatePath, "utf8");
-      if (this._doesBootstrapNavigation(appDelegateContents)) {
-        infon("AppDelegate already linked\n");
-        return;
-      }
+    if (!this.appDelegatePath) {
+      errorn(
+        "   AppDelegate not found! Does the file exist in the correct folder?\n   Please check the manual installation docs:\n   https://wix.github.io/react-native-navigation/docs/installing#native-installation"
+      );
+      return;
+    }
+
+    logn("Linking AppDelegate...");
+
+    var appDelegateContents = fs.readFileSync(this.appDelegatePath, "utf8");
+
+    try {
       appDelegateContents = this._removeUnneededImports(appDelegateContents);
-      appDelegateContents = this._importNavigation(appDelegateContents);
-      appDelegateContents = this._bootstrapNavigation(appDelegateContents);
+      this.removeUnneededImportsSuccess = true;
+    } catch (e) {
+      errorn("   " + e);
+    }
+
+    appDelegateContents = this._importNavigation(appDelegateContents);
+
+    appDelegateContents = this._bootstrapNavigation(appDelegateContents);
+
+    try {
       appDelegateContents = this._removeApplicationLaunchContent(appDelegateContents);
-      fs.writeFileSync(this.appDelegatePath, appDelegateContents);
+      this.removeApplicationLaunchContentSuccess = true;
+    } catch (e) {
+      errorn("   " + e);
+    }
+
+    fs.writeFileSync(this.appDelegatePath, appDelegateContents);
+
+    if (this.removeUnneededImportsSuccess && this.removeApplicationLaunchContentSuccess) {
       infon("AppDelegate linked successfully!\n");
+    } else {
+      warnn("AppDelegate was partially linked, please check the details above and proceed with the manual installation documentation to complete the linking process.!\n");
     }
   }
 
-  _doesBootstrapNavigation(applicationContent) {
-    return /ReactNativeNavigation\s+bootstrap/.test(applicationContent);
-  }
-
-  _removeUnneededImports(applicationContent) {
-    const unneededImports = [/\#import\s+\<React\/RCTBridge.h>\s/, /#import\s+\<React\/RCTRootView.h>\s/];
+  _removeUnneededImports(content) {
     debugn("   Removing Unneeded imports");
+
+    const unneededImports = [/\#import\s+\<React\/RCTBridge.h>\s/, /#import\s+\<React\/RCTRootView.h>\s/];
+    let elementsRemoved = 0;
+
     unneededImports.forEach(unneededImport => {
-      if (unneededImport.test(applicationContent)) {
-        applicationContent = applicationContent.replace(unneededImport, "");
+      if (unneededImport.test(content)) {
+        content = content.replace(unneededImport, "");
+        elementsRemoved++;
       }
     });
 
-    return applicationContent;
-  }
-
-  _importNavigation(applicationContent) {
-    if (!this._doesImportNavigation(applicationContent)) {
-      debugn("   ");
-      return applicationContent
-        .replace(/#import\s+"AppDelegate.h"/, "#import \"AppDelegate.h\"\n#import <ReactNativeNavigation/ReactNativeNavigation.h>")
+    if (unneededImports.length === elementsRemoved) {
+      debugn("   All imports have been removed");
+    } else if (elementsRemoved === 0) {
+      warnn(
+        "   No imports could be removed. Check the manual installation docs to verify that everything is properly setup:\n   https://wix.github.io/react-native-navigation/docs/installing#native-installation"
+      );
+    } else {
+      throw new Error(
+        "Some imports were removed. Check the manual installation docs to verify that everything is properly setup:\n   https://wix.github.io/react-native-navigation/docs/installing#native-installation"
+      );
     }
-    warnn("   AppDelegate already imports Navigation");
-    return applicationContent;
+
+    return content;
   }
 
-  _removeApplicationLaunchContent(applicationContent) {
-    const toRemove = [/RCTRootView\s+\*rootView((.|\r|\s)*?)];\s+/, /rootView.backgroundColor((.|\r)*)];\s+/,
-      /self.window((.|\r)*)];\s+/, /UIViewController\s\*rootViewController((.|\r)*)];\s+/, /rootViewController\.view\s+=\s+rootView;\s+/,
-      /self.window.rootViewController\s+=\s+rootViewController;\s+/, /\[self.window\s+makeKeyAndVisible];\s+/
-    ]
+  _importNavigation(content) {
+    if (!this._doesImportNavigation(content)) {
+      debugn("   Importing ReactNativeNavigation.h");
+      return content.replace(/#import\s+"AppDelegate.h"/, '#import "AppDelegate.h"\n#import <ReactNativeNavigation/ReactNativeNavigation.h>');
+    }
+
+    warnn("   AppDelegate already imports ReactNativeNavigation.h");
+    return content;
+  }
+
+  _bootstrapNavigation(content) {
+    if (this._doesBootstrapNavigation(content)) {
+      warnn("   Navigation Bootstrap already present.");
+      return content;
+    }
+
+    debugn("   Bootstrapping Navigation");
+    return content.replace(/RCTBridge.*];/, "[ReactNativeNavigation bootstrapWithDelegate:self launchOptions:launchOptions];");
+  }
+
+  _doesBootstrapNavigation(content) {
+    return /ReactNativeNavigation\s+bootstrap/.test(content);
+  }
+
+  _removeApplicationLaunchContent(content) {
+    debugn("   Removing Application launch content");
+
+    const toRemove = [
+      /RCTRootView\s+\*rootView((.|\r|\s)*?)];\s+/,
+      /rootView.backgroundColor((.|\r)*)];\s+/,
+      /self.window((.|\r)*)];\s+/,
+      /UIViewController\s\*rootViewController((.|\r)*)];\s+/,
+      /rootViewController\.view\s+=\s+rootView;\s+/,
+      /self.window.rootViewController\s+=\s+rootViewController;\s+/,
+      /\[self.window\s+makeKeyAndVisible];\s+/
+    ];
+    let elementsRemoved = 0;
 
     toRemove.forEach(element => {
-      if (element.test(applicationContent)) {
-        applicationContent = applicationContent.replace(element, "");
+      if (element.test(content)) {
+        content = content.replace(element, "");
+        elementsRemoved++;
       }
     });
 
-    return applicationContent;
+    if (toRemove.length === elementsRemoved) {
+      debugn("   Application Launch content has been removed");
+    } else if (elementsRemoved === 0) {
+      warnn(
+        "   No elements could be removed. Check the manual installation docs to verify that everything is properly setup:\n   https://wix.github.io/react-native-navigation/docs/installing#native-installation"
+      );
+    } else {
+      throw new Error(
+        "Some elements were removed. Check the manual installation docs to verify that everything is properly setup:\n   https://wix.github.io/react-native-navigation/docs/installing#native-installation"
+      );
+    }
+
+    return content;
   }
 
-  _bootstrapNavigation(applicationContent) {
-    return applicationContent.replace(/RCTBridge.*];/, "[ReactNativeNavigation bootstrapWithDelegate:self launchOptions:launchOptions];");
-  }
-
-  _doesImportNavigation(applicationContent) {
-    return /#import\s+\<ReactNativeNavigation\/ReactNativeNavigation.h>/.test(applicationContent);
+  _doesImportNavigation(content) {
+    return /#import\s+\<ReactNativeNavigation\/ReactNativeNavigation.h>/.test(content);
   }
 }
 
-module.exports = ApplicationLinker;
+module.exports = AppDelegateLinker;

--- a/autolink/postlink/appDelegateLinker.js
+++ b/autolink/postlink/appDelegateLinker.js
@@ -26,7 +26,7 @@ class AppDelegateLinker {
       appDelegateContents = this._removeUnneededImports(appDelegateContents);
       this.removeUnneededImportsSuccess = true;
     } catch (e) {
-      errorn("   " + e);
+      errorn("   " + e.message);
     }
 
     appDelegateContents = this._importNavigation(appDelegateContents);
@@ -37,7 +37,7 @@ class AppDelegateLinker {
       appDelegateContents = this._removeApplicationLaunchContent(appDelegateContents);
       this.removeApplicationLaunchContentSuccess = true;
     } catch (e) {
-      errorn("   " + e);
+      errorn("   " + e.message);
     }
 
     fs.writeFileSync(this.appDelegatePath, appDelegateContents);
@@ -53,18 +53,18 @@ class AppDelegateLinker {
     debugn("   Removing Unneeded imports");
 
     const unneededImports = [/\#import\s+\<React\/RCTBridge.h>\s/, /#import\s+\<React\/RCTRootView.h>\s/];
-    let elementsRemoved = 0;
+    let elementsRemovedCount = 0;
 
-    unneededImports.forEach(unneededImport => {
+    unneededImports.forEach((unneededImport) => {
       if (unneededImport.test(content)) {
         content = content.replace(unneededImport, "");
-        elementsRemoved++;
+        elementsRemovedCount++;
       }
     });
 
-    if (unneededImports.length === elementsRemoved) {
+    if (unneededImports.length === elementsRemovedCount) {
       debugn("   All imports have been removed");
-    } else if (elementsRemoved === 0) {
+    } else if (elementsRemovedCount === 0) {
       warnn(
         "   No imports could be removed. Check the manual installation docs to verify that everything is properly setup:\n   https://wix.github.io/react-native-navigation/docs/installing#native-installation"
       );
@@ -111,20 +111,20 @@ class AppDelegateLinker {
       /UIViewController\s\*rootViewController((.|\r)*)];\s+/,
       /rootViewController\.view\s+=\s+rootView;\s+/,
       /self.window.rootViewController\s+=\s+rootViewController;\s+/,
-      /\[self.window\s+makeKeyAndVisible];\s+/
+      /\[self.window\s+makeKeyAndVisible];\s+/,
     ];
-    let elementsRemoved = 0;
+    let elementsRemovedCount = 0;
 
-    toRemove.forEach(element => {
+    toRemove.forEach((element) => {
       if (element.test(content)) {
         content = content.replace(element, "");
-        elementsRemoved++;
+        elementsRemovedCount++;
       }
     });
 
-    if (toRemove.length === elementsRemoved) {
+    if (toRemove.length === elementsRemovedCount) {
       debugn("   Application Launch content has been removed");
-    } else if (elementsRemoved === 0) {
+    } else if (elementsRemovedCount === 0) {
       warnn(
         "   No elements could be removed. Check the manual installation docs to verify that everything is properly setup:\n   https://wix.github.io/react-native-navigation/docs/installing#native-installation"
       );

--- a/autolink/postlink/applicationLinker.js
+++ b/autolink/postlink/applicationLinker.js
@@ -1,68 +1,126 @@
 // @ts-check
-var path = require('./path');
-var fs = require("fs");
-var { warnn, logn, infon, debugn } = require("./log");
+var path = require('./path')
+var fs = require('fs')
+var { warnn, logn, infon, debugn, errorn } = require('./log')
 
 class ApplicationLinker {
   constructor() {
-    this.applicationPath = path.mainApplicationJava;
+    this.applicationPath = path.mainApplicationJava
+    this.navigationApplicationSuccess = false
+    this.navigationHostSuccess = false
+    this.soLoaderInitSuccess = false
   }
 
   link() {
-    if (this.applicationPath) {
-      logn("Linking MainApplication...");
-      var applicationContents = fs.readFileSync(this.applicationPath, "utf8");
-      var linkers = [this._extendNavigationApplication, this._extendNavigationHost, this._removeSOLoaderInit];
-      applicationContents = this._extendNavigationApplication(applicationContents);
-      applicationContents = this._extendNavigationHost(applicationContents);
-      applicationContents = this._removeSOLoaderInit(applicationContents);
-      fs.writeFileSync(this.applicationPath, applicationContents);
-      infon("MainApplication linked successfully!\n");
+    if (!this.applicationPath) {
+      errorn(
+        'MainApplication.java not found! Does the file exist in the correct folder?\n   Please check the manual installation docs:\n   https://wix.github.io/react-native-navigation/docs/installing#3-update-mainapplicationjava'
+      )
+    }
+
+    logn('Linking MainApplication...')
+    var applicationContents = fs.readFileSync(this.applicationPath, 'utf8')
+
+    try {
+      applicationContents = this._extendNavigationApplication(applicationContents)
+      this.navigationApplicationSuccess = true
+    } catch (e) {
+      errorn('   ' + e)
+    }
+    try {
+      applicationContents = this._extendNavigationHost(applicationContents)
+      this.navigationHostSuccess = true
+    } catch (e) {
+      errorn('   ' + e)
+    }
+    try {
+      applicationContents = this._removeSOLoaderInit(applicationContents)
+      this.soLoaderInitSuccess = true
+    } catch (e) {
+      errorn('   ' + e)
+    }
+
+    fs.writeFileSync(this.applicationPath, applicationContents)
+
+    if (this.navigationApplicationSuccess && this.navigationHostSuccess && this.soLoaderInitSuccess) {
+      infon('MainApplication.java linked successfully!\n')
+    } else if (!this.navigationApplicationSuccess && !this.navigationHostSuccess && !this.soLoaderInitSuccess) {
+      errorn(
+        'MainApplication.java was not successfully linked! Please check the information above:\n   https://wix.github.io/react-native-navigation/docs/installing#3-update-mainapplicationjava'
+      )
+    } else {
+      warnn(
+        'MainApplication.java was partially linked. Please check the information above and complete the missing steps manually:\n   https://wix.github.io/react-native-navigation/docs/installing#3-update-mainapplicationjava'
+      )
     }
   }
 
   _extendNavigationApplication(applicationContent) {
     if (this._doesExtendApplication(applicationContent)) {
-      debugn("   Extending NavigationApplication");
+      debugn('   Extending NavigationApplication')
       return applicationContent
-        .replace(/extends\s+Application\s+implements\s+ReactApplication/gi, "extends NavigationApplication")
-        .replace("import com.facebook.react.ReactApplication;", "import com.reactnativenavigation.NavigationApplication;");
+        .replace(/extends\s+Application\s+implements\s+ReactApplication/gi, 'extends NavigationApplication')
+        .replace(
+          'import com.facebook.react.ReactApplication;',
+          'import com.reactnativenavigation.NavigationApplication;'
+        )
     }
-    warnn("   MainApplication already extends NavigationApplication");
-    return applicationContent;
+
+    if (this._hasAlreadyLinkedApplication(applicationContent)) {
+      warnn('   MainApplication already extends NavigationApplication, skipping.')
+      return applicationContent
+    }
+
+    throw new Error('There was a problem extending NavigationApplication from your MainApplication file.')
   }
 
   _doesExtendApplication(applicationContent) {
-    return /\s+MainApplication\s+extends\s+Application\s+implements\s+ReactApplication\s+/.test(applicationContent);
+    return /\s+MainApplication\s+extends\s+Application\s+implements\s+ReactApplication\s+/.test(applicationContent)
+  }
+
+  _hasAlreadyLinkedApplication(applicationContent) {
+    return /\s+extends\s+NavigationApplication\s+/.test(applicationContent)
   }
 
   _extendNavigationHost(applicationContent) {
     if (this._doesExtendReactNativeHost(applicationContent)) {
-      debugn("   Changing host implementation to NavigationReactNativeHost");
+      debugn('   Changing host implementation to NavigationReactNativeHost')
       return applicationContent
-        .replace("new ReactNativeHost(this)", "new NavigationReactNativeHost(this)")
-        .replace("import com.facebook.react.ReactNativeHost;", "import com.facebook.react.ReactNativeHost;\nimport com.reactnativenavigation.react.NavigationReactNativeHost;")
+        .replace('new ReactNativeHost(this)', 'new NavigationReactNativeHost(this)')
+        .replace(
+          'import com.facebook.react.ReactNativeHost;',
+          'import com.facebook.react.ReactNativeHost;\nimport com.reactnativenavigation.react.NavigationReactNativeHost;'
+        )
     }
-    warnn("   NavigationReactNativeHost is already used");
-    return applicationContent;
+
+    if (this._hasAlreadyLinkedNavigationHost(applicationContent)) {
+      warnn('   NavigationReactNativeHost is already used, skipping.')
+      return applicationContent
+    }
+
+    throw new Error('There was a problem extending NavigationReactNativeHost().')
+  }
+
+  _doesExtendReactNativeHost(applicationContent) {
+    return /\s*new ReactNativeHost\(this\)\s*/.test(applicationContent)
+  }
+
+  _hasAlreadyLinkedNavigationHost(applicationContent) {
+    return /\s*new NavigationReactNativeHost\(this\)\s*/.test(applicationContent)
   }
 
   _removeSOLoaderInit(applicationContent) {
     if (this._isSOLoaderInitCalled(applicationContent)) {
-      debugn("   Removing call to SOLoader.init()");
-      return applicationContent.replace(/SoLoader.init\(\s*this\s*,\s*[/* native exopackage */]*\s*false\s*\);/, "")
+      debugn('   Removing call to SOLoader.init()')
+      return applicationContent.replace(/SoLoader.init\(\s*this\s*,\s*[/* native exopackage */]*\s*false\s*\);/, '')
     }
-    warnn("   SOLoader.init() is not called");
-    return applicationContent;
+    warnn('   SOLoader.init() is not called, skipping.')
+    return applicationContent
   }
 
   _isSOLoaderInitCalled(applicationContent) {
-    return /SoLoader.init\(this,\s*[/* native exopackage */]*\s*false\);/.test(applicationContent);
-  }
-
-  _doesExtendReactNativeHost(applicationContent) {
-    return /\s*new ReactNativeHost\(this\)\s*/.test(applicationContent);
+    return /SoLoader.init\(this,\s*[/* native exopackage */]*\s*false\);/.test(applicationContent)
   }
 }
 
-module.exports = ApplicationLinker;
+module.exports = ApplicationLinker

--- a/autolink/postlink/applicationLinker.js
+++ b/autolink/postlink/applicationLinker.js
@@ -1,126 +1,118 @@
 // @ts-check
-var path = require('./path')
-var fs = require('fs')
-var { warnn, logn, infon, debugn, errorn } = require('./log')
+var path = require("./path");
+var fs = require("fs");
+var { warnn, logn, infon, debugn, errorn } = require("./log");
 
 class ApplicationLinker {
   constructor() {
-    this.applicationPath = path.mainApplicationJava
-    this.navigationApplicationSuccess = false
-    this.navigationHostSuccess = false
-    this.soLoaderInitSuccess = false
+    this.applicationPath = path.mainApplicationJava;
+    this.navigationApplicationSuccess = false;
+    this.navigationHostSuccess = false;
+    this.soLoaderInitSuccess = false;
   }
 
   link() {
     if (!this.applicationPath) {
       errorn(
-        'MainApplication.java not found! Does the file exist in the correct folder?\n   Please check the manual installation docs:\n   https://wix.github.io/react-native-navigation/docs/installing#3-update-mainapplicationjava'
-      )
+        "MainApplication.java not found! Does the file exist in the correct folder?\n   Please check the manual installation docs:\n   https://wix.github.io/react-native-navigation/docs/installing#3-update-mainapplicationjava"
+      );
     }
 
-    logn('Linking MainApplication...')
-    var applicationContents = fs.readFileSync(this.applicationPath, 'utf8')
+    logn("Linking MainApplication...");
+    var applicationContents = fs.readFileSync(this.applicationPath, "utf8");
 
     try {
-      applicationContents = this._extendNavigationApplication(applicationContents)
-      this.navigationApplicationSuccess = true
+      applicationContents = this._extendNavigationApplication(applicationContents);
+      this.navigationApplicationSuccess = true;
     } catch (e) {
-      errorn('   ' + e)
+      errorn("   " + e);
     }
     try {
-      applicationContents = this._extendNavigationHost(applicationContents)
-      this.navigationHostSuccess = true
+      applicationContents = this._extendNavigationHost(applicationContents);
+      this.navigationHostSuccess = true;
     } catch (e) {
-      errorn('   ' + e)
+      errorn("   " + e);
     }
     try {
-      applicationContents = this._removeSOLoaderInit(applicationContents)
-      this.soLoaderInitSuccess = true
+      applicationContents = this._removeSOLoaderInit(applicationContents);
+      this.soLoaderInitSuccess = true;
     } catch (e) {
-      errorn('   ' + e)
+      errorn("   " + e);
     }
 
-    fs.writeFileSync(this.applicationPath, applicationContents)
+    fs.writeFileSync(this.applicationPath, applicationContents);
 
     if (this.navigationApplicationSuccess && this.navigationHostSuccess && this.soLoaderInitSuccess) {
-      infon('MainApplication.java linked successfully!\n')
+      infon("MainApplication.java linked successfully!\n");
     } else if (!this.navigationApplicationSuccess && !this.navigationHostSuccess && !this.soLoaderInitSuccess) {
-      errorn(
-        'MainApplication.java was not successfully linked! Please check the information above:\n   https://wix.github.io/react-native-navigation/docs/installing#3-update-mainapplicationjava'
-      )
+      errorn("MainApplication.java was not successfully linked! Please check the information above:\n   https://wix.github.io/react-native-navigation/docs/installing#3-update-mainapplicationjava");
     } else {
       warnn(
-        'MainApplication.java was partially linked. Please check the information above and complete the missing steps manually:\n   https://wix.github.io/react-native-navigation/docs/installing#3-update-mainapplicationjava'
-      )
+        "MainApplication.java was partially linked. Please check the information above and complete the missing steps manually:\n   https://wix.github.io/react-native-navigation/docs/installing#3-update-mainapplicationjava"
+      );
     }
   }
 
   _extendNavigationApplication(applicationContent) {
     if (this._doesExtendApplication(applicationContent)) {
-      debugn('   Extending NavigationApplication')
+      debugn("   Extending NavigationApplication");
       return applicationContent
-        .replace(/extends\s+Application\s+implements\s+ReactApplication/gi, 'extends NavigationApplication')
-        .replace(
-          'import com.facebook.react.ReactApplication;',
-          'import com.reactnativenavigation.NavigationApplication;'
-        )
+        .replace(/extends\s+Application\s+implements\s+ReactApplication/gi, "extends NavigationApplication")
+        .replace("import com.facebook.react.ReactApplication;", "import com.reactnativenavigation.NavigationApplication;");
     }
 
     if (this._hasAlreadyLinkedApplication(applicationContent)) {
-      warnn('   MainApplication already extends NavigationApplication, skipping.')
-      return applicationContent
+      warnn("   MainApplication already extends NavigationApplication, skipping.");
+      return applicationContent;
     }
 
-    throw new Error('There was a problem extending NavigationApplication from your MainApplication file.')
+    throw new Error("There was a problem extending NavigationApplication from your MainApplication file.");
   }
 
   _doesExtendApplication(applicationContent) {
-    return /\s+MainApplication\s+extends\s+Application\s+implements\s+ReactApplication\s+/.test(applicationContent)
+    return /\s+MainApplication\s+extends\s+Application\s+implements\s+ReactApplication\s+/.test(applicationContent);
   }
 
   _hasAlreadyLinkedApplication(applicationContent) {
-    return /\s+extends\s+NavigationApplication\s+/.test(applicationContent)
+    return /\s+extends\s+NavigationApplication\s+/.test(applicationContent);
   }
 
   _extendNavigationHost(applicationContent) {
     if (this._doesExtendReactNativeHost(applicationContent)) {
-      debugn('   Changing host implementation to NavigationReactNativeHost')
+      debugn("   Changing host implementation to NavigationReactNativeHost");
       return applicationContent
-        .replace('new ReactNativeHost(this)', 'new NavigationReactNativeHost(this)')
-        .replace(
-          'import com.facebook.react.ReactNativeHost;',
-          'import com.facebook.react.ReactNativeHost;\nimport com.reactnativenavigation.react.NavigationReactNativeHost;'
-        )
+        .replace("new ReactNativeHost(this)", "new NavigationReactNativeHost(this)")
+        .replace("import com.facebook.react.ReactNativeHost;", "import com.facebook.react.ReactNativeHost;\nimport com.reactnativenavigation.react.NavigationReactNativeHost;");
     }
 
     if (this._hasAlreadyLinkedNavigationHost(applicationContent)) {
-      warnn('   NavigationReactNativeHost is already used, skipping.')
-      return applicationContent
+      warnn("   NavigationReactNativeHost is already used, skipping.");
+      return applicationContent;
     }
 
-    throw new Error('There was a problem extending NavigationReactNativeHost().')
+    throw new Error("There was a problem extending NavigationReactNativeHost().");
   }
 
   _doesExtendReactNativeHost(applicationContent) {
-    return /\s*new ReactNativeHost\(this\)\s*/.test(applicationContent)
+    return /\s*new ReactNativeHost\(this\)\s*/.test(applicationContent);
   }
 
   _hasAlreadyLinkedNavigationHost(applicationContent) {
-    return /\s*new NavigationReactNativeHost\(this\)\s*/.test(applicationContent)
+    return /\s*new NavigationReactNativeHost\(this\)\s*/.test(applicationContent);
   }
 
   _removeSOLoaderInit(applicationContent) {
     if (this._isSOLoaderInitCalled(applicationContent)) {
-      debugn('   Removing call to SOLoader.init()')
-      return applicationContent.replace(/SoLoader.init\(\s*this\s*,\s*[/* native exopackage */]*\s*false\s*\);/, '')
+      debugn("   Removing call to SOLoader.init()");
+      return applicationContent.replace(/SoLoader.init\(\s*this\s*,\s*[/* native exopackage */]*\s*false\s*\);/, "");
     }
-    warnn('   SOLoader.init() is not called, skipping.')
-    return applicationContent
+    warnn("   SOLoader.init() is not called, skipping.");
+    return applicationContent;
   }
 
   _isSOLoaderInitCalled(applicationContent) {
-    return /SoLoader.init\(this,\s*[/* native exopackage */]*\s*false\);/.test(applicationContent)
+    return /SoLoader.init\(this,\s*[/* native exopackage */]*\s*false\);/.test(applicationContent);
   }
 }
 
-module.exports = ApplicationLinker
+module.exports = ApplicationLinker;

--- a/autolink/postlink/gradleLinker.js
+++ b/autolink/postlink/gradleLinker.js
@@ -1,98 +1,92 @@
 // @ts-check
-var path = require('./path')
-var fs = require('fs')
-var { warnn, errorn, logn, infon, debugn } = require('./log')
-var { insertString } = require('./stringUtils')
-var DEFAULT_KOTLIN_VERSION = '1.3.61'
+var path = require("./path");
+var fs = require("fs");
+var { warnn, errorn, logn, infon, debugn } = require("./log");
+var { insertString } = require("./stringUtils");
+var DEFAULT_KOTLIN_VERSION = "1.3.61";
 // This should be the minSdkVersion required for RNN.
-var DEFAULT_MIN_SDK_VERSION = 19
+var DEFAULT_MIN_SDK_VERSION = 19;
 
 class GradleLinker {
   constructor() {
-    this.gradlePath = path.rootGradle
-    this.setKlotinVersionSuccess = false
-    this.setKotlinPluginDependency = false
-    this.setMinSdkVersion = false
+    this.gradlePath = path.rootGradle;
+    this.setKlotinVersionSuccess = false;
+    this.setKotlinPluginDependencySuccess = false;
+    this.setMinSdkVersionSuccess = false;
   }
 
   link() {
     if (!this.gradlePath) {
+      errorn("Root build.gradle not found! Does the file exist in the correct folder?\n   Please check the manual installation docs.");
+      return;
+    }
+
+    logn("Linking root build.gradle...");
+    var contents = fs.readFileSync(this.gradlePath, "utf8");
+
+    try {
+      contents = this._setKotlinVersion(contents);
+      this.setKlotinVersionSuccess = true;
+    } catch (e) {
+      errorn("   " + e);
+    }
+    try {
+      contents = this._setKotlinPluginDependency(contents);
+      this.setKotlinPluginDependencySuccess = true;
+    } catch (e) {
+      errorn("   " + e);
+    }
+    try {
+      contents = this._setMinSdkVersion(contents);
+      this.setMinSdkVersionSuccess = true;
+    } catch (e) {
+      errorn("   " + e);
+    }
+
+    fs.writeFileSync(this.gradlePath, contents);
+
+    if (this.setKlotinVersionSuccess && this.setKotlinPluginDependencySuccess && this.setMinSdkVersionSuccess) {
+      infon("Root build.gradle linked successfully!\n");
+    } else if (!this.setKlotinVersionSuccess && !this.setKotlinPluginDependencySuccess && !this.setMinSdkVersionSuccess) {
       errorn(
-        'Root build.gradle not found! Does the file exist in the correct folder?\n   Please check the manual installation docs.'
-      )
-      return
-    }
-
-    logn('Linking root build.gradle...')
-    var contents = fs.readFileSync(this.gradlePath, 'utf8')
-
-    try {
-      contents = this._setKotlinVersion(contents)
-      this.setKlotinVersionSuccess = true
-    } catch (e) {
-      errorn('   ' + e)
-    }
-    try {
-      contents = this._setKotlinPluginDependency(contents)
-      this.setKotlinPluginDependency = true
-    } catch (e) {
-      errorn('   ' + e)
-    }
-    try {
-      contents = this._setMinSdkVersion(contents)
-      this.setMinSdkVersion = true
-    } catch (e) {
-      errorn('   ' + e)
-    }
-
-    fs.writeFileSync(this.gradlePath, contents)
-
-    if (this.setKlotinVersionSuccess && this.setKotlinPluginDependency && this.setMinSdkVersion) {
-      infon('Root build.gradle linked successfully!\n')
-    } else if (!this.setKlotinVersionSuccess && !this.setKotlinPluginDependency && !this.setMinSdkVersion) {
-      errorn(
-        'Root build.gradle link failed. Please review the information above and complete the necessary steps manually by following the instructions on https://wix.github.io/react-native-navigation/docs/installing#1-update-androidbuildgradle\n'
-      )
+        "Root build.gradle link failed. Please review the information above and complete the necessary steps manually by following the instructions on https://wix.github.io/react-native-navigation/docs/installing#1-update-androidbuildgradle\n"
+      );
     } else {
       warnn(
-        'Root build.gradle link partially succeeded. Please review the information above and complete the necessary steps manually by following the instructions on https://wix.github.io/react-native-navigation/docs/installing#1-update-androidbuildgradle\n'
-      )
+        "Root build.gradle link partially succeeded. Please review the information above and complete the necessary steps manually by following the instructions on https://wix.github.io/react-native-navigation/docs/installing#1-update-androidbuildgradle\n"
+      );
     }
   }
 
   _setKotlinPluginDependency(contents) {
     if (this._isKotlinPluginDeclared(contents)) {
-      warnn('   Kotlin plugin already declared')
-      return contents
+      warnn("   Kotlin plugin already declared");
+      return contents;
     }
 
-    var match = /classpath\s*\(*["']com\.android\.tools\.build:gradle:/.exec(contents)
+    var match = /classpath\s*\(*["']com\.android\.tools\.build:gradle:/.exec(contents);
     if (match) {
-      debugn('   Adding Kotlin plugin')
-      return insertString(
-        contents,
-        match.index,
-        `classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${DEFAULT_KOTLIN_VERSION}"\n        `
-      )
+      debugn("   Adding Kotlin plugin");
+      return insertString(contents, match.index, `classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${DEFAULT_KOTLIN_VERSION}"\n        `);
     } else {
-      throw new Error('   Could not add kotlin plugin dependency')
+      throw new Error("   Could not add kotlin plugin dependency");
     }
   }
 
   _setKotlinVersion(contents) {
     if (this._isKotlinVersionSpecified(contents)) {
-      warnn('   Kotlin version already specified')
+      warnn("   Kotlin version already specified");
     } else {
-      var kotlinVersion = this._getKotlinVersion(contents)
+      var kotlinVersion = this._getKotlinVersion(contents);
       if (this._hasExtensionVariablesBlock(contents)) {
-        debugn('   Adding RNNKotlinVersion to extension block')
-        return contents.replace(/ext\s*{/, `ext {\n        RNNKotlinVersion = ${kotlinVersion}`)
+        debugn("   Adding RNNKotlinVersion to extension block");
+        return contents.replace(/ext\s*{/, `ext {\n        RNNKotlinVersion = ${kotlinVersion}`);
       } else {
-        debugn('   Adding RNNKotlinVersion extension variable')
-        return contents.replace(/buildscript\s*{/, `buildscript {\n    ext.RNNKotlinVersion = ${kotlinVersion}`)
+        debugn("   Adding RNNKotlinVersion extension variable");
+        return contents.replace(/buildscript\s*{/, `buildscript {\n    ext.RNNKotlinVersion = ${kotlinVersion}`);
       }
     }
-    return contents
+    return contents;
   }
 
   /**
@@ -100,30 +94,30 @@ class GradleLinker {
    * the required version, set it to the required version otherwise leave as it is.
    */
   _setMinSdkVersion(contents) {
-    var minSdkVersion = this._getMinSdkVersion(contents)
+    var minSdkVersion = this._getMinSdkVersion(contents);
     // If user entered minSdkVersion is lower than the default, set it to default.
     if (minSdkVersion < DEFAULT_MIN_SDK_VERSION) {
-      debugn(`   Updating minSdkVersion to ${DEFAULT_MIN_SDK_VERSION}`)
-      return contents.replace(/minSdkVersion\s{0,}=\s{0,}\d*/, `minSdkVersion = ${DEFAULT_MIN_SDK_VERSION}`)
+      debugn(`   Updating minSdkVersion to ${DEFAULT_MIN_SDK_VERSION}`);
+      return contents.replace(/minSdkVersion\s{0,}=\s{0,}\d*/, `minSdkVersion = ${DEFAULT_MIN_SDK_VERSION}`);
     }
 
-    warnn(`   Already specified minSdkVersion ${minSdkVersion}`)
-    return contents.replace(/minSdkVersion\s{0,}=\s{0,}\d*/, `minSdkVersion = ${minSdkVersion}`)
+    warnn(`   Already specified minSdkVersion ${minSdkVersion}`);
+    return contents.replace(/minSdkVersion\s{0,}=\s{0,}\d*/, `minSdkVersion = ${minSdkVersion}`);
   }
 
   /**
    * @param { string } contents
    */
   _getKotlinVersion(contents) {
-    var hardCodedVersion = contents.match(/(?<=kotlin-gradle-plugin:)\$*[\d\.]{3,}/)
+    var hardCodedVersion = contents.match(/(?<=kotlin-gradle-plugin:)\$*[\d\.]{3,}/);
     if (hardCodedVersion && hardCodedVersion.length > 0) {
-      return `"${hardCodedVersion[0]}"`
+      return `"${hardCodedVersion[0]}"`;
     }
-    var extensionVariableVersion = contents.match(/(?<=kotlin-gradle-plugin:)\$*[a-zA-Z\d\.]*/)
+    var extensionVariableVersion = contents.match(/(?<=kotlin-gradle-plugin:)\$*[a-zA-Z\d\.]*/);
     if (extensionVariableVersion && extensionVariableVersion.length > 0) {
-      return extensionVariableVersion[0].replace('$', '')
+      return extensionVariableVersion[0].replace("$", "");
     }
-    return `"${DEFAULT_KOTLIN_VERSION}"`
+    return `"${DEFAULT_KOTLIN_VERSION}"`;
   }
 
   /**
@@ -131,36 +125,36 @@ class GradleLinker {
    * @param { string } contents
    */
   _getMinSdkVersion(contents) {
-    var minSdkVersion = contents.match(/minSdkVersion\s{0,}=\s{0,}(\d*)/)
+    var minSdkVersion = contents.match(/minSdkVersion\s{0,}=\s{0,}(\d*)/);
 
     if (minSdkVersion && minSdkVersion[1]) {
       // It'd be something like 16 for a fresh React Native project.
-      return +minSdkVersion[1]
+      return +minSdkVersion[1];
     }
 
-    return DEFAULT_MIN_SDK_VERSION
+    return DEFAULT_MIN_SDK_VERSION;
   }
 
   /**
    * @param {string} contents
    */
   _hasExtensionVariablesBlock(contents) {
-    return /ext\s*{/.test(contents)
+    return /ext\s*{/.test(contents);
   }
 
   /**
    * @param {string} contents
    */
   _isKotlinVersionSpecified(contents) {
-    return /RNNKotlinVersion/.test(contents)
+    return /RNNKotlinVersion/.test(contents);
   }
 
   /**
    * @param {string} contents
    */
   _isKotlinPluginDeclared(contents) {
-    return /org.jetbrains.kotlin:kotlin-gradle-plugin:/.test(contents)
+    return /org.jetbrains.kotlin:kotlin-gradle-plugin:/.test(contents);
   }
 }
 
-module.exports = GradleLinker
+module.exports = GradleLinker;

--- a/autolink/postlink/gradleLinker.js
+++ b/autolink/postlink/gradleLinker.js
@@ -1,60 +1,98 @@
 // @ts-check
-var path = require('./path');
-var fs = require('fs');
-var { warnn, errorn, logn, infon, debugn } = require('./log');
-var { insertString } = require('./stringUtils');
-var DEFAULT_KOTLIN_VERSION = '1.3.61';
+var path = require('./path')
+var fs = require('fs')
+var { warnn, errorn, logn, infon, debugn } = require('./log')
+var { insertString } = require('./stringUtils')
+var DEFAULT_KOTLIN_VERSION = '1.3.61'
 // This should be the minSdkVersion required for RNN.
 var DEFAULT_MIN_SDK_VERSION = 19
 
 class GradleLinker {
   constructor() {
-    this.gradlePath = path.rootGradle;
+    this.gradlePath = path.rootGradle
+    this.setKlotinVersionSuccess = false
+    this.setKotlinPluginDependency = false
+    this.setMinSdkVersion = false
   }
 
   link() {
-    logn('Linking root build.gradle...');
-    if (this.gradlePath) {
-      var contents = fs.readFileSync(this.gradlePath, 'utf8');
-      contents = this._setKotlinVersion(contents);
-      contents = this._setKotlinPluginDependency(contents);
-      contents = this._setMinSdkVersion(contents);
-      fs.writeFileSync(this.gradlePath, contents);
-      infon('Root build.gradle linked successfully!\n');
+    if (!this.gradlePath) {
+      errorn(
+        'Root build.gradle not found! Does the file exist in the correct folder?\n   Please check the manual installation docs.'
+      )
+      return
+    }
+
+    logn('Linking root build.gradle...')
+    var contents = fs.readFileSync(this.gradlePath, 'utf8')
+
+    try {
+      contents = this._setKotlinVersion(contents)
+      this.setKlotinVersionSuccess = true
+    } catch (e) {
+      errorn('   ' + e)
+    }
+    try {
+      contents = this._setKotlinPluginDependency(contents)
+      this.setKotlinPluginDependency = true
+    } catch (e) {
+      errorn('   ' + e)
+    }
+    try {
+      contents = this._setMinSdkVersion(contents)
+      this.setMinSdkVersion = true
+    } catch (e) {
+      errorn('   ' + e)
+    }
+
+    fs.writeFileSync(this.gradlePath, contents)
+
+    if (this.setKlotinVersionSuccess && this.setKotlinPluginDependency && this.setMinSdkVersion) {
+      infon('Root build.gradle linked successfully!\n')
+    } else if (!this.setKlotinVersionSuccess && !this.setKotlinPluginDependency && !this.setMinSdkVersion) {
+      errorn(
+        'Root build.gradle link failed. Please review the information above and complete the necessary steps manually by following the instructions on https://wix.github.io/react-native-navigation/docs/installing#1-update-androidbuildgradle\n'
+      )
     } else {
-      warnn('   Root build.gradle not found!');
+      warnn(
+        'Root build.gradle link partially succeeded. Please review the information above and complete the necessary steps manually by following the instructions on https://wix.github.io/react-native-navigation/docs/installing#1-update-androidbuildgradle\n'
+      )
     }
   }
 
   _setKotlinPluginDependency(contents) {
     if (this._isKotlinPluginDeclared(contents)) {
       warnn('   Kotlin plugin already declared')
-      return contents;
+      return contents
     }
-    var match = /classpath\s*\(*["']com\.android\.tools\.build:gradle:/.exec(contents);
+
+    var match = /classpath\s*\(*["']com\.android\.tools\.build:gradle:/.exec(contents)
     if (match) {
-      debugn("   Adding Kotlin plugin");
-      return insertString(contents, match.index, `classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${DEFAULT_KOTLIN_VERSION}"\n        `);
+      debugn('   Adding Kotlin plugin')
+      return insertString(
+        contents,
+        match.index,
+        `classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${DEFAULT_KOTLIN_VERSION}"\n        `
+      )
     } else {
-      errorn("   Could not add kotlin plugin dependency")
+      throw new Error('   Could not add kotlin plugin dependency')
     }
-    return contents;
   }
 
   _setKotlinVersion(contents) {
     if (this._isKotlinVersionSpecified(contents)) {
-      warnn("   Kotlin version already specified");
+      warnn('   Kotlin version already specified')
     } else {
-      var kotlinVersion = this._getKotlinVersion(contents);
+      var kotlinVersion = this._getKotlinVersion(contents)
       if (this._hasExtensionVariablesBlock(contents)) {
-        debugn("   Adding RNNKotlinVersion to extension block");
-        return contents.replace(/ext\s*{/, `ext {\n        RNNKotlinVersion = ${kotlinVersion}`);
+        debugn('   Adding RNNKotlinVersion to extension block')
+        return contents.replace(/ext\s*{/, `ext {\n        RNNKotlinVersion = ${kotlinVersion}`)
       } else {
-        debugn("   Adding RNNKotlinVersion extension variable");
-        return contents.replace(/buildscript\s*{/, `buildscript {\n    ext.RNNKotlinVersion = ${kotlinVersion}`);
+        debugn('   Adding RNNKotlinVersion extension variable')
+        return contents.replace(/buildscript\s*{/, `buildscript {\n    ext.RNNKotlinVersion = ${kotlinVersion}`)
       }
     }
-    return contents;
+    return contents
   }
 
   /**
@@ -67,9 +105,9 @@ class GradleLinker {
     if (minSdkVersion < DEFAULT_MIN_SDK_VERSION) {
       debugn(`   Updating minSdkVersion to ${DEFAULT_MIN_SDK_VERSION}`)
       return contents.replace(/minSdkVersion\s{0,}=\s{0,}\d*/, `minSdkVersion = ${DEFAULT_MIN_SDK_VERSION}`)
-    } 
+    }
 
-    debugn(`   Already specified minSdkVersion ${minSdkVersion}`)
+    warnn(`   Already specified minSdkVersion ${minSdkVersion}`)
     return contents.replace(/minSdkVersion\s{0,}=\s{0,}\d*/, `minSdkVersion = ${minSdkVersion}`)
   }
 
@@ -77,15 +115,15 @@ class GradleLinker {
    * @param { string } contents
    */
   _getKotlinVersion(contents) {
-    var hardCodedVersion = contents.match(/(?<=kotlin-gradle-plugin:)\$*[\d\.]{3,}/);
+    var hardCodedVersion = contents.match(/(?<=kotlin-gradle-plugin:)\$*[\d\.]{3,}/)
     if (hardCodedVersion && hardCodedVersion.length > 0) {
-      return `"${hardCodedVersion[0]}"`;
+      return `"${hardCodedVersion[0]}"`
     }
-    var extensionVariableVersion = contents.match(/(?<=kotlin-gradle-plugin:)\$*[a-zA-Z\d\.]*/);
+    var extensionVariableVersion = contents.match(/(?<=kotlin-gradle-plugin:)\$*[a-zA-Z\d\.]*/)
     if (extensionVariableVersion && extensionVariableVersion.length > 0) {
-      return extensionVariableVersion[0].replace("$", "");
+      return extensionVariableVersion[0].replace('$', '')
     }
-    return `"${DEFAULT_KOTLIN_VERSION}"`;
+    return `"${DEFAULT_KOTLIN_VERSION}"`
   }
 
   /**
@@ -97,7 +135,7 @@ class GradleLinker {
 
     if (minSdkVersion && minSdkVersion[1]) {
       // It'd be something like 16 for a fresh React Native project.
-      return +minSdkVersion[1] 
+      return +minSdkVersion[1]
     }
 
     return DEFAULT_MIN_SDK_VERSION
@@ -107,22 +145,22 @@ class GradleLinker {
    * @param {string} contents
    */
   _hasExtensionVariablesBlock(contents) {
-    return /ext\s*{/.test(contents);
+    return /ext\s*{/.test(contents)
   }
 
   /**
    * @param {string} contents
    */
   _isKotlinVersionSpecified(contents) {
-    return /RNNKotlinVersion/.test(contents);
+    return /RNNKotlinVersion/.test(contents)
   }
 
   /**
    * @param {string} contents
    */
   _isKotlinPluginDeclared(contents) {
-    return /org.jetbrains.kotlin:kotlin-gradle-plugin:/.test(contents);
+    return /org.jetbrains.kotlin:kotlin-gradle-plugin:/.test(contents)
   }
 }
 
-module.exports = GradleLinker;
+module.exports = GradleLinker

--- a/autolink/postlink/log.js
+++ b/autolink/postlink/log.js
@@ -1,24 +1,24 @@
 const bColors = {
-  HEADER    : '\033[95m',
-  OKBLUE    : '\033[94m',
-  OKGREEN   : '\033[92m',
-  WARNING   : '\033[93m',
-  FAIL      : '\033[91m',
-  ENDC      : '\033[0m', 
-  BOLD      : '\033[1m',   
-  UNDERLINE : '\033[4m'
-}
+  HEADER: "\033[95m",
+  OKBLUE: "\033[94m",
+  OKGREEN: "\033[92m",
+  WARNING: "\033[93m",
+  FAIL: "\033[91m",
+  ENDC: "\033[0m",
+  BOLD: "\033[1m",
+  UNDERLINE: "\033[4m"
+};
 
-const log = (text) => process.stdout.write(text);
-const logn = (text) => process.stdout.write(text + "\n");
-const warn = (text) => process.stdout.write(`${bColors.WARNING}${text}${bColors.ENDC}`)
-const warnn = (text) => warn(text + "\n");
-const error = (text) => process.stdout.write(`${bColors.FAIL}${text}${bColors.ENDC}`)
-const errorn = (text) => error(text + "\n");
-const info = (text) => process.stdout.write(`${bColors.OKGREEN}${text}${bColors.ENDC}`)
-const infon = (text) => info(text + "\n");
-const debug = (text) => process.stdout.write(`${bColors.OKBLUE}${text}${bColors.ENDC}`)
-const debugn = (text) => debug(text + "\n");
+const log = text => process.stdout.write(text);
+const logn = text => process.stdout.write(text + "\n");
+const warn = text => process.stdout.write(`${bColors.WARNING}${text}${bColors.ENDC}`);
+const warnn = text => warn(text + "\n");
+const error = text => process.stdout.write(`${bColors.FAIL}${text}${bColors.ENDC}`);
+const errorn = text => error(text + "\n");
+const info = text => process.stdout.write(`${bColors.OKGREEN}${text}${bColors.ENDC}`);
+const infon = text => info(text + "\n");
+const debug = text => process.stdout.write(`${bColors.OKBLUE}${text}${bColors.ENDC}`);
+const debugn = text => debug(text + "\n");
 
 module.exports = {
   log,
@@ -30,4 +30,4 @@ module.exports = {
   debug,
   debugn,
   errorn
-}
+};

--- a/autolink/postlink/log.js
+++ b/autolink/postlink/log.js
@@ -1,24 +1,24 @@
 const bColors = {
-  HEADER: "\033[95m",
-  OKBLUE: "\033[94m",
-  OKGREEN: "\033[92m",
-  WARNING: "\033[93m",
-  FAIL: "\033[91m",
-  ENDC: "\033[0m",
-  BOLD: "\033[1m",
-  UNDERLINE: "\033[4m"
-};
+  HEADER    : '\033[95m',
+  OKBLUE    : '\033[94m',
+  OKGREEN   : '\033[92m',
+  WARNING   : '\033[93m',
+  FAIL      : '\033[91m',
+  ENDC      : '\033[0m', 
+  BOLD      : '\033[1m',   
+  UNDERLINE : '\033[4m'
+}
 
-const log = text => process.stdout.write(text);
-const logn = text => process.stdout.write(text + "\n");
-const warn = text => process.stdout.write(`${bColors.WARNING}${text}${bColors.ENDC}`);
-const warnn = text => warn(text + "\n");
-const error = text => process.stdout.write(`${bColors.FAIL}${text}${bColors.ENDC}`);
-const errorn = text => error(text + "\n");
-const info = text => process.stdout.write(`${bColors.OKGREEN}${text}${bColors.ENDC}`);
-const infon = text => info(text + "\n");
-const debug = text => process.stdout.write(`${bColors.OKBLUE}${text}${bColors.ENDC}`);
-const debugn = text => debug(text + "\n");
+const log = (text) => process.stdout.write(text);
+const logn = (text) => process.stdout.write(text + "\n");
+const warn = (text) => process.stdout.write(`${bColors.WARNING}${text}${bColors.ENDC}`)
+const warnn = (text) => warn(text + "\n");
+const error = (text) => process.stdout.write(`${bColors.FAIL}${text}${bColors.ENDC}`)
+const errorn = (text) => error(text + "\n");
+const info = (text) => process.stdout.write(`${bColors.OKGREEN}${text}${bColors.ENDC}`)
+const infon = (text) => info(text + "\n");
+const debug = (text) => process.stdout.write(`${bColors.OKBLUE}${text}${bColors.ENDC}`)
+const debugn = (text) => debug(text + "\n");
 
 module.exports = {
   log,
@@ -30,4 +30,4 @@ module.exports = {
   debug,
   debugn,
   errorn
-};
+}

--- a/autolink/postlink/podfileLinker.js
+++ b/autolink/postlink/podfileLinker.js
@@ -1,7 +1,7 @@
 // @ts-check
-var path = require('./path');
+var path = require("./path");
 var fs = require("fs");
-var {logn, debugn, infon} = require("./log");
+var { logn, debugn, infon, errorn, warnn } = require("./log");
 
 class PodfileLinker {
   constructor() {
@@ -9,31 +9,33 @@ class PodfileLinker {
   }
 
   link() {
-    if (this.podfilePath) {
-      logn("Updating Podfile...")
-      var podfileContent = fs.readFileSync(this.podfilePath, "utf8");
-
-      podfileContent = this._removeRNNPodLink(podfileContent);
-
-      fs.writeFileSync(this.podfilePath, podfileContent);
-      infon("Podfile updated successfully!\n")
+    if (!this.podfilePath) {
+      errorn("Podfile not found! Does the file exist in the correct folder?\n   Please check the manual installation docs.");
+      return;
     }
+
+    logn("Updating Podfile...");
+    var podfileContent = fs.readFileSync(this.podfilePath, "utf8");
+
+    podfileContent = this._removeRNNPodLink(podfileContent);
+
+    fs.writeFileSync(this.podfilePath, podfileContent);
   }
 
   /**
-   * Removes the RNN pod added by react-native link script. 
+   * Removes the RNN pod added by react-native link script.
    */
   _removeRNNPodLink(contents) {
-    const rnnPodLink  = contents.match(/\s+.*pod 'ReactNativeNavigation'.+react-native-navigation'/)
+    const rnnPodLink = contents.match(/\s+.*pod 'ReactNativeNavigation'.+react-native-navigation'/);
 
     if (!rnnPodLink) {
-      debugn("   RNN Pod has not been added to Podfile")
-      return contents
+      warnn("   RNN Pod has not been added to Podfile");
+      return contents;
     }
 
-    debugn("   Removing RNN Pod from Podfile")
-    return contents.replace(rnnPodLink, "")    
+    debugn("   Removing RNN Pod from Podfile");
+    return contents.replace(rnnPodLink, "");
   }
 }
 
-module.exports = PodfileLinker
+module.exports = PodfileLinker;

--- a/autolink/postlink/postLinkAndroid.js
+++ b/autolink/postlink/postLinkAndroid.js
@@ -1,12 +1,12 @@
 // @ts-check
-var { infon } = require("./log");
-var AppLinker = require("./applicationLinker");
-var ActivityLinker = require("./activityLinker");
-var GradleLinker = require("./gradleLinker");
+var { infon } = require('./log')
+var ApplicationLinker = require('./applicationLinker')
+var ActivityLinker = require('./activityLinker')
+var GradleLinker = require('./gradleLinker')
 
 module.exports = () => {
-  console.log("Running android postlink script\n");
-  new AppLinker().link();
-  new ActivityLinker().link();
-  new GradleLinker().link();
+  infon('\nRunning Android postlink script.\n')
+  new ApplicationLinker().link()
+  new ActivityLinker().link()
+  new GradleLinker().link()
 }

--- a/autolink/postlink/postLinkIOS.js
+++ b/autolink/postlink/postLinkIOS.js
@@ -1,9 +1,10 @@
 // @ts-check
-var AppDelegateLinker = require("./appDelegateLinker");
-var PodfileLinker = require('./podfileLinker');
+var { infon } = require('./log')
+var AppDelegateLinker = require('./appDelegateLinker')
+var PodfileLinker = require('./podfileLinker')
 
 module.exports = () => {
-  console.log("Running iOS postlink script\n");
-  new AppDelegateLinker().link();
-  new PodfileLinker().link();
+  infon('Running iOS postlink script.\n')
+  new AppDelegateLinker().link()
+  new PodfileLinker().link()
 }

--- a/autolink/postlink/run.js
+++ b/autolink/postlink/run.js
@@ -1,8 +1,13 @@
 // @ts-check
-var { infon } = require("./log");
-var postLinkAndroid = require('./postLinkAndroid');
-var postLinkIOS = require('./postLinkIOS');
+var { infon, warnn } = require("./log");
+var postLinkAndroid = require("./postLinkAndroid");
+var postLinkIOS = require("./postLinkIOS");
 
 postLinkAndroid();
 postLinkIOS();
-infon("react-native-navigation linked successfully");
+
+infon("\nReact Native Navigation link is completed. Check the logs above for more information.\n");
+warnn("   If any of the steps failed, check the installation docs and go through the necessary steps manually:");
+warnn("   https://wix.github.io/react-native-navigation/docs/installing#manual-installation\n");
+infon("When you're done, don't forget to update the index.js file as mentioned in docs!\n");
+infon("Thank you for using React Native Navigation!\n\n");


### PR DESCRIPTION
This PR aims to provide some basic error handling logic to the postlink scripts, which run after `react-native link`, by identifying potential drawbacks and managing the execution flow via try/catch statements and the use of throw under specific conditions. It was developed with the support of the @underscopeio team!

I added a few messages I thought are informative, which provide some basic feedback and direct the user to the specific section in the documentation whenever it's possible. The script was mostly optimistic, so I changed this a little bit to throw a few errors when unexpected things occur. On the previous version, errors would either be silent or be incorrectly informed as the library being already linked, as this could not be asserted from the information available during execution.

Also, I replaced a few single quote/double quote discrepancies on the files I worked on (went for double quotes since that was predominant among the scripts). But adding linting/prettier to these scripts would be nice too, this could be done in a future PR if there's interest.

I'd also like to address the issue of the deprecation warning for `react-native link` on a separate PR, I have a candidate solution that should require minimum changes on the docs and the process. I will send this shortly.

**Example of a successful link:** (mostly unchanged, added info of some steps which were silently completing the tasks)

![Screen Shot 2020-06-01 at 17 13 16](https://user-images.githubusercontent.com/3876078/83455007-7ddacc80-a433-11ea-9e01-9d4a59f5852b.png)

**Example of a partial link (either the app is already linked or part of it is):**

![Screen Shot 2020-06-01 at 17 14 07](https://user-images.githubusercontent.com/3876078/83455025-8c28e880-a433-11ea-981d-a0414f389947.png)

**Examples of failed links (some of the steps fail):**

![Screen Shot 2020-06-01 at 18 10 25](https://user-images.githubusercontent.com/3876078/83454986-73203780-a433-11ea-96ec-6f9d4723a42f.png)

![Screen Shot 2020-06-01 at 17 36 02](https://user-images.githubusercontent.com/3876078/83454997-76b3be80-a433-11ea-8fb5-0a78ef478847.png)

![Screen Shot 2020-06-01 at 17 33 42](https://user-images.githubusercontent.com/3876078/83455000-774c5500-a433-11ea-83d4-f87540d9b5af.png)

