### PR TITLE
Update static options prototype to include props param

### DIFF
--- a/lib/src/interfaces/NavigationComponent.ts
+++ b/lib/src/interfaces/NavigationComponent.ts
@@ -18,7 +18,13 @@ export class NavigationComponent<Props = {}, State = {}, Snapshot = any> extends
   State,
   Snapshot
 > {
-  static options?: (() => Options) | Options;
+  /**
+   * Options used to apply a style configuration when the screen appears.
+   *
+   * This field can either contain the concrete options to be applied, or a generator function
+   * which accepts props and returns an Options object.
+   */
+  static options: ((props?: any) => Options) | Options;
 
   componentDidAppear(_event: ComponentDidAppearEvent) {}
   componentDidDisappear(_event: ComponentDidDisappearEvent) {}


### PR DESCRIPTION
The static options field can either be a concrete options object or a generator function which accepts props as parameter. Unfortunately, static fields don't play well with TypeScript generics and the param was left as `any`.