### PR TITLE
fix: ios topbar flicker on route pop

### DIFF
--- a/lib/ios/TopBarPresenter.m
+++ b/lib/ios/TopBarPresenter.m
@@ -83,7 +83,6 @@
         self.navigationController.navigationBar.translucent = YES;
     } else {
         self.navigationController.navigationBar.translucent = NO;
-        self.navigationController.navigationBar.barTintColor = nil;
     }
 }
 


### PR DESCRIPTION
On iOS devices lower than iOS 13, the top bar flickered (turned white) while transitioning back to the last screen. This should fix it. Tested on different simulators and devices with iOS versions 11, 12, 13 and 14.

Closes #6608