### PR TITLE
Fix viewcontroller for pop animation lookup

### DIFF
--- a/lib/ios/StackControllerDelegate.m
+++ b/lib/ios/StackControllerDelegate.m
@@ -30,7 +30,7 @@
         RNNScreenTransition* screenTransition = toVC.resolveOptions.animations.push;
 		return [[TransitionDelegate alloc] initWithContentTransition:screenTransition.content elementTransitions:screenTransition.elementTransitions sharedElementTransitions:screenTransition.sharedElementTransitions duration:screenTransition.maxDuration bridge:_eventEmitter.bridge];
 	} else if (operation == UINavigationControllerOperationPop && fromVC.resolveOptionsWithDefault.animations.pop.hasCustomAnimation) {
-        RNNScreenTransition* screenTransition = toVC.resolveOptions.animations.pop;
+        RNNScreenTransition* screenTransition = fromVC.resolveOptions.animations.pop;
         return [[ReversedTransitionDelegate alloc] initWithContentTransition:screenTransition.content elementTransitions:screenTransition.elementTransitions sharedElementTransitions:screenTransition.sharedElementTransitions
                                                                     duration:screenTransition.maxDuration bridge:_eventEmitter.bridge];
 	} else {


### PR DESCRIPTION
Uses to lookup in the `toVC` when actual info is stored in the `fromVC`. `toVC` is screen beneath.