### PR TITLE
Fix return statement in the example code

### DIFF
--- a/website/docs/docs-passing-data-to-components.mdx
+++ b/website/docs/docs-passing-data-to-components.mdx
@@ -38,13 +38,13 @@ Following the code example [above](passing-data-to-components#initial-props), le
 ```jsx
 class UserProfileScreen extends React.Component {
   static options(props) {
-    return (
+    return {
       topBar: {
         title: {
           text: props.name
         }
       }
-    );
+    };
   }
 }
 ```


### PR DESCRIPTION
Fix return statement in the example code given in the `Handling passProps in static options` section