### PR TITLE
Remove unnecessary overrides to setDefaultOptions, apply defaultOptions to RNNSideMenuController

### DIFF
--- a/lib/ios/RNNBasePresenter.h
+++ b/lib/ios/RNNBasePresenter.h
@@ -17,8 +17,6 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 - (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry defaultOptions:(RNNNavigationOptions *)defaultOptions;
 
-- (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions;
-
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)initialOptions;
 
 - (void)applyOptionsOnViewDidLayoutSubviews:(RNNNavigationOptions *)options;

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -28,10 +28,6 @@
     _prefersHomeIndicatorAutoHidden = [withDefault.layout.autoHideHomeIndicator getWithDefaultValue:NO];
 }
 
-- (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions {
-    _defaultOptions = defaultOptions;
-}
-
 - (void)componentDidAppear {
     
 }

--- a/lib/ios/RNNComponentViewController.m
+++ b/lib/ios/RNNComponentViewController.m
@@ -16,11 +16,6 @@
 	return self;
 }
 
-- (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions {
-    _defaultOptions = defaultOptions;
-	[_presenter setDefaultOptions:defaultOptions];
-}
-
 - (void)overrideOptions:(RNNNavigationOptions *)options {
 	[self.options overrideOptions:options];
 }

--- a/lib/ios/RNNSideMenuController.m
+++ b/lib/ios/RNNSideMenuController.m
@@ -34,10 +34,6 @@
 	return self;
 }
 
-- (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions {
-	[self.presenter setDefaultOptions:defaultOptions];
-}
-
 - (void)loadView {
     [super loadView];
     [self setCenterViewController:self.center];

--- a/lib/ios/RNNStackController.m
+++ b/lib/ios/RNNStackController.m
@@ -16,11 +16,6 @@
     return self;
 }
 
-- (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions {
-	[super setDefaultOptions:defaultOptions];
-	[self.presenter setDefaultOptions:defaultOptions];
-}
-
 - (void)viewDidLayoutSubviews {
 	[super viewDidLayoutSubviews];
 	[self.presenter applyOptionsOnViewDidLayoutSubviews:self.resolveOptions];

--- a/lib/ios/UIViewController+LayoutProtocol.m
+++ b/lib/ios/UIViewController+LayoutProtocol.m
@@ -198,6 +198,7 @@
 
 - (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions {
 	objc_setAssociatedObject(self, @selector(defaultOptions), defaultOptions, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    self.presenter.defaultOptions = defaultOptions;
 }
 
 - (RNNLayoutInfo *)layoutInfo {

--- a/playground/src/screens/LayoutsScreen.tsx
+++ b/playground/src/screens/LayoutsScreen.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { Options, NavigationComponent } from 'react-native-navigation';
+import {
+  Options,
+  OptionsModalPresentationStyle,
+  NavigationComponent,
+} from 'react-native-navigation';
 
 import Root from '../components/Root';
 import Button from '../components/Button';
@@ -92,6 +96,12 @@ export default class LayoutsScreen extends NavigationComponent {
             id: 'right',
             name: Screens.SideMenuRight,
           },
+        },
+        options: {
+          layout: {
+            orientation: ['portrait', 'landscape'],
+          },
+          modalPresentationStyle: OptionsModalPresentationStyle.pageSheet,
         },
       },
     });


### PR DESCRIPTION
* Removes `setDefaultOptions` from RNNBasePresenter. This is already covered by the synthesized `defaultOptions` prop.
* Add calling `[presenter setDefaultOptions:]` to the default implementation in order to remove all the overrides that do the same thing.

Notice that the override implementation of `setDefaultOptions` in `RNNSideMenuController` does not call `super`. This leads to the `defaultOptions` only being available in the `RNNSideMenuPresenter` but not in the controller itself. Therefor causing bugs in accessing options that were set as defaults through the controller (as they are just not available).