### PR TITLE
feat: add preferredScreenEdgesDeferringSystemGestures to Options

### DIFF
--- a/lib/ios/RNNBasePresenter.h
+++ b/lib/ios/RNNBasePresenter.h
@@ -49,4 +49,6 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 - (BOOL)hidesBottomBarWhenPushed;
 
+- (UIRectEdge)preferredScreenEdgesDeferringSystemGestures;
+
 @end

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -124,4 +124,10 @@
     return ![withDefault.bottomTabs.visible getWithDefaultValue:YES];
 }
 
+- (UIRectEdge)preferredScreenEdgesDeferringSystemGestures {
+    RectEdge *rectEdge = [self.boundViewController.options withDefault:self.defaultOptions].preferredScreenEdgesDeferringSystemGestures;
+    UIRectEdge edge = [rectEdge getWithDefaultValue:UIRectEdgeNone];
+    return edge;
+}
+
 @end

--- a/lib/ios/RNNComponentViewController.m
+++ b/lib/ios/RNNComponentViewController.m
@@ -162,4 +162,9 @@
     return [self.presenter hidesBottomBarWhenPushed];
 }
 
+- (UIRectEdge)preferredScreenEdgesDeferringSystemGestures {
+    UIRectEdge edge = [self.presenter preferredScreenEdgesDeferringSystemGestures];
+    return edge;
+}
+
 @end

--- a/lib/ios/RNNNavigationOptions.h
+++ b/lib/ios/RNNNavigationOptions.h
@@ -14,6 +14,7 @@
 #import "RNNModalOptions.h"
 #import "DeprecationOptions.h"
 #import "WindowOptions.h"
+#import "RectEdge.h"
 
 extern const NSInteger BLUR_TOPBAR_TAG;
 
@@ -40,6 +41,7 @@ extern const NSInteger BLUR_TOPBAR_TAG;
 @property (nonatomic, strong) Image* rootBackgroundImage;
 @property (nonatomic, strong) Text* modalPresentationStyle;
 @property (nonatomic, strong) Text* modalTransitionStyle;
+@property (nonatomic, strong) RectEdge* preferredScreenEdgesDeferringSystemGestures;
 
 - (instancetype)initEmptyOptions;
 

--- a/lib/ios/RNNNavigationOptions.m
+++ b/lib/ios/RNNNavigationOptions.m
@@ -38,6 +38,7 @@
 	self.rootBackgroundImage = [ImageParser parse:dict key:@"rootBackgroundImage"];
 	self.modalPresentationStyle = [[Text alloc] initWithValue:dict[@"modalPresentationStyle"]];
 	self.modalTransitionStyle = [[Text alloc] initWithValue:dict[@"modalTransitionStyle"]];
+    self.preferredScreenEdgesDeferringSystemGestures = [[RectEdge alloc] initWithValue:dict[@"preferredScreenEdgesDeferringSystemGestures"]];
 	
 	return self;
 }

--- a/lib/ios/RectEdge.h
+++ b/lib/ios/RectEdge.h
@@ -1,0 +1,18 @@
+#import "Param.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RectEdge : Param
+
++ (instancetype)withValue:(nullable NSArray<NSString *> *)value;
+
+- (instancetype)initWithValue:(nullable NSArray<NSString *> *)value;
+
+- (UIRectEdge)get;
+
+- (UIRectEdge)getWithDefaultValue:(UIRectEdge)defaultValue;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/lib/ios/RectEdge.m
+++ b/lib/ios/RectEdge.m
@@ -1,0 +1,62 @@
+#import "RectEdge.h"
+
+@interface RectEdge ()
+@property (nonatomic) UIRectEdge value;
+@end
+
+@implementation RectEdge
+
++ (instancetype)withValue:(nullable NSArray<NSString *> *)value {
+    return [[RectEdge alloc] initWithValue:value];
+}
+
+- (instancetype)initWithValue:(nullable NSArray<NSString *> *)value {
+    self = [super init];
+
+    UIRectEdge defaultEdge = UIRectEdgeNone;
+    UIRectEdge edge = defaultEdge;
+    if (value == nil) {
+        // defaultEdge
+    } else if ([value isKindOfClass:NSArray.class]) {
+        for (NSString *edgeItem in value) {
+            if ([edgeItem isKindOfClass:NSString.class]) {
+                if ([edgeItem isEqualToString:@"all"]) {
+                    edge = UIRectEdgeAll;
+                    break;
+                } else if ([edgeItem isEqualToString:@"none"]) {
+                    edge = UIRectEdgeNone;
+                    break;
+                } else if ([edgeItem isEqualToString:@"left"]) {
+                    edge = edge | UIRectEdgeLeft;
+                } else if ([edgeItem isEqualToString:@"right"]) {
+                    edge = edge | UIRectEdgeRight;
+                } else if ([edgeItem isEqualToString:@"top"]) {
+                    edge = edge | UIRectEdgeTop;
+                } else if ([edgeItem isEqualToString:@"bottom"]) {
+                    edge = edge | UIRectEdgeBottom;
+                }
+            } else {
+                @throw [NSException exceptionWithName:@"RectEdge init" reason:@"value item is not a string" userInfo:nil];
+            }
+        }
+    } else {
+        @throw [NSException exceptionWithName:@"RectEdge init" reason:@"value is not an array" userInfo:nil];
+    }
+    
+    self.value = edge;
+    return self;
+}
+
+- (UIRectEdge)get {
+    return self.value;
+}
+
+- (UIRectEdge)getWithDefaultValue:(UIRectEdge)defaultValue {
+    return self.value;
+}
+
+- (BOOL)hasValue {
+    return YES;
+}
+
+@end

--- a/lib/ios/UIViewController+LayoutProtocol.m
+++ b/lib/ios/UIViewController+LayoutProtocol.m
@@ -30,6 +30,11 @@
     [self.options overrideOptions:options];
     [self.presenter mergeOptions:options resolvedOptions:self.resolveOptions];
     [self.parentViewController mergeChildOptions:options child:self];
+    
+    // TODO: call only if needed
+    if (@available(iOS 11.0, *)) {
+        [self setNeedsUpdateOfScreenEdgesDeferringSystemGestures];
+    }
 }
 
 - (void)mergeChildOptions:(RNNNavigationOptions *)options child:(UIViewController *)child {

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -40,6 +40,7 @@ type SystemItemIcon =
   | 'undo'
   | 'redo';
 type Interpolation = 'linear' | 'accelerateDecelerate' | 'decelerate' | 'accelerate' | 'decelerateAccelerate';
+type RectEdge = 'all' | 'none' | 'left' | 'right' | 'bottom' | 'top';
 
 export interface OptionsSplitView {
   /**
@@ -1128,4 +1129,9 @@ setRoot: {
    * @default false
    */
   blurOnUnmount?: boolean;
+  /**
+   * #### (iOS specific)
+   * @default ['none']
+   */
+  preferredScreenEdgesDeferringSystemGestures?: RectEdge[];
 }

--- a/playground/src/screens/OptionsScreen.js
+++ b/playground/src/screens/OptionsScreen.js
@@ -46,6 +46,11 @@ class Options extends Component {
         <Button label='StatusBar' onPress={this.statusBarScreen} />
         <Button label='Buttons Screen' testID={GOTO_BUTTONS_SCREEN} onPress={this.pushButtonsScreen} />
         <Button label='Toggle Navigation bar visibility' platform='android' onPress={this.toggleAndroidNavigationBar}/>
+        <Button
+          label='preferredScreenEdgesDeferringSystemGestures'
+          platform='ios'
+          onPress={this.setPreferredScreenEdgesDeferringSystemGestures}
+        />
       </Root>
     );
   }
@@ -122,6 +127,12 @@ class Options extends Component {
       }
     }
   });
+
+  setPreferredScreenEdgesDeferringSystemGestures = () =>
+    Navigation.push(
+      this,
+      Screens.PreferredScreenEdgesDeferringSystemGesturesScreen
+    );
 }
 
 module.exports = Options;

--- a/playground/src/screens/PreferredScreenEdgesDeferringSystemGesturesScreen.js
+++ b/playground/src/screens/PreferredScreenEdgesDeferringSystemGesturesScreen.js
@@ -1,0 +1,44 @@
+const React = require('react');
+const { ScrollView, StyleSheet, Text } = require('react-native');
+const Navigation = require('../services/Navigation');
+
+class PreferredScreenEdgesDeferringSystemGesturesScreen extends React.Component {
+  static options() {
+    return {
+      preferredScreenEdgesDeferringSystemGestures: ['bottom']
+    };
+  }
+
+  componentDidMount() {
+    setTimeout(() => {
+      Navigation.mergeOptions(this, {
+        preferredScreenEdgesDeferringSystemGestures: ['none']
+      });
+    }, 5000);
+  }
+
+  render() {
+    return (
+      <ScrollView style={styles.root}>
+        <Text style={styles.description}>
+          The home indicator is dimmed and will be normal after 5 seconds.
+        </Text>
+      </ScrollView>
+    );
+  }
+}
+
+module.exports = PreferredScreenEdgesDeferringSystemGesturesScreen;
+
+const styles = StyleSheet.create({
+  root: {
+    marginTop: 0
+  },
+  description: {
+    fontSize: 15,
+    letterSpacing: 0.2,
+    lineHeight: 25,
+    marginTop: 32,
+    marginHorizontal: 24
+  }
+});

--- a/playground/src/screens/Screens.js
+++ b/playground/src/screens/Screens.js
@@ -111,5 +111,7 @@ module.exports = {
   Alert: 'Alert',
   Orientation: 'Orientation',
   OrientationDetect: 'OrientationDetect',
-  Search: 'Search'
-}
+  Search: 'Search',
+  PreferredScreenEdgesDeferringSystemGesturesScreen:
+    'PreferredScreenEdgesDeferringSystemGesturesScreen'
+};

--- a/playground/src/screens/index.js
+++ b/playground/src/screens/index.js
@@ -46,6 +46,10 @@ function registerScreens() {
   Navigation.registerComponent(Screens.StatusBarFirstTab, () => require('./StatusBarFirstTab'));
   Navigation.registerComponent(Screens.TopBarBackground, () => require('../components/TopBarBackground'));
   Navigation.registerComponent(Screens.Toast, () => require('./Toast'));
+  Navigation.registerComponent(
+    Screens.PreferredScreenEdgesDeferringSystemGesturesScreen,
+    () => require('./PreferredScreenEdgesDeferringSystemGesturesScreen')
+  );
 
   const { ContextProvider } = require('../context');
   const ContextScreen = require('./ContextScreen');


### PR DESCRIPTION
There are still some TODOs. This PR is created because I need some HELP to fully implement this feature. Please DON'T merge it yet.

- [ ] [preferredScreenEdgesDeferringSystemGestures](https://developer.apple.com/documentation/uikit/uiviewcontroller/2887512-preferredscreenedgesdeferringsys) is implemented, but not sure how to implement [childViewControllerForScreenEdgesDeferringSystemGestures](https://developer.apple.com/documentation/uikit/uiviewcontroller/2887511-childviewcontrollerforscreenedge)
- [ ] is [RectEdge](https://github.com/yuntitech/react-native-navigation/blob/feature/preferred-screen-edges-deferring-system-gestures/lib/ios/RectEdge.m) OK? Not sure about the purpose of the super class `Param`
- [ ] [call](https://github.com/yuntitech/react-native-navigation/blob/feature%2Fpreferred-screen-edges-deferring-system-gestures/lib/ios/UIViewController%2BLayoutProtocol.m#L34) `[self setNeedsUpdateOfScreenEdgesDeferringSystemGestures]` only when preferredScreenEdgesDeferringSystemGestures is changed. Not sure the best way to do it.

A screen for demonstrating this feature is created in the playground.