### PR TITLE
Resolve 'push'-command with next componentId for ios

### DIFF
--- a/lib/ios/RNNBridgeModule.m
+++ b/lib/ios/RNNBridgeModule.m
@@ -45,8 +45,8 @@ RCT_EXPORT_METHOD(setDefaultOptions:(NSDictionary*)options resolver:(RCTPromiseR
 
 RCT_EXPORT_METHOD(push:(NSString*)commandId componentId:(NSString*)componentId layout:(NSDictionary*)layout resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     RCTExecuteOnMainQueue(^{
-        [self->_commandsHandler push:componentId commandId:commandId layout:layout completion:^{
-            resolve(componentId);
+        [self->_commandsHandler push:componentId commandId:commandId layout:layout completion:^(NSString *newComponentId){
+            resolve(newComponentId);
         } rejection:reject];
     });
 }
@@ -61,8 +61,8 @@ RCT_EXPORT_METHOD(pop:(NSString*)commandId componentId:(NSString*)componentId me
 
 RCT_EXPORT_METHOD(setStackRoot:(NSString*)commandId componentId:(NSString*)componentId children:(NSArray*)children resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     RCTExecuteOnMainQueue(^{
-        [self->_commandsHandler setStackRoot:componentId commandId:commandId children:children completion:^{
-            resolve(componentId);
+        [self->_commandsHandler setStackRoot:componentId commandId:commandId children:children completion:^(NSString *newComponentId){
+            resolve(newComponentId);
         } rejection:reject];
     });
 }

--- a/lib/ios/RNNCommandsHandler.h
+++ b/lib/ios/RNNCommandsHandler.h
@@ -16,7 +16,7 @@
 
 - (void)setDefaultOptions:(NSDictionary*)options completion:(RNNTransitionCompletionBlock)completion;
 
-- (void)push:(NSString*)componentId commandId:(NSString*)commandId layout:(NSDictionary*)layout completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;
+- (void)push:(NSString*)componentId commandId:(NSString*)commandId layout:(NSDictionary*)layout completion:(RNNTransitionWithComponentIdCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;
 
 - (void)pop:(NSString*)componentId commandId:(NSString*)commandId mergeOptions:(NSDictionary*)options completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;
 
@@ -24,7 +24,7 @@
 
 - (void)popToRoot:(NSString*)componentId commandId:(NSString*)commandId mergeOptions:(NSDictionary*)options completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;
 
-- (void)setStackRoot:(NSString*)componentId commandId:(NSString*)commandId children:(NSArray*)children completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;
+- (void)setStackRoot:(NSString*)componentId commandId:(NSString*)commandId children:(NSArray*)children completion:(RNNTransitionWithComponentIdCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;
 
 - (void)showModal:(NSDictionary*)layout commandId:(NSString*)commandId completion:(RNNTransitionWithComponentIdCompletionBlock)completion;
 

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -164,7 +164,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
         [newVc setReactViewReadyCallback:^{
             [fromVC.stack push:weakNewVC onTop:fromVC animated:[weakNewVC.resolveOptionsWithDefault.animations.push.enable getWithDefaultValue:YES] completion:^{
                 [self->_eventEmitter sendOnNavigationCommandCompletion:push commandId:commandId params:@{@"componentId": componentId}];
-                completion(newVc.layoutInfo.componentId);
+                completion(weakNewVC.layoutInfo.componentId);
             } rejection:rejection];
         }];
         

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -113,7 +113,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	completion();
 }
 
-- (void)push:(NSString*)componentId commandId:(NSString*)commandId layout:(NSDictionary*)layout completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection {
+- (void)push:(NSString*)componentId commandId:(NSString*)commandId layout:(NSDictionary*)layout completion:(RNNTransitionWithComponentIdCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection {
 	[self assertReady];
     RNNAssertMainQueue();
 	
@@ -133,7 +133,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 					[CATransaction begin];
 					[CATransaction setCompletionBlock:^{
 						[self->_eventEmitter sendOnNavigationCommandCompletion:push commandId:commandId params:@{@"componentId": componentId}];
-						completion();
+						completion(newVc.layoutInfo.componentId);
 					}];
 					[rvc.navigationController pushViewController:newVc animated:YES];
 					[CATransaction commit];
@@ -164,7 +164,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
         [newVc setReactViewReadyCallback:^{
             [fromVC.stack push:weakNewVC onTop:fromVC animated:[weakNewVC.resolveOptionsWithDefault.animations.push.enable getWithDefaultValue:YES] completion:^{
                 [self->_eventEmitter sendOnNavigationCommandCompletion:push commandId:commandId params:@{@"componentId": componentId}];
-                completion();
+                completion(newVc.layoutInfo.componentId);
             } rejection:rejection];
         }];
         
@@ -172,7 +172,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	}
 }
 
-- (void)setStackRoot:(NSString*)componentId commandId:(NSString*)commandId children:(NSArray*)children completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection {
+- (void)setStackRoot:(NSString*)componentId commandId:(NSString*)commandId children:(NSArray*)children completion:(RNNTransitionWithComponentIdCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection {
 	[self assertReady];
     RNNAssertMainQueue();
 	
@@ -191,7 +191,8 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
     [newVC setReactViewReadyCallback:^{
         [fromVC.stack setStackChildren:childViewControllers fromViewController:fromVC animated:[options.animations.setStackRoot.enable getWithDefaultValue:YES] completion:^{
             [weakEventEmitter sendOnNavigationCommandCompletion:setStackRoot commandId:commandId params:@{@"componentId": componentId}];
-            completion();
+			NSString* newComponentId = [childViewControllers.lastObject getCurrentChild].layoutInfo.componentId;
+            completion(newComponentId);
         } rejection:rejection];
     }];
 

--- a/playground/ios/NavigationTests/RNNCommandsHandlerTest.m
+++ b/playground/ios/NavigationTests/RNNCommandsHandlerTest.m
@@ -269,7 +269,7 @@
 	OCMStub(ClassMethod([classMock findComponentForId:@"vc1"])).andReturn(_nvc);
 	self.vc2.options.animations.setStackRoot.enable = [[Bool alloc] initWithBOOL:NO];
 	
-	[self.uut setStackRoot:@"vc1" commandId:@"" children:nil completion:^{
+	[self.uut setStackRoot:@"vc1" commandId:@"" children:nil completion:^(NSString *newComponentId){
 
 	} rejection:^(NSString *code, NSString *message, NSError *error) {
 		
@@ -287,7 +287,7 @@
 	[self.uut setReadyToReceiveCommands:true];
 	
 	_vc3.options.animations.setStackRoot.enable = [[Bool alloc] initWithBOOL:NO];
-	[self.uut setStackRoot:@"vc1" commandId:@"" children:nil completion:^{
+	[self.uut setStackRoot:@"vc1" commandId:@"" children:nil completion:^(NSString *newComponentId){
 	
 	} rejection:^(NSString *code, NSString *message, NSError *error) {
 		
@@ -302,7 +302,7 @@
 	
 	OCMStub([self.controllerFactory createChildrenLayout:[OCMArg any]]).andReturn(newViewControllers);
 	[self.uut setReadyToReceiveCommands:true];
-	[self.uut setStackRoot:@"vc1" commandId:@"" children:nil completion:^{
+	[self.uut setStackRoot:@"vc1" commandId:@"" children:nil completion:^(NSString *newComponentId){
 		
 	} rejection:^(NSString *code, NSString *message, NSError *error) {
 		
@@ -322,7 +322,7 @@
 	OCMStub([self.controllerFactory createChildrenLayout:[OCMArg any]]).andReturn(newViewControllers);
 	
 	[self.uut setReadyToReceiveCommands:true];
-	[self.uut setStackRoot:@"vc1" commandId:@"" children:nil completion:^{
+	[self.uut setStackRoot:@"vc1" commandId:@"" children:nil completion:^(NSString *newComponentId){
 		
 	} rejection:^(NSString *code, NSString *message, NSError *error) {
 		

--- a/playground/ios/SnapshotTests/StackOptionsTest.m
+++ b/playground/ios/SnapshotTests/StackOptionsTest.m
@@ -55,7 +55,7 @@
 	[_commandsHandler push:@"FirstComponent"
 				 commandId:@"push"
 					layout:secondComponent
-				completion:^{}
+				completion:^(NSString *newComponentId){}
 				 rejection:^(NSString *code, NSString *message, NSError *error) {}];
 	FBSnapshotVerifyView(_window, pushTestName);
 }


### PR DESCRIPTION
This is based on this PR: https://github.com/wix/react-native-navigation/pull/4229
This PR is very old and has many merge conflicts, to make your lives easier I created this PR. It does exactly the same.
Happy to see this merged! 😊 

>Behavior of Navigation.push(someComponentId, layout) between android and ios is different.
In android, promise resolves with next componentId (id of component that was pushed), but on ios - componentId on which we pushed.
Android: https://github.com/wix/react-native-navigation/blob/v2/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java#L145
The motivation of this PR - keep API behaviour more consistent.