### PR TITLE
Updated the documentation for mobx integration.

### DIFF
--- a/website/docs/docs/third-party-mobx.mdx
+++ b/website/docs/docs/third-party-mobx.mdx
@@ -3,9 +3,12 @@ id: third-party-mobx
 title: MobX
 sidebar_label: MobX
 ---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-MobX is one of the most popular state management libraries used by applications sized from small to large. 
+MobX is one of the most popular state management libraries used by applications sized from small to large.
 With the introduction of the new React Context API, MobX can now be very easily integrated in React Native Navigation
 projects.
 
@@ -21,23 +24,52 @@ Also the example uses `mobx-react-lite` but you can use the normal `mobx-react`.
 In the example below we will be creating a small Counter app. We will learn how to integrate Mobx with React-Native-Navigation and demonstrate how updating the store from one component, triggers renders in other components connected to the same store.
 
 Once you finish implementing the example, your screen should look similar to this:
+
 <img width="30%" src={useBaseUrl('/img/mobx_counter.png')} />
 
 ### Step 1 - Create a Counter store
+
 Let's first create a counter store using MobX. Our store has a single `count` object and two methods to increment and decrement it.
 
-```tsx file=./third-party-mobx/counter-store.tsx
+<Tabs
+  defaultValue="makeObservable"
+  values={[
+    { label: 'MakeObservable', value: 'makeObservable' },
+    { label: 'Decorator', value: 'decorator' },
+  ]}
+>
+
+<TabItem value="makeObservable">
+
+```tsx file=./third-party-mobx/counter-store.tsx 
 ```
 
+</TabItem>
+
+<TabItem value="decorator">
+
+  From `mobx@6.0.0` decorators have become an opt-in feature. To enable decorators for `mobx`, follow the [official guide](https://mobx.js.org/enabling-decorators.html).
+
+  ```tsx file=./third-party-mobx/counter-store-decorator.tsx 
+  ```
+
+</TabItem>
+
+</Tabs>
+
 ### Step 2 - Consuming the store
-You can consume the Counter store in any React components using `React.useContext`.
+
+You can consume the Counter store in any React components using `useCounterStore` hook or `React.useContext`
 
 ```tsx file=./third-party-mobx/counter-screen.tsx
 ```
 
 ## How to use MobX persistent data
+
 Often the app will require a persistent data solution and with MobX you can use [`mobx-react-persist`](https://github.com/pinqy520/mobx-persist).
-It only takes few extra steps to integrate the library.
+It only takes few extra steps to integrate the library. 
+
+Also the integration assumes that you are using the decorator pattern for `mobx`.
 
 ```tsx file=./third-party-mobx/persistent-data.tsx
 ```

--- a/website/docs/docs/third-party-mobx/counter-screen.tsx
+++ b/website/docs/docs/third-party-mobx/counter-screen.tsx
@@ -1,19 +1,28 @@
 // CounterScreen.js
-import React from 'react';
+import React, { useContext } from 'react';
 import { Button, Text, View } from 'react-native';
+import { Navigation } from 'react-native-navigation'
 import { observer } from 'mobx-react-lite';
-import { CounterStoreContext } from './counter.store';
 
-const CounterScreen = observer((props) => {
-  const { count, increment, decrement } = React.useContext(CounterStoreContext);
+import { useCounterStore, CounterStoreContext } from './counter.store';
+
+export const CounterScreen = observer(({ componentId }) => {
+  const { count, increment, decrement } = useCounterStore(); // OR useContext(CounterStoreContext)
+
+  const navigateToNextScreen = () => {
+    Navigation.push(componentId, {
+      component: {
+        name: 'NextScreen'
+      }
+    })
+  }
 
   return (
     <Root>
       <Text>{`Clicked ${count} times!`}</Text>
       <Button title="Increment" onPress={increment} />
       <Button title="Decrement" onPress={decrement} />
-      <Button title="Push" onPress={() => Navigation.push(props.componentId, 'CounterScreen')} />
+      <Button title="Push" onPress={navigateToNextScreen} />
     </Root>
   );
 });
-module.exports = CounterScreen;

--- a/website/docs/docs/third-party-mobx/counter-store-decorator.tsx
+++ b/website/docs/docs/third-party-mobx/counter-store-decorator.tsx
@@ -1,22 +1,20 @@
 // counter.store.js
 import React from 'react';
-import { makeObservable, action, observable } from 'mobx';
+import { observable, action, makeObservable } from 'mobx';
 
 class CounterStore {
-  count = 0;
+  @observable count = 0;
 
   constructor() {
-    makeObservable(this, {
-      count: observable,
-      increment: action.bound,
-      decrement: action.bound
-    })
+    makeObservable(this)
   }
 
+  @action.bound
   increment() {
     this.count += 1;
   }
 
+  @action.bound
   decrement() {
     this.count -= 1;
   }
@@ -24,6 +22,7 @@ class CounterStore {
 
 // Instantiate the counter store.
 const counterStore = new CounterStore();
+
 // Create a React Context with the counter store instance.
 export const CounterStoreContext = React.createContext(counterStore);
 export const useCounterStore = () => React.useContext(CounterStoreContext)

--- a/website/docs/docs/third-party-mobx/persistent-data.tsx
+++ b/website/docs/docs/third-party-mobx/persistent-data.tsx
@@ -1,10 +1,15 @@
 //counter.store.js
 import React from 'react';
-import { observable, action } from 'mobx';
+import { makeObservable, observable, action } from 'mobx';
 import { persist } from 'mobx-persist'; // add this.
 
 class CounterStore {
+  constructor() {
+    makeObservable(this)
+  }
+  
   @persist @observable count = 0; // count is now persistent.
+
 
   @action.bound
   increment() {
@@ -19,6 +24,7 @@ class CounterStore {
 
 export const counterStore = new CounterStore(); // You need to export the counterStore instance.
 export const CounterStoreContext = React.createContext(counterStore);
+export const useCounterStore = () => React.useContext(CounterStoreContext)
 
 // index.js
 import { Navigation } from 'react-native-navigation';


### PR DESCRIPTION
Updated the `mobx integration` documentation to reflect the latest mobx update. It highlights the new mobx standard pattern of using `makeObservable` but still provides an integration guide on using decorator pattern.

Closes #6739 