### PR TITLE
'spring' -> 'overshoot'

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/params/Interpolation.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/params/Interpolation.java
@@ -12,7 +12,7 @@ public enum Interpolation {
     ACCELERATE,
     DECELERATE,
     ACCELERATE_DECELERATE,
-    SPRING,
+    OVERSHOOT,
     DEFAULT,
     NO_VALUE;
 
@@ -24,8 +24,8 @@ public enum Interpolation {
                 return new DecelerateInterpolator();
             case ACCELERATE_DECELERATE:
                 return new AccelerateDecelerateInterpolator();
-            case SPRING:
-                // TODO: Expose tension property to JS-API and make uniform with iOS implementation (has springiness and mass properties)
+            case OVERSHOOT:
+                // TODO: Expose tension property to JS-API
                 return new OvershootInterpolator(1f);
             case DEFAULT:
                 return new LinearInterpolator();

--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/parsers/InterpolationParser.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/parsers/InterpolationParser.java
@@ -14,8 +14,8 @@ public class InterpolationParser {
                 return Interpolation.ACCELERATE_DECELERATE;
             case "accelerate":
                 return Interpolation.ACCELERATE;
-            case "spring":
-                return Interpolation.SPRING;
+            case "overshoot":
+                return Interpolation.OVERSHOOT;
             default:
                 return Interpolation.DEFAULT;
         }

--- a/lib/ios/RCTConvert+Interpolation.h
+++ b/lib/ios/RCTConvert+Interpolation.h
@@ -5,7 +5,7 @@ typedef NS_ENUM(NSInteger, RNNInterpolationOptions) {
     RNNInterpolationAccelerateDecelerate,
     RNNInterpolationDecelerate,
     RNNInterpolationAccelerate,
-    RNNInterpolationSpring
+    RNNInterpolationOvershoot
 };
 
 @interface RCTConvert (Interpolation)

--- a/lib/ios/RCTConvert+Interpolation.m
+++ b/lib/ios/RCTConvert+Interpolation.m
@@ -7,7 +7,7 @@ RCT_ENUM_CONVERTER(RNNInterpolationOptions, (@{
   @"accelerateDecelerate": @(RNNInterpolationAccelerateDecelerate),
   @"decelerate": @(RNNInterpolationDecelerate),
   @"accelerate": @(RNNInterpolationAccelerate),
-  @"spring": @(RNNInterpolationSpring),
+  @"overshoot": @(RNNInterpolationOvershoot),
 }), RNNInterpolationLinear, integerValue)
 
 @end

--- a/lib/ios/RNNInterpolator.m
+++ b/lib/ios/RNNInterpolator.m
@@ -28,9 +28,9 @@ static CGFloat RNNApplyInterpolation(CGFloat p, RNNInterpolationOptions interpol
             return RNNLinear(p);
         case RNNInterpolationDecelerate:
             return RNNDecelerate(p);
-        case RNNInterpolationSpring:
-			// TODO: Expose springiness and mass properties to JS-API and make uniform with Android implementation (only has tension property)
-            return RNNSpring(p, 0.3, 3);
+        case RNNInterpolationOvershoot:
+			// TODO: Expose tension property
+            return RNNOvershoot(p, 1);
     }
 }
 
@@ -38,7 +38,7 @@ static CGFloat RNNInterpolate(CGFloat from, CGFloat to, CGFloat p, RNNInterpolat
     return from + RNNApplyInterpolation(p, interpolation) * (to - from);
 }
 
-static CGFloat RNNSpring(CGFloat p, CGFloat springiness, CGFloat mass) {
+static CGFloat RNNOvershoot(CGFloat p, CGFloat tension) {
 	// _o(t) = t * t * ((tension + 1) * t + tension)
 	// o(t) = _o(t - 1) + 1
 	CGFloat t = p - 1;

--- a/lib/ios/RNNInterpolator.m
+++ b/lib/ios/RNNInterpolator.m
@@ -39,8 +39,6 @@ static CGFloat RNNInterpolate(CGFloat from, CGFloat to, CGFloat p, RNNInterpolat
 }
 
 static CGFloat RNNOvershoot(CGFloat p, CGFloat tension) {
-	// _o(t) = t * t * ((tension + 1) * t + tension)
-	// o(t) = _o(t - 1) + 1
 	CGFloat t = p - 1;
 	CGFloat _ot = t * t * ((tension + 1) * t + tension) + 1.0f;
 	return _ot;

--- a/lib/ios/RNNInterpolator.m
+++ b/lib/ios/RNNInterpolator.m
@@ -39,26 +39,11 @@ static CGFloat RNNInterpolate(CGFloat from, CGFloat to, CGFloat p, RNNInterpolat
 }
 
 static CGFloat RNNSpring(CGFloat p, CGFloat springiness, CGFloat mass) {
-	// TODO: Cache those allocations
-	CGFloat T0 = 1;
-	CGFloat v0 = 0;
-	CGFloat s0 = 1;
-
-	CGFloat stiffness = mass * pow((2 * M_PI) / (T0), 2);
-	CGFloat damping = 2 * (1 - springiness) * sqrt(stiffness * mass);
-
-	CGFloat lambda = damping / (2 * mass);
-	CGFloat w0 = sqrt(stiffness / mass);
-
-	CGFloat wd = sqrt(fabs(pow(w0, 2) - pow(lambda, 2)));
-
-	if (lambda < w0) {
-		return fabs(1 - exp(-lambda * p) * (s0 * cos(wd * p) + ((v0 + s0 * lambda)/wd) * sin(wd * p)));
-	} else if (lambda > w0) {
-		return fabs(1 - exp(-lambda * p) * (((v0+s0 * (lambda + wd))/(2 * wd)) * exp(wd * p) + (s0 - (v0 + s0 * (lambda + wd)) / (2 * wd)) * exp(-wd * p)));
-	} else {
-		return fabs(1 - exp(-lambda * p) * (s0 + (v0 + lambda * s0) * p));
-	}
+	// _o(t) = t * t * ((tension + 1) * t + tension)
+	// o(t) = _o(t - 1) + 1
+	CGFloat t = p - 1;
+	CGFloat _ot = t * t * ((tension + 1) * t + tension) + 1.0f;
+	return _ot;
 }
 
 static CGFloat RNNLinear(CGFloat p) {

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -917,7 +917,7 @@ export interface OptionsAnimationPropertyConfig {
   /**
    * Animation interplation
    */
-  interpolation?: 'accelerate' | 'decelerate' | 'overshoot';
+  interpolation?: Interpolation;
 }
 
 /**

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -51,7 +51,7 @@ type Interpolation =
   | 'decelerate'
   | 'accelerate'
   | 'decelerateAccelerate'
-  | 'spring';
+  | 'overshoot';
 
 export interface OptionsSplitView {
   /**
@@ -917,7 +917,7 @@ export interface OptionsAnimationPropertyConfig {
   /**
    * Animation interplation
    */
-  interpolation?: 'accelerate' | 'decelerate' | 'spring';
+  interpolation?: 'accelerate' | 'decelerate' | 'overshoot';
 }
 
 /**

--- a/playground/src/screens/sharedElementTransition/CocktailsListScreen.tsx
+++ b/playground/src/screens/sharedElementTransition/CocktailsListScreen.tsx
@@ -58,16 +58,19 @@ export default class CocktailsListScreen extends NavigationComponent {
                   fromId: `image${item.id}`,
                   toId: `image${item.id}Dest`,
                   duration: LONG_DURATION,
+                  interpolation: 'overshoot',
                 },
                 {
                   fromId: `title${item.id}`,
                   toId: `title${item.id}Dest`,
                   duration: LONG_DURATION,
+                  interpolation: 'overshoot',
                 },
                 {
                   fromId: `backdrop${item.id}`,
                   toId: 'backdrop',
                   duration: LONG_DURATION,
+                  interpolation: 'overshoot',
                 },
               ],
               elementTransitions: [
@@ -97,16 +100,19 @@ export default class CocktailsListScreen extends NavigationComponent {
                   fromId: `image${item.id}Dest`,
                   toId: `image${item.id}`,
                   duration: LONG_DURATION * POP_MULTIPLIER,
+                  interpolation: 'overshoot',
                 },
                 {
                   fromId: `title${item.id}Dest`,
                   toId: `title${item.id}`,
                   duration: LONG_DURATION * POP_MULTIPLIER,
+                  interpolation: 'overshoot',
                 },
                 {
                   fromId: 'backdrop',
                   toId: `backdrop${item.id}`,
                   duration: LONG_DURATION * POP_MULTIPLIER,
+                  interpolation: 'overshoot',
                 },
               ],
               elementTransitions: [

--- a/website/docs/docs/style-animations.mdx
+++ b/website/docs/docs/style-animations.mdx
@@ -214,6 +214,7 @@ Navigation.push(this.props.componentId, {
             {
               fromId: `image${item.id}`,
               toId: `image${item.id}Dest`,
+              interpolation: 'linear'
             },
           ],
         },
@@ -222,6 +223,15 @@ Navigation.push(this.props.componentId, {
   },
 });
 ```
+
+The `interpolation` property accepts the following modes:
+
+* `linear`: Linearly translate from source to destination without any easing curve.
+* `accelerateDecelerate`: Begin building up speed until half of the animation is complete, then begin slowing down to settle.
+* `decelerate`: Start at a high speed and slow down to settle.
+* `accelerate`: Begin building up speed until destination has been reached.
+* `decelerateAccelerate`: Start at a high speed and slow down until half of the animation is complete, then speed up again to settle.
+* `overshoot`: Begin building up speed and overshoot the destination, then fling back to settle.
 
 ## Element Transitions
 


### PR DESCRIPTION
This PR renames the `'spring'` interpolation mode to `'overshoot'`. 

On Android, an [`OvershootInterpolator`](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/view/animation/OvershootInterpolator.java) was used, so it made no sense to call it `'spring'`. On iOS, I changed the Spring implementation to be the exact same of the android's [`OvershootInterpolator::getInterpolation`](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/view/animation/OvershootInterpolator.java#73) so we have the same look and feel on both platforms. 

This means, using the `tension` property we can configure both animations. Now we only need to expose that to the JS API somehow.

If requested, I can add the spring implementation (which uses `mass`, `springiness`, `damping`, ... properties) again under the name `'spring'`, and try to find a way to implement that for Android.

Oh and also, I've added docs for the interpolation modes.