### PR TITLE
Fix updating currentTabIndex

### DIFF
--- a/e2e/BottomTabs.test.js
+++ b/e2e/BottomTabs.test.js
@@ -87,4 +87,12 @@ describe('BottomTabs', () => {
     await elementById(TestIDs.POP_BTN).tap();
     await expect(elementById(TestIDs.BOTTOM_TABS)).toBeVisible();
   });
+
+  it('hide Tab Bar on second tab after pressing the tab', async () => {
+    await elementById(TestIDs.SECOND_TAB_BAR_BTN).tap();
+    await elementById(TestIDs.HIDE_TABS_PUSH_BTN).tap();
+    await expect(elementById(TestIDs.BOTTOM_TABS)).toBeNotVisible();
+    await elementById(TestIDs.POP_BTN).tap();
+    await expect(elementById(TestIDs.BOTTOM_TABS)).toBeVisible();
+  });
 });

--- a/lib/ios/RNNBottomTabsController.m
+++ b/lib/ios/RNNBottomTabsController.m
@@ -104,6 +104,12 @@
     return children.count ? children[_currentTabIndex] : nil;
 }
 
+- (void)setSelectedViewController:(__kindof UIViewController *)selectedViewController {
+    NSArray* children = self.pendingChildViewControllers ?: self.childViewControllers;
+    _currentTabIndex = [children indexOfObject:selectedViewController];
+    [super setSelectedViewController:selectedViewController];
+}
+
 - (void)loadChildren:(NSArray *)children {
     if (self.viewWillAppearOnce) {
         [super loadChildren:children];

--- a/playground/src/screens/SecondBottomTabScreen.js
+++ b/playground/src/screens/SecondBottomTabScreen.js
@@ -10,7 +10,8 @@ const {
   PUSHED_BOTTOM_TABS,
   SIDE_MENU_TAB,
   FLAT_LIST_BTN,
-  HIDE_TABS_PUSH_BTN
+  HIDE_TABS_PUSH_BTN,
+  SECOND_TAB_BAR_BTN
 } = require('../testIDs')
 
 class SecondBottomTabScreen extends React.Component {
@@ -24,6 +25,7 @@ class SecondBottomTabScreen extends React.Component {
       bottomTab: {
         icon: require('../../img/star.png'),
         text: 'Tab 2',
+        testID: SECOND_TAB_BAR_BTN,
         dotIndicator: {
           visible: true,
           color: 'green'


### PR DESCRIPTION
`BottomTabsController.currentTabIndex` didn't get updated on pressing tabs which resulted in wrong option resolving and multiple styling bugs.

Closes #6310
Closes #6313 