### PR TITLE
Podspec: Depend on React-Core instead of React

### DIFF
--- a/ReactNativeNavigation.podspec
+++ b/ReactNativeNavigation.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
     ss.dependency 'Folly/Fabric'
   end
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.dependency 'React-RCTImage'
   s.dependency 'React-RCTText'
   s.frameworks = 'UIKit'


### PR DESCRIPTION
From now on native modules should only depend on `React-Core` instead of `React`.

This fixes Xcode 12 build errors, see: https://github.com/facebook/react-native/issues/29633