### PR TITLE
Create WindowOptions type

### DIFF
--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -1139,9 +1139,12 @@ export interface NavigationBarOptions {
 }
 
 /**
- * Configure iOS' default background color of View
+ * Used for configuring and controlling the main window in iOS
  */
 export interface WindowOptions {
+  /**
+   * Configure the background color of the application's main window.
+   */
   backgroundColor?: Color;
 }
 
@@ -1248,7 +1251,7 @@ setRoot: {
    */
   rootBackgroundImage?: ImageResource;
   /**
-   * Background color for the screen
+   * Provides a way to configure the overall presentation of your application's main user interface
    * #### (iOS specific)
    */
   window?: WindowOptions;

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -1138,6 +1138,13 @@ export interface NavigationBarOptions {
   visible?: boolean;
 }
 
+/**
+ * Configure iOS' default background color of View
+ */
+export interface WindowOptions {
+  backgroundColor?: Color;
+}
+
 export interface Options {
   /**
    * Configure the status bar
@@ -1240,6 +1247,11 @@ setRoot: {
    * #### (iOS specific)
    */
   rootBackgroundImage?: ImageResource;
+  /**
+   * Background color for the screen
+   * #### (iOS specific)
+   */
+  window?: WindowOptions;
   /**
    * Enable or disable automatically blurring focused input, dismissing keyboard on unmount
    * #### (Android specific)

--- a/playground/src/commons/Options.ts
+++ b/playground/src/commons/Options.ts
@@ -14,6 +14,9 @@ const SHOW_DURATION = 250 * (useSlowOpenScreenAnimations ? 2.5 : 1);
 
 const setDefaultOptions = () =>
   Navigation.setDefaultOptions({
+    window: {
+      backgroundColor: Colors.primary,
+    },
     layout: {
       componentBackgroundColor: Colors.background,
       orientation: ['portrait'],


### PR DESCRIPTION
Setting default root window view's background color. Fixes linter warning when setting window's view background color

Sample usage:
```
Navigation.setDefaultOptions({
    window: {
      backgroundColor: '#25C2A0',
    },
});
```

![Screenshot 2020-10-06 at 19 51 04](https://user-images.githubusercontent.com/2569355/95198391-bfc6b580-080d-11eb-8240-688cf49120aa.png)
