### PR TITLE
Rename `'spring'` to `'overshoot'` in playground demo

### DIFF
--- a/playground/src/screens/sharedElementTransitionAlt/Constants.ts
+++ b/playground/src/screens/sharedElementTransitionAlt/Constants.ts
@@ -18,13 +18,13 @@ export async function buildSharedElementAnimations(post: PostItem): Promise<Anim
           fromId: `image${post.id}`,
           toId: `image${post.id}Dest`,
           duration: SET_DURATION,
-          interpolation: 'spring',
+          interpolation: 'overshoot',
         },
         {
           fromId: `title${post.id}`,
           toId: `title${post.id}Dest`,
           duration: SET_DURATION,
-          interpolation: 'spring',
+          interpolation: 'overshoot',
         },
       ],
       bottomTabs: {
@@ -55,7 +55,7 @@ export async function buildSharedElementAnimations(post: PostItem): Promise<Anim
           fromId: `image${post.id}Dest`,
           toId: `image${post.id}`,
           duration: SET_DURATION,
-          interpolation: 'spring',
+          interpolation: 'overshoot',
         },
       ],
       bottomTabs: {


### PR DESCRIPTION
Small fix for the playground only (bug introduced in https://github.com/wix/react-native-navigation/commit/1d8e3b784ecedc7153fb0b0d900e42ab4a8b8f16)