### PR TITLE
Document button.allCaps

### DIFF
--- a/website/api/options-button.mdx
+++ b/website/api/options-button.mdx
@@ -19,7 +19,7 @@ const options = {
 
 ### `allCaps`
 
-This option will set wether characters are all capitalized or not.
+This option will set whether characters are all capitalized or not.
 
 | Type    | Required | Platform | Default |
 | ------- | -------- | -------- | ------- |

--- a/website/api/options-button.mdx
+++ b/website/api/options-button.mdx
@@ -9,11 +9,11 @@ const options = {
   topBar: {
     leftButtons: [
       {
-        id: "id",
-        text: "Button"
-      }
-    ]
-  }
+        id: 'id',
+        text: 'Button',
+      },
+    ],
+  },
 };
 ```
 
@@ -55,8 +55,8 @@ Button text. Ignored if an icon is specified, unless the button is displayed in 
 
 Set a react [component](layout-component.mdx) as this button's view which will be displayed instead of the regular view.
 
-| Type                   | Required | Platform |
-| ---------------------- | -------- | -------- |
+| Type                              | Required | Platform |
+| --------------------------------- | -------- | -------- |
 | [Component](layout-component.mdx) | No       | Both     |
 
 ### `iconInsets`

--- a/website/api/options-button.mdx
+++ b/website/api/options-button.mdx
@@ -17,6 +17,14 @@ const options = {
 };
 ```
 
+### `allCaps`
+
+This option will set wether characters are all capitalized or not.
+
+| Type    | Required | Platform | Default |
+| ------- | -------- | -------- | ------- |
+| boolean | No       | Android  | true    |
+
 ### `id`
 
 Buttons are identified by their id property. When a button is clicked, a buttonPress event is emitted to js, containing the id of the clicked button.


### PR DESCRIPTION
Support for the allCaps option was added in #6397 but was left undocumented.