### PR TITLE
Fix default alpha animation being reversed

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/FadeAnimation.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/FadeAnimation.java
@@ -4,11 +4,11 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class FadeAnimation extends NestedAnimationsOptions {
-    public FadeAnimation() {
+    public FadeAnimation(boolean reversed) {
         try {
             JSONObject alpha = new JSONObject();
-            alpha.put("from", 0);
-            alpha.put("to", 1);
+            alpha.put("from", reversed ? 1 : 0);
+            alpha.put("to", reversed ? 0 : 1);
             alpha.put("duration", 300);
 
             JSONObject content = new JSONObject();
@@ -20,5 +20,9 @@ public class FadeAnimation extends NestedAnimationsOptions {
         } catch (JSONException e) {
             e.printStackTrace();
         }
+    }
+
+    public FadeAnimation() {
+        this(false);
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackAnimator.kt
@@ -73,7 +73,7 @@ open class StackAnimator @JvmOverloads constructor(
     }
 
     private suspend fun popWithElementTransitions(appearing: ViewController<*>, disappearing: ViewController<*>, pop: NestedAnimationsOptions, set: AnimatorSet) {
-        val fade = if (pop.content.isFadeAnimation()) pop else FadeAnimation()
+        val fade = if (pop.content.isFadeAnimation()) pop else FadeAnimation(true)
         val transitionAnimators = transitionAnimatorCreator.create(pop, fade.content, disappearing, appearing)
         set.playTogether(fade.content.getAnimation(disappearing.view), transitionAnimators)
         transitionAnimators.listeners.forEach { listener: Animator.AnimatorListener -> set.addListener(listener) }


### PR DESCRIPTION
If you comment out [these](https://github.com/wix/react-native-navigation/blob/master/playground/src/screens/sharedElementTransition/CocktailsListScreen.tsx#L51-L57) and [these](https://github.com/wix/react-native-navigation/blob/master/playground/src/screens/sharedElementTransition/CocktailsListScreen.tsx#L93-L99) lines in the playground demo, then test the Cocktails screen and select your favourite gin cocktail (@danilobuerger !!!!), you can notice that on popping the alpha animation is reversed. You'd expect it to go from visible (opacity of `1`) to invisible (opacity of `0`), but instead it jumps to `0` and then goes to `1` making it look really weird.

This PR changes this default behavior to reverse the default `FadeAnimation` on pop.