### PR TITLE
Adding pre-commit hook and Enable Linter in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 dist
-.vscode/
 package-lock.json
 yarn.lock
 .history/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.formatOnSave": true,
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
+  "eslint.enable": true,
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package.json
+++ b/package.json
@@ -143,10 +143,7 @@
     }
   },
   "lint-staged": {
-    "*.{ts,tsx}": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.{js,ts,tsx}": "eslint"
   },
   "detox": {
     "test-runner": "jest",

--- a/package.json
+++ b/package.json
@@ -84,9 +84,11 @@
     "eslint-config-prettier": "6.11.0",
     "eslint-plugin-prettier": "3.1.4",
     "github-release-notes": "0.17.3",
+    "husky": "4.2.5",
     "identity-obj-proxy": "3.0.0",
     "jest": "26.1.0",
     "jest-circus": "26.1.0",
+    "lint-staged": "10.2.11",
     "lodash": "^4.17.15",
     "metro-react-native-babel-preset": "0.59.0",
     "prettier": "2.0.5",
@@ -135,6 +137,17 @@
       "html"
     ]
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
   "detox": {
     "test-runner": "jest",
     "specs": "",
@@ -171,7 +184,7 @@
         "build": "cd playground/android && ./gradlew app:assembleRelease app:assembleAndroidTest -DtestBuildType=release",
         "type": "android.emulator",
         "name": "Pixel_API_28"
-      }
+      },
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
         "build": "cd playground/android && ./gradlew app:assembleRelease app:assembleAndroidTest -DtestBuildType=release",
         "type": "android.emulator",
         "name": "Pixel_API_28"
-      },
+      }
     }
   }
 }

--- a/website/docs/meta-contributing.mdx
+++ b/website/docs/meta-contributing.mdx
@@ -57,6 +57,11 @@ Besides an overview of basic React Native Navigation functionality, the [Playgro
 If a screen contains too many buttons, e2e tests might fail if the button is positioned out of screen bounds because Detox matchers detect it's invisible.
 :::
 
+### Enable linting
+The project uses [ESLint](https://eslint.org/) with [Prettier](https://prettier.io/) to ensure code style consistency across the codebase. Make sure to install these plugins in your IDE.
+
+A pre-commit hook will verify that the linter passes when committing.
+
 ### Playground app Folder Structure
 
 | Folder | Description |

--- a/website/docs/meta-contributing.mdx
+++ b/website/docs/meta-contributing.mdx
@@ -57,7 +57,7 @@ Besides an overview of basic React Native Navigation functionality, the [Playgro
 If a screen contains too many buttons, e2e tests might fail if the button is positioned out of screen bounds because Detox matchers detect it's invisible.
 :::
 
-### Enable linting
+### Enable linter
 The project uses [ESLint](https://eslint.org/) with [Prettier](https://prettier.io/) to ensure code style consistency across the codebase. Make sure to install these plugins in your IDE.
 
 A pre-commit hook will verify that the linter passes when committing.


### PR DESCRIPTION
This PR includes:
- Adding `Enable linter` section in `Contributing` documentation to explain that the project uses `ESLint` with `Prettier` and has a pre-commit hook to verify the linter.
- Committing `.vscode` folder to enable `formatOnSave` in VSCode. 
- Adding pre-commit hook which runs the `eslint` check on staged files to block any unformatted to be staged.