### PR TITLE
Better resolving shared element corner radius value

### DIFF
--- a/lib/ios/AnimatedReactView.m
+++ b/lib/ios/AnimatedReactView.m
@@ -46,6 +46,7 @@
     _originalFrame = _reactView.frame;
     _originalTransform = element.layer.transform;
     _originalLayoutBounds = element.layer.bounds;
+    self.contentMode = element.contentMode;
     self.frame = self.location.fromFrame;
     _originalParent = _reactView.superview;
     _originalCornerRadius = element.layer.cornerRadius;

--- a/lib/ios/RNNViewLocation.h
+++ b/lib/ios/RNNViewLocation.h
@@ -8,6 +8,8 @@
 @property (nonatomic) CGRect toBounds;
 @property (nonatomic) CGFloat fromAngle;
 @property (nonatomic) CGFloat toAngle;
+@property (nonatomic) CGFloat fromCornerRadius;
+@property (nonatomic) CGFloat toCornerRadius;
 @property (nonatomic) CATransform3D fromTransform;
 @property (nonatomic) CATransform3D toTransform;
 

--- a/lib/ios/RNNViewLocation.m
+++ b/lib/ios/RNNViewLocation.m
@@ -14,8 +14,19 @@
     self.toTransform = [self getTransform:toElement];
     self.toBounds = toElement.layer.bounds;
     self.fromBounds = fromElement.layer.bounds;
-    
+    self.fromCornerRadius = [self getCornerRadius:fromElement];
+    self.toCornerRadius = [self getCornerRadius:toElement];
 	return self;
+}
+
+- (CGFloat)getCornerRadius:(UIView *)view {
+    if (view.layer.cornerRadius > 0) {
+        return view.layer.cornerRadius;
+    } else if (CGRectEqualToRect(view.frame, view.superview.bounds)) {
+        return [self getCornerRadius:view.superview];
+    }
+    
+    return 0;
 }
 
 - (CATransform3D)getTransform:(UIView *)view {

--- a/lib/ios/SharedElementAnimator.m
+++ b/lib/ios/SharedElementAnimator.m
@@ -62,12 +62,11 @@
         [animations addObject:[[TextStorageTransition alloc] initWithView:self.view from:((AnimatedTextView *)self.view).fromTextStorage to:((AnimatedTextView *)self.view).toTextStorage startDelay:startDelay duration:duration interpolation:interpolation]];
     }
 	
-	if (_fromView.layer.cornerRadius != _toView.layer.cornerRadius) {
+    if (self.view.location.fromCornerRadius != self.view.location.toCornerRadius) {
 		// TODO: Use MaskedCorners to only round specific corners, e.g.: borderTopLeftRadius
 		//   self.view.layer.maskedCorners = kCALayerMinXMinYCorner | kCALayerMaxXMinYCorner | kCALayerMinXMaxYCorner | kCALayerMaxXMaxYCorner;
-		// TODO: On pop the cornerRadius animation doesn't work, even though the CornerRadiusTransition::animateWithProgress function is called.
 		self.view.layer.masksToBounds = YES;
-		[animations addObject:[[CornerRadiusTransition alloc] initWithView:self.view fromFloat:_fromView.layer.cornerRadius toFloat:_toView.layer.cornerRadius startDelay:startDelay duration:duration interpolation:interpolation]];
+		[animations addObject:[[CornerRadiusTransition alloc] initWithView:self.view fromFloat:self.view.location.fromCornerRadius toFloat:self.view.location.toCornerRadius startDelay:startDelay duration:duration interpolation:interpolation]];
 	}
     
     return animations;


### PR DESCRIPTION
Until now we resolved the corner radius of shared element view from the view itself, but it is possible that corner radius are applied on this view from a wrapper parent so now we will also try to resolve it from any parent view that have the exact same bounds.

Closes #6596