### PR TITLE
Fix incorrect border radius end value

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/SharedElementTransition.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/SharedElementTransition.kt
@@ -36,7 +36,8 @@ class SharedElementTransition(appearing: ViewController<*>, private val options:
         return listOf(
                 ReactImageMatrixAnimator(from, to),
                 FastImageMatrixAnimator(from, to),
-                ClipBoundsAnimator(from, to),
+                ReactImageBoundsAnimator(from, to),
+                FastImageBoundsAnimator(from, to),
                 FastImageBorderRadiusAnimator(from, to),
                 XAnimator(from, to),
                 YAnimator(from, to),

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBoundsAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBoundsAnimator.kt
@@ -5,14 +5,17 @@ import android.animation.ObjectAnimator
 import android.graphics.Rect
 import android.view.View
 import android.widget.ImageView
+import com.facebook.react.views.image.ReactImageView
 import com.reactnativenavigation.options.SharedElementTransitionOptions
 import com.reactnativenavigation.utils.ViewUtils
 import com.reactnativenavigation.utils.computeInheritedScale
 import kotlin.math.roundToInt
 
-class ClipBoundsAnimator(from: View, to: View) : PropertyAnimatorCreator<ImageView>(from, to) {
+class FastImageBoundsAnimator(from: View, to: View) : PropertyAnimatorCreator<ImageView>(from, to) {
     override fun shouldAnimateProperty(fromChild: ImageView, toChild: ImageView): Boolean {
         return !ViewUtils.areDimensionsEqual(from, to)
+                && fromChild !is ReactImageView
+                && toChild !is ReactImageView
     }
 
     override fun create(options: SharedElementTransitionOptions): Animator {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/ReactImageBoundsAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/ReactImageBoundsAnimator.kt
@@ -1,0 +1,40 @@
+package com.reactnativenavigation.views.element.animators
+
+import android.animation.Animator
+import android.animation.ObjectAnimator
+import android.graphics.Rect
+import android.view.View
+import android.widget.ImageView
+import com.facebook.react.views.image.ReactImageView
+import com.reactnativenavigation.options.SharedElementTransitionOptions
+import com.reactnativenavigation.utils.ViewUtils
+import com.reactnativenavigation.utils.computeInheritedScale
+import kotlin.math.roundToInt
+
+class ReactImageBoundsAnimator(from: View, to: View) : PropertyAnimatorCreator<ReactImageView>(from, to) {
+    override fun shouldAnimateProperty(fromChild: ReactImageView, toChild: ReactImageView): Boolean {
+        return !ViewUtils.areDimensionsEqual(from, to)
+    }
+
+    override fun create(options: SharedElementTransitionOptions): Animator {
+        val startDrawingRect = Rect().apply { from.getDrawingRect(this) }
+        val endDrawingRect = Rect().apply { to.getDrawingRect(this) }
+
+        val (inheritedScaleX, inheritedScaleY) = computeInheritedScale(from)
+        startDrawingRect.right = (startDrawingRect.right * inheritedScaleX).roundToInt()
+        startDrawingRect.bottom = (startDrawingRect.bottom * inheritedScaleY).roundToInt()
+
+        return ObjectAnimator.ofObject(
+                BoundsEvaluator() {
+                    with(to as ReactImageView) {
+                        drawable.bounds = it
+                        drawable.current.bounds = it
+                        to.clipBounds = it
+                        invalidate()
+                    }
+                },
+                startDrawingRect,
+                endDrawingRect
+        )
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/ReactImageCornerRadiusAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/ReactImageCornerRadiusAnimator.kt
@@ -2,7 +2,9 @@ package com.reactnativenavigation.views.element.animators
 
 import android.animation.Animator
 import android.animation.ObjectAnimator
+import android.os.Build
 import android.view.View
+import androidx.annotation.RequiresApi
 import androidx.core.animation.doOnEnd
 import com.facebook.react.views.image.ReactImageView
 import com.reactnativenavigation.options.SharedElementTransitionOptions
@@ -14,8 +16,10 @@ import kotlin.math.min
 class ReactImageCornerRadiusAnimator(from: View, to: View) : PropertyAnimatorCreator<ReactImageView>(from, to) {
     override fun shouldAnimateProperty(fromChild: ReactImageView, toChild: ReactImageView): Boolean {
         return fromChild.getCornerRadius() != toChild.getCornerRadius()
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
     }
 
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     override fun create(options: SharedElementTransitionOptions): Animator {
         to as ReactImageView; from as ReactImageView
         val outlineProvider = BorderRadiusOutlineProvider(to, from.getCornerRadius())
@@ -31,6 +35,7 @@ class ReactImageCornerRadiusAnimator(from: View, to: View) : PropertyAnimatorCre
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     private fun setInitialOutline(to: ReactImageView, provider: BorderRadiusOutlineProvider) {
         to.outlineProvider = provider
         to.clipToOutline = true


### PR DESCRIPTION
While animating ReactImageView in shared element transition, we're changing the bounds of the destination image to max(sourceImage.bounds, destinationImage.bounds) and apply a clipping Rect.
This apparently messes up border-radius as Fresco isn't aware of the clipping Rect and draws the corners according to the actual image bounds.

This commit splits the clip bounds animator into two animators, one for Image and another for FastImage.
In the ReactImageView animator, we update both clip bounds and the drawable bounds

This was noticeable when the default resize mode (cover) was used.

**Note: this or doesn't add support for animating border-radius in ReactImageView. This will be added hopefully in a separate PR**

| Before                                                                                                                         | After                                                                                                                          |
|--------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
| ![Screenshot_1604324543](https://user-images.githubusercontent.com/12352397/97874934-683f3b00-1d22-11eb-96b1-8415984308d5.png) | ![Screenshot_1604324565](https://user-images.githubusercontent.com/12352397/97874965-6f664900-1d22-11eb-9e86-7c176af7e1b4.png) |
