### PR TITLE
Add `blurParent` option

### DIFF
--- a/lib/ios/RNNNavigationOptions.h
+++ b/lib/ios/RNNNavigationOptions.h
@@ -36,6 +36,7 @@ extern const NSInteger BLUR_TOPBAR_TAG;
 @property (nonatomic, strong) WindowOptions* window;
 
 @property (nonatomic, strong) Bool* popGesture;
+@property (nonatomic, strong) Bool* blurParent;
 @property (nonatomic, strong) Image* backgroundImage;
 @property (nonatomic, strong) Image* rootBackgroundImage;
 @property (nonatomic, strong) Text* modalPresentationStyle;

--- a/lib/ios/RNNNavigationOptions.m
+++ b/lib/ios/RNNNavigationOptions.m
@@ -15,7 +15,7 @@
 
 - (instancetype)initWithDict:(NSDictionary *)dict {
 	self = [super init];
-	
+
 	self.topBar = [[RNNTopBarOptions alloc] initWithDict:dict[@"topBar"]];
 	self.bottomTabs = [[RNNBottomTabsOptions alloc] initWithDict:dict[@"bottomTabs"]];
 	self.bottomTab = [[RNNBottomTabOptions alloc] initWithDict:dict[@"bottomTab"]];
@@ -31,14 +31,15 @@
     self.modal = [[RNNModalOptions alloc] initWithDict:dict[@"modal"]];
 	self.deprecations = [[DeprecationOptions alloc] initWithDict:dict[@"deprecations"]];
 	self.window = [[WindowOptions alloc] initWithDict:dict[@"window"]];
-	
+
 	self.popGesture = [[Bool alloc] initWithValue:dict[@"popGesture"]];
-	
+	self.blurParent = [[Bool alloc] initWithValue:dict[@"blurParent"]];
+
 	self.backgroundImage = [ImageParser parse:dict key:@"backgroundImage"];
 	self.rootBackgroundImage = [ImageParser parse:dict key:@"rootBackgroundImage"];
 	self.modalPresentationStyle = [[Text alloc] initWithValue:dict[@"modalPresentationStyle"]];
 	self.modalTransitionStyle = [[Text alloc] initWithValue:dict[@"modalTransitionStyle"]];
-	
+
 	return self;
 }
 
@@ -54,7 +55,7 @@
 - (RNNNavigationOptions *)copy {
 	RNNNavigationOptions* newOptions = [[RNNNavigationOptions alloc] initWithDict:@{}];
 	[newOptions overrideOptions:self];
-	
+
 	return newOptions;
 }
 

--- a/lib/ios/RNNStackPresenter.m
+++ b/lib/ios/RNNStackPresenter.m
@@ -50,7 +50,7 @@
     [super applyOptions:options];
     RNNStackController* stack = self.stackController;
     RNNNavigationOptions * withDefault = [options withDefault:[self defaultOptions]];
-    
+
     [_interactivePopGestureDelegate setEnabled:[withDefault.popGesture getWithDefaultValue:YES]];
     stack.interactivePopGestureRecognizer.delegate = _interactivePopGestureDelegate;
 
@@ -59,12 +59,12 @@
     [stack setNavigationBarTestId:[withDefault.topBar.testID getWithDefaultValue:nil]];
     [stack setNavigationBarVisible:[withDefault.topBar.visible getWithDefaultValue:YES] animated:[withDefault.topBar.animate getWithDefaultValue:YES]];
     [stack hideBarsOnScroll:[withDefault.topBar.hideOnScroll getWithDefaultValue:NO]];
-    
+
     [_topBarPresenter applyOptions:withDefault.topBar];
-    
+
     [stack setNavigationBarBlur:[withDefault.topBar.background.blur getWithDefaultValue:NO]];
     [stack setNavigationBarClipsToBounds:[withDefault.topBar.background.clipToBounds getWithDefaultValue:NO]];
-	
+
 	[stack.view setBackgroundColor:[withDefault.layout.backgroundColor getWithDefaultValue:nil]];
 }
 
@@ -82,35 +82,39 @@
 - (void)mergeOptions:(RNNNavigationOptions *)options resolvedOptions:(RNNNavigationOptions *)resolvedOptions {
     [super mergeOptions:options resolvedOptions:resolvedOptions];
     RNNStackController* stack = self.stackController;
-    
+
     if (options.popGesture.hasValue) {
         [_interactivePopGestureDelegate setEnabled:options.popGesture.get];
     }
-    
+
+    if (options.blurParent.hasValue) {
+        // TODO: Create blur overlay on parent
+    }
+
     if (options.rootBackgroundImage.hasValue) {
         [stack setRootBackgroundImage:options.rootBackgroundImage.get];
     }
-    
+
     if (options.topBar.testID.hasValue) {
         [stack setNavigationBarTestId:options.topBar.testID.get];
     }
-    
+
     if (options.topBar.visible.hasValue) {
         [stack setNavigationBarVisible:options.topBar.visible.get animated:[options.topBar.animate getWithDefaultValue:YES]];
     }
-    
+
     if (options.topBar.hideOnScroll.hasValue) {
         [stack hideBarsOnScroll:[options.topBar.hideOnScroll get]];
     }
-    
+
     if (options.topBar.barStyle.hasValue) {
         [stack setBarStyle:[RCTConvert UIBarStyle:options.topBar.barStyle.get]];
     }
-    
+
     if (options.topBar.background.clipToBounds.hasValue) {
         [stack setNavigationBarClipsToBounds:[options.topBar.background.clipToBounds get]];
     }
-    
+
     if (options.topBar.background.blur.hasValue) {
         [stack setNavigationBarBlur:[options.topBar.background.blur get]];
     }
@@ -118,11 +122,11 @@
     if (options.topBar.background.component.name.hasValue) {
         [self setCustomNavigationComponentBackground:options perform:nil];
     }
-	
+
 	if (options.layout.backgroundColor.hasValue) {
 		[stack.view setBackgroundColor:options.layout.backgroundColor.get];
 	}
-    
+
     RNNNavigationOptions * withDefault = (RNNNavigationOptions *) [[options mergeInOptions:resolvedOptions] withDefault:[self defaultOptions]];
     [_topBarPresenter mergeOptions:options.topBar withDefault:withDefault.topBar];
 }
@@ -130,16 +134,16 @@
 - (void)renderComponents:(RNNNavigationOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
         dispatch_group_t group = dispatch_group_create();
-        
+
         dispatch_group_enter(group);
         dispatch_async(dispatch_get_main_queue(), ^{
             [self setCustomNavigationComponentBackground:options perform:^{
                 dispatch_group_leave(group);
             }];
         });
-        
+
         dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
-        
+
         dispatch_async(dispatch_get_main_queue(), ^{
             if (readyBlock) {
                 readyBlock();
@@ -155,11 +159,11 @@
         readyBlock();
         readyBlock = nil;
     }
-    
+
     if (withDefault.topBar.background.component.name.hasValue) {
         NSString* currentChildComponentId = [stack getCurrentChild].layoutInfo.componentId;
         _topBarBackgroundReactView = [_componentRegistry createComponentIfNotExists:withDefault.topBar.background.component parentComponentId:currentChildComponentId componentType:RNNComponentTypeTopBarBackground reactViewReadyBlock:readyBlock];
-        
+
     } else {
         [_topBarBackgroundReactView componentDidDisappear];
         [_customTopBarBackground removeFromSuperview];
@@ -176,7 +180,7 @@
         [_customTopBarBackground removeFromSuperview];
     }
     _customTopBarBackground = [[RNNCustomTitleView alloc] initWithFrame:stack.navigationBar.bounds subView:_topBarBackgroundReactView alignment:@"fill"];
-    
+
     [stack.navigationBar insertSubview:_customTopBarBackground atIndex:1];
     [_topBarBackgroundReactView componentDidAppear];
 }

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -1231,6 +1231,13 @@ setRoot: {
    */
   popGesture?: boolean;
   /**
+   * Render a blur overlay above the parent screen. Requires `componentBackgroundColor` and
+   * `backgroundColor` to be transparent.
+   *
+   * @default false
+   */
+  blurParent?: boolean;
+  /**
    * Background image for the screen
    * #### (iOS specific)
    */

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -1233,7 +1233,7 @@ setRoot: {
   /**
    * Render a blur overlay above the parent screen. Requires `componentBackgroundColor` and
    * `backgroundColor` to be transparent.
-   *
+   * #### (iOS specific)
    * @default false
    */
   blurParent?: boolean;

--- a/website/docs/api/options-root.mdx
+++ b/website/docs/api/options-root.mdx
@@ -141,6 +141,14 @@ Enable or disable swipe back to pop gesture.
 | ------- | -------- | -------- |
 | boolean | No       | iOS      |
 
+## `blurParent`
+
+Render a blur overlay above the parent screen. Requires `componentBackgroundColor` and `backgroundColor` to be transparent.
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | iOS      |
+
 ## `backgroundImage`
 
 Background image of the screen.


### PR DESCRIPTION
### What

This adds support for a prop called `blurParent` which you can enable on a screen you're about to push. Once the new screen is pushed, the parent screen will be rendered beneath the child screen, and a blur-overlay (`UIBlurEffect`) is rendered above it.

> Requires `componentBackgroundColor` and `backgroundColor` to be transparent and a custom `push`/`pop` animation, like a simple fade-in animation, to be set (makes no sense in the default slide from right side animation)

### Why

I'm trying to implement Shared Element Animations that are as smooth as the Apple App of the Day Animation, see https://github.com/wix/react-native-navigation/issues/6391.

### Android

The blurParent effect only makes sense on iOS, since BlurViews aren't a common pattern on Android. Also, I have no idea how to do that in android. Would be great if we could see the same prop in Android, but with a dimmed overlay instead of blurred overlay.