### PR TITLE
Fix copy function mutating original buttons object

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/TopBarButtons.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/TopBarButtons.java
@@ -10,6 +10,9 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+
+import static com.reactnativenavigation.utils.CollectionUtils.*;
 
 public class TopBarButtons {
 
@@ -33,9 +36,18 @@ public class TopBarButtons {
     @Nullable public ArrayList<ButtonOptions> left;
     @Nullable public ArrayList<ButtonOptions> right;
 
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    public TopBarButtons(@Nullable ArrayList<ButtonOptions> right) {
+        this.right = right;
+    }
+
+    public TopBarButtons() {
+
+    }
+
     void mergeWith(TopBarButtons other) {
         if (other.left != null) left = mergeLeftButton(other.left);
-        if (other.right != null) right = other.right;
+        if (other.right != null) right = map(other.right, ButtonOptions::copy);
         back.mergeWith(other.back);
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/CollectionUtils.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/CollectionUtils.java
@@ -45,9 +45,9 @@ public class CollectionUtils {
         S map(T value);
     }
 
-    public static @Nullable <T, S> List<S> map(@Nullable Collection<T> items, Mapper<T, S> map) {
+    public static @Nullable <T, S> ArrayList<S> map(@Nullable Collection<T> items, Mapper<T, S> map) {
         if (items == null) return null;
-        List<S> result = new ArrayList<>();
+        ArrayList<S> result = new ArrayList<>();
         for (T item : items) {
             result.add(map.map(item));
         }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/options/TopBarButtonsTest.kt
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/options/TopBarButtonsTest.kt
@@ -1,0 +1,25 @@
+package com.reactnativenavigation.options
+
+import com.reactnativenavigation.BaseTest
+import org.assertj.core.api.Java6Assertions
+import org.assertj.core.api.Java6Assertions.assertThat
+import org.junit.Test
+import kotlin.test.assertTrue
+
+class TopBarButtonsTest : BaseTest() {
+    private lateinit var uut: TopBarButtons
+
+    override fun beforeEach() {
+        uut = TopBarButtons()
+    }
+
+    @Test
+    fun mergeWith_rightButtonsAreCopiedByValue() {
+        val right = arrayListOf(ButtonOptions(), ButtonOptions())
+        val other = TopBarButtons(right)
+
+        uut.mergeWith(other)
+        assertThat(uut.right).hasSize(2)
+        right.forEachIndexed { index, buttonOptions -> assertThat(buttonOptions).isNotEqualTo(uut.right!![index]) }
+    }
+}

--- a/playground/src/services/Navigation.ts
+++ b/playground/src/services/Navigation.ts
@@ -31,7 +31,8 @@ const pop = (selfOrCompId: SelfOrCompId, mergeOptions?: Options) =>
 const showModal = (screen: string | Layout, options?: Options) =>
   Navigation.showModal(isString(screen) ? stack(component(screen, options)) : screen);
 
-const dismissModal = (selfOrCompId: SelfOrCompId) => Navigation.dismissModal(compId(selfOrCompId));
+const dismissModal = (selfOrCompId: SelfOrCompId, mergeOptions?: Options) =>
+  Navigation.dismissModal(compId(selfOrCompId), mergeOptions);
 
 const dismissAllModals = () => Navigation.dismissAllModals();
 


### PR DESCRIPTION
When copying TopBarButtons, the copy function would mutate the original object and change the right buttons object.