### PR TITLE
Remove Playground project exclusion in tsconfig

### DIFF
--- a/playground/src/declarations.d.ts
+++ b/playground/src/declarations.d.ts
@@ -1,1 +1,2 @@
 declare module 'react-native-keyboard-tracking-view';
+declare module 'react-native-ui-lib';

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -7,8 +7,8 @@ run();
 function run() {
   if (isWindows) {
     exec.execSync(`del /F /S /Q lib\\dist`);
-    exec.execSync(`tsc --project tsconfig.build.json`);
   } else {
-    exec.execSync(`rm -rf ./lib/dist && tsc --project tsconfig.build.json`);
+    exec.execSync(`rm -rf ./lib/dist`);
   }
+  exec.execSync(`tsc`);
 }

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -5,10 +5,10 @@ const isWindows = process.platform === 'win32' ? true : false;
 run();
 
 function run() {
-    if (isWindows) {
-        exec.execSync(`del /F /S /Q lib\\dist`);
-        exec.execSync(`tsc --project tsconfig.build.json --watch`);
-    } else {
-        exec.execSync(`rm -rf ./lib/dist && tsc --project tsconfig.build.json --watch`);
-    }
+  if (isWindows) {
+    exec.execSync(`del /F /S /Q lib\\dist`);
+  } else {
+    exec.execSync(`rm -rf ./lib/dist`);
+  }
+  exec.execSync(`tsc --watch`);
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,3 +1,0 @@
-{
-  "extends": "./tsconfig.json"
-}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,3 @@
 {
-  "extends": "./tsconfig.json",
-  "exclude": ["./playground/**/*"]
+  "extends": "./tsconfig.json"
 }


### PR DESCRIPTION
The goal behind this MR is to make sure that MRs fail CI checks if any typescript errors are detected in the Playground project.
- Added module declaration for 'react-native-ui-lib' since it has no TS typings
- Remove tsconfig.build.json since it's only goal was to exclude Playground project