### PR TITLE
Fix timing issue with shared element animators

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/SharedElementTransition.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/SharedElementTransition.kt
@@ -34,10 +34,10 @@ class SharedElementTransition(appearing: ViewController<*>, private val options:
 
     private fun animators(): List<PropertyAnimatorCreator<*>> {
         return listOf(
-                FastImageBorderRadiusAnimator(from, to),
                 ReactImageMatrixAnimator(from, to),
                 FastImageMatrixAnimator(from, to),
                 ClipBoundsAnimator(from, to),
+                FastImageBorderRadiusAnimator(from, to),
                 XAnimator(from, to),
                 YAnimator(from, to),
                 RotationAnimator(from, to),


### PR DESCRIPTION
Corner radius has to be evaluated after clip bounds are evaluated as the radius calculation relies on bounds.