### PR TITLE
Remove broken bootstrap method

### DIFF
--- a/lib/ios/ReactNativeNavigation.h
+++ b/lib/ios/ReactNativeNavigation.h
@@ -7,8 +7,6 @@ typedef UIViewController * (^RNNExternalViewCreator)(NSDictionary* props, RCTBri
 
 @interface ReactNativeNavigation : NSObject
 
-+ (void)bootstrapWithlaunchOptions:(NSDictionary *)launchOptions;
-
 + (void)bootstrapWithDelegate:(id<RCTBridgeDelegate>)bridgeDelegate launchOptions:(NSDictionary *)launchOptions;
 
 + (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge;

--- a/lib/ios/ReactNativeNavigation.m
+++ b/lib/ios/ReactNativeNavigation.m
@@ -16,10 +16,6 @@
 
 # pragma mark - public API
 
-+ (void)bootstrapWithlaunchOptions:(NSDictionary *)launchOptions {
-	[[ReactNativeNavigation sharedInstance] bootstrapWithDelegate:nil launchOptions:launchOptions];
-}
-
 + (void)bootstrapWithDelegate:(id<RCTBridgeDelegate>)bridgeDelegate launchOptions:(NSDictionary *)launchOptions {
     [[ReactNativeNavigation sharedInstance] bootstrapWithDelegate:bridgeDelegate launchOptions:launchOptions];
 }


### PR DESCRIPTION
Without a delegate there is no support for source url and extra modules which are both needed since v7.

@guyca Maybe I missed something in your v7 commit, but it currently doesn't work without a delegate as the `RCTBridgeDelegate` wrapper in `RNNBridgeManager` was removed. So there is no fallback anymore if user doesn't provide a delegate.