### PR TITLE
Enable PlatformColor / DynamicColorIOS for iOS

### DIFF
--- a/lib/ios/ColorParser.m
+++ b/lib/ios/ColorParser.m
@@ -7,7 +7,7 @@
 
 + (Color *)parse:(NSDictionary *)json key:(NSString *)key {
 	if (json[key]) {
-		return [json[key] isKindOfClass:[NSNumber class]] ? [[Color alloc] initWithValue:[RCTConvert UIColor:json[key]]] : [NoColor new];
+		return [[Color alloc] initWithValue:[RCTConvert UIColor:json[key]]] ?: [NoColor new];
 	}
 	return [NullColor new];
 }


### PR DESCRIPTION
See https://reactnative.dev/blog/2020/07/06/version-0.63#native-colors-platformcolor-dynamiccolorios for an intro.
Fixes #6113

Color values can now be more than just numbers. So just pass through to `RCTConvert` for handling (this takes care of `PlatformColor` / `DynamicColorIOS` automatically). If it comes back as `nil` fallback onto `NoColor`. 