### PR TITLE
Restore bottomTabs visibility when needed

### DIFF
--- a/e2e/BottomTabs.test.js
+++ b/e2e/BottomTabs.test.js
@@ -81,7 +81,7 @@ describe('BottomTabs', () => {
     await elementById(TestIDs.HIDE_TABS_PUSH_BTN).tap();
     await expect(elementById(TestIDs.BOTTOM_TABS)).toBeNotVisible();
     await elementById(TestIDs.PUSH_BTN).tap();
-    await expect(elementById(TestIDs.BOTTOM_TABS)).toBeNotVisible();
+    await expect(elementById(TestIDs.BOTTOM_TABS)).toBeVisible();
     await elementById(TestIDs.POP_BTN).tap();
     await expect(elementById(TestIDs.BOTTOM_TABS)).toBeNotVisible();
     await elementById(TestIDs.POP_BTN).tap();

--- a/e2e/BottomTabs.test.js
+++ b/e2e/BottomTabs.test.js
@@ -75,4 +75,16 @@ describe('BottomTabs', () => {
     await elementById(TestIDs.POP_BTN).tap();
     await expect(elementById(TestIDs.BOTTOM_TABS)).toBeVisible();
   });
+
+  it('hide Tab Bar on push from second bottomTabs screen - deep stack', async () => {
+    await elementById(TestIDs.SWITCH_TAB_BY_INDEX_BTN).tap();
+    await elementById(TestIDs.HIDE_TABS_PUSH_BTN).tap();
+    await expect(elementById(TestIDs.BOTTOM_TABS)).toBeNotVisible();
+    await elementById(TestIDs.PUSH_BTN).tap();
+    await expect(elementById(TestIDs.BOTTOM_TABS)).toBeNotVisible();
+    await elementById(TestIDs.POP_BTN).tap();
+    await expect(elementById(TestIDs.BOTTOM_TABS)).toBeNotVisible();
+    await elementById(TestIDs.POP_BTN).tap();
+    await expect(elementById(TestIDs.BOTTOM_TABS)).toBeVisible();
+  });
 });

--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
@@ -33,6 +33,9 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        if (isFinishing()) {
+            return;
+        }
         addDefaultSplashLayout();
         navigator = new Navigator(this,
                 new ChildControllersRegistry(),
@@ -72,7 +75,9 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        navigator.destroy();
+        if (navigator != null) {
+            navigator.destroy();
+        }
         getReactGateway().onActivityDestroyed(this);
     }
 

--- a/lib/ios/BottomTabsBasePresenter.m
+++ b/lib/ios/BottomTabsBasePresenter.m
@@ -1,4 +1,5 @@
 #import "BottomTabsBasePresenter.h"
+#import "RNNBottomTabsController.h"
 
 @implementation BottomTabsBasePresenter
 
@@ -13,11 +14,11 @@
 }
 
 - (void)applyOptions:(RNNNavigationOptions *)options {
-    UITabBarController *bottomTabs = self.tabBarController;
+    RNNBottomTabsController *bottomTabs = self.tabBarController;
     RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
 
     [bottomTabs setTabBarTestID:[withDefault.bottomTabs.testID getWithDefaultValue:nil]];
-    ![withDefault.bottomTabs.visible getWithDefaultValue:YES] ?: [bottomTabs setTabBarVisible:[withDefault.bottomTabs.visible getWithDefaultValue:YES] animated:[withDefault.bottomTabs.animate getWithDefaultValue:NO]];
+    [bottomTabs restoreTabBarVisibility:[withDefault.bottomTabs.visible getWithDefaultValue:YES]];
     
     [bottomTabs.view setBackgroundColor:[withDefault.layout.backgroundColor getWithDefaultValue:nil]];
     [self applyBackgroundColor:[withDefault.bottomTabs.backgroundColor getWithDefaultValue:nil] translucent:[withDefault.bottomTabs.translucent getWithDefaultValue:NO]];
@@ -27,7 +28,7 @@
 
 - (void)mergeOptions:(RNNNavigationOptions *)options resolvedOptions:(RNNNavigationOptions *)currentOptions {
     [super mergeOptions:options resolvedOptions:currentOptions];
-    UITabBarController *bottomTabs = self.tabBarController;
+    RNNBottomTabsController *bottomTabs = self.tabBarController;
 
     if (options.bottomTabs.currentTabIndex.hasValue) {
         [bottomTabs setCurrentTabIndex:options.bottomTabs.currentTabIndex.get];
@@ -72,8 +73,8 @@
     }
 }
 
-- (UITabBarController *)tabBarController {
-    return (UITabBarController *)self.boundViewController;
+- (RNNBottomTabsController *)tabBarController {
+    return (RNNBottomTabsController *)self.boundViewController;
 }
 
 - (UITabBar *)tabBar {

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -120,7 +120,7 @@
 }
 
 - (BOOL)hidesBottomBarWhenPushed {
-    RNNNavigationOptions *withDefault = (RNNNavigationOptions *)[[self.boundViewController.topMostViewController.resolveOptions withDefault:self.defaultOptions] mergeOptions:self.boundViewController.options];
+    RNNNavigationOptions *withDefault = (RNNNavigationOptions *)[self.boundViewController.topMostViewController.resolveOptions withDefault:self.defaultOptions];
     return ![withDefault.bottomTabs.visible getWithDefaultValue:YES];
 }
 

--- a/lib/ios/RNNBottomTabsController.h
+++ b/lib/ios/RNNBottomTabsController.h
@@ -21,6 +21,10 @@
 
 - (void)setSelectedIndexByComponentID:(NSString *)componentID;
 
+- (void)setTabBarVisible:(BOOL)visible animated:(BOOL)animated;
+
+- (void)restoreTabBarVisibility:(BOOL)visible;
+
 @property (nonatomic, strong) NSArray* pendingChildViewControllers;
 
 @end

--- a/lib/ios/RNNBottomTabsController.m
+++ b/lib/ios/RNNBottomTabsController.m
@@ -10,6 +10,7 @@
 @implementation RNNBottomTabsController {
 	NSUInteger _currentTabIndex;
     BottomTabsBaseAttacher* _bottomTabsAttacher;
+    BOOL _tabBarNeedsRestore;
     
 }
 
@@ -107,6 +108,18 @@
     if (self.viewWillAppearOnce) {
         [super loadChildren:children];
         self.pendingChildViewControllers = nil;
+    }
+}
+
+- (void)setTabBarVisible:(BOOL)visible animated:(BOOL)animated {
+    _tabBarNeedsRestore = YES;
+    visible ? [self showTabBar:animated] : [self hideTabBar:animated];
+}
+
+- (void)restoreTabBarVisibility:(BOOL)visible {
+    if (_tabBarNeedsRestore) {
+        [self setTabBarVisible:visible animated:NO];
+        _tabBarNeedsRestore = NO;
     }
 }
 

--- a/lib/ios/UITabBarController+RNNOptions.h
+++ b/lib/ios/UITabBarController+RNNOptions.h
@@ -14,8 +14,10 @@
 
 - (void)setTabBarHideShadow:(BOOL)hideShadow;
 
-- (void)setTabBarVisible:(BOOL)visible animated:(BOOL)animated;
-
 - (void)centerTabItems;
+
+- (void)showTabBar:(BOOL)animated;
+
+- (void)hideTabBar:(BOOL)animated;
 
 @end

--- a/lib/ios/UITabBarController+RNNOptions.m
+++ b/lib/ios/UITabBarController+RNNOptions.m
@@ -28,51 +28,54 @@
 	self.tabBar.clipsToBounds = hideShadow;
 }
 
-- (void)setTabBarVisible:(BOOL)visible animated:(BOOL)animated {
-    const CGRect tabBarFrame = self.tabBar.frame;
-	const CGRect tabBarVisibleFrame = CGRectMake(tabBarFrame.origin.x,
-												 self.view.frame.size.height - tabBarFrame.size.height,
-												 tabBarFrame.size.width,
-												 tabBarFrame.size.height);
-	const CGRect tabBarHiddenFrame = CGRectMake(tabBarFrame.origin.x,
-												self.view.frame.size.height,
-												tabBarFrame.size.width,
-												tabBarFrame.size.height);
-	if (!animated) {
-		self.tabBar.hidden = !visible;
-		self.tabBar.frame = visible ? tabBarVisibleFrame : tabBarHiddenFrame;
-		return;
-	}
-	static const CGFloat animationDuration = 0.15;
-
-	if (visible) {
-		self.tabBar.hidden = NO;
-		[UIView animateWithDuration: animationDuration
-							  delay: 0
-							options: UIViewAnimationOptionCurveEaseOut
-						 animations:^()
-		 {
-			 self.tabBar.frame = tabBarVisibleFrame;
-		 }
-						 completion:^(BOOL finished)
-		 {}];
-	} else {
-		[UIView animateWithDuration: animationDuration
-							  delay: 0
-							options: UIViewAnimationOptionCurveEaseIn
-						 animations:^()
-		 {
-			 self.tabBar.frame = tabBarHiddenFrame;
-		 }
-						 completion:^(BOOL finished)
-		 {
-			 self.tabBar.hidden = YES;
-		 }];
-	}
-}
-
 - (void)centerTabItems {
 	[self.tabBar centerTabItems];
+}
+
+
+- (void)showTabBar:(BOOL)animated {
+    static const CGFloat animationDuration = 0.15;
+    const CGRect tabBarVisibleFrame = CGRectMake(self.tabBar.frame.origin.x,
+                                                 self.view.frame.size.height - self.tabBar.frame.size.height,
+                                                 self.tabBar.frame.size.width,
+                                                 self.tabBar.frame.size.height);
+    self.tabBar.hidden = NO;
+    if (!animated) {
+        self.tabBar.frame = tabBarVisibleFrame;
+    } else {
+        [UIView animateWithDuration: animationDuration
+                              delay: 0
+                            options: UIViewAnimationOptionCurveEaseOut
+                         animations:^()
+         {
+            self.tabBar.frame = tabBarVisibleFrame;
+        } completion:^(BOOL finished)
+         {}];
+    }
+}
+
+- (void)hideTabBar:(BOOL)animated {
+    static const CGFloat animationDuration = 0.15;
+    const CGRect tabBarHiddenFrame = CGRectMake(self.tabBar.frame.origin.x,
+                                                self.view.frame.size.height,
+                                                self.tabBar.frame.size.width,
+                                                self.tabBar.frame.size.height);
+    
+    if (!animated) {
+        self.tabBar.frame = tabBarHiddenFrame;
+        self.tabBar.hidden = YES;
+    } else {
+        [UIView animateWithDuration: animationDuration
+                              delay: 0
+                            options: UIViewAnimationOptionCurveEaseOut
+                         animations:^()
+         {
+            self.tabBar.frame = tabBarHiddenFrame;
+        } completion:^(BOOL finished)
+         {
+            self.tabBar.hidden = YES;
+        }];
+    }
 }
 
 - (void)forEachTab:(void (^)(UIView *, UIViewController * tabViewController, int tabIndex))performOnTab {

--- a/playground/ios/NavigationIOS12Tests/RNNBottomTabsPresenterTest.m
+++ b/playground/ios/NavigationIOS12Tests/RNNBottomTabsPresenterTest.m
@@ -28,7 +28,7 @@
 	[[(id)self.uut expect] applyBackgroundColor:nil translucent:NO];
     [[self.boundViewController expect] setTabBarHideShadow:NO];
     [[self.boundViewController expect] setTabBarStyle:UIBarStyleDefault];
-	[[self.boundViewController expect] setTabBarVisible:YES animated:NO];
+	[[self.boundViewController expect] restoreTabBarVisibility:YES];
     [self.uut applyOptions:emptyOptions];
     [self.boundViewController verify];
 }
@@ -55,7 +55,7 @@
     RNNNavigationOptions *initialOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
     initialOptions.bottomTabs.visible = [[Bool alloc] initWithValue:@(1)];
 	
-	[[self.boundViewController expect] setTabBarVisible:YES animated:NO];
+	[[self.boundViewController expect] restoreTabBarVisibility:YES];
 
     [self.uut applyOptions:initialOptions];
     [self.boundViewController verify];

--- a/playground/ios/NavigationTests/RNNBottomTabsAppearancePresenterTest.m
+++ b/playground/ios/NavigationTests/RNNBottomTabsAppearancePresenterTest.m
@@ -36,7 +36,7 @@
     [[self.boundViewController expect] setTabBarTestID:nil];
     [[(id)self.uut expect] applyBackgroundColor:nil translucent:NO];
     [[self.boundViewController expect] setTabBarHideShadow:NO];
-    [[self.boundViewController expect] setTabBarVisible:YES animated:NO];
+    [[self.boundViewController expect] restoreTabBarVisibility:YES];
 	[[self.boundViewController expect] setTabBarStyle:UIBarStyleDefault];
     [self.uut applyOptions:emptyOptions];
     [self.boundViewController verify];
@@ -64,7 +64,7 @@
     RNNNavigationOptions *initialOptions = [[RNNNavigationOptions alloc] initEmptyOptions];
     initialOptions.bottomTabs.visible = [[Bool alloc] initWithValue:@(1)];
 	
-	[[self.boundViewController expect] setTabBarVisible:YES animated:NO];
+	[[self.boundViewController expect] restoreTabBarVisibility:YES];
 
     [self.uut applyOptions:initialOptions];
     [self.boundViewController verify];


### PR DESCRIPTION
Until now, `tabBar.frame` got restored each time child appeared which resulted in wrong bottomTabs visibility.
In this PR we changed it so the `tabBar.frame` will get restored only after the tabBar frame has changed through `mergeOptions`.

Closes #6282