### PR TITLE
Fix shared element transition on pop

### DIFF
--- a/lib/ios/ContentTransitionCreator.h
+++ b/lib/ios/ContentTransitionCreator.h
@@ -2,4 +2,6 @@
 
 @interface ContentTransitionCreator : ElementTransitionsCreator
 
++ (id<DisplayLinkAnimatorDelegate>)createTransition:(TransitionOptions *)elementTransition view:(UIView *)view fromVC:(UIViewController *)fromVC toVC:(UIViewController *)toVC containerView:(UIView *)containerView operation:(UINavigationControllerOperation)operation;
+
 @end

--- a/lib/ios/ContentTransitionCreator.m
+++ b/lib/ios/ContentTransitionCreator.m
@@ -2,19 +2,21 @@
 
 @implementation ContentTransitionCreator
 
-+ (id<DisplayLinkAnimatorDelegate>)createTransition:(TransitionOptions *)elementTransition view:(UIView *)view fromVC:(UIViewController *)fromVC toVC:(UIViewController *)toVC containerView:(UIView *)containerView {
++ (id<DisplayLinkAnimatorDelegate>)createTransition:(TransitionOptions *)elementTransition view:(UIView *)view fromVC:(UIViewController *)fromVC toVC:(UIViewController *)toVC containerView:(UIView *)containerView operation:(UINavigationControllerOperation)operation {
    if (!elementTransition.alpha.hasAnimation) {
-       elementTransition.alpha = self.defaultAlphaTransition;
+       elementTransition.alpha = [self defaultAlphaTransitionForOperation:operation];
    }
     
     return [super createTransition:elementTransition view:view fromVC:fromVC toVC:toVC containerView:containerView];
 }
 
-+ (TransitionDetailsOptions *)defaultAlphaTransition {
++ (TransitionDetailsOptions *)defaultAlphaTransitionForOperation:(UINavigationControllerOperation)operation {
+    CGFloat from = operation == UINavigationControllerOperationPush ? 0 : 1;
+    CGFloat to = operation == UINavigationControllerOperationPush ? 1 : 0;
     TransitionDetailsOptions* defaultAlphaTransition = [TransitionDetailsOptions new];
     defaultAlphaTransition.duration = [TimeInterval withValue:300];
-    defaultAlphaTransition.from = [Double withValue:0];
-    defaultAlphaTransition.to = [Double withValue:1];
+    defaultAlphaTransition.from = [Double withValue:from];
+    defaultAlphaTransition.to = [Double withValue:to];
     return defaultAlphaTransition;
 }
 

--- a/lib/ios/StackControllerDelegate.m
+++ b/lib/ios/StackControllerDelegate.m
@@ -26,9 +26,9 @@
 											   fromViewController:(UIViewController*)fromVC
 												 toViewController:(UIViewController*)toVC {
 	if (operation == UINavigationControllerOperationPush && toVC.resolveOptions.animations.push.hasCustomAnimation) {
-		return [[StackTransitionDelegate alloc] initWithScreenTransition:toVC.resolveOptions.animations.push bridge:_eventEmitter.bridge];
+		return [[StackTransitionDelegate alloc] initWithScreenTransition:toVC.resolveOptions.animations.push bridge:_eventEmitter.bridge operation:operation];
 	} else if (operation == UINavigationControllerOperationPop && fromVC.resolveOptions.animations.pop.hasCustomAnimation) {
-		return [[StackTransitionDelegate alloc] initWithScreenTransition:fromVC.resolveOptions.animations.pop bridge:_eventEmitter.bridge];
+		return [[StackTransitionDelegate alloc] initWithScreenTransition:fromVC.resolveOptions.animations.pop bridge:_eventEmitter.bridge operation:operation];
 	} else {
 		return nil;
 	}

--- a/lib/ios/StackTransitionDelegate.h
+++ b/lib/ios/StackTransitionDelegate.h
@@ -5,6 +5,6 @@
 
 @interface StackTransitionDelegate : TransitionDelegate
 
-- (instancetype)initWithScreenTransition:(RNNScreenTransition *)screenTransition bridge:(RCTBridge *)bridge;
+- (instancetype)initWithScreenTransition:(RNNScreenTransition *)screenTransition bridge:(RCTBridge *)bridge operation:(UINavigationControllerOperation)operation;
 
 @end

--- a/lib/ios/StackTransitionDelegate.m
+++ b/lib/ios/StackTransitionDelegate.m
@@ -34,7 +34,7 @@
 
 - (id<DisplayLinkAnimatorDelegate>)createContentTransitionFromVC:(UIViewController *)fromVC toVC:(UIViewController *)toVC containerView:(UIView *)containerView {
     UIView* contentView = _operation == UINavigationControllerOperationPush ? toVC.view : fromVC.view;
-    return [ContentTransitionCreator createTransition:_screenTransition.content view:contentView fromVC:fromVC toVC:toVC containerView:containerView];
+    return [ContentTransitionCreator createTransition:_screenTransition.content view:contentView fromVC:fromVC toVC:toVC containerView:containerView operation:_operation];
 }
 
 - (NSArray *)createTransitionsFromVC:(UIViewController *)fromVC toVC:(UIViewController *)toVC containerView:(UIView *)containerView {

--- a/lib/ios/StackTransitionDelegate.m
+++ b/lib/ios/StackTransitionDelegate.m
@@ -5,11 +5,13 @@
 
 @implementation StackTransitionDelegate {
     RNNScreenTransition* _screenTransition;
+    UINavigationControllerOperation _operation;
 }
 
-- (instancetype)initWithScreenTransition:(RNNScreenTransition *)screenTransition bridge:(RCTBridge *)bridge {
+- (instancetype)initWithScreenTransition:(RNNScreenTransition *)screenTransition bridge:(RCTBridge *)bridge operation:(UINavigationControllerOperation)operation {
     self = [super initWithBridge:bridge];
     _screenTransition = screenTransition;
+    _operation = operation;
     return self;
 }
 
@@ -17,11 +19,28 @@
     return _screenTransition.maxDuration;
 }
 
+- (void)prepareTransitionContext:(id<UIViewControllerContextTransitioning>)transitionContext {
+    UIView* toView = [transitionContext viewForKey:UITransitionContextToViewKey];
+    UIView* fromView = [transitionContext viewForKey:UITransitionContextFromViewKey];
+    if (_operation == UINavigationControllerOperationPush) {
+        toView.alpha = 0;
+        [transitionContext.containerView addSubview:fromView];
+        [transitionContext.containerView addSubview:toView];
+    } else {
+        [transitionContext.containerView addSubview:toView];
+        [transitionContext.containerView addSubview:fromView];
+    }
+}
+
+- (id<DisplayLinkAnimatorDelegate>)createContentTransitionFromVC:(UIViewController *)fromVC toVC:(UIViewController *)toVC containerView:(UIView *)containerView {
+    UIView* contentView = _operation == UINavigationControllerOperationPush ? toVC.view : fromVC.view;
+    return [ContentTransitionCreator createTransition:_screenTransition.content view:contentView fromVC:fromVC toVC:toVC containerView:containerView];
+}
+
 - (NSArray *)createTransitionsFromVC:(UIViewController *)fromVC toVC:(UIViewController *)toVC containerView:(UIView *)containerView {
-    ContentTransitionCreator* contentTransition = [ContentTransitionCreator createTransition:_screenTransition.content view:toVC.view fromVC:fromVC toVC:toVC containerView:containerView];
-    
     NSArray* elementTransitions = [ElementTransitionsCreator create:_screenTransition.elementTransitions fromVC:fromVC toVC:toVC containerView:containerView];
     NSArray* sharedElementTransitions = [SharedElementTransitionsCreator create:_screenTransition.sharedElementTransitions fromVC:fromVC toVC:toVC containerView:containerView];
+    id<DisplayLinkAnimatorDelegate> contentTransition = [self createContentTransitionFromVC:fromVC toVC:toVC containerView:containerView];
     
     
     return [[[NSArray arrayWithObject:contentTransition] arrayByAddingObjectsFromArray:elementTransitions] arrayByAddingObjectsFromArray:sharedElementTransitions];

--- a/lib/ios/TransitionDelegate.m
+++ b/lib/ios/TransitionDelegate.m
@@ -57,7 +57,7 @@
 }
 
 - (NSArray *)createTransitionsFromVC:(UIViewController *)fromVC toVC:(UIViewController *)toVC containerView:(UIView *)containerView {
-    @throw [NSException exceptionWithName:@"Unimplemented method" reason:@"createTransitionFromVC:fromVC:toVC:containerView must be overridden by subclass" userInfo:nil];
+    @throw [NSException exceptionWithName:@"Unimplemented method" reason:@"createTransitionsFromVC:fromVC:toVC:containerView must be overridden by subclass" userInfo:nil];
     return @[];
 }
 


### PR DESCRIPTION
The transition context needs to be different for pop and push, until now we didn't handle that.