### PR TITLE
fix for truncated tab item names on ios14

### DIFF
--- a/lib/ios/TabBarItemAppearanceCreator.m
+++ b/lib/ios/TabBarItemAppearanceCreator.m
@@ -14,7 +14,7 @@
     tabItem.standardAppearance.compactInlineLayoutAppearance.normal.titleTextAttributes = titleAttributes;
     tabItem.standardAppearance.inlineLayoutAppearance.normal.titleTextAttributes = titleAttributes;
     if (@available(iOS 14.0, *)) {
-      UIColor *color = [titleAttributes valueForKey:@"NSColor"];
+      UIColor *color = [titleAttributes valueForKey:NSForegroundColorAttributeName];
       if (color) {
         tabItem.standardAppearance.inlineLayoutAppearance.normal.titleTextAttributes = @{NSForegroundColorAttributeName: color};
       }
@@ -27,7 +27,7 @@
     tabItem.standardAppearance.compactInlineLayoutAppearance.selected.titleTextAttributes = selectedTitleAttributes;
     tabItem.standardAppearance.inlineLayoutAppearance.selected.titleTextAttributes = selectedTitleAttributes;
     if (@available(iOS 14.0, *)) {
-      UIColor *color = [selectedTitleAttributes valueForKey:@"NSColor"];
+      UIColor *color = [selectedTitleAttributes valueForKey:NSForegroundColorAttributeName];
       if (color) {
         tabItem.standardAppearance.inlineLayoutAppearance.selected.titleTextAttributes = @{NSForegroundColorAttributeName: color};
       }

--- a/lib/ios/TabBarItemAppearanceCreator.m
+++ b/lib/ios/TabBarItemAppearanceCreator.m
@@ -13,6 +13,12 @@
     tabItem.standardAppearance.stackedLayoutAppearance.normal.titleTextAttributes = titleAttributes;
     tabItem.standardAppearance.compactInlineLayoutAppearance.normal.titleTextAttributes = titleAttributes;
     tabItem.standardAppearance.inlineLayoutAppearance.normal.titleTextAttributes = titleAttributes;
+    if (@available(iOS 14.0, *)) {
+      UIColor *color = [titleAttributes valueForKey:@"NSColor"];
+      if (color) {
+        tabItem.standardAppearance.inlineLayoutAppearance.normal.titleTextAttributes = @{NSForegroundColorAttributeName: color};
+      }
+    }
 }
 
 + (void)setSelectedTitleAttributes:(UITabBarItem *)tabItem selectedTitleAttributes:(NSDictionary *)selectedTitleAttributes {
@@ -20,6 +26,12 @@
     tabItem.standardAppearance.stackedLayoutAppearance.selected.titleTextAttributes = selectedTitleAttributes;
     tabItem.standardAppearance.compactInlineLayoutAppearance.selected.titleTextAttributes = selectedTitleAttributes;
     tabItem.standardAppearance.inlineLayoutAppearance.selected.titleTextAttributes = selectedTitleAttributes;
+    if (@available(iOS 14.0, *)) {
+      UIColor *color = [selectedTitleAttributes valueForKey:@"NSColor"];
+      if (color) {
+        tabItem.standardAppearance.inlineLayoutAppearance.selected.titleTextAttributes = @{NSForegroundColorAttributeName: color};
+      }
+    }
 }
 
 @end


### PR DESCRIPTION
this is a fix for when bottom tab items with custom title attributes get truncated on iPads running iOS14.

<img width="625" alt="rnn-before" src="https://user-images.githubusercontent.com/26149/96505779-7a41b980-120b-11eb-88a2-6155695e2660.png">

<img width="625" alt="rnn-after" src="https://user-images.githubusercontent.com/26149/96505793-7d3caa00-120b-11eb-8569-ca459310b60c.png">

Fixes #6533