### PR TITLE
Fix statusBar visibility through mergeOptions

### DIFF
--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -72,6 +72,10 @@
 	if (options.window.backgroundColor.hasValue) {
 		UIApplication.sharedApplication.delegate.window.backgroundColor = withDefault.window.backgroundColor.get;
 	}
+    
+    if (options.statusBar.visible.hasValue) {
+        [self.boundViewController setNeedsStatusBarAppearanceUpdate];
+    }
 }
 
 - (void)renderComponents:(RNNNavigationOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock {

--- a/playground/ios/NavigationTests/RNNBasePresenterTest.m
+++ b/playground/ios/NavigationTests/RNNBasePresenterTest.m
@@ -123,4 +123,13 @@
 	XCTAssertTrue(_boundViewController.hidesBottomBarWhenPushed);
 }
 
+- (void)testMergeOptions_updatesStatusBarVisibility {
+	RNNNavigationOptions* mergeOptions = [RNNNavigationOptions emptyOptions];
+	mergeOptions.statusBar.visible = [Bool withValue:@(0)];
+	
+	[[self.mockBoundViewController expect] setNeedsStatusBarAppearanceUpdate];
+	[self.uut mergeOptions:mergeOptions resolvedOptions:nil];
+	[self.mockBoundViewController verify];
+}
+
 @end


### PR DESCRIPTION
`mergeOptions` with `statusBar.visible` didn't work on iOS. This PR fix it.