### PR TITLE
Added ability to blur focus on push for iOS

### DIFF
--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -120,6 +120,13 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	UIViewController *newVc = [_controllerFactory createLayout:layout];
 	UIViewController *fromVC = [RNNLayoutManager findComponentForId:componentId];
 	
+    if ([newVc.resolveOptionsWithDefault.animations.push.blur getWithDefaultValue:NO]) {
+        __weak UIViewController* weakFromVC = fromVC;
+        RCTExecuteOnMainQueue(^{
+            [weakFromVC.view endEditing:true];
+        });
+    }
+
 	if ([[newVc.resolveOptionsWithDefault.preview.reactTag getWithDefaultValue:@(0)] floatValue] > 0) {
 		if ([fromVC isKindOfClass:[RNNComponentViewController class]]) {
 			RNNComponentViewController* rootVc = (RNNComponentViewController*)fromVC;

--- a/lib/ios/RNNScreenTransition.h
+++ b/lib/ios/RNNScreenTransition.h
@@ -14,6 +14,8 @@
 @property (nonatomic, strong) Bool* waitForRender;
 @property (nonatomic, strong) TimeInterval* duration;
 
+@property (nonatomic, strong) Bool* blur;
+
 - (BOOL)hasCustomAnimation;
 - (BOOL)shouldWaitForRender;
 - (NSTimeInterval)maxDuration;

--- a/lib/ios/RNNScreenTransition.m
+++ b/lib/ios/RNNScreenTransition.m
@@ -12,6 +12,7 @@
 	self.enable = [BoolParser parse:dict key:@"enabled"];
 	self.waitForRender = [BoolParser parse:dict key:@"waitForRender"];
     self.duration = [TimeIntervalParser parse:dict key:@"duration"];
+    self.blur = [BoolParser parse:dict key:@"blur"];
     self.sharedElementTransitions = [OptionsArrayParser parse:dict key:@"sharedElementTransitions" ofClass:SharedElementTransitionOptions.class];
 	self.elementTransitions = [OptionsArrayParser parse:dict key:@"elementTransitions" ofClass:ElementTransitionOptions.class];
     

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -1020,6 +1020,18 @@ export interface StackAnimationOptions {
 }
 
 /**
+ * Used for describing push-specific animations.
+ */
+export type PushAnimationOptions = {
+  /**
+   * Blurs the currently focused responder on push.
+   * #### (iOS specific)
+   * @default false
+   */
+  blur?: boolean;
+} & StackAnimationOptions;
+
+/**
  * Used for configuring command animations
  */
 export interface AnimationOptions {
@@ -1034,7 +1046,7 @@ export interface AnimationOptions {
   /**
    * Configure what animates when a screen is pushed
    */
-  push?: StackAnimationOptions;
+  push?: PushAnimationOptions;
   /**
    * Configure what animates when a screen is popped
    */


### PR DESCRIPTION
Setting
```
animations: {
  push: {
    blur: true
  }
}
```
blurs the old view controller (by calling `end editing`) when pushing onto it.

Fixes: #2318