### PR TITLE
Call dismissAllModals completion handler after the dismissal has actually completed

### DIFF
--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -312,10 +312,11 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	[CATransaction begin];
 	[CATransaction setCompletionBlock:^{
 		[self->_eventEmitter sendOnNavigationCommandCompletion:dismissAllModals commandId:commandId];
-		completion();
 	}];
 	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:mergeOptions];
-	[_modalManager dismissAllModalsAnimated:[options.animations.dismissModal.enable getWithDefaultValue:YES] completion:nil];
+	[_modalManager dismissAllModalsAnimated:[options.animations.dismissModal.enable getWithDefaultValue:YES] completion:^{
+		completion();
+    }];
 	
 	[CATransaction commit];
 }

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -292,33 +292,22 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	
 	RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initWithDict:mergeOptions];
 	[modalToDismiss.getCurrentChild overrideOptions:options];
-	
-	[CATransaction begin];
-	[CATransaction setCompletionBlock:^{
-        [self->_eventEmitter sendOnNavigationCommandCompletion:dismissModal commandId:commandId];
-	}];
-	
+
     [_modalManager dismissModal:modalToDismiss completion:^{
+        [self->_eventEmitter sendOnNavigationCommandCompletion:dismissModal commandId:commandId];
         completion(modalToDismiss.topMostViewController.layoutInfo.componentId);
     }];
-	
-	[CATransaction commit];
 }
 
 - (void)dismissAllModals:(NSDictionary *)mergeOptions commandId:(NSString*)commandId completion:(RNNTransitionCompletionBlock)completion {
 	[self assertReady];
     RNNAssertMainQueue();
-	
-	[CATransaction begin];
-	[CATransaction setCompletionBlock:^{
-		[self->_eventEmitter sendOnNavigationCommandCompletion:dismissAllModals commandId:commandId];
-	}];
+
 	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:mergeOptions];
 	[_modalManager dismissAllModalsAnimated:[options.animations.dismissModal.enable getWithDefaultValue:YES] completion:^{
+        [self->_eventEmitter sendOnNavigationCommandCompletion:dismissAllModals commandId:commandId];
 		completion();
     }];
-	
-	[CATransaction commit];
 }
 
 - (void)showOverlay:(NSDictionary *)layout commandId:(NSString*)commandId completion:(RNNTransitionWithComponentIdCompletionBlock)completion {


### PR DESCRIPTION
This moves the call to the completion handler to a later time. Instead of relying on the completion of the CATransaction, we are now waiting until [UIViewController dismissViewControllerAnimated:completion:] calls back

Fixes #5045, #5552