### PR TITLE
Fix default options being applied when calling mergeOptions on a stack layout

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenter.java
@@ -126,10 +126,10 @@ public class StackPresenter {
     }
 
     public void mergeOptions(Options options, StackController stack, ViewController currentChild) {
-        TopBarOptions withDefault = options.topBar.mergeWithDefault(stack.resolveChildOptions(currentChild).topBar).mergeWithDefault(defaultOptions.topBar);
+        TopBarOptions resolvedTopBarOptions = options.topBar.copy().mergeWithDefault(stack.resolveChildOptions(currentChild).topBar).mergeWithDefault(defaultOptions.topBar);
         mergeOrientation(options.layout.orientation);
-//        mergeButtons(topBar, withDefault.topBar.buttons, child);
-        mergeTopBarOptions(withDefault, options, stack, currentChild);
+        //        mergeButtons(topBar, withDefault.topBar.buttons, child);
+        mergeTopBarOptions(resolvedTopBarOptions, options, stack, currentChild);
         mergeTopTabsOptions(options.topTabs);
         mergeTopTabOptions(options.topTabOptions);
     }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenterTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenterTest.java
@@ -72,6 +72,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -350,6 +351,19 @@ public class StackPresenterTest extends BaseTest {
     }
 
     @Test
+    public void mergeOptions_defaultOptionsAreNotApplied() {
+        Options defaultOptions = new Options();
+        defaultOptions.topBar.background.color = new Colour(10);
+        uut.setDefaultOptions(defaultOptions);
+
+        Options toMerge = new Options();
+        toMerge.topBar.title.text = new Text("someText");
+        uut.mergeOptions(toMerge, parent, child);
+
+        verify(topBar, never()).setBackgroundColor(anyInt());
+    }
+
+    @Test
     public void mergeOptions_resolvedTitleFontOptionsAreApplied() {
         Options childOptions = new Options();
         childOptions.topBar.title.font.setFontFamily(new Text(SOME_FONT_FAMILY));
@@ -442,6 +456,19 @@ public class StackPresenterTest extends BaseTest {
     }
 
     @Test
+    public void mergeChildOptions_defaultOptionsAreNotApplied() {
+        Options defaultOptions = new Options();
+        defaultOptions.topBar.background.color = new Colour(10);
+        uut.setDefaultOptions(defaultOptions);
+
+        Options childOptions = new Options();
+        childOptions.topBar.title.text = new Text("someText");
+        uut.mergeChildOptions(childOptions, EMPTY_OPTIONS, parent, child);
+
+        verify(topBar, never()).setBackgroundColor(anyInt());
+    }
+
+    @Test
     public void applyTopBarOptions_setTitleComponent() {
         Options applyComponent = new Options();
         applyComponent.topBar.title.component.name = new Text("Component1");
@@ -520,19 +547,6 @@ public class StackPresenterTest extends BaseTest {
 
         uut.applyInitialChildLayoutOptions(options);
         verify(topBarController).hide();
-    }
-
-    @Test
-    public void mergeOptions_defaultOptionsAreNotApplied() {
-        Options defaultOptions = new Options();
-        defaultOptions.topBar.background.color = new Colour(10);
-        uut.setDefaultOptions(defaultOptions);
-
-        Options childOptions = new Options();
-        childOptions.topBar.title.text = new Text("someText");
-        uut.mergeChildOptions(childOptions, EMPTY_OPTIONS, parent, child);
-
-        verify(topBar, times(0)).setBackgroundColor(anyInt());
     }
 
     @Test


### PR DESCRIPTION
When calling mergeOptions on a stack layout directly, the default options were applied as well.