### PR TITLE
Fix edge case when only the React View in a modal was disappearing on dismiss

### DIFF
--- a/lib/ios/RNNModalManager.m
+++ b/lib/ios/RNNModalManager.m
@@ -120,14 +120,15 @@
 			[self removePendingNextModalIfOnTop:nil];
 		}];
 	} else {
-		[modalToDismiss.view removeFromSuperview];
-		modalToDismiss.view = nil;
-		modalToDismiss.getCurrentChild.resolveOptions.animations.dismissModal.enable = [[Bool alloc] initWithBOOL:NO];
-		[self dismissedModal:modalToDismiss];
-		
-		if (completion) {
-			completion();
-		}
+		[modalToDismiss dismissViewControllerAnimated:[optionsWithDefault.animations.dismissModal.enable getWithDefaultValue:YES] completion: ^ {
+			if (modalToDismiss.view) {
+				modalToDismiss.view = nil;
+				[self dismissedModal:modalToDismiss];
+			}
+			if (completion) {
+				completion();
+			}
+		}];
 	}
 }
 


### PR DESCRIPTION
So this is kind of an edge case with using modals. 

The code was assuming that I will only use a modal with a React View that doesn't have a topbar or bottom tabs in it, therefore was only dismissing the modal's view instead of dismissing the whole view controller. 

Basically, if you were using: 

```javascript
Navigation.showModal({
	component: {
		name: 'your.component.name'
	}
})
```

```javascript

Navigation.dismissModal(componentId)

```

The code was actually working. 


But there's another case where you can use: 

```javascript

Navigation.showModal({
	bottomTabs: {
		children: [
			{
				stack: {
					children: [
						{
							component: {
								name: 'your.component.name',
								options: {
									topBar: {...title, etc}
								}
							}
						}
					]
				}
			}
		]
	}
})

```

Basically, you want to use a stack within a modal (with title, buttons, etc). When dismissModal was called, it was causing **only** the React view to disappear, instead of dismissing the entire modal. 

This code actually fixes this issue. 👍 