### PR TITLE
Add allCaps option to TopBar buttons

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/ButtonOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/ButtonOptions.java
@@ -37,6 +37,7 @@ public class ButtonOptions {
     public String id = "btn" + CompatUtils.generateViewId();
     public Text accessibilityLabel = new NullText();
     public Text text = new NullText();
+    public Bool allCaps = new NullBool();
     public Bool enabled = new NullBool();
     public Bool disableIconTint = new NullBool();
     public Number showAsAction = new NullNumber();
@@ -53,6 +54,7 @@ public class ButtonOptions {
         return Objects.equals(id, other.id) &&
                accessibilityLabel.equals(other.accessibilityLabel) &&
                text.equals(other.text) &&
+               allCaps.equals(other.allCaps) &&
                enabled.equals(other.enabled) &&
                disableIconTint.equals(other.disableIconTint) &&
                showAsAction.equals(other.showAsAction) &&
@@ -71,6 +73,7 @@ public class ButtonOptions {
         button.id = take(json.optString("id"), "btn" + CompatUtils.generateViewId());
         button.accessibilityLabel = TextParser.parse(json, "accessibilityLabel");
         button.text = TextParser.parse(json, "text");
+        button.allCaps = BoolParser.parse(json, "allCaps");
         button.enabled = BoolParser.parse(json, "enabled");
         button.disableIconTint = BoolParser.parse(json, "disableIconTint");
         button.showAsAction = parseShowAsAction(json);
@@ -153,6 +156,7 @@ public class ButtonOptions {
 
     public void mergeWith(ButtonOptions other) {
         if (other.text.hasValue()) text = other.text;
+        if (other.allCaps.hasValue()) allCaps = other.allCaps;
         if (other.accessibilityLabel.hasValue()) accessibilityLabel = other.accessibilityLabel;
         if (other.enabled.hasValue()) enabled = other.enabled;
         if (other.disableIconTint.hasValue()) disableIconTint = other.disableIconTint;
@@ -171,6 +175,7 @@ public class ButtonOptions {
 
     public void mergeWithDefault(ButtonOptions defaultOptions) {
         if (!text.hasValue()) text = defaultOptions.text;
+        if (!allCaps.hasValue()) allCaps = defaultOptions.allCaps;
         if (!accessibilityLabel.hasValue()) accessibilityLabel = defaultOptions.accessibilityLabel;
         if (!enabled.hasValue()) enabled = defaultOptions.enabled;
         if (!disableIconTint.hasValue()) disableIconTint = defaultOptions.disableIconTint;

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/ButtonPresenter.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/ButtonPresenter.kt
@@ -96,6 +96,12 @@ open class ButtonPresenter(private val button: ButtonOptions, private val iconRe
         }
     }
 
+    private fun applyAllCaps(view: View) {
+        if (view is TextView && button.allCaps.hasValue()) {
+            view.isAllCaps = button.allCaps.get()
+        }
+    }
+
     private fun applyOptionsDirectlyOnView(titleBar: TitleBar, menuItem: MenuItem, onViewFound: (View) -> Unit) {
         titleBar.doOnPreDraw {
             if (button.hasComponent()) onViewFound(menuItem.actionView!!)

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/ButtonPresenter.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/ButtonPresenter.kt
@@ -44,6 +44,7 @@ open class ButtonPresenter(private val button: ButtonOptions, private val iconRe
         applyOptionsDirectlyOnView(titleBar, menuItem) {
             applyTestId(it)
             applyTextColor(it)
+            applyAllCaps(it)
         }
     }
 
@@ -97,9 +98,7 @@ open class ButtonPresenter(private val button: ButtonOptions, private val iconRe
     }
 
     private fun applyAllCaps(view: View) {
-        if (view is TextView && button.allCaps.hasValue()) {
-            view.isAllCaps = button.allCaps.get()
-        }
+        if (view is TextView) view.isAllCaps = button.allCaps.get(true)
     }
 
     private fun applyOptionsDirectlyOnView(titleBar: TitleBar, menuItem: MenuItem, onViewFound: (View) -> Unit) {

--- a/lib/android/app/src/test/java/com/reactnativenavigation/utils/ButtonPresenterTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/utils/ButtonPresenterTest.java
@@ -56,7 +56,6 @@ public class ButtonPresenterTest extends BaseTest {
     @Test
     public void applyOptions_buttonIsAddedToMenu() {
         addButtonAndApplyOptions();
-
         assertThat(findButtonView().getText().toString()).isEqualTo(BTN_TEXT);
     }
 
@@ -64,7 +63,6 @@ public class ButtonPresenterTest extends BaseTest {
     public void applyOptions_appliesColorOnButtonTextView() {
         button.color = new Colour(Color.RED);
         addButtonAndApplyOptions();
-
         assertThat(findButtonView().getCurrentTextColor()).isEqualTo(Color.RED);
     }
 
@@ -72,13 +70,19 @@ public class ButtonPresenterTest extends BaseTest {
     public void apply_disabledColor() {
         button.enabled = new Bool(false);
         addButtonAndApplyOptions();
-
         assertThat(findButtonView().getCurrentTextColor()).isEqualTo(ButtonPresenter.DISABLED_COLOR);
     }
 
     private void addButtonAndApplyOptions() {
         MenuItem menuItem = buttonController.createAndAddButtonToTitleBar(titleBar, 0);
         uut.applyOptions(titleBar, menuItem, buttonController::getView);
+    }
+
+    @Test
+    public void apply_allCaps() {
+        button.allCaps = new Bool(false);
+        addButtonAndApplyOptions();
+        assertThat(findButtonView().isAllCaps()).isEqualTo(false);
     }
 
     private TextView findButtonView() {

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -327,6 +327,10 @@ export interface OptionsTopBarBackground {
 
 export interface OptionsTopBarButton {
   /**
+   * (Android only) Sets a textual button to be ALL CAPS. default value is true
+   */
+  allCaps?: boolean;
+  /**
    * Button id for reference press event
    */
   id: string;


### PR DESCRIPTION
TopBar buttons are allCaps by default on Android. This option can be used to turn this option off, making camel case buttons possible.