### PR TITLE
types: allow assigning OpaqueColorValue as a color

### DIFF
--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -1,7 +1,9 @@
 // tslint:disable jsdoc-format
 import { ImageRequireSource, Insets } from 'react-native';
 
-type Color = string;
+// TODO: Import ColorValue instead when upgrading @types/react-native to 0.63+
+// Only assign PlatformColor or DynamicColorIOS as a Color symbol!
+declare type Color = string | symbol;
 type FontFamily = string;
 type FontWeight =
   | 'regular'


### PR DESCRIPTION
The new react-native color typings (rn 63+) look like:

declare const OpaqueColorValue: unique symbol;
type OpaqueColorValue = typeof OpaqueColorValue;
export type ColorValue = string | OpaqueColorValue;

Since we can't import any of those yet without breaking backwards compatibility (library consumer would have to have rn63 types), this PR instead types Color as string or generic symbol. We can't use unique symbol as that would require a reference to OpaqueColorValue.

This is a bit hacky as library consumers could potentially assign any symbol to Color without getting an typescript error but that is rather unlikely.

Color should now be assigned the regular string colors or PlatformColor or DynamicColorIOS.