### PR TITLE
iOS installation documentation/autolink in parity with Playground app

### DIFF
--- a/autolink/postlink/appDelegateLinker.js
+++ b/autolink/postlink/appDelegateLinker.js
@@ -52,7 +52,7 @@ class AppDelegateLinker {
   _removeUnneededImports(content) {
     debugn("   Removing Unneeded imports");
 
-    const unneededImports = [/\#import\s+\<React\/RCTBridge.h>\s/, /#import\s+\<React\/RCTRootView.h>\s/];
+    const unneededImports = [/#import\s+\<React\/RCTRootView.h>\s/];
     let elementsRemovedCount = 0;
 
     unneededImports.forEach((unneededImport) => {

--- a/website/docs/docs-Installing.mdx
+++ b/website/docs/docs-Installing.mdx
@@ -147,10 +147,10 @@ If autolinking is not available in your project (RN version < 0.60), you can alw
 
   ```objectivec
    - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions { ... }
-
   ```
 
   Its content should look like this:
+
   ```objectivec
   #import "AppDelegate.h"
 
@@ -162,10 +162,18 @@ If autolinking is not available in your project (RN version < 0.60), you can alw
 
   -(BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
   {
-    NSURL *jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
-    [ReactNativeNavigation bootstrap:jsCodeLocation launchOptions:launchOptions];
-
+    [ReactNativeNavigation bootstrapWithDelegate:self launchOptions:launchOptions];
+    
     return YES;
+  }
+
+  -(NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+  {
+    #if DEBUG
+      return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+    #else
+      return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+    #endif
   }
 
   @end
@@ -178,17 +186,6 @@ If autolinking is not available in your project (RN version < 0.60), you can alw
     This is because the `React` scheme is missing from your project. You can verify this by opening the `Product` menu and the `Scheme` submenu. 
     To make the `React` scheme available to your project, run `npm install -g react-native-git-upgrade` followed by `react-native-git-upgrade`. Once this is done, you can click back to the menu in Xcode: `Product -> Scheme -> Manage Schemes`, then click '+' to add a new scheme. From the `Target` menu, select "React", and click the checkbox to make the scheme `shared`. This should make the error disappear.
 
-    b. If, in Xcode, you see the following warning message in `AppDelegate.m` next to `#import "@implementation AppDelegate"`:
-    ```
-    Class 'AppDelegate' does not conform to protocol 'RCTBridgeDelegate'
-    ```
-    You can remove `RCTBridgeDelegate` from this file: `AppDelegate.h`:
-    ```diff
-    - #import <React/RCTBridgeDelegate.h>
-    - @interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate>
-    + @interface AppDelegate : UIResponder <UIApplicationDelegate>
-      ...
-    ```
 
 ### Android
 


### PR DESCRIPTION
This PR includes:
- Not removing `#import <React/RCTBridge.h>` in `AppDelegate.m` as per playground app.
- Updated the Installation documentation to reflect the correct iOS `AppDeletegate.m` file.

Related to #6270 