### PR TITLE
Fix category warnings for RNNInterpolationOptions

### DIFF
--- a/lib/ios/RCTConvert+Interpolation.h
+++ b/lib/ios/RCTConvert+Interpolation.h
@@ -9,15 +9,6 @@ typedef NS_ENUM(NSInteger, RNNInterpolationOptions) {
 
 @interface RCTConvert (Interpolation)
 
-@end
-
-@implementation RCTConvert (Interpolation)
-
-RCT_ENUM_CONVERTER(RNNInterpolationOptions, (@{
-  @"linear": @(RNNInterpolationLinear),
-  @"accelerateDecelerate": @(RNNInterpolationAccelerateDecelerate),
-  @"decelerate": @(RNNInterpolationDecelerate),
-  @"accelerate": @(RNNInterpolationAccelerate),
-}), RNNInterpolationLinear, integerValue)
++ (RNNInterpolationOptions)RNNInterpolationOptions:(id)json;
 
 @end

--- a/lib/ios/RCTConvert+Interpolation.m
+++ b/lib/ios/RCTConvert+Interpolation.m
@@ -1,0 +1,12 @@
+#import "RCTConvert+Interpolation.h"
+
+@implementation RCTConvert (Interpolation)
+
+RCT_ENUM_CONVERTER(RNNInterpolationOptions, (@{
+  @"linear": @(RNNInterpolationLinear),
+  @"accelerateDecelerate": @(RNNInterpolationAccelerateDecelerate),
+  @"decelerate": @(RNNInterpolationDecelerate),
+  @"accelerate": @(RNNInterpolationAccelerate),
+}), RNNInterpolationLinear, integerValue)
+
+@end

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -414,6 +414,7 @@
 		7BEF0D191E437684003E96B0 /* RNNComponentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BEF0D171E437684003E96B0 /* RNNComponentViewController.m */; };
 		7BEF0D1C1E43771B003E96B0 /* RNNLayoutNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BEF0D1A1E43771B003E96B0 /* RNNLayoutNode.h */; };
 		7BEF0D1D1E43771B003E96B0 /* RNNLayoutNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BEF0D1B1E43771B003E96B0 /* RNNLayoutNode.m */; };
+		9F8E06B524EBDB48004BDA83 /* RCTConvert+Interpolation.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8E06B424EBDB48004BDA83 /* RCTConvert+Interpolation.m */; };
 		A7626BFD1FC2FB2C00492FB8 /* RNNTopBarOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = A7626BFC1FC2FB2C00492FB8 /* RNNTopBarOptions.m */; };
 		A7626C011FC5796200492FB8 /* RNNBottomTabsOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = A7626C001FC5796200492FB8 /* RNNBottomTabsOptions.m */; };
 		C2A57A1C21E815F80066711C /* InteractivePopGestureDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = C2A57A1A21E815F80066711C /* InteractivePopGestureDelegate.h */; };
@@ -912,6 +913,7 @@
 		7BEF0D171E437684003E96B0 /* RNNComponentViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNComponentViewController.m; sourceTree = "<group>"; };
 		7BEF0D1A1E43771B003E96B0 /* RNNLayoutNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNLayoutNode.h; sourceTree = "<group>"; };
 		7BEF0D1B1E43771B003E96B0 /* RNNLayoutNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNLayoutNode.m; sourceTree = "<group>"; };
+		9F8E06B424EBDB48004BDA83 /* RCTConvert+Interpolation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+Interpolation.m"; sourceTree = "<group>"; };
 		A7626BFC1FC2FB2C00492FB8 /* RNNTopBarOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNTopBarOptions.m; sourceTree = "<group>"; };
 		A7626BFE1FC2FB6700492FB8 /* RNNTopBarOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNTopBarOptions.h; sourceTree = "<group>"; };
 		A7626BFF1FC578AB00492FB8 /* RNNBottomTabsOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNBottomTabsOptions.h; sourceTree = "<group>"; };
@@ -1026,6 +1028,7 @@
 				7365070F21E4B16F004E020F /* RCTConvert+UIBarButtonSystemItem.h */,
 				7365071021E4B16F004E020F /* RCTConvert+UIBarButtonSystemItem.m */,
 				5030B62823D5C9AF008F1642 /* RCTConvert+Interpolation.h */,
+				9F8E06B424EBDB48004BDA83 /* RCTConvert+Interpolation.m */,
 				5095BB702416A3B900C4CD41 /* RNNConvert.h */,
 				5095BB712416A3B900C4CD41 /* RNNConvert.m */,
 				50EF5BA924CD96F4009CBFD0 /* NSObject+Utils.h */,
@@ -2077,6 +2080,7 @@
 				50495957216F6B3D006D2B81 /* DictionaryParser.m in Sources */,
 				503A8A0223BB7B810094D1C4 /* ElementAnimator.m in Sources */,
 				5082CC3823CDC3C800FD2B6A /* VerticalTranslationTransition.m in Sources */,
+				9F8E06B524EBDB48004BDA83 /* RCTConvert+Interpolation.m in Sources */,
 				390AD478200F499D00A8250D /* RNNSwizzles.m in Sources */,
 				50E02BD921A6EE0F00A43942 /* SideMenuOpenMode.m in Sources */,
 				503A8A0E23BC9BC50094D1C4 /* ElementVerticalTransition.m in Sources */,


### PR DESCRIPTION
Resolves 
```
ld: warning: meta method 'RNNInterpolationOptions:' in category from [...] conflicts with same method from another category
```
from build.

Obj-C `@implementation` shouldn't be in header files!