### PR TITLE
Parse icon only if it is defined

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/parsers/IconParser.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/parsers/IconParser.java
@@ -10,7 +10,7 @@ import javax.annotation.Nullable;
 
 public class IconParser {
     public static Text parse(@Nullable JSONObject json, String key) {
-        if (json == null) return new NullText();
+        if (json == null || !json.has(key)) return new NullText();
         try {
             return json.get(key) instanceof String ? TextParser.parse(json, key) : TextParser.parse(json.optJSONObject(key), "uri");
         } catch (JSONException e) {


### PR DESCRIPTION
We always parsed icons, even if they are undefined. This addresses the JSON parse exception stack trace users often saw when opening the app.