### PR TITLE
Make constants getting synchronous

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
@@ -77,16 +77,16 @@ public class NavigationModule extends ReactContextBaseJavaModule {
     public void getLaunchArgs(String commandId, Promise promise) {
         promise.resolve(LaunchArgsParser.parse(activity()));
     }
-    
-    @ReactMethod
-    public void getNavigationConstants(Promise promise) {
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    public WritableMap getNavigationConstants() {
         ReactApplicationContext ctx = getReactApplicationContext();
         WritableMap constants = Arguments.createMap();
         constants.putString(Constants.BACK_BUTTON_JS_KEY, Constants.BACK_BUTTON_ID);
         constants.putDouble(Constants.BOTTOM_TABS_HEIGHT_KEY, Constants.BOTTOM_TABS_HEIGHT);
         constants.putDouble(Constants.STATUS_BAR_HEIGHT_KEY, pxToDp(ctx, StatusBarUtils.getStatusBarHeight(ctx)));
         constants.putDouble(Constants.TOP_BAR_HEIGHT_KEY, pxToDp(ctx, UiUtils.getTopBarHeight(ctx)));
-        promise.resolve(constants);
+        return constants;
     }
 
     @ReactMethod

--- a/lib/ios/RNNBridgeModule.m
+++ b/lib/ios/RNNBridgeModule.m
@@ -128,10 +128,8 @@ RCT_EXPORT_METHOD(getLaunchArgs:(NSString*)commandId :(RCTPromiseResolveBlock)re
     resolve(args);
 }
 
-RCT_EXPORT_METHOD(getNavigationConstants:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-    RCTExecuteOnMainQueue(^{
-        resolve([Constants getConstants]);
-    });
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getNavigationConstants) {
+	return [Constants getConstants];
 }
 
 @end

--- a/lib/src/Navigation.ts
+++ b/lib/src/Navigation.ts
@@ -211,7 +211,7 @@ export class NavigationRoot {
   /**
    * Constants coming from native
    */
-  public async constants(): Promise<NavigationConstants> {
-    return await Constants.get();
+  public constants(): NavigationConstants {
+    return Constants.get();
   }
 }

--- a/lib/src/adapters/Constants.ts
+++ b/lib/src/adapters/Constants.ts
@@ -8,8 +8,8 @@ export interface NavigationConstants {
 }
 
 export class Constants {
-  static async get(): Promise<NavigationConstants> {
-    const constants: NavigationConstants = await NativeModules.RNNBridgeModule.getNavigationConstants();
+  static get(): NavigationConstants {
+    const constants: NavigationConstants = NativeModules.RNNBridgeModule.getNavigationConstants();
     return new Constants(constants);
   }
 


### PR DESCRIPTION
## PR

I've been thinking about making the constant getting synchronous. This is especially helpful, because by using the constants we can measure our layout and create styles statically. Similar to `Dimensions.get('window')`, we can get react-native-navigation constants.

Note: before I thoroughly test this I wanted to ask if this even was a great idea (or has been considered before)?

:warning: Warning: As far as I know, this does not work in the Chrome debugger because of a limitation on react-native's side.

## Details

Use `isBlockingSynchronousMethod = true` for Java and `RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD` for Objective-C to remove the Promise logic.
