### PR TITLE
Remove old iOS < 11 code

### DIFF
--- a/ReactNativeNavigation.podspec
+++ b/ReactNativeNavigation.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.authors      = "Wix.com"
   s.homepage     = package['homepage']
   s.license      = package['license']
-  s.platform     = :ios, "9.0"
+  s.platform     = :ios, "11.0"
 
   s.module_name  = 'ReactNativeNavigation'
   s.default_subspec = 'Core'

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -59,22 +59,20 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 - (void)setRoot:(NSDictionary*)layout commandId:(NSString*)commandId completion:(RNNTransitionWithComponentIdCompletionBlock)completion {
 	[self assertReady];
     RNNAssertMainQueue();
-	
-	if (@available(iOS 9, *)) {
-		if(_controllerFactory.defaultOptions.layout.direction.hasValue) {
-			if ([_controllerFactory.defaultOptions.layout.direction.get isEqualToString:@"rtl"]) {
-				[[RCTI18nUtil sharedInstance] allowRTL:YES];
-				[[RCTI18nUtil sharedInstance] forceRTL:YES];
-				[[UIView appearance] setSemanticContentAttribute:UISemanticContentAttributeForceRightToLeft];
-				[[UINavigationBar appearance] setSemanticContentAttribute:UISemanticContentAttributeForceRightToLeft];
-			} else {
-				[[RCTI18nUtil sharedInstance] allowRTL:NO];
-				[[RCTI18nUtil sharedInstance] forceRTL:NO];
-				[[UIView appearance] setSemanticContentAttribute:UISemanticContentAttributeForceLeftToRight];
-				[[UINavigationBar appearance] setSemanticContentAttribute:UISemanticContentAttributeForceLeftToRight];
-			}
-		}
-	}
+
+    if(_controllerFactory.defaultOptions.layout.direction.hasValue) {
+        if ([_controllerFactory.defaultOptions.layout.direction.get isEqualToString:@"rtl"]) {
+            [[RCTI18nUtil sharedInstance] allowRTL:YES];
+            [[RCTI18nUtil sharedInstance] forceRTL:YES];
+            [[UIView appearance] setSemanticContentAttribute:UISemanticContentAttributeForceRightToLeft];
+            [[UINavigationBar appearance] setSemanticContentAttribute:UISemanticContentAttributeForceRightToLeft];
+        } else {
+            [[RCTI18nUtil sharedInstance] allowRTL:NO];
+            [[RCTI18nUtil sharedInstance] forceRTL:NO];
+            [[UIView appearance] setSemanticContentAttribute:UISemanticContentAttributeForceLeftToRight];
+            [[UINavigationBar appearance] setSemanticContentAttribute:UISemanticContentAttributeForceLeftToRight];
+        }
+    }
 	
 	[_modalManager dismissAllModalsAnimated:NO completion:nil];
     

--- a/lib/ios/RNNStackController.m
+++ b/lib/ios/RNNStackController.m
@@ -12,9 +12,7 @@
     self = [super initWithLayoutInfo:layoutInfo creator:creator options:options defaultOptions:defaultOptions presenter:presenter eventEmitter:eventEmitter childViewControllers:childViewControllers];
     _stackDelegate = [[StackControllerDelegate alloc] initWithEventEmitter:self.eventEmitter];
     self.delegate = _stackDelegate;
-    if (@available(iOS 11.0, *)) {
-        self.navigationBar.prefersLargeTitles = YES;
-    }
+    self.navigationBar.prefersLargeTitles = YES;
     return self;
 }
 

--- a/lib/ios/RNNSwizzles.m
+++ b/lib/ios/RNNSwizzles.m
@@ -19,12 +19,7 @@ static void __RNN_setFrame_orig(UIScrollView* self, SEL _cmd, CGRect frame)
 	
 	__SWZ_setFrame_orig(self, _cmd, frame);
 	
-	UIEdgeInsets contentInset;
-	if (@available(iOS 11.0, *)) {
-		contentInset = self.adjustedContentInset;
-	} else {
-		contentInset = self.contentInset;
-	}
+	UIEdgeInsets contentInset = self.adjustedContentInset;
 	
 	CGSize contentSize = self.contentSize;
 	
@@ -44,14 +39,11 @@ static void __RNN_setFrame_orig(UIScrollView* self, SEL _cmd, CGRect frame)
 
 @implementation RNNSwizzles
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_10_3
 - (id)__swz_initWithEventDispatcher:(id)eventDispatcher
 {
 	id returnValue = __SWZ_initWithEventDispatcher_orig(self, _cmd, eventDispatcher);
 	
-	if (@available(iOS 11.0, *)) {
-		[(UIScrollView*)[returnValue valueForKey:@"scrollView"] setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentScrollableAxes];
-	}
+    [(UIScrollView*)[returnValue valueForKey:@"scrollView"] setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentScrollableAxes];
 	
 	return returnValue;
 }
@@ -74,135 +66,15 @@ static void __RNN_setFrame_orig(UIScrollView* self, SEL _cmd, CGRect frame)
 	Method m2 = class_getInstanceMethod([RNNSwizzles class], NSSelectorFromString(@"__swz_initWithEventDispatcher:"));
 	method_exchangeImplementations(m1, m2);
 	
-	if (@available(iOS 11.0, *)) {
-		cls = NSClassFromString(@"RCTCustomScrollView");
-		if(cls == NULL)
-		{
-			return;
-		}
-			
-		m1 = class_getInstanceMethod(cls, @selector(setFrame:));
-		__SWZ_setFrame_orig = (void*)method_getImplementation(m1);
-		method_setImplementation(m1, (IMP)__RNN_setFrame_orig);
-	}
-}
-#endif
+    cls = NSClassFromString(@"RCTCustomScrollView");
+    if(cls == NULL)
+    {
+        return;
+    }
 
-@end
-
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
-
-@interface UIView (OS10SafeAreaSupport) @end
-
-@implementation UIView (OS10SafeAreaSupport)
-
-- (UIEdgeInsets)_ln_safeAreaInsets
-{
-	static NSString* const b64 = @"X3ZpZXdDb250cm9sbGVyRm9yQW5jZXN0b3I=";
-	UIViewController* vc = [self valueForKey:[[NSString alloc] initWithData:[[NSData alloc] initWithBase64EncodedString:b64 options:0] encoding:NSUTF8StringEncoding]];
-	if(vc == nil)
-	{
-		return UIEdgeInsetsZero;
-	}
-	
-	CGRect myFrameInVCView = [vc.view convertRect:self.bounds fromView:self];
-	
-	UIEdgeInsets rv = UIEdgeInsetsZero;
-	rv.top = CGRectIntersection(myFrameInVCView, CGRectMake(0, 0, vc.view.bounds.size.width, vc.topLayoutGuide.length)).size.height;
-	rv.bottom = CGRectIntersection(myFrameInVCView, CGRectMake(0, vc.view.bounds.size.height - vc.bottomLayoutGuide.length, vc.view.bounds.size.width, vc.bottomLayoutGuide.length)).size.height;
-	
-	return rv;
-}
-
-- (void)_ln_triggerSafeAreaInsetsDidChange
-{
-	if([self respondsToSelector:@selector(safeAreaInsetsDidChange)])
-	{
-		[self performSelector:@selector(safeAreaInsetsDidChange)];
-	}
-}
-
-- (void)_ln_layoutSubviews
-{
-	[self _ln_triggerSafeAreaInsetsDidChange];
-	
-	struct objc_super super = {.receiver = self, .super_class = class_getSuperclass(object_getClass(self))};
-	void (*super_class)(struct objc_super*, SEL) = (void*)objc_msgSendSuper;
-	super_class(&super, _cmd);
-}
-
-- (void)_ln_setFrame:(CGRect)frame
-{
-	[self _ln_triggerSafeAreaInsetsDidChange];
-	
-	struct objc_super super = {.receiver = self, .super_class = class_getSuperclass(object_getClass(self))};
-	void (*super_class)(struct objc_super*, SEL, CGRect) = (void*)objc_msgSendSuper;
-	super_class(&super, _cmd, frame);
-}
-
-- (void)_ln_setCenter:(CGPoint)center
-{
-	[self _ln_triggerSafeAreaInsetsDidChange];
-	
-	struct objc_super super = {.receiver = self, .super_class = class_getSuperclass(object_getClass(self))};
-	void (*super_class)(struct objc_super*, SEL, CGPoint) = (void*)objc_msgSendSuper;
-	super_class(&super, _cmd, center);
-}
-
-- (void)_ln_setBounds:(CGRect)bounds
-{
-	[self _ln_triggerSafeAreaInsetsDidChange];
-	
-	struct objc_super super = {.receiver = self, .super_class = class_getSuperclass(object_getClass(self))};
-	void (*super_class)(struct objc_super*, SEL, CGRect) = (void*)objc_msgSendSuper;
-	super_class(&super, _cmd, bounds);
-}
-
-+ (void)load
-{
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		if(NSProcessInfo.processInfo.operatingSystemVersion.majorVersion < 11)
-		{
-			Class cls = NSClassFromString(@"RCTSafeAreaView");
-			if(cls == NULL)
-			{
-				return;
-			}
-			
-			Method m = class_getInstanceMethod([UIView class], @selector(_ln_safeAreaInsets));
-			if(NO == class_addMethod(cls, @selector(safeAreaInsets), method_getImplementation(m), method_getTypeEncoding(m)))
-			{
-				return;
-			}
-			
-			m = class_getInstanceMethod([UIView class], @selector(_ln_layoutSubviews));
-			if(NO == class_addMethod(cls, @selector(layoutSubviews), method_getImplementation(m), method_getTypeEncoding(m)))
-			{
-				return;
-			}
-			
-			m = class_getInstanceMethod([UIView class], @selector(_ln_setFrame:));
-			if(NO == class_addMethod(cls, @selector(setFrame:), method_getImplementation(m), method_getTypeEncoding(m)))
-			{
-				return;
-			}
-			
-			m = class_getInstanceMethod([UIView class], @selector(_ln_setCenter:));
-			if(NO == class_addMethod(cls, @selector(setCenter:), method_getImplementation(m), method_getTypeEncoding(m)))
-			{
-				return;
-			}
-			
-			m = class_getInstanceMethod([UIView class], @selector(_ln_setBounds:));
-			if(NO == class_addMethod(cls, @selector(setBounds:), method_getImplementation(m), method_getTypeEncoding(m)))
-			{
-				return;
-			}
-		}
-	});
+    m1 = class_getInstanceMethod(cls, @selector(setFrame:));
+    __SWZ_setFrame_orig = (void*)method_getImplementation(m1);
+    method_setImplementation(m1, (IMP)__RNN_setFrame_orig);
 }
 
 @end
-
-#endif

--- a/lib/ios/TopBarPresenter.m
+++ b/lib/ios/TopBarPresenter.m
@@ -109,9 +109,7 @@
     NSNumber* fontSize = [largeTitleOptions.fontSize getWithDefaultValue:nil];
     UIColor* fontColor = [largeTitleOptions.color getWithDefaultValue:nil];
     
-    if (@available(iOS 11.0, *)) {
-        self.navigationController.navigationBar.largeTitleTextAttributes = [RNNFontAttributesCreator createFromDictionary:self.navigationController.navigationBar.largeTitleTextAttributes fontFamily:fontFamily fontSize:fontSize defaultFontSize:nil fontWeight:fontWeight color:fontColor defaultColor:nil];
-    }
+    self.navigationController.navigationBar.largeTitleTextAttributes = [RNNFontAttributesCreator createFromDictionary:self.navigationController.navigationBar.largeTitleTextAttributes fontFamily:fontFamily fontSize:fontSize defaultFontSize:nil fontWeight:fontWeight color:fontColor defaultColor:nil];
 }
 
 - (void)componentDidAppear {

--- a/lib/ios/UISplitViewController+RNNOptions.m
+++ b/lib/ios/UISplitViewController+RNNOptions.m
@@ -16,13 +16,11 @@
 }
 
 - (void)rnn_setPrimaryEdge:(NSString *)primaryEdge {
-	if (@available(iOS 11.0, *)) {
-		if ([primaryEdge isEqualToString:@"trailing"]) {
-			self.primaryEdge = UISplitViewControllerPrimaryEdgeTrailing;
-		} else {
-			self.primaryEdge = UISplitViewControllerPrimaryEdgeLeading;
-		}
-	}
+    if ([primaryEdge isEqualToString:@"trailing"]) {
+        self.primaryEdge = UISplitViewControllerPrimaryEdgeTrailing;
+    } else {
+        self.primaryEdge = UISplitViewControllerPrimaryEdgeLeading;
+    }
 }
 
 - (void)rnn_setMinWidth:(Number *)minWidth {

--- a/lib/ios/UIViewController+RNNOptions.m
+++ b/lib/ios/UIViewController+RNNOptions.m
@@ -28,37 +28,33 @@ const NSInteger BLUR_STATUS_TAG = 78264801;
        searchBarHiddenWhenScrolling:(BOOL)searchBarHiddenWhenScrolling
                     backgroundColor:(nullable UIColor *)backgroundColor
                           tintColor:(nullable UIColor *)tintColor {
-	if (@available(iOS 11.0, *)) {
-		if (!self.navigationItem.searchController) {
-			UISearchController *search = [[UISearchController alloc]initWithSearchResultsController:nil];
-			search.dimsBackgroundDuringPresentation = NO;
-			if ([self conformsToProtocol:@protocol(UISearchResultsUpdating)]) {
-				[search setSearchResultsUpdater:((UIViewController <UISearchResultsUpdating> *) self)];
-			}
-			search.searchBar.delegate = (id<UISearchBarDelegate>)self;
-			if (placeholder) {
-				search.searchBar.placeholder = placeholder;
-			}
-			search.hidesNavigationBarDuringPresentation = hideNavBarOnFocusSearchBar;
-			search.searchBar.searchBarStyle = UISearchBarStyleProminent;
-			search.searchBar.tintColor = tintColor;
-			if (@available(iOS 13.0, *)) {
-				search.searchBar.searchTextField.backgroundColor = backgroundColor;
-			}
+    if (!self.navigationItem.searchController) {
+        UISearchController *search = [[UISearchController alloc]initWithSearchResultsController:nil];
+        search.dimsBackgroundDuringPresentation = NO;
+        if ([self conformsToProtocol:@protocol(UISearchResultsUpdating)]) {
+            [search setSearchResultsUpdater:((UIViewController <UISearchResultsUpdating> *) self)];
+        }
+        search.searchBar.delegate = (id<UISearchBarDelegate>)self;
+        if (placeholder) {
+            search.searchBar.placeholder = placeholder;
+        }
+        search.hidesNavigationBarDuringPresentation = hideNavBarOnFocusSearchBar;
+        search.searchBar.searchBarStyle = UISearchBarStyleProminent;
+        search.searchBar.tintColor = tintColor;
+        if (@available(iOS 13.0, *)) {
+            search.searchBar.searchTextField.backgroundColor = backgroundColor;
+        }
 
-			self.navigationItem.searchController = search;
-			[self.navigationItem setHidesSearchBarWhenScrolling:searchBarHiddenWhenScrolling];
+        self.navigationItem.searchController = search;
+        [self.navigationItem setHidesSearchBarWhenScrolling:searchBarHiddenWhenScrolling];
 
-			// Fixes #3450, otherwise, UIKit will infer the presentation context to be the root most view controller
-			self.definesPresentationContext = YES;
-		}
-	}
+        // Fixes #3450, otherwise, UIKit will infer the presentation context to be the root most view controller
+        self.definesPresentationContext = YES;
+    }
 }
 
 - (void)setSearchBarHiddenWhenScrolling:(BOOL)searchBarHidden {
-	if (@available(iOS 11.0, *)) {
-		self.navigationItem.hidesSearchBarWhenScrolling = searchBarHidden;
-	}
+        self.navigationItem.hidesSearchBarWhenScrolling = searchBarHidden;
 }
 
 - (void)setNavigationItemTitle:(NSString *)title {
@@ -81,7 +77,7 @@ const NSInteger BLUR_STATUS_TAG = 78264801;
 	if (@available(iOS 13.0, *)) {
         self.tabBarItem.standardAppearance.stackedLayoutAppearance.normal.badgeBackgroundColor = badgeColor;
     }
-    else if (@available(iOS 10.0, *)) {
+    else {
         self.tabBarItem.badgeColor = badgeColor;
     }
 }
@@ -97,13 +93,11 @@ const NSInteger BLUR_STATUS_TAG = 78264801;
 }
 
 - (void)setTopBarPrefersLargeTitle:(BOOL)prefersLargeTitle {
-	if (@available(iOS 11.0, *)) {
-		if (prefersLargeTitle) {
-			self.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeAlways;
-		} else {
-			self.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-		}
-	}
+    if (prefersLargeTitle) {
+        self.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeAlways;
+    } else {
+        self.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+    }
 }
 
 

--- a/playground/ios/Podfile
+++ b/playground/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../../node_modules/react-native/scripts/react_native_pods'
 require_relative '../../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '10.0'
+platform :ios, '11.0'
 
 def all_pods  
   config = use_native_modules!


### PR DESCRIPTION
RNN supports iOS 11 and upwards. There is no need to keep legacy available statements around.