### PR TITLE
Fix merging options

### DIFF
--- a/lib/ios/NSObject+Utils.h
+++ b/lib/ios/NSObject+Utils.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface NSObject (Utils)
+
+- (NSArray *)objectProperties;
+
+@end

--- a/lib/ios/NSObject+Utils.h
+++ b/lib/ios/NSObject+Utils.h
@@ -2,6 +2,6 @@
 
 @interface NSObject (Utils)
 
-- (NSArray *)objectProperties;
+- (NSArray *)classProperties;
 
 @end

--- a/lib/ios/NSObject+Utils.m
+++ b/lib/ios/NSObject+Utils.m
@@ -4,7 +4,7 @@
 
 @implementation NSObject (Utils)
 
-- (NSArray *)objectProperties {
+- (NSArray *)classProperties {
     NSMutableArray* properties = [NSMutableArray new];
     unsigned int count;
     Class cls = [self class];

--- a/lib/ios/NSObject+Utils.m
+++ b/lib/ios/NSObject+Utils.m
@@ -1,0 +1,24 @@
+#import "NSObject+Utils.h"
+#import "RNNOptions.h"
+#import <objc/runtime.h>
+
+@implementation NSObject (Utils)
+
+- (NSArray *)objectProperties {
+    NSMutableArray* properties = [NSMutableArray new];
+    unsigned int count;
+    Class cls = [self class];
+    do {
+      objc_property_t* props = class_copyPropertyList(cls, &count);
+      for (int i = 0; i < count; i++) {
+        objc_property_t property = props[i];
+        NSString *propertyName = [NSString stringWithCString:property_getName(property) encoding:NSUTF8StringEncoding];
+        [properties addObject:propertyName];
+      }
+      free(props);
+      cls = [cls superclass];
+    } while (![cls isEqual:[NSObject class]] && cls != nil);
+    return properties;
+}
+
+@end

--- a/lib/ios/RNNOptions.m
+++ b/lib/ios/RNNOptions.m
@@ -9,7 +9,7 @@
 }
 
 - (RNNOptions *)mergeOptions:(RNNOptions *)otherOptions overrideOptions:(BOOL)override {
-	for (id prop in self.objectProperties) {
+	for (id prop in self.classProperties) {
 		id value = [otherOptions valueForKey:prop];
 		if ([value isKindOfClass:[RNNOptions class]]) {
 			[[self valueForKey:prop] mergeOptions:value overrideOptions:override];

--- a/lib/ios/RNNOptions.m
+++ b/lib/ios/RNNOptions.m
@@ -1,6 +1,5 @@
-
 #import "RNNOptions.h"
-#import <objc/runtime.h>
+#import "NSObject+Utils.h"
 
 @implementation RNNOptions
 
@@ -10,7 +9,7 @@
 }
 
 - (RNNOptions *)mergeOptions:(RNNOptions *)otherOptions overrideOptions:(BOOL)override {
-	for (id prop in [self objectProperties:otherOptions]) {
+	for (id prop in self.objectProperties) {
 		id value = [otherOptions valueForKey:prop];
 		if ([value isKindOfClass:[RNNOptions class]]) {
 			[[self valueForKey:prop] mergeOptions:value overrideOptions:override];
@@ -48,20 +47,6 @@
 	[newOptions mergeOptions:self overrideOptions:YES];
 
 	return newOptions;
-}
-
-- (NSArray *)objectProperties:(NSObject *)object {
-	NSMutableArray* properties = [NSMutableArray new];
-	unsigned int count;
-	objc_property_t* props = class_copyPropertyList([object class], &count);
-	for (int i = 0; i < count; i++) {
-		objc_property_t property = props[i];
-		NSString *propertyName = [NSString stringWithCString:property_getName(property) encoding:NSUTF8StringEncoding];
-		[properties addObject:propertyName];
-	}
-	
-	free(props);
-	return properties;
 }
 
 @end

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -369,6 +369,8 @@
 		50EB4ED72068EBE000D6ED34 /* RNNBackgroundOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 50EB4ED52068EBE000D6ED34 /* RNNBackgroundOptions.h */; };
 		50EB4ED82068EBE000D6ED34 /* RNNBackgroundOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EB4ED62068EBE000D6ED34 /* RNNBackgroundOptions.m */; };
 		50EB93421FE14A3E00BD8EEE /* RNNBottomTabOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EB93401FE14A3E00BD8EEE /* RNNBottomTabOptions.m */; };
+		50EF5BAB24CD96F4009CBFD0 /* NSObject+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 50EF5BA924CD96F4009CBFD0 /* NSObject+Utils.h */; };
+		50EF5BAC24CD96F4009CBFD0 /* NSObject+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EF5BAA24CD96F4009CBFD0 /* NSObject+Utils.m */; };
 		50F5DFC11F407A8C001A00BC /* RNNBottomTabsController.h in Headers */ = {isa = PBXBuildFile; fileRef = 50F5DFBF1F407A8C001A00BC /* RNNBottomTabsController.h */; };
 		50F5DFC21F407A8C001A00BC /* RNNBottomTabsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 50F5DFC01F407A8C001A00BC /* RNNBottomTabsController.m */; };
 		50F5DFC51F407AA0001A00BC /* RNNStackController.h in Headers */ = {isa = PBXBuildFile; fileRef = 50F5DFC31F407AA0001A00BC /* RNNStackController.h */; };
@@ -859,6 +861,8 @@
 		50EB4ED62068EBE000D6ED34 /* RNNBackgroundOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNBackgroundOptions.m; sourceTree = "<group>"; };
 		50EB933F1FE14A3E00BD8EEE /* RNNBottomTabOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNBottomTabOptions.h; sourceTree = "<group>"; };
 		50EB93401FE14A3E00BD8EEE /* RNNBottomTabOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNBottomTabOptions.m; sourceTree = "<group>"; };
+		50EF5BA924CD96F4009CBFD0 /* NSObject+Utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSObject+Utils.h"; sourceTree = "<group>"; };
+		50EF5BAA24CD96F4009CBFD0 /* NSObject+Utils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSObject+Utils.m"; sourceTree = "<group>"; };
 		50F5DFBF1F407A8C001A00BC /* RNNBottomTabsController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNBottomTabsController.h; sourceTree = "<group>"; };
 		50F5DFC01F407A8C001A00BC /* RNNBottomTabsController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNBottomTabsController.m; sourceTree = "<group>"; };
 		50F5DFC31F407AA0001A00BC /* RNNStackController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNStackController.h; sourceTree = "<group>"; };
@@ -1024,6 +1028,8 @@
 				5030B62823D5C9AF008F1642 /* RCTConvert+Interpolation.h */,
 				5095BB702416A3B900C4CD41 /* RNNConvert.h */,
 				5095BB712416A3B900C4CD41 /* RNNConvert.m */,
+				50EF5BA924CD96F4009CBFD0 /* NSObject+Utils.h */,
+				50EF5BAA24CD96F4009CBFD0 /* NSObject+Utils.m */,
 				5038A3BB216E1490009280BC /* RNNTabBarItemCreator.h */,
 				5038A3BC216E1490009280BC /* RNNTabBarItemCreator.m */,
 				5022EDBF24053C9F00852BA6 /* TabBarItemAppearanceCreator.h */,
@@ -1806,6 +1812,7 @@
 				5039559B2174867000B0A663 /* DoubleParser.h in Headers */,
 				E8AEDB3C1F55A1C2000F5A6A /* RNNElementView.h in Headers */,
 				E8E518321F83B3E0000467AC /* RNNUtils.h in Headers */,
+				50EF5BAB24CD96F4009CBFD0 /* NSObject+Utils.h in Headers */,
 				50E5F791223FA04C002AFEAD /* TransitionDetailsOptions.h in Headers */,
 				50D4656D23CE2553005A84B2 /* Transition.h in Headers */,
 				5049594E216F6277006D2B81 /* NumberParser.h in Headers */,
@@ -2032,6 +2039,7 @@
 				5022EDBE2405237100852BA6 /* BottomTabPresenterCreator.m in Sources */,
 				5038A3C7216E2D93009280BC /* Number.m in Sources */,
 				E5F6C3A622DB4D0F0093C2CE /* UIViewController+Utils.m in Sources */,
+				50EF5BAC24CD96F4009CBFD0 /* NSObject+Utils.m in Sources */,
 				5048862E20BE976D000908DE /* RNNLayoutOptions.m in Sources */,
 				501CD320214A5B6900A6E225 /* RNNLayoutInfo.m in Sources */,
 				7BEF0D191E437684003E96B0 /* RNNComponentViewController.m in Sources */,

--- a/playground/ios/NavigationTests/NSObjectUtilsTests.m
+++ b/playground/ios/NavigationTests/NSObjectUtilsTests.m
@@ -1,0 +1,38 @@
+#import <XCTest/XCTest.h>
+#import <ReactNativeNavigation/NSObject+Utils.h>
+#import <ReactNativeNavigation/RNNLayoutOptions.h>
+#import <ReactNativeNavigation/ElementTransitionOptions.h>
+
+@interface TestClass : NSObject
+@property (nonatomic, strong) NSString* testProperty;
+@end
+@implementation TestClass
+@end
+
+@interface TestSubClass : TestClass
+@property (nonatomic, strong) NSString* testSubProperty;
+@end
+@implementation TestSubClass
+@end
+
+@interface NSObjectUtilsTests : XCTestCase
+
+@end
+
+@implementation NSObjectUtilsTests
+
+- (void)testReturnObjectProperties {
+	TestClass* testObject = [TestClass new];
+	NSArray* properties = [testObject objectProperties];
+	NSArray* expectedProperties = @[@"testProperty"];
+	XCTAssertTrue([properties isEqualToArray:expectedProperties]);
+}
+
+- (void)testReturnSuperClassObjectProperties {
+	TestSubClass* testObject = [TestSubClass new];
+	NSArray* properties = [testObject objectProperties];
+	NSArray* expectedProperties = @[@"testSubProperty", @"testProperty"];
+	XCTAssertTrue([properties isEqualToArray:expectedProperties]);
+}
+
+@end

--- a/playground/ios/NavigationTests/NSObjectUtilsTests.m
+++ b/playground/ios/NavigationTests/NSObjectUtilsTests.m
@@ -21,16 +21,16 @@
 
 @implementation NSObjectUtilsTests
 
-- (void)testReturnObjectProperties {
+- (void)testReturnClassProperties {
 	TestClass* testObject = [TestClass new];
-	NSArray* properties = [testObject objectProperties];
+	NSArray* properties = [testObject classProperties];
 	NSArray* expectedProperties = @[@"testProperty"];
 	XCTAssertTrue([properties isEqualToArray:expectedProperties]);
 }
 
-- (void)testReturnSuperClassObjectProperties {
+- (void)testReturnSuperClassProperties {
 	TestSubClass* testObject = [TestSubClass new];
-	NSArray* properties = [testObject objectProperties];
+	NSArray* properties = [testObject classProperties];
 	NSArray* expectedProperties = @[@"testSubProperty", @"testProperty"];
 	XCTAssertTrue([properties isEqualToArray:expectedProperties]);
 }

--- a/playground/ios/playground.xcodeproj/project.pbxproj
+++ b/playground/ios/playground.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		50C9A8D1240EB95F00BD699F /* RNNBottomTabsController+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 50CF233C240695B10098042D /* RNNBottomTabsController+Helpers.m */; };
 		50C9A8D4240FB9D000BD699F /* RNNComponentViewController+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 50C9A8D3240FB9D000BD699F /* RNNComponentViewController+Utils.m */; };
 		50CF233D240695B10098042D /* RNNBottomTabsController+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 50CF233C240695B10098042D /* RNNBottomTabsController+Helpers.m */; };
+		50EF5BAE24CDCF04009CBFD0 /* NSObjectUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EF5BAD24CDCF04009CBFD0 /* NSObjectUtilsTests.m */; };
 		67C681D42B662A53F29C19DA /* Pods_NavigationIOS12Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEE0B5D45FD34FBABC6586CF /* Pods_NavigationIOS12Tests.framework */; };
 		9D204F3DC4FBCD81583BF99F /* Pods_playground.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A3340545EAAF11C1F146864 /* Pods_playground.framework */; };
 		B9EA50B19EF52C45E9399616 /* Pods_SnapshotTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE0C1AD81D2043249E7FE924 /* Pods_SnapshotTests.framework */; };
@@ -132,6 +133,7 @@
 		50CF233B240695B10098042D /* RNNBottomTabsController+Helpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RNNBottomTabsController+Helpers.h"; sourceTree = "<group>"; };
 		50CF233C240695B10098042D /* RNNBottomTabsController+Helpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "RNNBottomTabsController+Helpers.m"; sourceTree = "<group>"; };
 		50E4888A2427DA4800B11A8E /* StackOptionsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StackOptionsTest.m; sourceTree = "<group>"; };
+		50EF5BAD24CDCF04009CBFD0 /* NSObjectUtilsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSObjectUtilsTests.m; sourceTree = "<group>"; };
 		7F8E255E2E08F6ECE7DF6FE3 /* Pods-playground.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-playground.release.xcconfig"; path = "Target Support Files/Pods-playground/Pods-playground.release.xcconfig"; sourceTree = "<group>"; };
 		84E32151E3A71C2B7328BCB4 /* Pods_NavigationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NavigationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B484A10A046B0046B98A76B5 /* Pods-playground.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-playground.debug.xcconfig"; path = "Target Support Files/Pods-playground/Pods-playground.debug.xcconfig"; sourceTree = "<group>"; };
@@ -364,6 +366,7 @@
 				50CF233B240695B10098042D /* RNNBottomTabsController+Helpers.h */,
 				50CF233C240695B10098042D /* RNNBottomTabsController+Helpers.m */,
 				50647FE223E3196800B92025 /* RNNExternalViewControllerTests.m */,
+				50EF5BAD24CDCF04009CBFD0 /* NSObjectUtilsTests.m */,
 				E58D261F238587F4003F36BA /* Info.plist */,
 			);
 			path = NavigationTests;
@@ -994,6 +997,7 @@
 				50CF233D240695B10098042D /* RNNBottomTabsController+Helpers.m in Sources */,
 				E58D265D2385888C003F36BA /* RNNControllerFactoryTest.m in Sources */,
 				E58D265C2385888C003F36BA /* RNNStackControllerTest.m in Sources */,
+				50EF5BAE24CDCF04009CBFD0 /* NSObjectUtilsTests.m in Sources */,
 				E58D26482385888C003F36BA /* RNNDotIndicatorPresenterTest.m in Sources */,
 				E58D26522385888C003F36BA /* RNNComponentPresenterTest.m in Sources */,
 				E58D264C2385888C003F36BA /* RNNSideMenuParserTest.m in Sources */,


### PR DESCRIPTION
* Fix options.animations merging - `objectProperties` function didn't return superclass properties which resulted in wrong option merging.
* Rename `objectProperties` to `classProperties`.

Closes #6373