### PR TITLE
Show deprecation warning while toggling bottomTabs visibility on iOS

### DIFF
--- a/lib/src/commands/Commands.test.ts
+++ b/lib/src/commands/Commands.test.ts
@@ -1,6 +1,6 @@
-import forEach from 'lodash/forEach'
-import filter from 'lodash/filter'
-import invoke from 'lodash/invoke'
+import forEach from 'lodash/forEach';
+import filter from 'lodash/filter';
+import invoke from 'lodash/invoke';
 import { mock, verify, instance, deepEqual, when, anything, anyString } from 'ts-mockito';
 
 import { LayoutTreeParser } from './LayoutTreeParser';
@@ -45,7 +45,7 @@ describe('Commands', () => {
   describe('setRoot', () => {
     it('sends setRoot to native after parsing into a correct layout tree', () => {
       uut.setRoot({
-        root: { component: { name: 'com.example.MyScreen' } }
+        root: { component: { name: 'com.example.MyScreen' } },
       });
       verify(
         mockedNativeCommandsSender.setRoot(
@@ -55,10 +55,10 @@ describe('Commands', () => {
               type: 'Component',
               id: 'Component+UNIQUE_ID',
               children: [],
-              data: { name: 'com.example.MyScreen', options: {}, passProps: undefined }
+              data: { name: 'com.example.MyScreen', options: {}, passProps: undefined },
             },
             modals: [],
-            overlays: []
+            overlays: [],
           })
         )
       ).called();
@@ -76,7 +76,7 @@ describe('Commands', () => {
       uut.setRoot({
         root: { component: { name: 'com.example.MyScreen' } },
         modals: [{ component: { name: 'com.example.MyModal' } }],
-        overlays: [{ component: { name: 'com.example.MyOverlay' } }]
+        overlays: [{ component: { name: 'com.example.MyOverlay' } }],
       });
       verify(
         mockedNativeCommandsSender.setRoot(
@@ -89,8 +89,8 @@ describe('Commands', () => {
               data: {
                 name: 'com.example.MyScreen',
                 options: {},
-                passProps: undefined
-              }
+                passProps: undefined,
+              },
             },
             modals: [
               {
@@ -100,9 +100,9 @@ describe('Commands', () => {
                 data: {
                   name: 'com.example.MyModal',
                   options: {},
-                  passProps: undefined
-                }
-              }
+                  passProps: undefined,
+                },
+              },
             ],
             overlays: [
               {
@@ -112,10 +112,10 @@ describe('Commands', () => {
                 data: {
                   name: 'com.example.MyOverlay',
                   options: {},
-                  passProps: undefined
-                }
-              }
-            ]
+                  passProps: undefined,
+                },
+              },
+            ],
           })
         )
       ).called();
@@ -136,13 +136,18 @@ describe('Commands', () => {
 
   describe('updateProps', () => {
     it('delegates to store', () => {
-      uut.updateProps('theComponentId', {someProp: 'someValue'});
-      verify(mockedStore.updateProps('theComponentId', deepEqual({someProp: 'someValue'})));
+      uut.updateProps('theComponentId', { someProp: 'someValue' });
+      verify(mockedStore.updateProps('theComponentId', deepEqual({ someProp: 'someValue' })));
     });
 
     it('notifies commands observer', () => {
-      uut.updateProps('theComponentId', {someProp: 'someValue'});
-      verify(commandsObserver.notify('updateProps', deepEqual({componentId: 'theComponentId', props: {someProp: 'someValue'}})));
+      uut.updateProps('theComponentId', { someProp: 'someValue' });
+      verify(
+        commandsObserver.notify(
+          'updateProps',
+          deepEqual({ componentId: 'theComponentId', props: { someProp: 'someValue' } })
+        )
+      );
     });
   });
 
@@ -158,9 +163,9 @@ describe('Commands', () => {
             data: {
               name: 'com.example.MyScreen',
               options: {},
-              passProps: undefined
+              passProps: undefined,
             },
-            children: []
+            children: [],
           })
         )
       ).called();
@@ -219,7 +224,7 @@ describe('Commands', () => {
         'the resolved layout'
       );
       const result = await uut.push('theComponentId', {
-        component: { name: 'com.example.MyScreen' }
+        component: { name: 'com.example.MyScreen' },
       });
       expect(result).toEqual('the resolved layout');
     });
@@ -236,9 +241,9 @@ describe('Commands', () => {
             data: {
               name: 'com.example.MyScreen',
               options: {},
-              passProps: undefined
+              passProps: undefined,
             },
-            children: []
+            children: [],
           })
         )
       ).called();
@@ -315,10 +320,10 @@ describe('Commands', () => {
               data: {
                 name: 'com.example.MyScreen',
                 options: {},
-                passProps: undefined
+                passProps: undefined,
               },
-              children: []
-            }
+              children: [],
+            },
           ])
         )
       ).called();
@@ -337,9 +342,9 @@ describe('Commands', () => {
             data: {
               name: 'com.example.MyScreen',
               options: {},
-              passProps: undefined
+              passProps: undefined,
             },
-            children: []
+            children: [],
           })
         )
       ).called();
@@ -421,12 +426,12 @@ describe('Commands', () => {
         setStackRoot: ['id', [{}]],
         showOverlay: [{}],
         dismissOverlay: ['id'],
-        getLaunchArgs: ['id']
+        getLaunchArgs: ['id'],
       };
       const paramsForMethodName: Record<string, object> = {
         setRoot: {
           commandId: 'setRoot+UNIQUE_ID',
-          layout: { root: null, modals: [], overlays: [] }
+          layout: { root: null, modals: [], overlays: [] },
         },
         setDefaultOptions: { options: {} },
         mergeOptions: { componentId: 'id', options: {} },
@@ -441,11 +446,11 @@ describe('Commands', () => {
         setStackRoot: {
           commandId: 'setStackRoot+UNIQUE_ID',
           componentId: 'id',
-          layout: [null]
+          layout: [null],
         },
         showOverlay: { commandId: 'showOverlay+UNIQUE_ID', layout: null },
         dismissOverlay: { commandId: 'dismissOverlay+UNIQUE_ID', componentId: 'id' },
-        getLaunchArgs: { commandId: 'getLaunchArgs+UNIQUE_ID' }
+        getLaunchArgs: { commandId: 'getLaunchArgs+UNIQUE_ID' },
       };
       forEach(getAllMethodsOfUut(), (m) => {
         it(`for ${m}`, () => {

--- a/lib/src/commands/Deprecations.ts
+++ b/lib/src/commands/Deprecations.ts
@@ -1,10 +1,22 @@
+import isEqual from 'lodash/isEqual';
+import once from 'lodash/once';
+import { Platform } from 'react-native';
 
 export class Deprecations {
-  public onProcessOptions(_key: string, _parentOptions: Record<string, any>) {
-
+  public onProcessOptions(key: string, parentOptions: Record<string, any>, commandName: string) {
+    if (
+      isEqual(key, 'bottomTabs') &&
+      parentOptions[key].visible !== undefined &&
+      Platform.OS === 'ios' &&
+      commandName === 'mergeOptions'
+    ) {
+      this.deprecateBottomTabsVisibility(parentOptions);
+    }
   }
 
-  public onProcessDefaultOptions(_key: string, _parentOptions: Record<string, any>) {
+  public onProcessDefaultOptions(_key: string, _parentOptions: Record<string, any>) {}
 
-  }
+  private deprecateBottomTabsVisibility = once((parentOptions: object) => {
+    console.warn(`toggling bottomTabs visibility is deprecated on iOS.`, parentOptions);
+  });
 }

--- a/lib/src/commands/Deprecations.ts
+++ b/lib/src/commands/Deprecations.ts
@@ -17,6 +17,9 @@ export class Deprecations {
   public onProcessDefaultOptions(_key: string, _parentOptions: Record<string, any>) {}
 
   private deprecateBottomTabsVisibility = once((parentOptions: object) => {
-    console.warn(`toggling bottomTabs visibility is deprecated on iOS.`, parentOptions);
+    console.warn(
+      `toggling bottomTabs visibility is deprecated on iOS. For more information see https://github.com/wix/react-native-navigation/issues/6416`,
+      parentOptions
+    );
   });
 }

--- a/lib/src/commands/Deprecations.ts
+++ b/lib/src/commands/Deprecations.ts
@@ -1,4 +1,3 @@
-import isEqual from 'lodash/isEqual';
 import once from 'lodash/once';
 import { Platform } from 'react-native';
 

--- a/lib/src/commands/Deprecations.ts
+++ b/lib/src/commands/Deprecations.ts
@@ -5,7 +5,7 @@ import { Platform } from 'react-native';
 export class Deprecations {
   public onProcessOptions(key: string, parentOptions: Record<string, any>, commandName: string) {
     if (
-      isEqual(key, 'bottomTabs') &&
+      key === 'bottomTabs' &&
       parentOptions[key].visible !== undefined &&
       Platform.OS === 'ios' &&
       commandName === 'mergeOptions'

--- a/lib/src/commands/OptionsProcessor.test.ts
+++ b/lib/src/commands/OptionsProcessor.test.ts
@@ -212,8 +212,11 @@ describe('navigation options', () => {
   it('show warning on iOS when toggling bottomTabs visibility through mergeOptions', () => {
     jest.spyOn(console, 'warn');
     uut.processOptions({ bottomTabs: { visible: false } }, 'mergeOptions');
-    expect(console.warn).toBeCalledWith('toggling bottomTabs visibility is deprecated on iOS.', {
-      bottomTabs: { visible: false },
-    });
+    expect(console.warn).toBeCalledWith(
+      'toggling bottomTabs visibility is deprecated on iOS. For more information see https://github.com/wix/react-native-navigation/issues/6416',
+      {
+        bottomTabs: { visible: false },
+      }
+    );
   });
 });

--- a/lib/src/commands/OptionsProcessor.test.ts
+++ b/lib/src/commands/OptionsProcessor.test.ts
@@ -208,4 +208,12 @@ describe('navigation options', () => {
     verify(mockedStore.ensureClassForName('helloThere1')).called();
     verify(mockedStore.ensureClassForName('helloThere2')).called();
   });
+
+  it('show warning on iOS when toggling bottomTabs visibility through mergeOptions', () => {
+    jest.spyOn(console, 'warn');
+    uut.processOptions({ bottomTabs: { visible: false } }, 'mergeOptions');
+    expect(console.warn).toBeCalledWith('toggling bottomTabs visibility is deprecated on iOS.', {
+      bottomTabs: { visible: false },
+    });
+  });
 });

--- a/lib/src/commands/OptionsProcessor.ts
+++ b/lib/src/commands/OptionsProcessor.ts
@@ -29,7 +29,7 @@ export class OptionsProcessor {
       options,
       clone(options),
       (key, parentOptions) => {
-        this.deprecations.onProcessOptions(key, parentOptions);
+        this.deprecations.onProcessOptions(key, parentOptions, commandName);
       },
       commandName
     );


### PR DESCRIPTION
On iOS the system doesn't support dynamically toggling bottomTabs at all so we had to hack through it which resulted in many issues with this feature. We plan on entirely removing it and stick to the framework's guidelines which means that toggling the bottomTabs will not be possible at all and controlling it with static options will be the only option.
