### PR TITLE
Don't reject promise if popToRoot is called and there's nothing to pop

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
@@ -314,7 +314,7 @@ public class StackController extends ParentController<StackLayout> {
 
     public void popToRoot(Options mergeOptions, CommandListener listener) {
         if (!canPop()) {
-            listener.onError("Nothing to pop");
+            listener.onSuccess("");
             return;
         }
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.java
@@ -883,7 +883,7 @@ public class StackControllerTest extends BaseTest {
         CommandListenerAdapter listener = spy(new CommandListenerAdapter());
         uut.popToRoot(Options.EMPTY, listener);
         assertThat(uut.isEmpty()).isTrue();
-        verify(listener, times(1)).onError(any());
+        verify(listener).onSuccess("");
     }
 
     @Test


### PR DESCRIPTION
When popToRoot is called and the stack size is 1, the command promise is now resolved successfully instead of being rejected. This PR introduces parity with iOS.