### PR TITLE
Fix initial shared element corner radius glitch

### DIFF
--- a/lib/ios/AnimatedReactView.m
+++ b/lib/ios/AnimatedReactView.m
@@ -52,6 +52,7 @@
     _originalCornerRadius = element.layer.cornerRadius;
     _reactView.frame = self.bounds;
     _reactView.layer.transform = CATransform3DIdentity;
+    _reactView.layer.cornerRadius = self.location.fromCornerRadius;
     [self addSubview:_reactView];
 }
 


### PR DESCRIPTION
For a split second, the shared element view isn't initialised with the correct corner radius.

<img width="416" alt="Screen Shot 2020-10-01 at 15 57 32" src="https://user-images.githubusercontent.com/10794586/94812028-d41a4500-03fe-11eb-8c44-83145c37aa67.png">
