### PR TITLE
Recreate wrapped component on re-register component

### DIFF
--- a/lib/src/components/Store.ts
+++ b/lib/src/components/Store.ts
@@ -27,6 +27,7 @@ export class Store {
   }
 
   setComponentClassForName(componentName: string | number, ComponentClass: ComponentProvider) {
+    delete this.wrappedComponents[componentName];
     this.componentsByName[componentName.toString()] = ComponentClass;
   }
 


### PR DESCRIPTION
Currently when re-registering a component (calling `Navigation.registerComponent` with the same `componentName` more than once), the actual registered component does not get used if the component before that was already used. This is because on creation of the wrapped component it is cached. Therefor, we have to clear the wrapped component from the cache when registering a new component under the same name.

This also keeps the intended fix of #6239 (not calling the generator more than once), but restores the capability to replace a component.