### PR TITLE
[ios] Allow sync loading of sf symbols

### DIFF
--- a/lib/ios/ImageParser.m
+++ b/lib/ios/ImageParser.m
@@ -5,7 +5,25 @@
 @implementation ImageParser
 
 + (Image *)parse:(NSDictionary *)json key:(NSString *)key {
-	return json[key] ? [[Image alloc] initWithValue:[RCTConvert UIImage:json[key]]] : [NullImage new];
+    id data = json[key];
+    if (!data) {
+        return [NullImage new];
+    }
+
+    UIImage *image;
+
+    if ([data isKindOfClass:[NSDictionary class]] && [data[@"system"] isKindOfClass:[NSString class]]) {
+        if (@available(iOS 13.0, *)) {
+            image = [UIImage systemImageNamed:data[@"system"]];
+        }
+        if (!image) {
+            image = [RCTConvert UIImage:data[@"fallback"]];
+        }
+    } else {
+        image = [RCTConvert UIImage:data];
+    }
+
+    return [[Image alloc] initWithValue:image];
 }
 
 @end

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -276,7 +276,7 @@ export interface OptionsTopBarBackButton {
   /**
    * Image to show as the back button
    */
-  icon?: ImageRequireSource;
+  icon?: ImageResource;
   /**
    * Weither the back button is visible or not
    * @default true
@@ -354,7 +354,7 @@ export interface OptionsTopBarButton {
   /**
    * Set the button icon
    */
-  icon?: ImageRequireSource;
+  icon?: ImageResource;
   /**
    * Set the button icon insets
    */
@@ -605,7 +605,7 @@ export interface OptionsFab {
   clickColor?: Color;
   rippleColor?: Color;
   visible?: boolean;
-  icon?: ImageRequireSource;
+  icon?: ImageResource;
   iconColor?: Color;
   alignHorizontally?: 'left' | 'right';
   hideOnScroll?: boolean;
@@ -696,7 +696,12 @@ export interface DotIndicatorOptions {
   visible?: boolean;
 }
 
-export type ImageResource = string;
+export interface ImageSystemSource {
+  system: string;
+  fallback?: ImageRequireSource | string;
+}
+
+export type ImageResource = ImageRequireSource | string | ImageSystemSource;
 
 export interface OptionsBottomTab {
   dotIndicator?: DotIndicatorOptions;
@@ -725,7 +730,7 @@ export interface OptionsBottomTab {
   /**
    * Set the tab icon
    */
-  icon?: ImageRequireSource | ImageResource;
+  icon?: ImageResource;
   /**
    * Set the icon tint
    */
@@ -764,7 +769,7 @@ export interface OptionsBottomTab {
    * Set selected icon image
    * #### (iOS specific)
    */
-  selectedIcon?: ImageRequireSource;
+  selectedIcon?: ImageResource;
   /**
    * Set true if you want to disable the icon tinting
    * #### (iOS specific)
@@ -1171,12 +1176,12 @@ setRoot: {
    * Background image for the screen
    * #### (iOS specific)
    */
-  backgroundImage?: ImageRequireSource;
+  backgroundImage?: ImageResource;
   /**
    * Background image for the Navigation View
    * #### (iOS specific)
    */
-  rootBackgroundImage?: ImageRequireSource;
+  rootBackgroundImage?: ImageResource;
   /**
    * Enable or disable automatically blurring focused input, dismissing keyboard on unmount
    * #### (Android specific)


### PR DESCRIPTION
Note: This PR needs https://github.com/wix/react-native-navigation/pull/6575 merged in order to work on all icons in RNN.

Apple introduced SF Symbols with iOS 13: https://developer.apple.com/design/human-interface-guidelines/sf-symbols/overview/

> SF Symbols provides a set of over 2,400 consistent, highly configurable symbols you can use in your app.

This PR enables using those throughout all images that can be specified with RNN.

Instead of 
```ts
{
  icon: require("my-custom-camera-icon.png")
}
```
it is now possible to use
```ts
{
  icon: {
    system: "camera.fill",
    fallback: require("my-custom-camera-icon.png")
  }
}
```
which will result in the SF Symbol `camera.fill` to be used on iOS >= 13. The fallback for everything else.

In theorie this would be better suited in `RCTConvert` upstream. However, there are a few key points that we should consider:
* `[RCTConvert UIImage:]` for sync loading is deprecated anyway and could disappear. In that case we would have to implement a custom sync loading logic anyway.
* Since it is deprecated, chances for an upstream change are very slim.
* Even if it would be considered, it would still take a long time to get merged.

