### PR TITLE
Do not close "needs triage" issues as stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -9,6 +9,7 @@ daysUntilClose: 7
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
+  - "needs triage"
   - "type: accepted/enhancement"
   - "user: looking for contributors"
   - "📌 pinned"


### PR DESCRIPTION
If an issue still needs to be looked at, it can't be stale.