### PR TITLE
Fix props type in options function

### DIFF
--- a/lib/src/interfaces/NavigationFunctionComponent.ts
+++ b/lib/src/interfaces/NavigationFunctionComponent.ts
@@ -4,5 +4,5 @@ import { Options } from './Options';
 
 export interface NavigationFunctionComponent<Props = {}>
   extends React.FunctionComponent<Props & NavigationComponentProps> {
-  options?: ((props: Props) => Options) | Options;
+  options?: ((props: Props & NavigationComponentProps) => Options) | Options;
 }


### PR DESCRIPTION
* Adds `NavigationComponentProps` type (e.g. `componentId`) to options function (`(props) => Options`)