### PR TITLE
Animate borderRadius for Shared Element Transitions

### DIFF
--- a/lib/ios/AnimatedReactView.m
+++ b/lib/ios/AnimatedReactView.m
@@ -1,9 +1,11 @@
 #import "AnimatedReactView.h"
 #import <React/UIView+React.h>
+#import "UIView+Utils.h"
 
 @implementation AnimatedReactView {
     UIView* _originalParent;
     CGRect _originalFrame;
+    CGFloat _originalCornerRadius;
     UIView* _toElement;
     UIColor* _fromColor;
     NSInteger _zIndex;
@@ -28,6 +30,11 @@
     _reactView.backgroundColor = backgroundColor;
 }
 
+- (void)setCornerRadius:(CGFloat)cornerRadius {
+    [super setCornerRadius:cornerRadius];
+    [_reactView setCornerRadius:cornerRadius];
+}
+
 - (NSNumber *)reactZIndex {
     return @(_zIndex);
 }
@@ -37,12 +44,14 @@
     _originalFrame = _reactView.frame;
     self.frame = self.location.fromFrame;
     _originalParent = _reactView.superview;
+    _originalCornerRadius = element.layer.cornerRadius;
     _reactView.frame = self.bounds;
     [self addSubview:_reactView];
 }
 
 - (void)reset {
     _reactView.frame = _originalFrame;
+    _reactView.layer.cornerRadius = _originalCornerRadius;
     [_originalParent addSubview:_reactView];
     _toElement.hidden = NO;
     _reactView.backgroundColor = _fromColor;

--- a/lib/ios/AnimatedReactView.m
+++ b/lib/ios/AnimatedReactView.m
@@ -6,6 +6,8 @@
     UIView* _originalParent;
     CGRect _originalFrame;
     CGFloat _originalCornerRadius;
+    CGRect _originalLayoutBounds;
+    CATransform3D _originalTransform;
     UIView* _toElement;
     UIColor* _fromColor;
     NSInteger _zIndex;
@@ -42,19 +44,25 @@
 - (void)hijackReactElement:(UIView *)element {
     _reactView = element;
     _originalFrame = _reactView.frame;
+    _originalTransform = element.layer.transform;
+    _originalLayoutBounds = element.layer.bounds;
     self.frame = self.location.fromFrame;
     _originalParent = _reactView.superview;
     _originalCornerRadius = element.layer.cornerRadius;
     _reactView.frame = self.bounds;
+    _reactView.layer.transform = CATransform3DIdentity;
     [self addSubview:_reactView];
 }
 
 - (void)reset {
     _reactView.frame = _originalFrame;
     _reactView.layer.cornerRadius = _originalCornerRadius;
+    _reactView.bounds = _originalLayoutBounds;
+    _reactView.layer.bounds = _originalLayoutBounds;
     [_originalParent addSubview:_reactView];
     _toElement.hidden = NO;
     _reactView.backgroundColor = _fromColor;
+    _reactView.layer.transform = _originalTransform;
     [self removeFromSuperview];
 }
 

--- a/lib/ios/CornerRadiusTransition.h
+++ b/lib/ios/CornerRadiusTransition.h
@@ -1,0 +1,13 @@
+//
+//  CornerRadiusTransition.h
+//  Pods
+//
+//  Created by Marc Rousavy on 02.09.20.
+//
+
+#import "ElementBaseTransition.h"
+#import "FloatTransition.h"
+
+@interface CornerRadiusTransition : FloatTransition
+
+@end

--- a/lib/ios/CornerRadiusTransition.m
+++ b/lib/ios/CornerRadiusTransition.m
@@ -6,12 +6,13 @@
 //
 
 #import "CornerRadiusTransition.h"
+#import "UIView+Utils.h"
 
 @implementation CornerRadiusTransition
 
 - (CATransform3D)animateWithProgress:(CGFloat)p {
     CGFloat toRadius = [RNNInterpolator fromFloat:self.from toFloat:self.to precent:p interpolation:self.interpolation];
-	self.view.layer.cornerRadius = toRadius;
+    [self.view setCornerRadius:toRadius];
     return CATransform3DIdentity;
 }
 

--- a/lib/ios/CornerRadiusTransition.m
+++ b/lib/ios/CornerRadiusTransition.m
@@ -10,8 +10,8 @@
 @implementation CornerRadiusTransition
 
 - (CATransform3D)animateWithProgress:(CGFloat)p {
-    CGFloat toRadius = [RNNInterpolator from:self.from to:self.to precent:p interpolation:self.interpolation];
-	self.view.layout.cornerRadius = toRadius;
+    CGFloat toRadius = [RNNInterpolator fromFloat:self.from toFloat:self.to precent:p interpolation:self.interpolation];
+	self.view.layer.cornerRadius = toRadius;
     return CATransform3DIdentity;
 }
 

--- a/lib/ios/CornerRadiusTransition.m
+++ b/lib/ios/CornerRadiusTransition.m
@@ -1,0 +1,18 @@
+//
+//  CornerRadiusTransition.m
+//  abseil
+//
+//  Created by Marc Rousavy on 02.09.20.
+//
+
+#import "CornerRadiusTransition.h"
+
+@implementation CornerRadiusTransition
+
+- (CATransform3D)animateWithProgress:(CGFloat)p {
+    CGFloat toRadius = [RNNInterpolator from:self.from to:self.to precent:p interpolation:self.interpolation];
+	self.view.layout.cornerRadius = toRadius;
+    return CATransform3DIdentity;
+}
+
+@end

--- a/lib/ios/RNNViewLocation.h
+++ b/lib/ios/RNNViewLocation.h
@@ -4,8 +4,12 @@
 
 @property (nonatomic) CGRect fromFrame;
 @property (nonatomic) CGRect toFrame;
+@property (nonatomic) CGRect fromBounds;
+@property (nonatomic) CGRect toBounds;
 @property (nonatomic) CGFloat fromAngle;
 @property (nonatomic) CGFloat toAngle;
+@property (nonatomic) CATransform3D fromTransform;
+@property (nonatomic) CATransform3D toTransform;
 
 - (instancetype)initWithFromElement:(UIView*)fromElement toElement:(UIView*)toElement;
 

--- a/lib/ios/RNNViewLocation.m
+++ b/lib/ios/RNNViewLocation.m
@@ -10,6 +10,11 @@
     self.toFrame = [self convertViewFrame:toElement];
     self.fromAngle = [self getViewAngle:fromElement];
     self.toAngle = [self getViewAngle:toElement];
+    self.fromTransform = fromElement.layer.transform;
+    self.toTransform = toElement.layer.transform;
+    self.toBounds = toElement.layer.bounds;
+    self.fromBounds = fromElement.layer.bounds;
+    
 	return self;
 }
 

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -421,6 +421,8 @@
 		9FDA2AC024F2A43B005678CC /* RCTConvert+SideMenuOpenGestureMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FDA2ABF24F2A43B005678CC /* RCTConvert+SideMenuOpenGestureMode.m */; };
 		A7626BFD1FC2FB2C00492FB8 /* RNNTopBarOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = A7626BFC1FC2FB2C00492FB8 /* RNNTopBarOptions.m */; };
 		A7626C011FC5796200492FB8 /* RNNBottomTabsOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = A7626C001FC5796200492FB8 /* RNNBottomTabsOptions.m */; };
+		B8B2BB6524FFCC9500FC6575 /* CornerRadiusTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = B8B2BB6324FFCC9500FC6575 /* CornerRadiusTransition.h */; };
+		B8B2BB6624FFCC9500FC6575 /* CornerRadiusTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = B8B2BB6424FFCC9500FC6575 /* CornerRadiusTransition.m */; };
 		C2A57A1C21E815F80066711C /* InteractivePopGestureDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = C2A57A1A21E815F80066711C /* InteractivePopGestureDelegate.h */; };
 		C2A57A1D21E815F80066711C /* InteractivePopGestureDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C2A57A1B21E815F80066711C /* InteractivePopGestureDelegate.m */; };
 		E33AC20020B5BA0B0090DB8A /* RNNSplitViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E33AC1FF20B5BA0B0090DB8A /* RNNSplitViewController.m */; };
@@ -926,6 +928,8 @@
 		A7626BFE1FC2FB6700492FB8 /* RNNTopBarOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNTopBarOptions.h; sourceTree = "<group>"; };
 		A7626BFF1FC578AB00492FB8 /* RNNBottomTabsOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNBottomTabsOptions.h; sourceTree = "<group>"; };
 		A7626C001FC5796200492FB8 /* RNNBottomTabsOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNBottomTabsOptions.m; sourceTree = "<group>"; };
+		B8B2BB6324FFCC9500FC6575 /* CornerRadiusTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CornerRadiusTransition.h; sourceTree = "<group>"; };
+		B8B2BB6424FFCC9500FC6575 /* CornerRadiusTransition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CornerRadiusTransition.m; sourceTree = "<group>"; };
 		C2A57A1A21E815F80066711C /* InteractivePopGestureDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InteractivePopGestureDelegate.h; sourceTree = "<group>"; };
 		C2A57A1B21E815F80066711C /* InteractivePopGestureDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = InteractivePopGestureDelegate.m; sourceTree = "<group>"; };
 		D8AFADBD1BEE6F3F00A4592D /* libReactNativeNavigation.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReactNativeNavigation.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1313,6 +1317,8 @@
 		50588B8723AA87E3001F6A5E /* Animations */ = {
 			isa = PBXGroup;
 			children = (
+				B8B2BB6324FFCC9500FC6575 /* CornerRadiusTransition.h */,
+				B8B2BB6424FFCC9500FC6575 /* CornerRadiusTransition.m */,
 				50E38DDC23A7A306009817F6 /* AnimatedImageView.m */,
 				50E38DDB23A7A306009817F6 /* AnimatedImageView.h */,
 				50EA541823AEE1C6006F881A /* AnimatedReactView.h */,
@@ -1797,6 +1803,7 @@
 				50AD288823CDB71C00FF3134 /* ElementHorizontalTransition.h in Headers */,
 				507ACAFF23F3013900829911 /* TransformRectTransition.h in Headers */,
 				263905E61E4CAC950023D7D3 /* RNNSideMenuChildVC.h in Headers */,
+				B8B2BB6524FFCC9500FC6575 /* CornerRadiusTransition.h in Headers */,
 				50588B8C23AAC2FF001F6A5E /* DisplayLinkAnimation.h in Headers */,
 				50F5DFC51F407AA0001A00BC /* RNNStackController.h in Headers */,
 				50BAFE4B2399405800798674 /* RNNExternalViewController.h in Headers */,
@@ -2167,6 +2174,7 @@
 				50AD288923CDB71C00FF3134 /* ElementHorizontalTransition.m in Sources */,
 				E33AC20820B5C4F90090DB8A /* RNNSplitViewOptions.m in Sources */,
 				50BCB28A23F2B4DE00D6C8E5 /* ColorTransition.m in Sources */,
+				B8B2BB6624FFCC9500FC6575 /* CornerRadiusTransition.m in Sources */,
 				E33AC20020B5BA0B0090DB8A /* RNNSplitViewController.m in Sources */,
 				50BAFE4C2399405800798674 /* RNNExternalViewController.m in Sources */,
 				503A8A2623BD04410094D1C4 /* ElementTransitionsCreator.m in Sources */,

--- a/lib/ios/SharedElementAnimator.m
+++ b/lib/ios/SharedElementAnimator.m
@@ -55,6 +55,20 @@
     if ([self.view isKindOfClass:AnimatedTextView.class]) {
         [animations addObject:[[TextStorageTransition alloc] initWithView:self.view from:((AnimatedTextView *)self.view).fromTextStorage to:((AnimatedTextView *)self.view).toTextStorage startDelay:startDelay duration:duration interpolation:interpolation]];
     }
+	
+	if (_fromView.layer.cornerRadius != _toView.layer.cornerRadius) {
+		printf("Should animated borderRadius %f -> %f\n", _fromView.layer.cornerRadius, _toView.layer.cornerRadius);
+		
+		CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"cornerRadius"];
+		animation.duration = duration;
+		animation.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
+		animation.toValue = @(_toView.layer.cornerRadius);
+		animation.fillMode = kCAFillModeForwards;
+		animation.removedOnCompletion = NO;
+		[self.view.layer addAnimation:animation forKey:@"setCornerRadius:"];
+		[_fromView.layer addAnimation:animation forKey:@"setCornerRadius:"];
+		[_toView.layer addAnimation:animation forKey:@"setCornerRadius:"];
+	}
     
     return animations;
 }

--- a/lib/ios/SharedElementAnimator.m
+++ b/lib/ios/SharedElementAnimator.m
@@ -45,7 +45,7 @@
         if ([self.view isKindOfClass:AnimatedTextView.class]) {
             [animations addObject:[[RectTransition alloc] initWithView:self.view from:self.view.location.fromFrame to:self.view.location.toFrame startDelay:startDelay duration:duration interpolation:interpolation]];
         } else {
-            [animations addObject:[[TransformRectTransition alloc] initWithView:self.view fromRect:self.view.location.fromFrame toRect:self.view.location.toFrame fromAngle:self.view.location.fromAngle toAngle:self.view.location.toAngle startDelay:startDelay duration:duration interpolation:interpolation]];
+            [animations addObject:[[TransformRectTransition alloc] initWithView:self.view viewLocation:self.view.location startDelay:startDelay duration:duration interpolation:interpolation]];
         }
     }
     

--- a/lib/ios/SharedElementAnimator.m
+++ b/lib/ios/SharedElementAnimator.m
@@ -7,6 +7,7 @@
 #import "AnimatedTextView.h"
 #import "TextStorageTransition.h"
 #import "AnchorTransition.h"
+#import "CornerRadiusTransition.h"
 
 @implementation SharedElementAnimator {
     SharedElementTransitionOptions* _transitionOptions;
@@ -57,17 +58,11 @@
     }
 	
 	if (_fromView.layer.cornerRadius != _toView.layer.cornerRadius) {
-		printf("Should animated borderRadius %f -> %f\n", _fromView.layer.cornerRadius, _toView.layer.cornerRadius);
-		
-		CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"cornerRadius"];
-		animation.duration = duration;
-		animation.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
-		animation.toValue = @(_toView.layer.cornerRadius);
-		animation.fillMode = kCAFillModeForwards;
-		animation.removedOnCompletion = NO;
-		[self.view.layer addAnimation:animation forKey:@"setCornerRadius:"];
-		[_fromView.layer addAnimation:animation forKey:@"setCornerRadius:"];
-		[_toView.layer addAnimation:animation forKey:@"setCornerRadius:"];
+		// TODO: Use MaskedCorners to only round specific corners, e.g.: borderTopLeftRadius
+		//   self.view.layer.maskedCorners = kCALayerMinXMinYCorner | kCALayerMaxXMinYCorner | kCALayerMinXMaxYCorner | kCALayerMaxXMaxYCorner;
+		// TODO: On pop the cornerRadius animation doesn't work, even though the CornerRadiusTransition::animateWithProgress function is called.
+		self.view.layer.masksToBounds = YES;
+		[animations addObject:[[CornerRadiusTransition alloc] initWithView:self.view fromFloat:_fromView.layer.cornerRadius toFloat:_toView.layer.cornerRadius startDelay:startDelay duration:duration interpolation:interpolation]];
 	}
     
     return animations;

--- a/lib/ios/TransformRectTransition.h
+++ b/lib/ios/TransformRectTransition.h
@@ -1,9 +1,14 @@
 #import "ElementBaseTransition.h"
 #import "RectTransition.h"
+#import "RNNViewLocation.h"
 
 @interface TransformRectTransition : RectTransition
 
-- (instancetype)initWithView:(UIView *)view fromRect:(CGRect)fromRect toRect:(CGRect)toRect fromAngle:(CGFloat)fromAngle toAngle:(CGFloat)toAngle startDelay:(NSTimeInterval)startDelay duration:(NSTimeInterval)duration interpolation:(Text *)interpolation;
+- (instancetype)initWithView:(UIView *)view
+                viewLocation:(RNNViewLocation *)viewLocation
+                  startDelay:(NSTimeInterval)startDelay
+                    duration:(NSTimeInterval)duration
+               interpolation:(Text *)interpolation;
 
 @property (nonatomic, readonly) CGFloat fromAngle;
 @property (nonatomic, readonly) CGFloat toAngle;

--- a/lib/ios/TransformRectTransition.m
+++ b/lib/ios/TransformRectTransition.m
@@ -1,30 +1,57 @@
 #import "TransformRectTransition.h"
 
-@implementation TransformRectTransition
+@implementation TransformRectTransition {
+    CATransform3D _fromTransform;
+    CATransform3D _toTransform;
+    CGRect _fromBounds;
+    CGRect _toBounds;
+}
 
-- (instancetype)initWithView:(UIView *)view fromRect:(CGRect)fromRect toRect:(CGRect)toRect fromAngle:(CGFloat)fromAngle toAngle:(CGFloat)toAngle startDelay:(NSTimeInterval)startDelay duration:(NSTimeInterval)duration interpolation:(Text *)interpolation {
-    self = [super initWithView:view from:fromRect to:toRect startDelay:startDelay duration:duration interpolation:interpolation];
-    _fromAngle = fromAngle;
-    _toAngle = toAngle;
+- (instancetype)initWithView:(UIView *)view
+                viewLocation:(RNNViewLocation *)viewLocation
+                  startDelay:(NSTimeInterval)startDelay
+                    duration:(NSTimeInterval)duration
+               interpolation:(Text *)interpolation {
+    self = [super initWithView:view from:viewLocation.fromFrame to:viewLocation.toFrame startDelay:startDelay duration:duration interpolation:interpolation];
+    _fromAngle = viewLocation.fromAngle;
+    _toAngle = viewLocation.toAngle;
+    _fromTransform = viewLocation.fromTransform;
+    _toTransform = viewLocation.toTransform;
+    _fromBounds = viewLocation.fromBounds;
+    _toBounds = viewLocation.toBounds;
     return self;
 }
 
 - (CATransform3D)animateWithProgress:(CGFloat)p {
+    CGRect toBounds = [RNNInterpolator fromRect:_fromBounds toRect:_toBounds precent:p interpolation:self.interpolation];
     CGRect toFrame = [RNNInterpolator fromRect:self.from toRect:self.to precent:p interpolation:self.interpolation];
-    CGFloat toAngle = [RNNInterpolator fromFloat:self.fromAngle toFloat:self.toAngle precent:p interpolation:self.interpolation];
     
-    CGFloat scaleX = toFrame.size.width / self.from.size.width;
-    CGFloat scaleY = toFrame.size.height / self.from.size.height;
-    CGFloat offsetX = toFrame.origin.x - self.from.origin.x;
-    CGFloat offsetY = toFrame.origin.y - self.from.origin.y;
-    CGFloat translateX = (offsetX + (toFrame.size.width - self.from.size.width)/2);
-    CGFloat translateY = (offsetY + (toFrame.size.height - self.from.size.height)/2);
+    CATransform3D toTransform = CATransform3DIdentity;
     
-    CATransform3D translate = CATransform3DMakeTranslation(translateX, translateY, 0);
-    CATransform3D scale = CATransform3DScale(translate, scaleX, scaleY, 0);
-    CATransform3D rotate = CATransform3DRotate(scale, toAngle, 0, 0, 1);
+    toTransform.m11 = [RNNInterpolator fromFloat:_fromTransform.m11 toFloat:_toTransform.m11 precent:p interpolation:self.interpolation];
+    toTransform.m12 = [RNNInterpolator fromFloat:_fromTransform.m12 toFloat:_toTransform.m12 precent:p interpolation:self.interpolation];
+    toTransform.m13 = [RNNInterpolator fromFloat:_fromTransform.m13 toFloat:_toTransform.m13 precent:p interpolation:self.interpolation];
+    toTransform.m14 = [RNNInterpolator fromFloat:_fromTransform.m14 toFloat:_toTransform.m14 precent:p interpolation:self.interpolation];
+
+    toTransform.m21 = [RNNInterpolator fromFloat:_fromTransform.m21 toFloat:_toTransform.m21 precent:p interpolation:self.interpolation];
+    toTransform.m22 = [RNNInterpolator fromFloat:_fromTransform.m22 toFloat:_toTransform.m22 precent:p interpolation:self.interpolation];
+    toTransform.m23 = [RNNInterpolator fromFloat:_fromTransform.m23 toFloat:_toTransform.m23 precent:p interpolation:self.interpolation];
+    toTransform.m24 = [RNNInterpolator fromFloat:_fromTransform.m24 toFloat:_toTransform.m24 precent:p interpolation:self.interpolation];
+
+    toTransform.m31 = [RNNInterpolator fromFloat:_fromTransform.m31 toFloat:_toTransform.m31 precent:p interpolation:self.interpolation];
+    toTransform.m32 = [RNNInterpolator fromFloat:_fromTransform.m32 toFloat:_toTransform.m32 precent:p interpolation:self.interpolation];
+    toTransform.m33 = [RNNInterpolator fromFloat:_fromTransform.m33 toFloat:_toTransform.m33 precent:p interpolation:self.interpolation];
+    toTransform.m34 = [RNNInterpolator fromFloat:_fromTransform.m34 toFloat:_toTransform.m34 precent:p interpolation:self.interpolation];
+
+    toTransform.m41 = [RNNInterpolator fromFloat:_fromTransform.m41 toFloat:_toTransform.m41 precent:p interpolation:self.interpolation];
+    toTransform.m42 = [RNNInterpolator fromFloat:_fromTransform.m42 toFloat:_toTransform.m42 precent:p interpolation:self.interpolation];
+    toTransform.m43 = [RNNInterpolator fromFloat:_fromTransform.m43 toFloat:_toTransform.m43 precent:p interpolation:self.interpolation];
+    toTransform.m44 = [RNNInterpolator fromFloat:_fromTransform.m44 toFloat:_toTransform.m44 precent:p interpolation:self.interpolation];
     
-    return rotate;
+    self.view.frame = toFrame;
+    self.view.layer.bounds = toBounds;
+
+    return toTransform;
 }
 
 @end

--- a/lib/ios/Utils/UIView+Utils.h
+++ b/lib/ios/Utils/UIView+Utils.h
@@ -15,4 +15,6 @@ typedef NS_ENUM(NSInteger, ViewType) {
 
 - (void)stopMomentumScrollViews;
 
+- (void)setCornerRadius:(CGFloat)cornerRadius;
+
 @end

--- a/lib/ios/Utils/UIView+Utils.m
+++ b/lib/ios/Utils/UIView+Utils.m
@@ -32,4 +32,8 @@
     }
 }
 
+- (void)setCornerRadius:(CGFloat)cornerRadius {
+    self.layer.cornerRadius = cornerRadius;
+}
+
 @end

--- a/playground/src/screens/sharedElementTransition/CocktailDetailsScreen.tsx
+++ b/playground/src/screens/sharedElementTransition/CocktailDetailsScreen.tsx
@@ -111,5 +111,6 @@ const styles = StyleSheet.create({
     // transform: [{ rotate: '45deg' }],
     marginLeft: 24,
     marginBottom: -24,
+    borderRadius: 20,
   },
 });

--- a/scripts/test-snapshot.js
+++ b/scripts/test-snapshot.js
@@ -21,7 +21,7 @@ function runAndroidSnapshotTests() {
 function runIosSnapshotTests() {
   exec.execSync('npm run build');
   exec.execSync('npm run pod-install');
-  testTarget(RECORD ? 'SnapshotRecordTests' : 'SnapshotTests', 'iPhone 11', '13.3');
+  testTarget(RECORD ? 'SnapshotRecordTests' : 'SnapshotTests', 'iPhone 11', '13.7');
 }
 
 function testTarget(scheme, device, OS = 'latest') {


### PR DESCRIPTION
See https://github.com/wix/react-native-navigation/issues/6519

Creates a new `CornerRadiusTransition` which allows animating the `cornerRadius` property of a View's layer. The new Transition is added to the `DisplayLinkAnimation` array (in `createAnimations`) when the fromView's cornerRadius property is different than the toView's cornerRadius property.

## TODO

1. **Android support.** Sorry, I'm more of an iOS dev.
2. **Pop support.** I don't know why, but the cornerRadius animation only works on push. When going back in the Cocktail example app, the cornerRadius will not be visibly animated, even though the `CornerRadiusTransition::animateWithProgress` function is called.
3. [optional] **Masked Corner support.** Support cornerRadius only being animated on corners that actually change. Currently all 4 corners are being animated, which is not desirable in some rare occasions. I don't know if the Yoga engine uses the `UIView::layer.maskedCorners` property, but if yes, we just need to mirror that to our SharedElement view. I could look into that.