### PR TITLE
Use correct ScaleType when animating same element multiple times

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/MatrixAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/MatrixAnimator.kt
@@ -42,8 +42,12 @@ class MatrixAnimator(from: View, to: View) : PropertyAnimatorCreator<ReactImageV
     }
 
     private fun getScaleType(child: View): ScalingUtils.ScaleType? {
-        val scaleType = (child as ReactImageView).hierarchy.actualImageScaleType
-        return if (scaleType is InterpolatingScaleType) scaleType.scaleTypeFrom else scaleType
+        return getScaleType(child as ReactImageView, child.hierarchy.actualImageScaleType!!)
+    }
+
+    private fun getScaleType(child: ReactImageView, scaleType: ScalingUtils.ScaleType): ScalingUtils.ScaleType? {
+        if (scaleType is InterpolatingScaleType) return getScaleType(child, scaleType.scaleTypeTo )
+        return scaleType
     }
 
     private fun calculateBounds(view: View) = Rect(0, 0, view.width, view.height)


### PR DESCRIPTION
When animating images in shared element transition, we change their ScaleType to an InterpolatingScaleType.
At the end of the animation we need to restore the ScaleType back to its original value but for some reason this doesn't seem to work.

The current solution recursively find the original scale type used for the destination image.

Related to #6505