### PR TITLE
Add the ability to control the iOS home indicator auto-hiding

### DIFF
--- a/lib/ios/RNNBasePresenter.h
+++ b/lib/ios/RNNBasePresenter.h
@@ -49,4 +49,6 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 - (BOOL)hidesBottomBarWhenPushed;
 
+- (BOOL)prefersHomeIndicatorAutoHidden;
+
 @end

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -5,7 +5,9 @@
 #import "UIViewController+LayoutProtocol.h"
 #import "DotIndicatorOptions.h"
 
-@implementation RNNBasePresenter
+@implementation RNNBasePresenter {
+    BOOL _prefersHomeIndicatorAutoHidden;
+}
 
 - (instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions {
     self = [super init];
@@ -22,6 +24,8 @@
 - (void)bindViewController:(UIViewController *)boundViewController {
     self.boundComponentId = boundViewController.layoutInfo.componentId;
     _boundViewController = boundViewController;
+    RNNNavigationOptions *withDefault = (RNNNavigationOptions *)[self.boundViewController.topMostViewController.resolveOptions withDefault:self.defaultOptions];
+    _prefersHomeIndicatorAutoHidden = [withDefault.layout.autoHideHomeIndicator getWithDefaultValue:NO];
 }
 
 - (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions {
@@ -50,33 +54,38 @@
     if (@available(iOS 13.0, *)) {
         viewController.modalInPresentation = ![withDefault.modal.swipeToDismiss getWithDefaultValue:YES];
     }
-	
-	if (withDefault.window.backgroundColor.hasValue) {
-		UIApplication.sharedApplication.delegate.window.backgroundColor = withDefault.window.backgroundColor.get;
-	}
+    
+    if (withDefault.window.backgroundColor.hasValue) {
+        UIApplication.sharedApplication.delegate.window.backgroundColor = withDefault.window.backgroundColor.get;
+    }
 }
 
 - (void)applyOptionsOnViewDidLayoutSubviews:(RNNNavigationOptions *)options {
-
+    
 }
 
 - (void)applyOptionsOnWillMoveToParentViewController:(RNNNavigationOptions *)options {
-
+    
 }
 
 - (void)applyOptions:(RNNNavigationOptions *)options {
-
+    
 }
 
 - (void)mergeOptions:(RNNNavigationOptions *)options resolvedOptions:(RNNNavigationOptions *)resolvedOptions {
     RNNNavigationOptions* withDefault = (RNNNavigationOptions *) [[resolvedOptions withDefault:_defaultOptions] overrideOptions:options];
-	
-	if (options.window.backgroundColor.hasValue) {
-		UIApplication.sharedApplication.delegate.window.backgroundColor = withDefault.window.backgroundColor.get;
-	}
+    
+    if (options.window.backgroundColor.hasValue) {
+        UIApplication.sharedApplication.delegate.window.backgroundColor = withDefault.window.backgroundColor.get;
+    }
     
     if (options.statusBar.visible.hasValue) {
         [self.boundViewController setNeedsStatusBarAppearanceUpdate];
+    }
+    
+    if (options.layout.autoHideHomeIndicator.hasValue && options.layout.autoHideHomeIndicator.get != _prefersHomeIndicatorAutoHidden) {
+        _prefersHomeIndicatorAutoHidden = options.layout.autoHideHomeIndicator.get;
+        [self.boundViewController setNeedsUpdateOfHomeIndicatorAutoHidden];
     }
 }
 
@@ -88,7 +97,7 @@
 }
 
 - (void)viewDidLayoutSubviews {
-
+    
 }
 
 - (UIStatusBarStyle)getStatusBarStyle {
@@ -132,6 +141,10 @@
 - (BOOL)hidesBottomBarWhenPushed {
     RNNNavigationOptions *withDefault = (RNNNavigationOptions *)[self.boundViewController.topMostViewController.resolveOptions withDefault:self.defaultOptions];
     return ![withDefault.bottomTabs.visible getWithDefaultValue:YES];
+}
+
+- (BOOL)prefersHomeIndicatorAutoHidden {
+    return _prefersHomeIndicatorAutoHidden;
 }
 
 @end

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -24,7 +24,7 @@
 - (void)bindViewController:(UIViewController *)boundViewController {
     self.boundComponentId = boundViewController.layoutInfo.componentId;
     _boundViewController = boundViewController;
-    RNNNavigationOptions *withDefault = (RNNNavigationOptions *)[self.boundViewController.topMostViewController.resolveOptions withDefault:self.defaultOptions];
+    RNNNavigationOptions *withDefault = (RNNNavigationOptions *)[self.boundViewController.resolveOptions withDefault:self.defaultOptions];
     _prefersHomeIndicatorAutoHidden = [withDefault.layout.autoHideHomeIndicator getWithDefaultValue:NO];
 }
 

--- a/lib/ios/RNNComponentViewController.m
+++ b/lib/ios/RNNComponentViewController.m
@@ -214,4 +214,8 @@
     return [self.presenter hidesBottomBarWhenPushed];
 }
 
+- (BOOL)prefersHomeIndicatorAutoHidden {
+    return [self.presenter prefersHomeIndicatorAutoHidden];
+}
+
 @end

--- a/lib/ios/RNNLayoutOptions.h
+++ b/lib/ios/RNNLayoutOptions.h
@@ -6,6 +6,7 @@
 @property (nonatomic, strong) Color* componentBackgroundColor;
 @property (nonatomic, strong) Text* direction;
 @property (nonatomic, strong) id orientation;
+@property (nonatomic, strong) Bool* autoHideHomeIndicator;
 
 - (UIInterfaceOrientationMask)supportedOrientations;
 

--- a/lib/ios/RNNLayoutOptions.m
+++ b/lib/ios/RNNLayoutOptions.m
@@ -6,12 +6,11 @@
 
 - (instancetype)initWithDict:(NSDictionary *)dict {
 	self = [super init];
-	
 	self.backgroundColor = [ColorParser parse:dict key:@"backgroundColor"];
     self.componentBackgroundColor = [ColorParser parse:dict key:@"componentBackgroundColor"];
 	self.direction = [TextParser parse:dict key:@"direction"];
 	self.orientation = dict[@"orientation"];
-
+    self.autoHideHomeIndicator = [BoolParser parse:dict key:@"autoHideHomeIndicator"];
 	return self;
 }
 

--- a/lib/ios/UIViewController+LayoutProtocol.m
+++ b/lib/ios/UIViewController+LayoutProtocol.m
@@ -18,9 +18,9 @@
 	self.creator = creator;
     self.eventEmitter = eventEmitter;
     self.presenter = presenter;
+    [self loadChildren:childViewControllers];
     [self.presenter bindViewController:self];
     self.extendedLayoutIncludesOpaqueBars = YES;
-    [self loadChildren:childViewControllers];
     [self.presenter applyOptionsOnInit:self.resolveOptions];
 
 	return self;

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -147,6 +147,12 @@ export interface OptionsLayout {
    * only works with DefaultOptions
    */
   direction?: 'rtl' | 'ltr' | 'locale';
+
+  /**
+   * Controls the application's preferred home indicator auto-hiding.
+   * #### (iOS specific)
+   */
+  autoHideHomeIndicator?: boolean;
 }
 
 export enum OptionsModalPresentationStyle {

--- a/website/docs/api/options-layout.mdx
+++ b/website/docs/api/options-layout.mdx
@@ -6,7 +6,7 @@ sidebar_label: Layout
 
 ```js
 const options = {
-  layout: {}
+  layout: {},
 };
 ```
 
@@ -52,6 +52,14 @@ Set the layout top margin.
 
 Set language direction, only works with DefaultOptions. `locale` is an Android specific option which sets the direction according to the device locale.
 
-| Type               | Required | Platform |
-| ------------------ | -------- | -------- |
+| Type                         | Required | Platform |
+| ---------------------------- | -------- | -------- |
 | enum('rtl', 'ltr', 'locale') | No       | Both     |
+
+### `autoHideHomeIndicator`
+
+Controls the application's preferred home indicator auto-hiding.
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | iOS      |


### PR DESCRIPTION
```js
const options = {
  layout: {
    autoHideHomeIndicator: true // Default is false
  }
}
```

Closes https://github.com/wix/react-native-navigation/issues/6290