### PR TITLE
Fix searchBarHiddenWhenScrolling when presented on root screen

### DIFF
--- a/lib/ios/RNNComponentPresenter.m
+++ b/lib/ios/RNNComponentPresenter.m
@@ -57,10 +57,12 @@
     
     if ([withDefault.topBar.searchBar getWithDefaultValue:NO]) {
         BOOL hideNavBarOnFocusSearchBar = YES;
+        
+        [viewController setSearchBarWithPlaceholder:[withDefault.topBar.searchBarPlaceholder getWithDefaultValue:@""] hideNavBarOnFocusSearchBar:hideNavBarOnFocusSearchBar];
+        
         if (withDefault.topBar.hideNavBarOnFocusSearchBar.hasValue) {
             hideNavBarOnFocusSearchBar = withDefault.topBar.hideNavBarOnFocusSearchBar.get;
         }
-        [viewController setSearchBarWithPlaceholder:[withDefault.topBar.searchBarPlaceholder getWithDefaultValue:@""] hideNavBarOnFocusSearchBar:hideNavBarOnFocusSearchBar];
     }
     
     [_topBarTitlePresenter applyOptions:withDefault.topBar];


### PR DESCRIPTION
This one fixes #3429 

searchBarHiddenWhenScrolling was called before setting navigationItem.searchController. This PR fixes this issue. 