### PR TITLE
Fix bottomTabs long press event

### DIFF
--- a/lib/ios/RNNBottomTabsController.h
+++ b/lib/ios/RNNBottomTabsController.h
@@ -25,6 +25,8 @@
 
 - (void)setTabBarVisible:(BOOL)visible;
 
+- (void)handleTabBarLongPress:(CGPoint)locationInTabBar;
+
 @property (nonatomic, strong) NSArray* pendingChildViewControllers;
 
 @end

--- a/lib/ios/RNNBottomTabsController.m
+++ b/lib/ios/RNNBottomTabsController.m
@@ -5,6 +5,8 @@
 @property (nonatomic, strong) BottomTabPresenter* bottomTabPresenter;
 @property (nonatomic, strong) RNNDotIndicatorPresenter* dotIndicatorPresenter;
 @property (nonatomic) BOOL viewWillAppearOnce;
+@property (nonatomic, strong) UILongPressGestureRecognizer *longPressRecognizer;
+
 @end
 
 @implementation RNNBottomTabsController {
@@ -32,6 +34,10 @@
     if (@available(iOS 13.0, *)) {
         self.tabBar.standardAppearance = [UITabBarAppearance new];
     }
+    
+    self.longPressRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPressGesture:)];
+    [self.tabBar addGestureRecognizer:self.longPressRecognizer];
+    
     return self;
 }
 
@@ -62,14 +68,6 @@
 
 - (void)viewDidLayoutSubviews {
     [self.presenter viewDidLayoutSubviews];
-    
-    for (UIView *view in [[self tabBar] subviews]) {
-         UILongPressGestureRecognizer *longPressGesture = [[UILongPressGestureRecognizer alloc] initWithTarget: self action: @selector(handleLongPress:)];
-          if ([NSStringFromClass([view class]) isEqualToString:@"UITabBarButton"]) {
-              [view addGestureRecognizer: longPressGesture];
-          }
-    }
-    
     [_dotIndicatorPresenter bottomTabsDidLayoutSubviews:self];
 }
 
@@ -129,6 +127,15 @@
     }
 }
 
+- (void)handleTabBarLongPress:(CGPoint)locationInTabBar {
+    for (UITabBarItem* item in self.tabBar.items) {
+        if (CGRectContainsPoint([[item valueForKey:@"view"] frame], locationInTabBar)) {
+            NSUInteger tabIndex = [self.tabBar.items indexOfObject:item];
+            [self.eventEmitter sendBottomTabLongPressed:@(tabIndex)];
+        }
+    }
+}
+
 #pragma mark UITabBarControllerDelegate
 
 - (void)tabBarController:(UITabBarController *)tabBarController didSelectViewController:(UIViewController *)viewController {
@@ -136,10 +143,10 @@
 	_currentTabIndex = tabBarController.selectedIndex;
 }
 
-- (void)handleLongPress:(UILongPressGestureRecognizer *) recognizer {
+- (void)handleLongPressGesture:(UILongPressGestureRecognizer *)recognizer {
     if (recognizer.state == UIGestureRecognizerStateBegan) {
-        NSUInteger _index = [self.tabBar.subviews indexOfObject:(UIView *)recognizer.view];
-        [self.eventEmitter sendBottomTabLongPressed:@(_index)];
+        CGPoint locationInTabBar = [recognizer locationInView:self.tabBar];
+        [self handleTabBarLongPress:locationInTabBar];
     }
 }
 

--- a/lib/ios/RNNBottomTabsController.m
+++ b/lib/ios/RNNBottomTabsController.m
@@ -132,6 +132,7 @@
         if (CGRectContainsPoint([[item valueForKey:@"view"] frame], locationInTabBar)) {
             NSUInteger tabIndex = [self.tabBar.items indexOfObject:item];
             [self.eventEmitter sendBottomTabLongPressed:@(tabIndex)];
+            break;
         }
     }
 }

--- a/lib/ios/UITabBar+utils.h
+++ b/lib/ios/UITabBar+utils.h
@@ -2,6 +2,8 @@
 
 @interface UITabBar (utils)
 
+- (UIView *)tabBarItemViewAtIndex:(NSUInteger)index;
+
 - (void)centerTabItems;
 
 @end

--- a/lib/ios/UITabBar+utils.m
+++ b/lib/ios/UITabBar+utils.m
@@ -9,6 +9,10 @@ static UITabBarButton_layoutSubviews__IMP original_UITabBarButton_layoutSubviews
 
 @implementation UITabBar (utils)
 
+- (UIView *)tabBarItemViewAtIndex:(NSUInteger)index {
+    return [self.items[index] valueForKey:@"view"];
+}
+
 - (void)centerTabItems {
 	[self removeTabBarItemTitles];
 	[self swizzleUITabBarButton];

--- a/playground/ios/NavigationTests/BottomTabsControllerTest.m
+++ b/playground/ios/NavigationTests/BottomTabsControllerTest.m
@@ -6,6 +6,7 @@
 #import <ReactNativeNavigation/BottomTabPresenterCreator.h>
 #import "RNNBottomTabsController+Helpers.h"
 #import "RNNComponentViewController+Utils.h"
+#import <ReactNativeNavigation/UITabBar+utils.h>
 
 @interface BottomTabsControllerTest : XCTestCase
 

--- a/playground/ios/NavigationTests/BottomTabsControllerTest.m
+++ b/playground/ios/NavigationTests/BottomTabsControllerTest.m
@@ -185,6 +185,18 @@
     XCTAssertTrue(uut.selectedIndex == 1);
 }
 
+- (void)testTabLongPress_ShouldEmitEvent {
+    RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initEmptyOptions];
+    RNNComponentViewController *vc = [[RNNComponentViewController alloc] initWithLayoutInfo:nil rootViewCreator:nil eventEmitter:nil presenter:nil options:nil defaultOptions:nil];
+	RNNBottomTabsController *uut = [RNNBottomTabsController createWithChildren:@[[UIViewController new], vc] options:options];
+	[uut viewWillAppear:YES];
+	
+	[[(id)uut.eventEmitter expect] sendBottomTabLongPressed:@(1)];
+	UIView* secondTabItemView = [uut.tabBar tabBarItemViewAtIndex:1];
+	[uut handleTabBarLongPress:secondTabItemView.center];
+	[(id)uut.eventEmitter verify];
+}
+
 - (void)testOnViewDidLayoutSubviews_ShouldUpdateDotIndicatorForChildren {
 	id dotIndicator = [OCMockObject partialMockForObject:[[RNNDotIndicatorPresenter alloc] initWithDefaultOptions:nil]];
     RNNComponentViewController *vc = [[RNNComponentViewController alloc] initWithLayoutInfo:nil rootViewCreator:nil eventEmitter:nil presenter:nil options:nil defaultOptions:nil];

--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -1,8 +1,8 @@
 // @ts-check
 const Navigation = require('./services/Navigation');
-const { registerScreens } = require('./screens');
-const { Platform } = require('react-native');
-const { setDefaultOptions } = require('./commons/Options')
+const {registerScreens} = require('./screens');
+const {Platform} = require('react-native');
+const {setDefaultOptions} = require('./commons/Options')
 const testIDs = require('./testIDs');
 const Screens = require('./screens/Screens');
 


### PR DESCRIPTION
Until now, `bottomTabs` longPress event gesture was implemented wrong and caused this [bug](https://github.com/wix/react-native-navigation/issues/6305).
It also reported wrong index in the first place, starting from 1 instead of 0.
This PR fixes both issues.

Closes #6305 