### PR TITLE
Fix waitForRender + mergeOptions not working when view controller is in transit

### DIFF
--- a/lib/ios/RNNBridgeManager.h
+++ b/lib/ios/RNNBridgeManager.h
@@ -19,4 +19,6 @@ typedef UIViewController * (^RNNExternalViewCreator)(NSDictionary *props,
 
 @property(readonly, nonatomic, strong) RCTBridge *bridge;
 
+- (UIViewController *)findComponentForId:(NSString *)componentId;
+
 @end

--- a/lib/ios/RNNBridgeManager.mm
+++ b/lib/ios/RNNBridgeManager.mm
@@ -7,6 +7,7 @@
 #import <React/RCTSurfacePresenter.h>
 #endif
 
+#import "RNNLayoutManager.h"
 #import "RNNEventEmitter.h"
 #import "RNNSplashScreen.h"
 #import "RNNBridgeModule.h"
@@ -23,6 +24,7 @@
 @property (nonatomic, strong, readwrite) RCTBridge *bridge;
 @property (nonatomic, strong, readwrite) RNNExternalComponentStore *store;
 @property (nonatomic, strong, readwrite) RNNReactComponentRegistry *componentRegistry;
+@property (nonatomic, strong, readonly) RNNLayoutManager *layoutManager;
 @property (nonatomic, strong, readonly) RNNOverlayManager *overlayManager;
 @property (nonatomic, strong, readonly) RNNModalManager *modalManager;
 
@@ -44,7 +46,7 @@
 		_mainWindow = mainWindow;
 		_launchOptions = launchOptions;
 		_delegate = delegate;
-		
+
 		_overlayManager = [RNNOverlayManager new];
 		
 		_store = [RNNExternalComponentStore new];
@@ -82,15 +84,21 @@
 	RNNEventEmitter *eventEmitter = [[RNNEventEmitter alloc] init];
     RNNModalManagerEventHandler* modalManagerEventHandler = [[RNNModalManagerEventHandler alloc] initWithEventEmitter:eventEmitter];
     _modalManager = [[RNNModalManager alloc] initWithBridge:bridge eventHandler:modalManagerEventHandler];
+
+    _layoutManager = [[RNNLayoutManager alloc] init];
     
 	id<RNNComponentViewCreator> rootViewCreator = [[RNNReactRootViewCreator alloc] initWithBridge:bridge eventEmitter:eventEmitter];
 	_componentRegistry = [[RNNReactComponentRegistry alloc] initWithCreator:rootViewCreator];
 	RNNControllerFactory *controllerFactory = [[RNNControllerFactory alloc] initWithRootViewCreator:rootViewCreator eventEmitter:eventEmitter store:_store componentRegistry:_componentRegistry andBridge:bridge bottomTabsAttachModeFactory:[BottomTabsAttachModeFactory new]];
     RNNSetRootAnimator* setRootAnimator = [RNNSetRootAnimator new];
-	_commandsHandler = [[RNNCommandsHandler alloc] initWithControllerFactory:controllerFactory eventEmitter:eventEmitter modalManager:_modalManager overlayManager:_overlayManager setRootAnimator:setRootAnimator mainWindow:_mainWindow];
+	_commandsHandler = [[RNNCommandsHandler alloc] initWithControllerFactory:controllerFactory layoutManager:_layoutManager eventEmitter:eventEmitter modalManager:_modalManager overlayManager:_overlayManager setRootAnimator:setRootAnimator mainWindow:_mainWindow];
 	RNNBridgeModule *bridgeModule = [[RNNBridgeModule alloc] initWithCommandsHandler:_commandsHandler];
 
 	return @[bridgeModule,eventEmitter];
+}
+
+- (UIViewController *)findComponentForId:(NSString *)componentId {
+    return [_layoutManager findComponentForId:componentId];
 }
 
 # pragma mark - JavaScript & Bridge Notifications

--- a/lib/ios/RNNCommandsHandler.h
+++ b/lib/ios/RNNCommandsHandler.h
@@ -4,10 +4,12 @@
 #import "RNNModalManager.h"
 #import "RNNOverlayManager.h"
 #import "RNNSetRootAnimator.h"
+#import "RNNLayoutManager.h"
 
 @interface RNNCommandsHandler : NSObject
 
 - (instancetype)initWithControllerFactory:(RNNControllerFactory*)controllerFactory
+                            layoutManager:(RNNLayoutManager *)layoutManager
                              eventEmitter:(RNNEventEmitter *)eventEmitter
                              modalManager:(RNNModalManager *)modalManager
                            overlayManager:(RNNOverlayManager *)overlayManager

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -80,8 +80,11 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	[_modalManager dismissAllModalsAnimated:NO completion:nil];
     
     UIViewController *vc = [_controllerFactory createLayout:layout[@"root"]];
+    [_layoutManager addPendingViewController:vc];
+
     RNNNavigationOptions* optionsWithDefault = vc.resolveOptionsWithDefault;
     vc.waitForRender = [optionsWithDefault.animations.setRoot.waitForRender getWithDefaultValue:NO];
+
     __weak UIViewController* weakVC = vc;
     [vc setReactViewReadyCallback:^{
         [self->_mainWindow.rootViewController destroy];
@@ -90,6 +93,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
         [self->_setRootAnimator animate:self->_mainWindow
                          duration:[optionsWithDefault.animations.setRoot.alpha.duration getWithDefaultValue:0]
                       completion:^{
+            [self->_layoutManager removePendingViewController:weakVC];
             [self->_eventEmitter sendOnNavigationCommandCompletion:setRoot commandId:commandId];
             completion(weakVC.layoutInfo.componentId);
         }];
@@ -131,6 +135,8 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
     RNNAssertMainQueue();
 	
 	UIViewController *newVc = [_controllerFactory createLayout:layout];
+    [_layoutManager addPendingViewController:newVc];
+
 	UIViewController *fromVC = [_layoutManager findComponentForId:componentId];
 	
 	if ([[newVc.resolveOptionsWithDefault.preview.reactTag getWithDefaultValue:@(0)] floatValue] > 0) {
@@ -145,6 +151,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 				if ([newVc.resolveOptionsWithDefault.preview.commit getWithDefaultValue:NO]) {
 					[CATransaction begin];
 					[CATransaction setCompletionBlock:^{
+                        [self->_layoutManager removePendingViewController:newVc];
 						[self->_eventEmitter sendOnNavigationCommandCompletion:push commandId:commandId ];
 						completion(newVc.layoutInfo.componentId);
 					}];
@@ -176,6 +183,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
         __weak UIViewController* weakNewVC = newVc;
         [newVc setReactViewReadyCallback:^{
             [fromVC.stack push:weakNewVC onTop:fromVC animated:[weakNewVC.resolveOptionsWithDefault.animations.push.enable getWithDefaultValue:YES] completion:^{
+                [self->_layoutManager removePendingViewController:weakNewVC];
                 [self->_eventEmitter sendOnNavigationCommandCompletion:push commandId:commandId];
                 completion(weakNewVC.layoutInfo.componentId);
             } rejection:rejection];
@@ -195,14 +203,20 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 			[viewController render];
 		}
 	}
-	UIViewController *newVC = childViewControllers.lastObject;
-	UIViewController *fromVC = [_layoutManager findComponentForId:componentId];
-	RNNNavigationOptions* options = newVC.resolveOptionsWithDefault;
-	__weak typeof(RNNEventEmitter*) weakEventEmitter = _eventEmitter;
 
+	UIViewController *newVC = childViewControllers.lastObject;
+    [_layoutManager addPendingViewController:newVC];
+
+	UIViewController *fromVC = [_layoutManager findComponentForId:componentId];
+
+	RNNNavigationOptions* options = newVC.resolveOptionsWithDefault;
     newVC.waitForRender = ([options.animations.setStackRoot.waitForRender getWithDefaultValue:NO]);
+
+    __weak typeof(RNNEventEmitter*) weakEventEmitter = _eventEmitter;
+    __weak UIViewController *weakNewVC = newVC;
     [newVC setReactViewReadyCallback:^{
         [fromVC.stack setStackChildren:childViewControllers fromViewController:fromVC animated:[options.animations.setStackRoot.enable getWithDefaultValue:YES] completion:^{
+            [self->_layoutManager removePendingViewController:weakNewVC];
             [weakEventEmitter sendOnNavigationCommandCompletion:setStackRoot commandId:commandId];
             completion();
         } rejection:rejection];
@@ -271,10 +285,13 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
     RNNAssertMainQueue();
 	
 	UIViewController *newVc = [_controllerFactory createLayout:layout];
+    [_layoutManager addPendingViewController:newVc];
+
     __weak UIViewController* weakNewVC = newVc;
     newVc.waitForRender = [newVc.resolveOptionsWithDefault.animations.showModal shouldWaitForRender];
     [newVc setReactViewReadyCallback:^{
         [self->_modalManager showModal:weakNewVC animated:[weakNewVC.resolveOptionsWithDefault.animations.showModal.enable getWithDefaultValue:YES] completion:^(NSString *componentId) {
+            [self->_layoutManager removePendingViewController:weakNewVC];
             [self->_eventEmitter sendOnNavigationCommandCompletion:showModal commandId:commandId];
             completion(weakNewVC.layoutInfo.componentId);
         }];
@@ -318,6 +335,8 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
     RNNAssertMainQueue();
     
 	UIViewController* overlayVC = [_controllerFactory createLayout:layout];
+    [_layoutManager addPendingViewController:overlayVC];
+
     __weak UIViewController* weakOverlayVC = overlayVC;
     [overlayVC setReactViewReadyCallback:^{UIWindow* overlayWindow = [[RNNOverlayWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
         overlayWindow.rootViewController = weakOverlayVC;
@@ -326,7 +345,8 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
         } else {
             [self->_overlayManager showOverlayWindow:overlayWindow];
         }
-        
+
+        [self->_layoutManager removePendingViewController:weakOverlayVC];
         [self->_eventEmitter sendOnNavigationCommandCompletion:showOverlay commandId:commandId];
         completion(weakOverlayVC.layoutInfo.componentId);
         

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -31,6 +31,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 
 @implementation RNNCommandsHandler {
 	RNNControllerFactory *_controllerFactory;
+    RNNLayoutManager *_layoutManager;
 	RNNModalManager* _modalManager;
 	RNNOverlayManager* _overlayManager;
 	RNNEventEmitter* _eventEmitter;
@@ -39,6 +40,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 }
 
 - (instancetype)initWithControllerFactory:(RNNControllerFactory*)controllerFactory
+                            layoutManager:(RNNLayoutManager *)layoutManager
                              eventEmitter:(RNNEventEmitter *)eventEmitter
                              modalManager:(RNNModalManager *)modalManager
                            overlayManager:(RNNOverlayManager *)overlayManager
@@ -46,6 +48,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
      mainWindow:(UIWindow *)mainWindow {
 	self = [super init];
 	_controllerFactory = controllerFactory;
+    _layoutManager = layoutManager;
 	_eventEmitter = eventEmitter;
 	_modalManager = modalManager;
 	_overlayManager = overlayManager;
@@ -99,7 +102,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	[self assertReady];
     RNNAssertMainQueue();
 	
-	UIViewController<RNNLayoutProtocol>* vc = [RNNLayoutManager findComponentForId:componentId];
+	UIViewController<RNNLayoutProtocol>* vc = [_layoutManager findComponentForId:componentId];
 	RNNNavigationOptions* newOptions = [[RNNNavigationOptions alloc] initWithDict:mergeOptions];
 	if ([vc conformsToProtocol:@protocol(RNNLayoutProtocol)] || [vc isKindOfClass:[RNNComponentViewController class]]) {
 		[CATransaction begin];
@@ -128,7 +131,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
     RNNAssertMainQueue();
 	
 	UIViewController *newVc = [_controllerFactory createLayout:layout];
-	UIViewController *fromVC = [RNNLayoutManager findComponentForId:componentId];
+	UIViewController *fromVC = [_layoutManager findComponentForId:componentId];
 	
 	if ([[newVc.resolveOptionsWithDefault.preview.reactTag getWithDefaultValue:@(0)] floatValue] > 0) {
 		if ([fromVC isKindOfClass:[RNNComponentViewController class]]) {
@@ -193,7 +196,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 		}
 	}
 	UIViewController *newVC = childViewControllers.lastObject;
-	UIViewController *fromVC = [RNNLayoutManager findComponentForId:componentId];
+	UIViewController *fromVC = [_layoutManager findComponentForId:componentId];
 	RNNNavigationOptions* options = newVC.resolveOptionsWithDefault;
 	__weak typeof(RNNEventEmitter*) weakEventEmitter = _eventEmitter;
 
@@ -212,7 +215,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	[self assertReady];
 	RNNAssertMainQueue();
     
-	RNNComponentViewController *vc = (RNNComponentViewController*)[RNNLayoutManager findComponentForId:componentId];
+	RNNComponentViewController *vc = (RNNComponentViewController*)[_layoutManager findComponentForId:componentId];
   if (vc) {
       RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initWithDict:mergeOptions];
       [vc overrideOptions:options];
@@ -230,7 +233,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	[self assertReady];
     RNNAssertMainQueue();
     
-	RNNComponentViewController *vc = (RNNComponentViewController*)[RNNLayoutManager findComponentForId:componentId];
+	RNNComponentViewController *vc = (RNNComponentViewController*)[_layoutManager findComponentForId:componentId];
 	RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initWithDict:mergeOptions];
 	[vc overrideOptions:options];
 	
@@ -244,7 +247,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	[self assertReady];
     RNNAssertMainQueue();
     
-	RNNComponentViewController *vc = (RNNComponentViewController*)[RNNLayoutManager findComponentForId:componentId];
+	RNNComponentViewController *vc = (RNNComponentViewController*)[_layoutManager findComponentForId:componentId];
 	RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initWithDict:mergeOptions];
 	[vc overrideOptions:options];
 	
@@ -283,7 +286,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	[self assertReady];
     RNNAssertMainQueue();
 	
-	UIViewController *modalToDismiss = (UIViewController *)[RNNLayoutManager findComponentForId:componentId];
+	UIViewController *modalToDismiss = (UIViewController *)[_layoutManager findComponentForId:componentId];
 
 	if (!modalToDismiss.isModal) {
 		[RNNErrorHandler reject:reject withErrorCode:1013 errorDescription:@"component is not a modal"];
@@ -336,7 +339,7 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	[self assertReady];
     RNNAssertMainQueue();
     
-	UIViewController* viewController = [RNNLayoutManager findComponentForId:componentId];
+	UIViewController* viewController = [_layoutManager findComponentForId:componentId];
 	if (viewController) {
 		[_overlayManager dismissOverlay:viewController];
 		[_eventEmitter sendOnNavigationCommandCompletion:dismissOverlay commandId:commandId];

--- a/lib/ios/RNNLayoutManager.h
+++ b/lib/ios/RNNLayoutManager.h
@@ -4,6 +4,9 @@
 
 @interface RNNLayoutManager : NSObject
 
+- (void)addPendingViewController:(UIViewController *)vc;
+- (void)removePendingViewController:(UIViewController *)vc;
+
 - (UIViewController *)findComponentForId:(NSString *)componentId;
 
 @end

--- a/lib/ios/RNNLayoutManager.h
+++ b/lib/ios/RNNLayoutManager.h
@@ -4,6 +4,6 @@
 
 @interface RNNLayoutManager : NSObject
 
-+ (UIViewController *)findComponentForId:(NSString *)componentId;
+- (UIViewController *)findComponentForId:(NSString *)componentId;
 
 @end

--- a/lib/ios/RNNLayoutManager.m
+++ b/lib/ios/RNNLayoutManager.m
@@ -4,7 +4,7 @@
 
 @implementation RNNLayoutManager
 
-+ (UIViewController *)findComponentForId:(NSString *)componentId {
+- (UIViewController *)findComponentForId:(NSString *)componentId {
 	for (UIWindow *window in UIApplication.sharedApplication.windows) {
 		UIViewController *result = [self findChildComponentForParent:window.rootViewController forId:componentId];
 		if (result) {
@@ -15,7 +15,7 @@
 	return nil;
 }
 
-+ (UIViewController *)findChildComponentForParent:(UIViewController *)parentViewController forId:(NSString *)componentId {
+- (UIViewController *)findChildComponentForParent:(UIViewController *)parentViewController forId:(NSString *)componentId {
 	if ([parentViewController.layoutInfo.componentId isEqualToString:componentId]) {
 		return parentViewController;
 	}

--- a/lib/ios/RNNLayoutManager.m
+++ b/lib/ios/RNNLayoutManager.m
@@ -2,9 +2,43 @@
 #import "RNNLayoutProtocol.h"
 #import "UIViewController+LayoutProtocol.h"
 
+@interface RNNLayoutManager ()
+
+@property (nonatomic, strong) NSHashTable<UIViewController *> *pendingViewControllers;
+
+@end
+
 @implementation RNNLayoutManager
 
+- (instancetype)init {
+    if (self = [super init]) {
+        _pendingViewControllers = [NSHashTable weakObjectsHashTable];
+    }
+    return self;
+}
+
+- (void)addPendingViewController:(UIViewController *)vc {
+    if (!vc) {
+        return;
+    }
+    [self.pendingViewControllers addObject:vc];
+}
+
+- (void)removePendingViewController:(UIViewController *)vc {
+    if (!vc) {
+        return;
+    }
+    [self.pendingViewControllers removeObject:vc];
+}
+
 - (UIViewController *)findComponentForId:(NSString *)componentId {
+    for (UIViewController *vc in self.pendingViewControllers) {
+        UIViewController *result = [self findChildComponentForParent:vc forId:componentId];
+        if (result) {
+            return result;
+        }
+    }
+
 	for (UIWindow *window in UIApplication.sharedApplication.windows) {
 		UIViewController *result = [self findChildComponentForParent:window.rootViewController forId:componentId];
 		if (result) {

--- a/lib/ios/RNNLayoutManager.m
+++ b/lib/ios/RNNLayoutManager.m
@@ -67,6 +67,16 @@
 			return result;
 		}
 	}
+
+    if ([parentViewController respondsToSelector:@selector(pendingChildViewControllers)]) {
+        NSArray *pendingChildVCs = [parentViewController pendingChildViewControllers];
+        for (UIViewController *childVC in pendingChildVCs) {
+            UIViewController *result = [self findChildComponentForParent:childVC forId:componentId];
+            if (result) {
+                return result;
+            }
+        }
+    }
 	
 	return nil;
 }

--- a/lib/ios/RNNLayoutProtocol.h
+++ b/lib/ios/RNNLayoutProtocol.h
@@ -41,4 +41,8 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 - (void)readyForPresentation;
 
+@optional
+
+- (NSArray<UIViewController *> *)pendingChildViewControllers;
+
 @end

--- a/lib/ios/ReactNativeNavigation.m
+++ b/lib/ios/ReactNativeNavigation.m
@@ -33,7 +33,7 @@
 }
 
 + (UIViewController *)findViewController:(NSString *)componentId {
-    return [RNNLayoutManager findComponentForId:componentId];
+    return [[ReactNativeNavigation sharedInstance].bridgeManager findComponentForId:componentId];
 }
 
 

--- a/lib/ios/UINavigationController+RNNCommands.m
+++ b/lib/ios/UINavigationController+RNNCommands.m
@@ -15,9 +15,9 @@ typedef void (^RNNAnimationBlock)(void);
         self.navigationBar.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
     }
     
-    [self performAnimationBlock:^{
+    [self performBlock:^{
         [self pushViewController:newTop animated:animated];
-    } completion:completion];
+    } animated:animated completion:completion];
 }
 
 - (void)pop:(UIViewController *)viewController animated:(BOOL)animated completion:(RNNTransitionCompletionBlock)completion rejection:(RNNTransitionRejectionBlock)rejection {
@@ -29,15 +29,15 @@ typedef void (^RNNAnimationBlock)(void);
     if ([self topViewController] != viewController) {
         NSMutableArray * vcs = self.viewControllers.mutableCopy;
         [vcs removeObject:viewController];
-        [self performAnimationBlock:^{
+        [self performBlock:^{
             [self setViewControllers:vcs animated:animated];
-        } completion:^{
+        } animated:animated completion:^{
             completion();
         }];
     } else {
-        [self performAnimationBlock:^{
+        [self performBlock:^{
             [self popViewControllerAnimated:animated];
-        } completion:^{
+        } animated:animated completion:^{
             completion();
         }];
     }
@@ -46,9 +46,9 @@ typedef void (^RNNAnimationBlock)(void);
 - (void)popTo:(UIViewController *)viewController animated:(BOOL)animated completion:(RNNPopCompletionBlock)completion rejection:(RNNTransitionRejectionBlock)rejection; {
     __block NSArray* poppedVCs;
     if ([self.childViewControllers containsObject:viewController]) {
-        [self performAnimationBlock:^{
+        [self performBlock:^{
             poppedVCs = [self popToViewController:viewController animated:animated];
-        } completion:^{
+        } animated:animated completion:^{
             if (completion) {
                 completion(poppedVCs);
             }
@@ -60,22 +60,30 @@ typedef void (^RNNAnimationBlock)(void);
 
 - (void)popToRoot:(UIViewController*)viewController animated:(BOOL)animated completion:(RNNPopCompletionBlock)completion rejection:(RNNTransitionRejectionBlock)rejection {
     __block NSArray* poppedVCs;
-    [self performAnimationBlock:^{
+    [self performBlock:^{
         poppedVCs = [self popToRootViewControllerAnimated:animated];
-    } completion:^{
+    } animated:animated completion:^{
         completion(poppedVCs);
     }];
 }
 
 - (void)setStackChildren:(NSArray<UIViewController *> *)children fromViewController:(UIViewController *)fromViewController animated:(BOOL)animated completion:(RNNTransitionCompletionBlock)completion rejection:(RNNTransitionRejectionBlock)rejection {
-    [self performAnimationBlock:^{
+    [self performBlock:^{
         [self setViewControllers:children animated:animated];
-    } completion:completion];
+    } animated:animated completion:completion];
 }
 
 # pragma mark Private
 
-- (void)performAnimationBlock:(RNNAnimationBlock)animationBlock completion:(RNNTransitionCompletionBlock)completion {
+- (void)performBlock:(RNNAnimationBlock)animationBlock animated:(BOOL)animated completion:(RNNTransitionCompletionBlock)completion {
+    if (!animated) {
+        animationBlock();
+        if (completion) {
+            completion();
+        }
+        return;
+    }
+
     [CATransaction begin];
     [CATransaction setCompletionBlock:^{
         if (completion) {

--- a/playground/ios/NavigationTests/RNNLayoutManagerTest.m
+++ b/playground/ios/NavigationTests/RNNLayoutManagerTest.m
@@ -6,6 +6,8 @@
 
 @interface RNNLayoutManagerTest : XCTestCase
 
+@property (nonatomic, strong) RNNLayoutManager *layoutManager;
+
 @property (nonatomic, strong) UIViewController* vc1;
 @property (nonatomic, strong) UIViewController* vc2;
 @property (nonatomic, strong) UIViewController* vc3;
@@ -18,6 +20,8 @@
 @implementation RNNLayoutManagerTest
 
 - (void)setUp {
+	_layoutManager = [[RNNLayoutManager alloc] init];
+
 	_vc1 = [self createMockViewControllerWithComponentId:@"vc1"];
 	_vc2 = [self createMockViewControllerWithComponentId:@"vc2"];
 	_vc3 = [self createMockViewControllerWithComponentId:@"vc3"];
@@ -35,13 +39,13 @@
 
 - (void)testFindComponentForIdShouldReturnVCInFirstWindowRoot {
 	_firstWindow.rootViewController = _vc1;
-	UIViewController *resultVC = [RNNLayoutManager findComponentForId:@"vc1"];
+	UIViewController *resultVC = [_layoutManager findComponentForId:@"vc1"];
 	XCTAssertEqual(resultVC, _vc1);
 }
 
 - (void)testFindComponentForIdShouldReturnVCFromSecondWindowRoot {
 	_secondWindow.rootViewController = _vc1;
-	UIViewController *resultVC = [RNNLayoutManager findComponentForId:@"vc1"];
+	UIViewController *resultVC = [_layoutManager findComponentForId:@"vc1"];
 	XCTAssertEqual(resultVC, _vc1);
 }
 
@@ -51,7 +55,7 @@
 	UIViewController* modal = _vc1;
 	OCMStub([rootViewController presentedViewController]).andReturn(modal);
 	_firstWindow.rootViewController = rootViewController;
-	UIViewController *resultVC = [RNNLayoutManager findComponentForId:@"vc1"];
+	UIViewController *resultVC = [_layoutManager findComponentForId:@"vc1"];
 	XCTAssertEqual(resultVC, modal);
 }
 
@@ -60,13 +64,13 @@
 	UIViewController* modal = _vc1;
 	OCMStub([rootViewController presentedViewController]).andReturn(modal);
 	_secondWindow.rootViewController = rootViewController;
-	UIViewController *resultVC = [RNNLayoutManager findComponentForId:@"vc1"];
+	UIViewController *resultVC = [_layoutManager findComponentForId:@"vc1"];
 	XCTAssertEqual(resultVC, modal);
 }
 
 - (void)testFindComponentShouldReturnNilForUndefindComponent {
 	_firstWindow.rootViewController = _vc1;
-	UIViewController *resultVC = [RNNLayoutManager findComponentForId:@"vvc"];
+	UIViewController *resultVC = [_layoutManager findComponentForId:@"vvc"];
 	XCTAssertNil(resultVC);
 }
 
@@ -75,7 +79,7 @@
 	[nvc setViewControllers:@[_vc1, _vc2, _vc3]];
 	_secondWindow.rootViewController = nvc;
 	
-	UIViewController *resultVC = [RNNLayoutManager findComponentForId:@"vc3"];
+	UIViewController *resultVC = [_layoutManager findComponentForId:@"vc3"];
 	XCTAssertEqual(resultVC, _vc3);
 }
 

--- a/playground/ios/SnapshotTests/Utils/CommandsHandlerCreator.m
+++ b/playground/ios/SnapshotTests/Utils/CommandsHandlerCreator.m
@@ -1,5 +1,6 @@
 #import "CommandsHandlerCreator.h"
 #import "RNNTestRootViewCreator.h"
+#import <ReactNativeNavigation/RNNLayoutManager.h>
 #import <ReactNativeNavigation/RNNEventEmitter.h>
 #import <ReactNativeNavigation/RNNOverlayManager.h>
 #import <ReactNativeNavigation/RNNModalManager.h>
@@ -10,11 +11,12 @@
 
 + (RNNCommandsHandler *)createWithWindow:(UIWindow *)window {
 	RNNTestRootViewCreator* creator = [RNNTestRootViewCreator new];
+	RNNLayoutManager *layoutManager = [[RNNLayoutManager alloc] init];
 	RNNEventEmitter* eventEmmiter = [RNNEventEmitter new];
 	RNNOverlayManager* overlayManager = [RNNOverlayManager new];
 	RNNModalManager* modalManager = [RNNModalManager new];
 	RNNControllerFactory* controllerFactory = [[RNNControllerFactory alloc] initWithRootViewCreator:creator eventEmitter:eventEmmiter store:nil componentRegistry:nil andBridge:nil bottomTabsAttachModeFactory:[BottomTabsAttachModeFactory new]];
-	RNNCommandsHandler* commandsHandler = [[RNNCommandsHandler alloc] initWithControllerFactory:controllerFactory eventEmitter:eventEmmiter modalManager:modalManager overlayManager:overlayManager setRootAnimator:[RNNSetRootAnimator new] mainWindow:window];
+	RNNCommandsHandler* commandsHandler = [[RNNCommandsHandler alloc] initWithControllerFactory:controllerFactory layoutManager:layoutManager eventEmitter:eventEmmiter modalManager:modalManager overlayManager:overlayManager setRootAnimator:[RNNSetRootAnimator new] mainWindow:window];
 	[commandsHandler setReadyToReceiveCommands:YES];
 	[commandsHandler setDefaultOptions:@{
 		@"animations": @{


### PR DESCRIPTION
When `waitForRender` is set to `true`, calling `Navigation.mergeOptions` early (for example in `componentDidMount`) will lead to the options not being applied as the backing view controller has not yet been placed in the window hierarchy. This PR aims to keep track of any pending view controllers and opens them up to being found via their component id. Thus enabling `Navigation.mergeOptions` to work on view controllers in transit.

The pending view controllers are now being kept in `RNNLayoutManager`. For that reason, the layout manager was converted to be instantiable.

A `NSHashTable` was chosen as the backing storage to support keeping the view controllers as a weak reference.

Fixes #6085