### PR TITLE
Fixes issue with border shown on iOS TopBar

### DIFF
--- a/lib/ios/TopBarAppearancePresenter.m
+++ b/lib/ios/TopBarAppearancePresenter.m
@@ -52,6 +52,7 @@
 - (void)showBorder:(BOOL)showBorder {
     UIColor* shadowColor = showBorder ? [[UINavigationBarAppearance new] shadowColor] : nil;
     self.getAppearance.shadowColor = shadowColor;
+    self.getScrollEdgeAppearance.shadowColor = shadowColor;
 }
 
 - (void)setBackIndicatorImage:(UIImage *)image withColor:(UIColor *)color {


### PR DESCRIPTION
Fixes issue with border shown on iOS TopBar in combination with `largeTitle {visible: true}`, even though `{noBorder:true}` is passed in the config