### PR TITLE
Fixed up the doc and type for Fab button

### DIFF
--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -565,6 +565,10 @@ export interface ElementAnimation {
 }
 
 export interface OptionsFab {
+  /**
+   * ID is required when first instantiating the Fab button,
+   * however when updating the existing Fab button, ID is not required.
+   */
   id?: string;
   backgroundColor?: Color;
   clickColor?: Color;
@@ -573,10 +577,8 @@ export interface OptionsFab {
   icon?: ImageRequireSource;
   iconColor?: Color;
   alignHorizontally?: 'left' | 'right';
-  alignVertically?: 'top' | 'bottom';
   hideOnScroll?: boolean;
-  size?: number;
-  actions?: OptionsFab[];
+  size?: 'mini' | 'regular';
 }
 
 export interface OptionsBottomTabs {

--- a/website/api/options-fab.mdx
+++ b/website/api/options-fab.mdx
@@ -32,7 +32,7 @@ This option is mandatory when you are initiating the FAB button. However you do 
 
 | Type   | Required | Platform |
 | ------ | -------- | -------- |
-| string | No     | Android  |
+| string | No       | Android  |
 
 ### `icon`
 
@@ -90,14 +90,6 @@ Set the horizontal position of the FAB button on the screen.
 | ----------------- | -------- | -------- |
 | 'left' or 'right' | No       | Android  |
 
-### `alignVertically`
-
-Set the vertical position of the FAB button on the screen.
-
-| Type              | Required | Platform |
-| ----------------- | -------- | -------- |
-| 'top' or 'bottom' | No       | Android  |
-
 ### `hideOnScroll`
 
 Hide the FAB button on scroll.
@@ -110,14 +102,6 @@ Hide the FAB button on scroll.
 
 Set the size of the FAB button.
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | Android  |
-
-### `actions`
-
-Clicking the FAB button will display the defined FAB buttons in `actions`.
-
-| Type                     | Required | Platform |
-| ------------------------ | -------- | -------- |
-| [[FAB]](options-fab.mdx) | No       | Android  |
+| Type                | Required | Platform |
+| ------------------- | -------- | -------- |
+| 'mini' or 'regular' | No       | Android  |


### PR DESCRIPTION
This PR closes #6369:
- Removed `alignVeritically` option for Fab button
- Removed `actions` option for Fab button
- Updated `size` option to `'mini' | 'regular'`