### PR TITLE
Pass componentId on showModal completion callback

### DIFF
--- a/lib/ios/RNNModalManager.m
+++ b/lib/ios/RNNModalManager.m
@@ -53,7 +53,7 @@
 	
 	[topVC presentViewController:viewController animated:animated completion:^{
 		if (completion) {
-			completion(nil);
+            completion(viewController.layoutInfo.componentId);
 		}
 		
         [self->_presentedModals addObject:[viewController topMostViewController]];


### PR DESCRIPTION
The typedef of `RNNTransitionWithComponentIdCompletionBlock`:
```objc
typedef void (^RNNTransitionWithComponentIdCompletionBlock)(NSString * _Nonnull componentId);
```
requires the completion handler to be called with a non-null string.