### PR TITLE
Add support for searchBarBackgroundColor and searchBarTintColor

### DIFF
--- a/lib/ios/RNNComponentPresenter.m
+++ b/lib/ios/RNNComponentPresenter.m
@@ -60,7 +60,7 @@
         if (withDefault.topBar.hideNavBarOnFocusSearchBar.hasValue) {
             hideNavBarOnFocusSearchBar = withDefault.topBar.hideNavBarOnFocusSearchBar.get;
         }
-        [viewController setSearchBarWithPlaceholder:[withDefault.topBar.searchBarPlaceholder getWithDefaultValue:@""] hideNavBarOnFocusSearchBar:hideNavBarOnFocusSearchBar];
+        [viewController setSearchBarWithPlaceholder:[withDefault.topBar.searchBarPlaceholder getWithDefaultValue:@""] hideNavBarOnFocusSearchBar:hideNavBarOnFocusSearchBar  backgroundColor:[options.topBar.searchBarBackgroundColor getWithDefaultValue:nil] tintColor:[options.topBar.searchBarTintColor getWithDefaultValue:nil]];
     }
     
     [_topBarTitlePresenter applyOptions:withDefault.topBar];
@@ -97,7 +97,7 @@
         if (options.topBar.hideNavBarOnFocusSearchBar.hasValue) {
             hideNavBarOnFocusSearchBar = options.topBar.hideNavBarOnFocusSearchBar.get;
         }
-        [viewController setSearchBarWithPlaceholder:[options.topBar.searchBarPlaceholder getWithDefaultValue:@""] hideNavBarOnFocusSearchBar:hideNavBarOnFocusSearchBar];
+        [viewController setSearchBarWithPlaceholder:[options.topBar.searchBarPlaceholder getWithDefaultValue:@""] hideNavBarOnFocusSearchBar:hideNavBarOnFocusSearchBar backgroundColor:[options.topBar.searchBarBackgroundColor getWithDefaultValue:nil] tintColor:[options.topBar.searchBarTintColor getWithDefaultValue:nil]];
     }
 
     if (options.topBar.drawBehind.hasValue) {

--- a/lib/ios/RNNTopBarOptions.h
+++ b/lib/ios/RNNTopBarOptions.h
@@ -27,6 +27,8 @@
 @property (nonatomic, strong) Text* testID;
 @property (nonatomic, strong) Text* barStyle;
 @property (nonatomic, strong) Text* searchBarPlaceholder;
+@property (nonatomic, strong) Color* searchBarBackgroundColor;
+@property (nonatomic, strong) Color* searchBarTintColor;
 @property (nonatomic, strong) RNNLargeTitleOptions* largeTitle;
 @property (nonatomic, strong) RNNTitleOptions* title;
 @property (nonatomic, strong) RNNSubtitleOptions* subtitle;

--- a/lib/ios/RNNTopBarOptions.m
+++ b/lib/ios/RNNTopBarOptions.m
@@ -29,6 +29,8 @@
 	self.testID = [TextParser parse:dict key:@"testID"];
 	self.barStyle = [TextParser parse:dict key:@"barStyle"];
 	self.searchBarPlaceholder = [TextParser parse:dict key:@"searchBarPlaceholder"];
+	self.searchBarBackgroundColor = [ColorParser parse:dict key:@"searchBarBackgroundColor"];
+	self.searchBarTintColor = [ColorParser parse:dict key:@"searchBarTintColor"];
 	self.largeTitle = [[RNNLargeTitleOptions alloc] initWithDict:dict[@"largeTitle"]];
 	self.title = [[RNNTitleOptions alloc] initWithDict:dict[@"title"]];
 	self.subtitle = [[RNNSubtitleOptions alloc] initWithDict:dict[@"subtitle"]];

--- a/lib/ios/UIViewController+RNNOptions.h
+++ b/lib/ios/UIViewController+RNNOptions.h
@@ -8,7 +8,7 @@
 
 - (void)setBackgroundImage:(UIImage *)backgroundImage;
 
-- (void)setSearchBarWithPlaceholder:(NSString *)placeholder hideNavBarOnFocusSearchBar:(BOOL)hideNavBarOnFocusSearchBar;
+- (void)setSearchBarWithPlaceholder:(NSString *)placeholder hideNavBarOnFocusSearchBar:(BOOL)hideNavBarOnFocusSearchBar backgroundColor:(nullable UIColor *)backgroundColor tintColor:(nullable UIColor *)tintColor;
 
 - (void)setSearchBarHiddenWhenScrolling:(BOOL)searchBarHidden;
 

--- a/lib/ios/UIViewController+RNNOptions.m
+++ b/lib/ios/UIViewController+RNNOptions.m
@@ -24,7 +24,9 @@ const NSInteger BLUR_STATUS_TAG = 78264801;
 }
 
 - (void)setSearchBarWithPlaceholder:(NSString *)placeholder
-		 hideNavBarOnFocusSearchBar:(BOOL)hideNavBarOnFocusSearchBar {
+		 hideNavBarOnFocusSearchBar:(BOOL)hideNavBarOnFocusSearchBar
+					backgroundColor:(nullable UIColor *)backgroundColor
+						  tintColor:(nullable UIColor *)tintColor {
 	if (@available(iOS 11.0, *)) {
 		if (!self.navigationItem.searchController) {
 			UISearchController *search = [[UISearchController alloc]initWithSearchResultsController:nil];
@@ -37,6 +39,12 @@ const NSInteger BLUR_STATUS_TAG = 78264801;
 				search.searchBar.placeholder = placeholder;
 			}
 			search.hidesNavigationBarDuringPresentation = hideNavBarOnFocusSearchBar;
+			search.searchBar.searchBarStyle = UISearchBarStyleProminent;
+			search.searchBar.tintColor = tintColor;
+			if (@available(iOS 13.0, *)) {
+				search.searchBar.searchTextField.backgroundColor = backgroundColor;
+			}
+
 			self.navigationItem.searchController = search;
 			[self.navigationItem setHidesSearchBarWhenScrolling:NO];
 

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -518,7 +518,7 @@ export interface OptionsTopBar {
    */
   searchBarPlaceholder?: string;
   /**
-   * The background color of the UISearchBar
+   * The background color of the UISearchBar's TextField
    * #### (iOS 13+ specific)
    */
   searchBarBackgroundColor?: string;

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -518,6 +518,16 @@ export interface OptionsTopBar {
    */
   searchBarPlaceholder?: string;
   /**
+   * The background color of the UISearchBar
+   * #### (iOS 13+ specific)
+   */
+  searchBarBackgroundColor?: string;
+  /**
+   * The tint color of the UISearchBar
+   * #### (iOS 11+ specific)
+   */
+  searchBarTintColor?: string;
+  /**
    * Controls Hiding NavBar on focus UISearchBar
    * #### (iOS 11+ specific)
    */

--- a/website/docs/api/options-stack.mdx
+++ b/website/docs/api/options-stack.mdx
@@ -190,3 +190,19 @@ The placeholder value in the UISearchBar.
 | Type   | Required | Platform |
 | ------ | -------- | -------- |
 | string | No       | iOS 11+  |
+
+### `searchBarBackgroundColor`
+
+The background color of the UISearchBar's TextField.
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| Color  | No       | iOS 13+  |
+
+### `searchBarTintColor`
+
+The tint color of the UISearchBar. Affects text selection color, as well as "Cancel" button color.
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| Color  | No       | iOS 13+  |


### PR DESCRIPTION
## Changes

* Sets [`UISearchBar::searchTextField::backgroundColor`](https://developer.apple.com/documentation/uikit/uisearchbar/3175433-searchtextfield?language=objc) to the value supplied in the `Options.searchBarBackgroundColor` (only available on > iOS 13)
* Sets [`UISearchBar::tintColor`](https://developer.apple.com/documentation/uikit/uisearchbar/1624286-tintcolor?language=objc) to the value supplied in the `Options.searchBarTintColor` (only available on > iOS 11)
* As a side-effect, sets [`UISearchBar::searchBarStyle`](https://developer.apple.com/documentation/uikit/uisearchbar/1624281-searchbarstyle?language=objc) to [`UISearchBarStyleProminent`](https://developer.apple.com/documentation/uikit/uisearchbarstyle/uisearchbarstyleprominent?language=objc)
* Adds `searchBarBackgroundColor` and `searchBarTintColor` to the `Options` interface


## That's how it looks

### Before

![image](https://user-images.githubusercontent.com/15199031/92713359-2f569b80-f35b-11ea-9961-6c8dc941f222.png)

### After

![search bar demo](https://user-images.githubusercontent.com/15199031/92713248-0c2bec00-f35b-11ea-9a4e-3995a171c0e8.png)