### PR TITLE
Fix modalPresentationStyle docs

### DIFF
--- a/website/api/options-root.mdx
+++ b/website/api/options-root.mdx
@@ -123,7 +123,7 @@ The default presentation style is different on each platform.
 
 | iOS                                                                                      | Android      |
 | ---------------------------------------------------------------------------------------- | ------------ |
-| <ul><li>iOS 12 and below - `fullScreen`</li><li>iOS 13 and above - `pageSheet`</li></ul> | `fullScreen` |
+| <ul><li>iOS 12 and below - `fullScreen`</li><li>iOS 13 and above - `pageSheet`</li></ul> | `none` |
 
 ## `modalTransitionStyle`
 


### PR DESCRIPTION
The current default is said to be `modalPresentationStyle: 'fullScreen'` however this is not supported on Android. Making it `none` to reflect this (the actual android code seems to have it be `unspecified`, but it should be falling back to `none` from what I can understand)