### PR TITLE
Balance out addChildViewController with didMoveToParentViewController

### DIFF
--- a/lib/ios/RNNSideMenuChildVC.m
+++ b/lib/ios/RNNSideMenuChildVC.m
@@ -30,6 +30,9 @@
         [self.child.view.topAnchor constraintEqualToAnchor:self.view.topAnchor],
         [self.child.view.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor]
     ]];
+
+    [self.child didMoveToParentViewController:self];
+
     [self.child render];
 }
 

--- a/lib/ios/RNNSideMenuController.m
+++ b/lib/ios/RNNSideMenuController.m
@@ -120,8 +120,6 @@
 			else if(child.type == RNNSideMenuChildTypeRight) {
 				self.right = child;
 			}
-
-			[self addChildViewController:child];
 		}
 
 		else {

--- a/lib/ios/RNNTopTabsViewController.m
+++ b/lib/ios/RNNTopTabsViewController.m
@@ -64,6 +64,7 @@
 		[childVc.view setFrame:_contentView.bounds];
 //		[childVc.options.topTab applyOn:childVc];
 		[self addChildViewController:childVc];
+        [childVc didMoveToParentViewController:self];
 	}
 	
 	[self setSelectedViewControllerIndex:0];


### PR DESCRIPTION
As per the docs:

> If you are implementing your own container view controller, it must call the didMoveToParentViewController: method of the child view controller after the transition to the new controller is complete or, if there is no transition, immediately after calling the addChildViewController: method.
>
> The removeFromParentViewController method automatically calls the didMoveToParentViewController: method of the child view controller after it removes the child.