### PR TITLE
Remove redundant awaitPost before popping screen with Shared Element Transition

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackAnimator.kt
@@ -73,14 +73,11 @@ open class StackAnimator @JvmOverloads constructor(
     }
 
     private suspend fun popWithElementTransitions(appearing: ViewController<*>, disappearing: ViewController<*>, pop: NestedAnimationsOptions, set: AnimatorSet) {
-        appearing.view.visibility = View.INVISIBLE
-        appearing.view.awaitPost()
         val fade = if (pop.content.isFadeAnimation()) pop else FadeAnimation()
         val transitionAnimators = transitionAnimatorCreator.create(pop, fade.content, disappearing, appearing)
         set.playTogether(fade.content.getAnimation(disappearing.view), transitionAnimators)
         transitionAnimators.listeners.forEach { listener: Animator.AnimatorListener -> set.addListener(listener) }
         transitionAnimators.removeAllListeners()
-        appearing.view.visibility = View.VISIBLE
         set.start()
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackAnimator.kt
@@ -65,7 +65,6 @@ open class StackAnimator @JvmOverloads constructor(
         GlobalScope.launch(Dispatchers.Main.immediate) {
             val set = createPopAnimator(onAnimationEnd)
             if (pop.sharedElements.hasValue()) {
-                appearing.view.awaitPost()
                 popWithElementTransitions(appearing, disappearing, pop, set)
             } else {
                 popWithoutElementTransitions(pop, set, disappearing)
@@ -74,11 +73,14 @@ open class StackAnimator @JvmOverloads constructor(
     }
 
     private suspend fun popWithElementTransitions(appearing: ViewController<*>, disappearing: ViewController<*>, pop: NestedAnimationsOptions, set: AnimatorSet) {
+        appearing.view.visibility = View.INVISIBLE
+        appearing.view.awaitPost()
         val fade = if (pop.content.isFadeAnimation()) pop else FadeAnimation()
         val transitionAnimators = transitionAnimatorCreator.create(pop, fade.content, disappearing, appearing)
         set.playTogether(fade.content.getAnimation(disappearing.view), transitionAnimators)
         transitionAnimators.listeners.forEach { listener: Animator.AnimatorListener -> set.addListener(listener) }
         transitionAnimators.removeAllListeners()
+        appearing.view.visibility = View.VISIBLE
         set.start()
     }
 


### PR DESCRIPTION
This was originally added to workaround an issue with flickering images. We've since added a better workaround so this can be removed.