### PR TITLE
Pass props to components by ref (without deep cloning)

### DIFF
--- a/lib/src/commands/Commands.test.ts
+++ b/lib/src/commands/Commands.test.ts
@@ -1,7 +1,7 @@
 import forEach from 'lodash/forEach';
 import filter from 'lodash/filter';
 import invoke from 'lodash/invoke';
-import { mock, verify, instance, deepEqual, when, anything, anyString } from 'ts-mockito';
+import { mock, verify, instance, deepEqual, when, anything, anyString, capture } from 'ts-mockito';
 
 import { LayoutTreeParser } from './LayoutTreeParser';
 import { LayoutTreeCrawler } from './LayoutTreeCrawler';
@@ -139,6 +139,13 @@ describe('Commands', () => {
         CommandName.SetRoot
       );
     });
+
+    it('retains passProps properties identity', () => {
+      const obj = { some: 'content' };
+      uut.setRoot({ root: { component: { name: 'com.example.MyScreen', passProps: { obj } } } });
+      const args = capture(mockedStore.updateProps).last();
+      expect(args[1].obj).toBe(obj);
+    });
   });
 
   describe('mergeOptions', () => {
@@ -204,6 +211,13 @@ describe('Commands', () => {
         { component: { name: 'com.example.MyScreen' } },
         CommandName.ShowModal
       );
+    });
+
+    it('retains passProps properties identity', () => {
+      const obj = { some: 'content' };
+      uut.showModal({ component: { name: 'com.example.MyScreen', passProps: { obj } } });
+      const args = capture(mockedStore.updateProps).last();
+      expect(args[1].obj).toBe(obj);
     });
   });
 
@@ -282,6 +296,15 @@ describe('Commands', () => {
         { component: { name: 'com.example.MyScreen' } },
         CommandName.Push
       );
+    });
+
+    it('retains passProps properties identity', () => {
+      const obj = { some: 'content' };
+      uut.push('theComponentId', {
+        component: { name: 'com.example.MyScreen', passProps: { obj } },
+      });
+      const args = capture(mockedStore.updateProps).last();
+      expect(args[1].obj).toBe(obj);
     });
   });
 
@@ -371,6 +394,15 @@ describe('Commands', () => {
         CommandName.SetStackRoot
       );
     });
+
+    it('retains passProps properties identity', () => {
+      const obj = { some: 'content' };
+      uut.setStackRoot('theComponentId', [
+        { component: { name: 'com.example.MyScreen', passProps: { obj } } },
+      ]);
+      const args = capture(mockedStore.updateProps).last();
+      expect(args[1].obj).toBe(obj);
+    });
   });
 
   describe('showOverlay', () => {
@@ -407,6 +439,13 @@ describe('Commands', () => {
         { component: { name: 'com.example.MyScreen' } },
         CommandName.ShowOverlay
       );
+    });
+
+    it('retains passProps properties identity', () => {
+      const obj = { some: 'content' };
+      uut.showOverlay({ component: { name: 'com.example.MyScreen', passProps: { obj } } });
+      const args = capture(mockedStore.updateProps).last();
+      expect(args[1].obj).toBe(obj);
     });
   });
 

--- a/lib/src/commands/Commands.ts
+++ b/lib/src/commands/Commands.ts
@@ -1,3 +1,4 @@
+import cloneDeepWith from 'lodash/cloneDeepWith';
 import cloneDeep from 'lodash/cloneDeep';
 import map from 'lodash/map';
 import { CommandsObserver } from '../events/CommandsObserver';
@@ -25,7 +26,7 @@ export class Commands {
   ) {}
 
   public setRoot(simpleApi: LayoutRoot) {
-    const input = cloneDeep(simpleApi);
+    const input = cloneLayout(simpleApi);
     const processedRoot = this.layoutProcessor.process(input.root, CommandName.SetRoot);
     const root = this.layoutTreeParser.parse(processedRoot);
 
@@ -79,7 +80,7 @@ export class Commands {
   }
 
   public showModal(layout: Layout) {
-    const layoutCloned = cloneDeep(layout);
+    const layoutCloned = cloneLayout(layout);
     const layoutProcessed = this.layoutProcessor.process(layoutCloned, CommandName.ShowModal);
     const layoutNode = this.layoutTreeParser.parse(layoutProcessed);
 
@@ -110,7 +111,7 @@ export class Commands {
   }
 
   public push(componentId: string, simpleApi: Layout) {
-    const input = cloneDeep(simpleApi);
+    const input = cloneLayout(simpleApi);
     const layoutProcessed = this.layoutProcessor.process(input, CommandName.Push);
     const layout = this.layoutTreeParser.parse(layoutProcessed);
 
@@ -144,7 +145,7 @@ export class Commands {
   }
 
   public setStackRoot(componentId: string, children: Layout[]) {
-    const input = map(cloneDeep(children), (simpleApi) => {
+    const input = map(cloneLayout(children), (simpleApi) => {
       const layoutProcessed = this.layoutProcessor.process(simpleApi, CommandName.SetStackRoot);
       const layout = this.layoutTreeParser.parse(layoutProcessed);
       return layout;
@@ -165,7 +166,7 @@ export class Commands {
   }
 
   public showOverlay(simpleApi: Layout) {
-    const input = cloneDeep(simpleApi);
+    const input = cloneLayout(simpleApi);
     const layoutProcessed = this.layoutProcessor.process(input, CommandName.ShowOverlay);
     const layout = this.layoutTreeParser.parse(layoutProcessed);
 
@@ -190,4 +191,10 @@ export class Commands {
     this.commandsObserver.notify(CommandName.GetLaunchArgs, { commandId });
     return result;
   }
+}
+
+function cloneLayout<L>(layout: L): L {
+  return cloneDeepWith(layout, (value, key) => {
+    if (key === 'passProps' && typeof value === 'object' && value !== null) return { ...value };
+  });
 }


### PR DESCRIPTION
According to documentation passProps don't need to be serializable. So
don't try to deep clone them. Add tests for this behavior.

Should fix #6768