### PR TITLE
Include all ancestors scale when determining an element's initial scale

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/ImageUtils.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/ImageUtils.kt
@@ -1,6 +1,9 @@
 package com.reactnativenavigation.utils
 
 import android.view.View
+import android.view.ViewParent
+import com.reactnativenavigation.react.ReactView
+import com.reactnativenavigation.viewcontrollers.viewcontroller.OverlayLayout
 
 fun areDimensionsWithInheritedScaleEqual(a: View, b: View): Boolean {
     val (aScaleX, aScaleY) = computeInheritedScale(a)
@@ -10,10 +13,15 @@ fun areDimensionsWithInheritedScaleEqual(a: View, b: View): Boolean {
 }
 
 fun computeInheritedScale(v: View): Scale {
-    return Scale(
-            x = v.scaleX * v.parent.scaleX * v.grandparent.scaleX,
-            y = v.scaleY * v.parent.scaleY * v.grandparent.scaleY
-    )
+    return computeInheritedScale(v.parent, Scale(x = v.scaleX, y = v.scaleY))
+}
+
+private fun computeInheritedScale(v: ViewParent, childrenScale: Scale): Scale {
+    return if (v is ReactView || v is OverlayLayout) {
+        childrenScale
+    } else {
+        computeInheritedScale(v.parent, Scale(x = childrenScale.x * v.scaleX, y = childrenScale.y * v.scaleY))
+    }
 }
 
 data class Scale(val x: Float, val y: Float)

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/OverlayLayout.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/OverlayLayout.kt
@@ -1,0 +1,6 @@
+package com.reactnativenavigation.viewcontrollers.viewcontroller
+
+import android.content.Context
+import android.widget.FrameLayout
+
+class OverlayLayout(context: Context) : FrameLayout(context)

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/ViewControllerOverlay.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/ViewControllerOverlay.kt
@@ -8,7 +8,7 @@ import android.widget.FrameLayout
 import com.reactnativenavigation.utils.ViewUtils.removeFromParent
 
 class ViewControllerOverlay(context: Context) {
-    private val overlay: FrameLayout = FrameLayout(context)
+    private val overlay = OverlayLayout(context)
 
     fun add(parent: ViewGroup, view: View, layoutParams: ViewGroup.LayoutParams) {
         attachOverlayToParent(parent)


### PR DESCRIPTION
This is needed when an entire screen is scaled down, typically with a gesture, and when the gesture reaches
a certain threshold the screen is popped.