### PR TITLE
TopBar title and subtitle font size is measured in dp instead of sp

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/StackPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/StackPresenter.java
@@ -92,8 +92,8 @@ public class StackPresenter {
         this.iconResolver = iconResolver;
         this.renderChecker = renderChecker;
         this.defaultOptions = defaultOptions;
-        defaultTitleFontSize = UiUtils.dpToSp(activity, 18);
-        defaultSubtitleFontSize = UiUtils.dpToSp(activity, 14);
+        defaultTitleFontSize = 18;
+        defaultSubtitleFontSize = 14;
     }
 
     public void setDefaultOptions(Options defaultOptions) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBar.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/titlebar/TitleBar.java
@@ -7,6 +7,7 @@ import android.graphics.PorterDuffColorFilter;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -101,7 +102,7 @@ public class TitleBar extends Toolbar {
 
     public void setTitleFontSize(double size) {
         TextView titleTextView = findTitleTextView();
-        if (titleTextView != null) titleTextView.setTextSize((float) size);
+        if (titleTextView != null) titleTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, (float) size);
     }
 
     public void setTitleTypeface(Typeface typeface) {
@@ -120,7 +121,7 @@ public class TitleBar extends Toolbar {
 
     public void setSubtitleFontSize(double size) {
         TextView subtitleTextView = findSubtitleTextView();
-        if (subtitleTextView != null) subtitleTextView.setTextSize((float) size);
+        if (subtitleTextView != null) subtitleTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, (float) size);
     }
 
     public void setSubtitleAlignment(Alignment alignment) {

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TitleBarTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/TitleBarTest.java
@@ -1,6 +1,7 @@
 package com.reactnativenavigation.viewcontrollers;
 
 import android.app.Activity;
+import android.util.TypedValue;
 import android.view.View;
 import android.widget.TextView;
 
@@ -91,5 +92,25 @@ public class TitleBarTest extends BaseTest {
         ActionMenuView spy = TestUtils.spyOn(buttonsContainer);
         uut.setLayoutDirection(View.LAYOUT_DIRECTION_RTL);
         verify(spy).setLayoutDirection(View.LAYOUT_DIRECTION_RTL);
+    }
+
+    @Test
+    public void setSubtitleFontSize_usesDpInsteadofSp() {
+        TextView mockSubtitleView = mock(TextView.class);
+
+        when(uut.findSubtitleTextView()).thenReturn(mockSubtitleView);
+        uut.setSubtitleFontSize(10);
+
+        verify(mockSubtitleView).setTextSize(eq(TypedValue.COMPLEX_UNIT_DIP), eq(10f));
+    }
+
+    @Test
+    public void setTitleFontSize_usesDpInsteadofSp() {
+        TextView mockTitleView = mock(TextView.class);
+
+        when(uut.findTitleTextView()).thenReturn(mockTitleView);
+        uut.setTitleFontSize(10);
+
+        verify(mockTitleView).setTextSize(eq(TypedValue.COMPLEX_UNIT_DIP), eq(10f));
     }
 }


### PR DESCRIPTION
This change addresses an issue where if the user increased their device's font size in accessibility settings, then they would exceed from TopBar bounds.