### PR TITLE
Updated the instructions for tutorial

### DIFF
--- a/website/docs/docs-basic-navigation.mdx
+++ b/website/docs/docs-basic-navigation.mdx
@@ -221,7 +221,7 @@ Navigation.setDefaultOptions({
 });
 ```
 
-We need to add this snippet before registering the `registerAppLaunchedListener`. This way we ensure our theme is applied when our root is set. Our code should now look like this:
+We need to add this snippet inside `registerAppLaunchedListener`, before we set the root (`Navigation.setRoot({})`). This way we ensure our theme is applied correctly during the initialization. Our code should now look like this:
 
 ```jsx
 // In index.js of a new project

--- a/website/docs/docs-basic-navigation.mdx
+++ b/website/docs/docs-basic-navigation.mdx
@@ -272,24 +272,25 @@ const SettingsScreen = () => {
 Navigation.registerComponent('Home', () => HomeScreen);
 Navigation.registerComponent('Settings', () => SettingsScreen);
 
-
-Navigation.setDefaultOptions({
-  statusBar: {
-    backgroundColor: '#4d089a'
-  },
-  topBar: {
-    title: {
-      color: 'white'
-    },
-    backButton: {
-      color: 'white'
-    },
-    background: {
-      color: '#4d089a'
-    }
-  }
-});
 Navigation.events().registerAppLaunchedListener(async () => {
+
+  Navigation.setDefaultOptions({
+    statusBar: {
+      backgroundColor: '#4d089a'
+    },
+    topBar: {
+      title: {
+        color: 'white'
+      },
+      backButton: {
+        color: 'white'
+      },
+      background: {
+        color: '#4d089a'
+      }
+    }
+  });
+
   Navigation.setRoot({
     root: {
       stack: {


### PR DESCRIPTION
Currently the tutorial specifies `Navigation.setDefaultOptions({`to be declared before `registerAppLaunchedListener` snippet. This is incorrect, and should be passed inside that function, but before the `Navigation.setRoot({})`. Otherwise the `Bridge not yet loaded` error will be thrown.

https://stackoverflow.com/questions/56740889/bridge-not-yet-loaded-thrown-when-using-latest-wix-react-native-navigation/56748173?noredirect=1#comment100061919_56748173