### PR TITLE
Fix Documentation link on Before you start page

### DIFF
--- a/website/docs/docs-before-you-start.mdx
+++ b/website/docs/docs-before-you-start.mdx
@@ -8,5 +8,5 @@ React Native Navigation is a module, dependent on and intended to be used alongs
 
 We also assume you are working on a Mac with XCode and Android Studio installed and setup. You can also make it work in a Linux distribution, of course, but in that case bare in mind that some sections of the docs that deal with iOS might not be relevant to you.
 
-If you want to dig right into it, start with [installing](installing) the library. If you're just looking around, we suggest checking out [basic navigation](basic-navigation) first.
+If you want to dig right into it, start with [installing](docs-Installing.mdx) the library. If you're just looking around, we suggest checking out [basic navigation](docs-basic-navigation.mdx) first.
 


### PR DESCRIPTION
This PR fixes #6299 

---

Interesting to find that on the very first initial load of the doc site before user clicks any of the pages in the side bar, if you reference another page by its `id`, it will navigate to the wrong url.

![Initial-opening](https://user-images.githubusercontent.com/17612922/84455647-2ba27280-aca1-11ea-8d7b-9f6f68b4d6f6.gif)

Using the file name fixes the problem

![after](https://user-images.githubusercontent.com/17612922/84455722-5ee50180-aca1-11ea-8233-888588405aae.gif)

