### PR TITLE
Damped harmonic spring interpolation

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/params/Interpolation.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/params/Interpolation.java
@@ -8,11 +8,14 @@ import android.view.animation.AccelerateInterpolator;
 import android.view.animation.DecelerateInterpolator;
 import android.view.animation.LinearInterpolator;
 
+import com.reactnativenavigation.utils.SpringInterpolator;
+
 public enum Interpolation {
     ACCELERATE,
     DECELERATE,
     ACCELERATE_DECELERATE,
     OVERSHOOT,
+    SPRING,
     DEFAULT,
     NO_VALUE;
 
@@ -27,6 +30,9 @@ public enum Interpolation {
             case OVERSHOOT:
                 // TODO: Expose tension property to JS-API
                 return new OvershootInterpolator(1f);
+            case SPRING:
+                // TODO: Expose mass, damping and stiffness property to JS-API
+                return new SpringInterpolator(3, 500, 1000);
             case DEFAULT:
                 return new LinearInterpolator();
         }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/parsers/InterpolationParser.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/parsers/InterpolationParser.java
@@ -16,6 +16,8 @@ public class InterpolationParser {
                 return Interpolation.ACCELERATE;
             case "overshoot":
                 return Interpolation.OVERSHOOT;
+            case "spring":
+                return Interpolation.SPRING;
             default:
                 return Interpolation.DEFAULT;
         }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/SpringInterpolator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/SpringInterpolator.kt
@@ -3,13 +3,14 @@ package com.reactnativenavigation.utils
 import android.animation.TimeInterpolator
 import kotlin.math.*
 
-class SpringInterpolator(private val _mass: Float, private val _damping: Float, private val _stiffness: Float) : TimeInterpolator {
+class SpringInterpolator(private val mass: Float, private val damping: Float, private val stiffness: Float) : TimeInterpolator {
     override fun getInterpolation(p: Float): Float {
+        // See: https://en.wikipedia.org/wiki/Harmonic_oscillator#Damped_harmonic_oscillator
         val v0 = 0
         val s0 = 1
 
-        val lambda = _damping / (2 * _mass)
-        val w0 = sqrt(_stiffness / _mass)
+        val lambda = damping / (2 * mass)
+        val w0 = sqrt(stiffness / mass)
 
         val wd = sqrt(abs(w0.pow(2) - lambda.pow(2)))
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/SpringInterpolator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/SpringInterpolator.kt
@@ -16,12 +16,15 @@ class SpringInterpolator(private val mass: Float, private val damping: Float, pr
 
         return when {
             lambda < w0 -> {
+                // underdamped
                 abs(1 - exp(-lambda * p) * (s0 * cos(wd * p) + (v0 + s0 * lambda) / wd * sin(wd * p)))
             }
             lambda > w0 -> {
+                // overdamped
                 abs(1 - exp(-lambda * p) * ((v0 + s0 * (lambda + wd)) / (2 * wd) * exp(wd * p) + (s0 - (v0 + s0 * (lambda + wd)) / (2 * wd)) * exp(-wd * p)))
             }
             else -> {
+                // critically damped
                 abs(1 - exp(-lambda * p) * (s0 + (v0 + lambda * s0) * p))
             }
         }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/SpringInterpolator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/SpringInterpolator.kt
@@ -1,0 +1,28 @@
+package com.reactnativenavigation.utils
+
+import android.animation.TimeInterpolator
+import kotlin.math.*
+
+class SpringInterpolator(private val _mass: Float, private val _damping: Float, private val _stiffness: Float) : TimeInterpolator {
+    override fun getInterpolation(p: Float): Float {
+        val v0 = 0
+        val s0 = 1
+
+        val lambda = _damping / (2 * _mass)
+        val w0 = sqrt(_stiffness / _mass)
+
+        val wd = sqrt(abs(w0.pow(2) - lambda.pow(2)))
+
+        return when {
+            lambda < w0 -> {
+                abs(1 - exp(-lambda * p) * (s0 * cos(wd * p) + (v0 + s0 * lambda) / wd * sin(wd * p)))
+            }
+            lambda > w0 -> {
+                abs(1 - exp(-lambda * p) * ((v0 + s0 * (lambda + wd)) / (2 * wd) * exp(wd * p) + (s0 - (v0 + s0 * (lambda + wd)) / (2 * wd)) * exp(-wd * p)))
+            }
+            else -> {
+                abs(1 - exp(-lambda * p) * (s0 + (v0 + lambda * s0) * p))
+            }
+        }
+    }
+}

--- a/lib/ios/RCTConvert+Interpolation.h
+++ b/lib/ios/RCTConvert+Interpolation.h
@@ -5,7 +5,8 @@ typedef NS_ENUM(NSInteger, RNNInterpolationOptions) {
     RNNInterpolationAccelerateDecelerate,
     RNNInterpolationDecelerate,
     RNNInterpolationAccelerate,
-    RNNInterpolationOvershoot
+    RNNInterpolationOvershoot,
+    RNNInterpolationSpring
 };
 
 @interface RCTConvert (Interpolation)

--- a/lib/ios/RCTConvert+Interpolation.m
+++ b/lib/ios/RCTConvert+Interpolation.m
@@ -8,6 +8,7 @@ RCT_ENUM_CONVERTER(RNNInterpolationOptions, (@{
   @"decelerate": @(RNNInterpolationDecelerate),
   @"accelerate": @(RNNInterpolationAccelerate),
   @"overshoot": @(RNNInterpolationOvershoot),
+  @"spring": @(RNNInterpolationSpring),
 }), RNNInterpolationLinear, integerValue)
 
 @end

--- a/lib/ios/RNNInterpolator.m
+++ b/lib/ios/RNNInterpolator.m
@@ -54,9 +54,12 @@ static CGFloat RNNApplyInterpolation(CGFloat p, RNNInterpolationOptions interpol
             return RNNLinear(p);
         case RNNInterpolationDecelerate:
             return RNNDecelerate(p);
-        case RNNInterpolationOvershoot:
-			// TODO: Expose tension property
-            return RNNOvershoot(p, 1);
+		case RNNInterpolationOvershoot:
+			// TODO: Expose tension property to JS-API (see https://github.com/wix/react-native-navigation/pull/6591)
+			return RNNOvershoot(p, 1);
+		case RNNInterpolationSpring:
+			// TODO: Expose mass, damping and stiffness property to JS-API (see https://github.com/wix/react-native-navigation/pull/6591)
+			return RNNSpring(p, 3, 500, 1000);
     }
 }
 
@@ -68,6 +71,28 @@ static CGFloat RNNOvershoot(CGFloat p, CGFloat tension) {
 	CGFloat t = p - 1;
 	CGFloat _ot = t * t * ((tension + 1) * t + tension) + 1.0f;
 	return _ot;
+}
+
+static CGFloat RNNSpring(CGFloat p, CGFloat mass, CGFloat damping, CGFloat stiffness) {
+	// See: https://en.wikipedia.org/wiki/Harmonic_oscillator#Damped_harmonic_oscillator
+	CGFloat v0 = 0;
+	CGFloat s0 = 1;
+
+	CGFloat lambda = damping / (2 * mass);
+	CGFloat w0 = sqrt(stiffness / mass);
+
+	CGFloat wd = sqrt(fabs(pow(w0, 2) - pow(lambda, 2)));
+
+	if (lambda < w0) {
+		// underdamped
+		return fabs(1 - exp(-lambda * p) * (s0 * cos(wd * p) + ((v0 + s0 * lambda)/wd) * sin(wd * p)));
+	} else if (lambda > w0) {
+		// overdamped
+		return fabs(1 - exp(-lambda * p) * (((v0+s0 * (lambda + wd))/(2 * wd)) * exp(wd * p) + (s0 - (v0 + s0 * (lambda + wd)) / (2 * wd)) * exp(-wd * p)));
+	} else {
+		// critically damped
+		return fabs(1 - exp(-lambda * p) * (s0 + (v0 + lambda * s0) * p));
+	}
 }
 
 static CGFloat RNNLinear(CGFloat p) {

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -65,7 +65,8 @@ type Interpolation =
   | 'decelerate'
   | 'accelerate'
   | 'decelerateAccelerate'
-  | 'overshoot';
+  | 'overshoot'
+  | 'spring';
 
 export interface OptionsSplitView {
   /**


### PR DESCRIPTION
### Progress

- [x] iOS (`RNNSpring`)
- [x] Android (custom `TimeInterpolator`: `SpringInterpolator.kt`)
- [x] JS API
- [ ] Customizable parameters (`mass`, `damping`, `stiffness`) (waiting for https://github.com/wix/react-native-navigation/pull/6591)

### Description

I've added the damped harmonic oscillator ("spring") function again, this time it has the same behaviour on Android and iOS.

Compared to the Overshoot interpolator, the Spring function is more customizeable and can bounce forward & backwards more than just once.

Currently the properties (`mass`, `damping`, `stiffness`) are static, (`3`, `500`, `1000` respectively), so we should probably wait for https://github.com/wix/react-native-navigation/pull/6591 until this lands in master. Could someone lend me a hand over there? @guyca @yogevbd ...

### Sources

[Here](https://github.com/software-mansion/react-native-reanimated/blob/2576ab80ef8cec6900d054dd080b44234f709a4a/src/reanimated2/animations.js#L135-L207) is the spring function from reanimated. I will take a look at that and check if it differs from my implementation!

Also, note that this function is not exactly the same as [the one on Wikipedia](https://en.wikipedia.org/wiki/Harmonic_oscillator#Damped_harmonic_oscillator). I've used [this medium article](https://medium.com/ios-os-x-development/demystifying-uikit-spring-animations-2bb868446773) as a source for my function (specifically [this grapher file (download)](https://github.com/jenox/UIKit-Playground/tree/master/01-Demystifying-UIKit-Spring-Animations/Resources/DampedHarmonicSpring.gcx)).

![Screenshot 2020-09-17 at 16 48 28](https://user-images.githubusercontent.com/15199031/93487484-9e0c9980-f905-11ea-8ab2-4d8ba82c1142.png)

> I will compare this to the function on Wikipedia and see if there are any differences.

#### React Native

React Native (RCTAnimated) also has a spring function, which can be found in [Libraries/NativeAnimation/Drivers/RCTSpringAnimation.m](https://github.com/facebook/react-native/blob/aee88b6843cea63d6aa0b5879ad6ef9da4701846/Libraries/NativeAnimation/Drivers/RCTSpringAnimation.m#L108-L206). I've tried using that, but couldn't figure out a way to make this work without copying their source code. I had the crazy idea to use their API instead of our custom one, so instead of using `interpolation: 'spring'`, we could use `interpolation: Easing.elastic(1)` or `interpolation: Easing.ease`.

### Stiffness and Damping

Also note that the stiffness is static, but can be calculated using:
```objc
CGFloat stiffness = mass * pow((2 * M_PI) / (T0), 2);
```
Same for damping:
```objc
CGFloat damping = 2 * (1 - springiness) * sqrt(stiffness * mass);
```