### PR TITLE
Fix link script on iOS

### DIFF
--- a/.github/support.yml
+++ b/.github/support.yml
@@ -7,7 +7,7 @@ supportLabel: "type: question/stack overflow"
 supportComment: >
   We use the issue tracker exclusively for bug reports and feature requests.
   This issue appears to be a general usage or support question. 
-  Instead, please ask a question on Stack Overflow with the `wix-react-native-navigation` tag.
+  Instead, please ask a question on Stack Overflow with the `wix-react-native-navigation` tag or on [Discord](https://discord.gg/DhkZjq2).
 # Whether to close issues marked as support requests
 close: true
 # Whether to lock issues marked as support requests

--- a/autolink/postlink/podfileLinker.js
+++ b/autolink/postlink/podfileLinker.js
@@ -1,7 +1,7 @@
 // @ts-check
 var path = require("./path");
 var fs = require("fs");
-var { logn, debugn, infon, errorn, warnn } = require("./log");
+var {logn, debugn, infon, errorn, warnn} = require("./log");
 
 class PodfileLinker {
   constructor() {
@@ -18,8 +18,19 @@ class PodfileLinker {
     var podfileContent = fs.readFileSync(this.podfilePath, "utf8");
 
     podfileContent = this._removeRNNPodLink(podfileContent);
+    podfileContent = this._setMinimumIOSVersion(podfileContent);
 
     fs.writeFileSync(this.podfilePath, podfileContent);
+  }
+
+  /**
+   * Sets the minimum iOS version to iOS 11.0 which is the minimum version required by the library.
+   */
+  _setMinimumIOSVersion(contents) {
+    const minimumIOSVersion = contents.match(/platform :ios, '.*'/);
+
+    debugn("   Set the minumum iOS version to iOS 11.0");
+    return contents.replace(minimumIOSVersion, "platform :ios, '11.0'");
   }
 
   /**

--- a/autolink/postlink/podfileLinker.js
+++ b/autolink/postlink/podfileLinker.js
@@ -27,10 +27,15 @@ class PodfileLinker {
    * Sets the minimum iOS version to iOS 11.0 which is the minimum version required by the library.
    */
   _setMinimumIOSVersion(contents) {
-    const minimumIOSVersion = contents.match(/platform :ios, '.*'/);
+    const platformDefinition = contents.match(/platform :ios, '.*'/);
+    const minimumIOSVersion = contents.match(/(?<=platform\s:ios,\s(?:"|'))(.*)(?=(?:"|'))/);
 
-    debugn("   Set the minumum iOS version to iOS 11.0");
-    return contents.replace(minimumIOSVersion, "platform :ios, '11.0'");
+    if (parseFloat(minimumIOSVersion) < 11) {
+      debugn("   Set the minumum iOS version to iOS 11.0");
+      return contents.replace(platformDefinition, "platform :ios, '11.0'");
+    }
+
+    return contents;
   }
 
   /**

--- a/autolink/postlink/podfileLinker.js
+++ b/autolink/postlink/podfileLinker.js
@@ -31,7 +31,7 @@ class PodfileLinker {
     const minimumIOSVersion = contents.match(/(?<=platform\s:ios,\s(?:"|'))(.*)(?=(?:"|'))/);
 
     if (parseFloat(minimumIOSVersion) < 11) {
-      debugn("   Set the minumum iOS version to iOS 11.0");
+      debugn("   Bump minumum iOS version to iOS 11.0");
       return contents.replace(platformDefinition, "platform :ios, '11.0'");
     }
 


### PR DESCRIPTION
Sets the minimum iOS version to iOS 11.0 which is the minimum version required by the library.