### PR TITLE
Fix TouchablePreview regression

### DIFF
--- a/lib/src/adapters/TouchablePreview.tsx
+++ b/lib/src/adapters/TouchablePreview.tsx
@@ -131,7 +131,7 @@ export class TouchablePreview extends React.PureComponent<Props> {
        * Ignoring this for now so that it builds.
        */
       // @ts-ignore
-      <Touchable ref={this.onRef} onPress={this.onPress} onPressIn={this.onPressIn} {...props}>
+      <Touchable {...props} ref={this.onRef} onPress={this.onPress} onPressIn={this.onPressIn}>
         <View
           onTouchStart={this.onTouchStart}
           onTouchMove={this.onTouchMove as (event: GestureResponderEvent) => void}

--- a/playground/src/components/Button.tsx
+++ b/playground/src/components/Button.tsx
@@ -14,15 +14,21 @@ type RnnButtonProps = {
   testID?: string;
 };
 
-const RnnButton = ({ platform, testID, ...props }: RnnButtonProps) => {
-  // If the platform prop is provided, only render if provided platform matches the current platform.
-  if (platform && platform !== Platform.OS) {
-    return null;
+export default class RnnButton extends React.Component<RnnButtonProps> {
+  render() {
+    const { platform, testID, ...props } = this.props;
+    // If the platform prop is provided, only render if provided platform matches the current platform.
+    if (platform && platform !== Platform.OS) {
+      return null;
+    }
+
+    return (
+      <Button
+        {...props}
+        testID={testID}
+        backgroundColor={testID ? undefined : '#65C888'}
+        marginB-8
+      />
+    );
   }
-
-  return (
-    <Button {...props} testID={testID} backgroundColor={testID ? undefined : '#65C888'} marginB-8 />
-  );
-};
-
-export default RnnButton;
+}


### PR DESCRIPTION
This PR includes:
- Ensuring the `onPress` or `onPressIn` props are not being overriden in `Navigation.TouchablePreview` as the internal `onPress` and `onPressIn` are handling the touch.
- Revert the `Button` component in the Playground app to class component to provide access to `ref`. 

Related to #6420 

@yogevbd This PR does fix triggering the `Preview` API in the Playground app however the Preview is still not appearing.