### PR TITLE
Fix playground docs

### DIFF
--- a/website/docs/docs-playground-app.mdx
+++ b/website/docs/docs-playground-app.mdx
@@ -11,7 +11,7 @@ If you want to have a quick look around and test things out, you can run the pla
 1. Install dependencies via `npm install` (if you haven't already)
 2. Run the playground project on Android and iOS
     - `npm run start` to get the packager running in the terminal, leave it open
-    - **iOS**: open `./playground/ios` in Xcode and run it
+    - **iOS**: `cd ./playground/ios && pod install` then open `./playground/ios` in Xcode and run it
     - **Android**: open `./playground/android` in Android Studio and run it
 3. You can run tests if / when you need to (list of scripts [available here](meta-contributing#scripts)). Before
 you start changing things, make sure everything works.

--- a/website/docs/docs-playground-app.mdx
+++ b/website/docs/docs-playground-app.mdx
@@ -8,10 +8,10 @@ sidebar_label: Playground app
 
 If you want to have a quick look around and test things out, you can run the playground app, bundled with this repo.
 
-1. Install dependencies via `npm install` (if you haven't already)
+1. Install dependencies via `npm install` (if you haven't already) and `cd ./playground/ios && pod install` (for iOS)
 2. Run the playground project on Android and iOS
     - `npm run start` to get the packager running in the terminal, leave it open
-    - **iOS**: `cd ./playground/ios && pod install` then open `./playground/ios` in Xcode and run it
+    - **iOS**: open `./playground/ios` in Xcode and run it
     - **Android**: open `./playground/android` in Android Studio and run it
 3. You can run tests if / when you need to (list of scripts [available here](meta-contributing#scripts)). Before
 you start changing things, make sure everything works.

--- a/website/docs/docs-playground-app.mdx
+++ b/website/docs/docs-playground-app.mdx
@@ -8,7 +8,7 @@ sidebar_label: Playground app
 
 If you want to have a quick look around and test things out, you can run the playground app, bundled with this repo.
 
-1. Install dependencies via `npm install` (if you haven't already) and `cd ./playground/ios && pod install` (for iOS)
+1. Install dependencies via `npm install` (if you haven't already) and `npm run pod-install` (for iOS)
 2. Run the playground project on Android and iOS
     - `npm run start` to get the packager running in the terminal, leave it open
     - **iOS**: open `./playground/ios` in Xcode and run it


### PR DESCRIPTION
Fixes #6414

Adds missing `pod install` to  playground installation instructions at `website/docs/docs-playground-app.mdx`:

```js
1. Install dependencies via `npm install` (if you haven't already) and `cd ./playground/ios && pod install` (for iOS)
```