### PR TITLE
Resolve dismissModal promise with topmost parent componentId

### DIFF
--- a/lib/ios/RNNBridgeManager.mm
+++ b/lib/ios/RNNBridgeManager.mm
@@ -80,7 +80,8 @@
 
 - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge {
 	RNNEventEmitter *eventEmitter = [[RNNEventEmitter alloc] init];
-    _modalManager = [[RNNModalManager alloc] initWithBridge:bridge];
+    RNNModalManagerEventHandler* modalManagerEventHandler = [[RNNModalManagerEventHandler alloc] initWithEventEmitter:eventEmitter];
+    _modalManager = [[RNNModalManager alloc] initWithBridge:bridge eventHandler:modalManagerEventHandler];
     
 	id<RNNComponentViewCreator> rootViewCreator = [[RNNReactRootViewCreator alloc] initWithBridge:bridge eventEmitter:eventEmitter];
 	_componentRegistry = [[RNNReactComponentRegistry alloc] initWithCreator:rootViewCreator];

--- a/lib/ios/RNNBridgeModule.m
+++ b/lib/ios/RNNBridgeModule.m
@@ -93,7 +93,7 @@ RCT_EXPORT_METHOD(showModal:(NSString*)commandId layout:(NSDictionary*)layout re
 
 RCT_EXPORT_METHOD(dismissModal:(NSString*)commandId componentId:(NSString*)componentId mergeOptions:(NSDictionary*)options resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     RCTExecuteOnMainQueue(^{
-        [self->_commandsHandler dismissModal:componentId commandId:commandId mergeOptions:options completion:^{
+        [self->_commandsHandler dismissModal:componentId commandId:commandId mergeOptions:options completion:^(NSString *componentId) {
             resolve(componentId);
         } rejection:reject];
     });

--- a/lib/ios/RNNCommandsHandler.h
+++ b/lib/ios/RNNCommandsHandler.h
@@ -28,7 +28,7 @@
 
 - (void)showModal:(NSDictionary*)layout commandId:(NSString*)commandId completion:(RNNTransitionWithComponentIdCompletionBlock)completion;
 
-- (void)dismissModal:(NSString*)componentId commandId:(NSString*)commandId mergeOptions:(NSDictionary*)options completion:(RNNTransitionCompletionBlock)completion rejection:(RNNTransitionRejectionBlock)reject;
+- (void)dismissModal:(NSString*)componentId commandId:(NSString*)commandId mergeOptions:(NSDictionary*)options completion:(RNNTransitionWithComponentIdCompletionBlock)completion rejection:(RNNTransitionRejectionBlock)reject;
 
 - (void)dismissAllModals:(NSDictionary *)options commandId:(NSString*)commandId completion:(RNNTransitionCompletionBlock)completion;
 

--- a/lib/ios/RNNEventEmitter.h
+++ b/lib/ios/RNNEventEmitter.h
@@ -24,7 +24,7 @@
 
 - (void)sendOnPreviewCompleted:(NSString *)componentId previewComponentId:(NSString *)previewComponentId;
 
-- (void)sendModalsDismissedEvent:(NSString *)componentId componentName:(NSString *)componentName numberOfModalsDismissed:(NSNumber *)modalsDismissed;
+- (void)sendModalsDismissedEvent:(NSString *)componentId numberOfModalsDismissed:(NSNumber *)modalsDismissed;
 
 - (void)sendModalAttemptedToDismissEvent:(NSString *)componentId;
 

--- a/lib/ios/RNNEventEmitter.m
+++ b/lib/ios/RNNEventEmitter.m
@@ -124,10 +124,9 @@ static NSString* const BottomTabPressed         = @"RNN.BottomTabPressed";
     }];
 }
 
-- (void)sendModalsDismissedEvent:(NSString *)componentId componentName:(NSString *)componentName numberOfModalsDismissed:(NSNumber *)modalsDismissed {
+- (void)sendModalsDismissedEvent:(NSString *)componentId numberOfModalsDismissed:(NSNumber *)modalsDismissed {
     [self send:ModalDismissed body:@{
         @"componentId": componentId,
-        @"componentName": componentName,
         @"modalsDismissed": modalsDismissed
     }];
 }

--- a/lib/ios/RNNModalManager.h
+++ b/lib/ios/RNNModalManager.h
@@ -1,27 +1,18 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <React/RCTBridge.h>
+#import "RNNModalManagerEventHandler.h"
 
 typedef void (^RNNTransitionCompletionBlock)(void);
 typedef void (^RNNTransitionWithComponentIdCompletionBlock)(NSString * _Nonnull componentId);
 typedef void (^RNNTransitionRejectionBlock)(NSString * _Nonnull code, NSString * _Nonnull message, NSError * _Nullable error);
 
-@protocol RNNModalManagerDelegate <NSObject>
-
-- (void)dismissedModal:(UIViewController * _Nonnull)viewController;
-- (void)attemptedToDismissModal:(UIViewController * _Nonnull)viewController;
-- (void)dismissedMultipleModals:(NSArray * _Nonnull)viewControllers;
-
-@end
-
 @interface RNNModalManager : NSObject <UIAdaptivePresentationControllerDelegate>
 
-- (instancetype _Nullable)initWithBridge:(RCTBridge * _Nonnull)bridge;
+- (instancetype _Nonnull )initWithBridge:(RCTBridge * _Nonnull)bridge eventHandler:(RNNModalManagerEventHandler * _Nonnull)eventHandler;
 
-@property (nonatomic, weak) id<RNNModalManagerDelegate> _Nullable delegate;
-
-- (void)showModal:(UIViewController * _Nonnull)viewController animated:(BOOL)animated completion:(RNNTransitionWithComponentIdCompletionBlock _Nonnull)completion;
-- (void)dismissModal:(UIViewController * _Nonnull)viewController completion:(RNNTransitionCompletionBlock _Nonnull)completion;
+- (void)showModal:(UIViewController * _Nonnull)viewController animated:(BOOL)animated completion:(RNNTransitionWithComponentIdCompletionBlock _Nullable)completion;
+- (void)dismissModal:(UIViewController * _Nullable)viewController completion:(RNNTransitionCompletionBlock _Nullable)completion;
 - (void)dismissAllModalsAnimated:(BOOL)animated completion:(void (^ __nullable)(void))completion;
 - (void)dismissAllModalsSynchronosly;
 

--- a/lib/ios/RNNModalManager.m
+++ b/lib/ios/RNNModalManager.m
@@ -13,6 +13,7 @@
 	NSMutableArray* _pendingModalIdsToDismiss;
 	NSMutableArray* _presentedModals;
     RCTBridge* _bridge;
+    RNNModalManagerEventHandler* _eventHandler;
 }
 
 
@@ -23,9 +24,10 @@
 	return self;
 }
 
-- (instancetype)initWithBridge:(RCTBridge *)bridge {
+- (instancetype)initWithBridge:(RCTBridge *)bridge eventHandler:(RNNModalManagerEventHandler *)eventHandler {
     self = [self init];
     _bridge = bridge;
+    _eventHandler = eventHandler;
     return self;
 }
 
@@ -68,7 +70,7 @@
 - (void)dismissAllModalsAnimated:(BOOL)animated completion:(void (^ __nullable)(void))completion {
 	UIViewController *root = UIApplication.sharedApplication.delegate.window.rootViewController;
 	[root dismissViewControllerAnimated:animated completion:completion];
-	[_delegate dismissedMultipleModals:_presentedModals];
+	[_eventHandler dismissedMultipleModals:_presentedModals];
 	[_pendingModalIdsToDismiss removeAllObjects];
 	[_presentedModals removeAllObjects];
 }
@@ -131,16 +133,16 @@
 
 - (void)dismissedModal:(UIViewController *)viewController {
 	[_presentedModals removeObject:[viewController topMostViewController]];
-	[_delegate dismissedModal:viewController.presentedComponentViewController];
+	[_eventHandler dismissedModal:viewController.presentedComponentViewController];
 }
 
 - (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
 	[_presentedModals removeObject:presentationController.presentedViewController];
-    [_delegate dismissedModal:presentationController.presentedViewController.presentedComponentViewController];
+    [_eventHandler dismissedModal:presentationController.presentedViewController.presentedComponentViewController];
 }
 
 - (void)presentationControllerDidAttemptToDismiss:(UIPresentationController *)presentationController {
-    [_delegate attemptedToDismissModal:presentationController.presentedViewController.presentedComponentViewController];
+    [_eventHandler attemptedToDismissModal:presentationController.presentedViewController.presentedComponentViewController];
 }
 
 -(UIViewController*)topPresentedVC {

--- a/lib/ios/RNNModalManagerEventHandler.h
+++ b/lib/ios/RNNModalManagerEventHandler.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+#import "RNNEventEmitter.h"
+
+@interface RNNModalManagerEventHandler : NSObject
+
+- (instancetype _Nonnull)initWithEventEmitter:(RNNEventEmitter * _Nonnull)eventEmitter;
+
+- (void)dismissedModal:(UIViewController * _Nonnull)viewController;
+- (void)attemptedToDismissModal:(UIViewController * _Nonnull)viewController;
+- (void)dismissedMultipleModals:(NSArray * _Nonnull)viewControllers;
+
+@end

--- a/lib/ios/RNNModalManagerEventHandler.m
+++ b/lib/ios/RNNModalManagerEventHandler.m
@@ -1,0 +1,29 @@
+#import "RNNModalManagerEventHandler.h"
+#import "UIViewController+LayoutProtocol.h"
+
+@implementation RNNModalManagerEventHandler {
+    RNNEventEmitter* _eventEmitter;
+}
+
+- (instancetype)initWithEventEmitter:(RNNEventEmitter *)eventEmitter {
+    self = [super init];
+    _eventEmitter = eventEmitter;
+    return self;
+}
+
+- (void)dismissedModal:(UIViewController *)viewController {
+    [_eventEmitter sendModalsDismissedEvent:viewController.topMostViewController.layoutInfo.componentId numberOfModalsDismissed:@(1)];
+}
+
+- (void)attemptedToDismissModal:(UIViewController *)viewController {
+    [_eventEmitter sendModalAttemptedToDismissEvent:viewController.topMostViewController.layoutInfo.componentId];
+}
+
+- (void)dismissedMultipleModals:(NSArray *)viewControllers {
+    if (viewControllers && viewControllers.count) {
+        UIViewController* lastViewController = [viewControllers.lastObject presentedComponentViewController];
+        [_eventEmitter sendModalsDismissedEvent:lastViewController.topMostViewController.layoutInfo.componentId numberOfModalsDismissed:@(viewControllers.count)];
+    }
+}
+
+@end

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -369,6 +369,10 @@
 		50EB4ED72068EBE000D6ED34 /* RNNBackgroundOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 50EB4ED52068EBE000D6ED34 /* RNNBackgroundOptions.h */; };
 		50EB4ED82068EBE000D6ED34 /* RNNBackgroundOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EB4ED62068EBE000D6ED34 /* RNNBackgroundOptions.m */; };
 		50EB93421FE14A3E00BD8EEE /* RNNBottomTabOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EB93401FE14A3E00BD8EEE /* RNNBottomTabOptions.m */; };
+		50EF5BAB24CD96F4009CBFD0 /* NSObject+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 50EF5BA924CD96F4009CBFD0 /* NSObject+Utils.h */; };
+		50EF5BAC24CD96F4009CBFD0 /* NSObject+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EF5BAA24CD96F4009CBFD0 /* NSObject+Utils.m */; };
+		50EF5BC624D1878D009CBFD0 /* RNNModalManagerEventHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 50EF5BC424D1878D009CBFD0 /* RNNModalManagerEventHandler.h */; };
+		50EF5BC724D1878D009CBFD0 /* RNNModalManagerEventHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EF5BC524D1878D009CBFD0 /* RNNModalManagerEventHandler.m */; };
 		50F5DFC11F407A8C001A00BC /* RNNBottomTabsController.h in Headers */ = {isa = PBXBuildFile; fileRef = 50F5DFBF1F407A8C001A00BC /* RNNBottomTabsController.h */; };
 		50F5DFC21F407A8C001A00BC /* RNNBottomTabsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 50F5DFC01F407A8C001A00BC /* RNNBottomTabsController.m */; };
 		50F5DFC51F407AA0001A00BC /* RNNStackController.h in Headers */ = {isa = PBXBuildFile; fileRef = 50F5DFC31F407AA0001A00BC /* RNNStackController.h */; };
@@ -859,6 +863,10 @@
 		50EB4ED62068EBE000D6ED34 /* RNNBackgroundOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNBackgroundOptions.m; sourceTree = "<group>"; };
 		50EB933F1FE14A3E00BD8EEE /* RNNBottomTabOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNBottomTabOptions.h; sourceTree = "<group>"; };
 		50EB93401FE14A3E00BD8EEE /* RNNBottomTabOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNBottomTabOptions.m; sourceTree = "<group>"; };
+		50EF5BA924CD96F4009CBFD0 /* NSObject+Utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSObject+Utils.h"; sourceTree = "<group>"; };
+		50EF5BAA24CD96F4009CBFD0 /* NSObject+Utils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSObject+Utils.m"; sourceTree = "<group>"; };
+		50EF5BC424D1878D009CBFD0 /* RNNModalManagerEventHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNModalManagerEventHandler.h; sourceTree = "<group>"; };
+		50EF5BC524D1878D009CBFD0 /* RNNModalManagerEventHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNModalManagerEventHandler.m; sourceTree = "<group>"; };
 		50F5DFBF1F407A8C001A00BC /* RNNBottomTabsController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNBottomTabsController.h; sourceTree = "<group>"; };
 		50F5DFC01F407A8C001A00BC /* RNNBottomTabsController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNBottomTabsController.m; sourceTree = "<group>"; };
 		50F5DFC31F407AA0001A00BC /* RNNStackController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNStackController.h; sourceTree = "<group>"; };
@@ -1471,6 +1479,8 @@
 				507ACB1023F44D1E00829911 /* RNNComponentView.m */,
 				507ACB1323F44E5200829911 /* RNNComponentRootView.h */,
 				507ACB1423F44E5200829911 /* RNNComponentRootView.m */,
+				50EF5BC424D1878D009CBFD0 /* RNNModalManagerEventHandler.h */,
+				50EF5BC524D1878D009CBFD0 /* RNNModalManagerEventHandler.m */,
 				503A8A1723BCB2ED0094D1C4 /* RNNReactButtonView.h */,
 				503A8A1823BCB2ED0094D1C4 /* RNNReactButtonView.m */,
 				503A8A1B23BCB3230094D1C4 /* RNNReactTitleView.h */,
@@ -1706,6 +1716,7 @@
 				503A8A0923BB86200094D1C4 /* TimeIntervalParser.h in Headers */,
 				263905B01E4C6F440023D7D3 /* MMDrawerController+Subclass.h in Headers */,
 				E8AEDB4A1F5C0BAF000F5A6A /* RNNInteractivePopAnimator.h in Headers */,
+				50EF5BC624D1878D009CBFD0 /* RNNModalManagerEventHandler.h in Headers */,
 				263905B71E4C6F440023D7D3 /* UIViewController+MMDrawerController.h in Headers */,
 				C2A57A1C21E815F80066711C /* InteractivePopGestureDelegate.h in Headers */,
 				507F43F41FF4FCFE00D9425B /* HMSegmentedControl.h in Headers */,
@@ -2127,6 +2138,7 @@
 				2DCD9196200014A900EDC75D /* RNNBridgeManager.mm in Sources */,
 				263905D71E4C94970023D7D3 /* RNNSideMenuController.m in Sources */,
 				50EB4ED82068EBE000D6ED34 /* RNNBackgroundOptions.m in Sources */,
+				50EF5BC724D1878D009CBFD0 /* RNNModalManagerEventHandler.m in Sources */,
 				5022EDCA24054C8A00852BA6 /* BottomTabsPresenterCreator.m in Sources */,
 				507F43CA1FF4F9CC00D9425B /* RNNTopTabOptions.m in Sources */,
 				26916C991E4B9E7700D13680 /* RNNReactRootViewCreator.m in Sources */,

--- a/playground/ios/NavigationTests/RNNModalManagerEventHandlerTest.m
+++ b/playground/ios/NavigationTests/RNNModalManagerEventHandlerTest.m
@@ -1,0 +1,55 @@
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import <ReactNativeNavigation/RNNModalManagerEventHandler.h>
+#import "RNNComponentViewController+Utils.h"
+#import <ReactNativeNavigation/RNNStackController.h>
+
+@interface RNNModalManagerEventHandlerTest : XCTestCase
+
+@end
+
+@implementation RNNModalManagerEventHandlerTest {
+	RNNModalManagerEventHandler* _uut;
+	id _eventEmitter;
+}
+
+- (void)setUp {
+	_eventEmitter = [OCMockObject mockForClass:RNNEventEmitter.class];
+	_uut = [[RNNModalManagerEventHandler alloc] initWithEventEmitter:_eventEmitter];
+}
+
+- (void)testDismissedModal_shouldEmitEventWithTopMostComponentId {
+	RNNLayoutInfo* stackLayoutInfo = [RNNLayoutInfo new];
+	stackLayoutInfo.componentId = @"stack";
+	RNNComponentViewController* child = [OCMockObject partialMockForObject:[RNNComponentViewController createWithComponentId:@"child"]];
+	__unused RNNStackController* stack = [[RNNStackController alloc] initWithLayoutInfo:stackLayoutInfo creator:nil options:nil defaultOptions:nil presenter:nil eventEmitter:nil childViewControllers:@[child]];
+	
+	[[_eventEmitter expect] sendModalsDismissedEvent:@"stack" numberOfModalsDismissed:@(1)];
+	[_uut dismissedModal:child];
+	[_eventEmitter verify];
+}
+
+- (void)testAttemptToDismissModal_shouldEmitEventWithTopMostComponentId {
+	RNNLayoutInfo* stackLayoutInfo = [RNNLayoutInfo new];
+	stackLayoutInfo.componentId = @"stack";
+	RNNComponentViewController* child = [OCMockObject partialMockForObject:[RNNComponentViewController createWithComponentId:@"child"]];
+	__unused RNNStackController* stack = [[RNNStackController alloc] initWithLayoutInfo:stackLayoutInfo creator:nil options:nil defaultOptions:nil presenter:nil eventEmitter:nil childViewControllers:@[child]];
+	
+	[[_eventEmitter expect] sendModalAttemptedToDismissEvent:@"stack"];
+	[_uut attemptedToDismissModal:child];
+	[_eventEmitter verify];
+}
+
+- (void)testDismissedMultipleModals_shouldEmitEventWithTopMostComponentId {
+	RNNLayoutInfo* stackLayoutInfo = [RNNLayoutInfo new];
+	stackLayoutInfo.componentId = @"stack";
+	RNNComponentViewController* child = [OCMockObject partialMockForObject:[RNNComponentViewController createWithComponentId:@"child"]];
+	__unused RNNStackController* stack = [[RNNStackController alloc] initWithLayoutInfo:stackLayoutInfo creator:nil options:nil defaultOptions:nil presenter:nil eventEmitter:nil childViewControllers:@[child]];
+	
+	[[_eventEmitter expect] sendModalsDismissedEvent:@"stack" numberOfModalsDismissed:@(2)];
+	[_uut dismissedMultipleModals:@[UIViewController.new, child]];
+	[_eventEmitter verify];
+}
+
+
+@end

--- a/playground/ios/playground.xcodeproj/project.pbxproj
+++ b/playground/ios/playground.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		501C86B9239FE9C400E0B631 /* UIImage+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 501C86B8239FE9C400E0B631 /* UIImage+Utils.m */; };
 		5022EDCD2405522000852BA6 /* RNNBottomTabsPresenterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E58D263A2385888C003F36BA /* RNNBottomTabsPresenterTest.m */; };
 		5022EDCE2405524700852BA6 /* RNNBottomTabsAppearancePresenterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5022EDCB240551EE00852BA6 /* RNNBottomTabsAppearancePresenterTest.m */; };
+		503F775C24D19D96005E596D /* RNNModalManagerEventHandlerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 503F775B24D19D96005E596D /* RNNModalManagerEventHandlerTest.m */; };
 		50647FE323E3196800B92025 /* RNNExternalViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 50647FE223E3196800B92025 /* RNNExternalViewControllerTests.m */; };
 		50650A23242FB0F800688104 /* CommandsHandlerCreator.m in Sources */ = {isa = PBXBuildFile; fileRef = 50650A22242FB0F800688104 /* CommandsHandlerCreator.m */; };
 		5078DF39242BE8AA007B0B4F /* TestingAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 5078DF38242BE8AA007B0B4F /* TestingAppDelegate.m */; };
@@ -112,6 +113,7 @@
 		501C86B8239FE9C400E0B631 /* UIImage+Utils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Utils.m"; sourceTree = "<group>"; };
 		5022EDCB240551EE00852BA6 /* RNNBottomTabsAppearancePresenterTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNBottomTabsAppearancePresenterTest.m; sourceTree = "<group>"; };
 		50364D6B238E7F0A000E62A2 /* ReactNativeNavigation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ReactNativeNavigation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		503F775B24D19D96005E596D /* RNNModalManagerEventHandlerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNModalManagerEventHandlerTest.m; sourceTree = "<group>"; };
 		50647FE223E3196800B92025 /* RNNExternalViewControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNExternalViewControllerTests.m; sourceTree = "<group>"; };
 		50650A21242FB0F800688104 /* CommandsHandlerCreator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CommandsHandlerCreator.h; sourceTree = "<group>"; };
 		50650A22242FB0F800688104 /* CommandsHandlerCreator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CommandsHandlerCreator.m; sourceTree = "<group>"; };
@@ -339,6 +341,7 @@
 				E58D26282385888B003F36BA /* RNNFontAttributesCreatorTest.m */,
 				E58D262A2385888B003F36BA /* RNNLayoutManagerTest.m */,
 				E58D26432385888C003F36BA /* RNNModalManagerTest.m */,
+				503F775B24D19D96005E596D /* RNNModalManagerEventHandlerTest.m */,
 				E58D263F2385888C003F36BA /* RNNStackControllerTest.m */,
 				E58D26322385888B003F36BA /* RNNNavigationOptionsTest.m */,
 				E58D263C2385888C003F36BA /* RNNNavigationStackManagerTest.m */,
@@ -801,6 +804,7 @@
 				E58D26502385888C003F36BA /* RNNNavigationOptionsTest.m in Sources */,
 				E58D264E2385888C003F36BA /* RNNTestBase.m in Sources */,
 				5022EDCE2405524700852BA6 /* RNNBottomTabsAppearancePresenterTest.m in Sources */,
+				503F775C24D19D96005E596D /* RNNModalManagerEventHandlerTest.m in Sources */,
 				500E9FE72406A52100C61231 /* BottomTabPresenterTest.m in Sources */,
 				E58D26612385888C003F36BA /* RNNTestNoColor.m in Sources */,
 				50CF233D240695B10098042D /* RNNBottomTabsController+Helpers.m in Sources */,


### PR DESCRIPTION
* Resolve `Navigation.dismissModal()` with topmost parent `componentId`.
* Resolve `ModalDismissedListener` event with topmost parent `componentId`.
* Remove `componentName` from `ModalDismissedListener` event.