### PR TITLE
Fix typo in React Context API documentation

### DIFF
--- a/website/docs/third-party-react-context.mdx
+++ b/website/docs/third-party-react-context.mdx
@@ -33,11 +33,11 @@ const counterContextWrapper = (component) => ({
   ...initialCounterState,
   increment: () => {
     initialCounterState.count += 1
-    component.setState({ context: contextWrapper(component) })
+    component.setState({ context: counterContextWrapper(component) })
   },
   decrement: () => {
     initialCounterState.count -= 1
-    component.setState({ context: contextWrapper(component) })
+    component.setState({ context: counterContextWrapper(component) })
   },
 })
 


### PR DESCRIPTION
Documentation appeared to references an undefined function. Likely an
overlooked find-and-replace change.
