### PR TITLE
Only initialize UIWindow if needed

### DIFF
--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -51,7 +51,9 @@
         viewController.modalInPresentation = ![withDefault.modal.swipeToDismiss getWithDefaultValue:YES];
     }
 	
-	UIApplication.sharedApplication.delegate.window.backgroundColor = [withDefault.window.backgroundColor getWithDefaultValue:nil];
+	if (withDefault.window.backgroundColor.hasValue) {
+		UIApplication.sharedApplication.delegate.window.backgroundColor = withDefault.window.backgroundColor.get;
+	}
 }
 
 - (void)applyOptionsOnViewDidLayoutSubviews:(RNNNavigationOptions *)options {

--- a/lib/ios/ReactNativeNavigation.m
+++ b/lib/ios/ReactNativeNavigation.m
@@ -67,15 +67,18 @@
 }
 
 - (void)bootstrap:(NSURL *)jsCodeLocation launchOptions:(NSDictionary *)launchOptions bridgeManagerDelegate:(id<RCTBridgeDelegate>)delegate {
-	UIWindow* mainWindow = [self initializeKeyWindow];
+	UIWindow* mainWindow = [self initializeKeyWindowIfNeeded];
 	
 	self.bridgeManager = [[RNNBridgeManager alloc] initWithJsCodeLocation:jsCodeLocation launchOptions:launchOptions bridgeManagerDelegate:delegate mainWindow:mainWindow];
 	[RNNSplashScreen showOnWindow:mainWindow];
 }
 
-- (UIWindow *)initializeKeyWindow {
-	UIWindow* keyWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-	UIApplication.sharedApplication.delegate.window = keyWindow;
+- (UIWindow *)initializeKeyWindowIfNeeded {
+	UIWindow* keyWindow = UIApplication.sharedApplication.delegate.window;
+	if (!keyWindow) {
+		keyWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+		UIApplication.sharedApplication.delegate.window = keyWindow;
+	}
 	return keyWindow;
 }
 


### PR DESCRIPTION
Usually UIWindow is initalized in the UIAppDelegate.
This is also how the standard react-native template is set up.

By replacing an already setup window, we are not only doing more work
but also loosing already set properties or custom UIWindow implementations.

Other libraries (like fbsdk) depend on the UIWindow already being setup in the app delegate.

Lastly, this presents a potential debugging nightmare as nobody would expect their UIWindow just being replaced.

Therefor, we should only set it up from inside rnn if it doesn't exist already.