### PR TITLE
Fix missing apostrophes

### DIFF
--- a/website/docs/third-party-react-context.mdx
+++ b/website/docs/third-party-react-context.mdx
@@ -22,7 +22,7 @@ If you need to trigger a re-render across all screens, there are many popular th
 
 ```tsx
 // CounterContext.js
-import React from 'react
+import React from 'react'
 
 // Declaring the state object globally.
 const initialCounterState = {
@@ -64,9 +64,9 @@ with the Counter Context Provider we created earlier.
 
 ```tsx
 // index.js
-import { Navigation } from 'react-native-navigation
-import { CounterContextProvider } from './CounterContext
-import { App } from './App
+import { Navigation } from 'react-native-navigation'
+import { CounterContextProvider } from './CounterContext'
+import { App } from './App'
 
 Navigation.registerComponent(
   'App', 


### PR DESCRIPTION
Example docs were missing apostrophes on several import statements in the examples