### PR TITLE
Enable side menu readyForPresentation callbacks

### DIFF
--- a/lib/ios/RNNSideMenuChildVC.m
+++ b/lib/ios/RNNSideMenuChildVC.m
@@ -33,7 +33,7 @@
 
     [self.child didMoveToParentViewController:self];
 
-    [self.child render];
+    [super render];
 }
 
 - (void)setChild:(UIViewController<RNNLayoutProtocol> *)child {

--- a/lib/ios/RNNSideMenuController.m
+++ b/lib/ios/RNNSideMenuController.m
@@ -3,6 +3,7 @@
 
 @interface RNNSideMenuController ()
 
+@property (nonatomic, strong) NSArray *childViewControllers;
 @property (readwrite) RNNSideMenuChildVC *center;
 @property (readwrite) RNNSideMenuChildVC *left;
 @property (readwrite) RNNSideMenuChildVC *right;
@@ -12,8 +13,9 @@
 @implementation RNNSideMenuController
 
 - (instancetype)initWithLayoutInfo:(RNNLayoutInfo *)layoutInfo creator:(id<RNNComponentViewCreator>)creator childViewControllers:(NSArray *)childViewControllers options:(RNNNavigationOptions *)options defaultOptions:(RNNNavigationOptions *)defaultOptions presenter:(RNNBasePresenter *)presenter eventEmitter:(RNNEventEmitter *)eventEmitter {
-	[self setControllers:childViewControllers];
 	self = [super init];
+
+    self.childViewControllers = childViewControllers;
 	
 	self.presenter = presenter;
     [self.presenter bindViewController:self];
@@ -43,9 +45,12 @@
 
 - (void)render {
     [super render];
-    [self.center render];
-    [self.left render];
-    [self.right render];
+    UIViewController *currentChild = self.getCurrentChild;
+    for (UIViewController *vc in self.childViewControllers) {
+        if (vc != currentChild) {
+            [vc render];
+        }
+    }
 }
 
 - (void)setAnimationType:(NSString *)animationType {
@@ -102,8 +107,9 @@
 	}
 }
 
--(void)setControllers:(NSArray*)controllers {
-	for (id controller in controllers) {
+-(void)setChildViewControllers:(NSArray *)childViewControllers {
+    _childViewControllers = childViewControllers;
+	for (id controller in childViewControllers) {
 		if ([controller isKindOfClass:[RNNSideMenuChildVC class]]) {
 			RNNSideMenuChildVC *child = (RNNSideMenuChildVC*)controller;
 


### PR DESCRIPTION
By calling [super render] the child render will get called via getCurrentChild.
Afterwards the super method will call the readyForPresentation callback.

Fixes #6000 

⚠️ Relies on #6689 to be merged first in order for `waitForRender` to propagate properly down the parent / child chain.