### PR TITLE
Fix crash when disabledButtonColor is undefined

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/ButtonSpan.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/ButtonSpan.kt
@@ -1,5 +1,6 @@
 package com.reactnativenavigation.utils
 
+import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Typeface
 import android.text.TextPaint
@@ -9,19 +10,22 @@ import com.reactnativenavigation.parse.params.Colour
 import com.reactnativenavigation.parse.params.Fraction
 
 class ButtonSpan(private val button: Button) : MetricAffectingSpan() {
+    companion object {
+        const val DISABLED_COLOR = Color.LTGRAY
+    }
+
     override fun updateDrawState(drawState: TextPaint) = apply(drawState)
 
     override fun updateMeasureState(paint: TextPaint) = apply(paint)
 
-    private fun apply(paint: Paint) {
+    public fun apply(paint: Paint) {
         with(button) {
             val fakeStyle = (paint.typeface?.style ?: 0) and (fontFamily?.style?.inv() ?: 1)
             if (fakeStyle and Typeface.BOLD != 0) paint.isFakeBoldText = true
             if (fakeStyle and Typeface.ITALIC != 0) paint.textSkewX = -0.25f
             if (fontSize.hasValue()) paint.textSize = fontSize.get().toFloat()
-            if (color.hasValue()) paint.color = if (enabled.isTrueOrUndefined) color.get() else disabledColor.get()
+            if (color.hasValue()) paint.color = if (enabled.isTrueOrUndefined) color.get() else disabledColor.get(DISABLED_COLOR)
             paint.typeface = fontFamily
         }
-
     }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/utils/ButtonSpanTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/utils/ButtonSpanTest.java
@@ -1,0 +1,51 @@
+package com.reactnativenavigation.utils;
+
+import android.graphics.Color;
+import android.graphics.Paint;
+
+import com.reactnativenavigation.BaseTest;
+import com.reactnativenavigation.parse.params.Bool;
+import com.reactnativenavigation.parse.params.Button;
+import com.reactnativenavigation.parse.params.Colour;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import static com.reactnativenavigation.utils.ButtonSpan.DISABLED_COLOR;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class ButtonSpanTest extends BaseTest {
+    private ButtonSpan uut;
+    private Button button;
+
+    @Override
+    public void beforeEach() {
+        button = createButton();
+        uut = new ButtonSpan(button);
+    }
+
+    @Test
+    public void apply_color() {
+        Paint paint = new Paint();
+        uut.apply(paint);
+
+        assertThat(paint.getColor()).isEqualTo(button.color.get());
+    }
+
+    @Test
+    public void apply_disabledColor() {
+        button.enabled = new Bool(false);
+
+        Paint paint = new Paint();
+        uut.apply(paint);
+
+        assertThat(paint.getColor()).isEqualTo(DISABLED_COLOR);
+    }
+
+    @NotNull
+    private Button createButton() {
+        Button button = new Button();
+        button.color = new Colour(Color.RED);
+        return button;
+    }
+}


### PR DESCRIPTION
When attempting to show a disabled TopBar button, RNN attempted to obtain the `disabledButtonColor` option even it was undefined which led to a crash.

closes #6257
closes #6204