### PR TITLE
Fix unnecessary button recreation through mergeOptions

### DIFF
--- a/e2e/Buttons.test.js
+++ b/e2e/Buttons.test.js
@@ -1,7 +1,7 @@
 import Utils from './Utils';
 import TestIDs from '../playground/src/testIDs';
 
-const { elementById, elementByLabel } = Utils;
+const { elementById, elementByLabel, sleep } = Utils;
 
 describe('Buttons', () => {
   beforeEach(async () => {
@@ -57,7 +57,17 @@ describe('Buttons', () => {
     await elementById(TestIDs.BUTTON_THREE).tap();
   });
 
-  it('Button component is not recreated if it has a predefined componentId', async () => {
+  it.only('Button component is not recreated if it has a predefined componentId', async () => {
+    await elementById(TestIDs.ADD_BUTTON).tap();
+    await elementById(TestIDs.ROUND_BUTTON).tap();
+    await expect(elementByLabel('Times created: 1')).toBeVisible();
+    await elementById(TestIDs.OK_BUTTON).tap();
+
+    await elementById(TestIDs.ADD_BUTTON).tap();
+    await elementById(TestIDs.ROUND_BUTTON).tap();
+    await expect(elementByLabel('Times created: 1')).toBeVisible();
+    await elementById(TestIDs.OK_BUTTON).tap();
+
     await elementById(TestIDs.ADD_BUTTON).tap();
     await elementById(TestIDs.ROUND_BUTTON).tap();
     await expect(elementByLabel('Times created: 1')).toBeVisible();

--- a/e2e/Buttons.test.js
+++ b/e2e/Buttons.test.js
@@ -35,7 +35,7 @@ describe('Buttons', () => {
     await expect(elementByLabel('Times created: 1')).toExist();
   });
 
-  it(':ios: Resetting buttons should unmount button react view', async () => {
+  it('Resetting buttons should unmount button react view', async () => {
     await elementById(TestIDs.SHOW_LIFECYCLE_BTN).tap();
     await elementById(TestIDs.RESET_BUTTONS).tap();
     await expect(elementByLabel('Button component unmounted')).toBeVisible();

--- a/e2e/Buttons.test.js
+++ b/e2e/Buttons.test.js
@@ -1,11 +1,11 @@
 import Utils from './Utils';
 import TestIDs from '../playground/src/testIDs';
 
-const { elementById, elementByLabel, sleep } = Utils;
+const {elementById, elementByLabel, sleep} = Utils;
 
 describe('Buttons', () => {
   beforeEach(async () => {
-    await device.launchApp({ newInstance: true });
+    await device.launchApp({newInstance: true});
     await elementById(TestIDs.OPTIONS_TAB).tap();
     await elementById(TestIDs.GOTO_BUTTONS_SCREEN).tap();
   });
@@ -57,7 +57,7 @@ describe('Buttons', () => {
     await elementById(TestIDs.BUTTON_THREE).tap();
   });
 
-  it.only('Button component is not recreated if it has a predefined componentId', async () => {
+  it('Button component is not recreated if it has a predefined componentId', async () => {
     await elementById(TestIDs.ADD_BUTTON).tap();
     await elementById(TestIDs.ROUND_BUTTON).tap();
     await expect(elementByLabel('Times created: 1')).toBeVisible();

--- a/lib/ios/NSArray+utils.m
+++ b/lib/ios/NSArray+utils.m
@@ -8,7 +8,13 @@
     for (NSObject *object in array) {
         NSArray *filteredArray = [self
             filteredArrayUsingPredicate:[NSPredicate
-                                            predicateWithFormat:@"%@ == %@", propertyName, object]];
+                                            predicateWithBlock:^BOOL(
+                                                id _Nullable evaluatedObject,
+                                                NSDictionary<NSString *, id> *_Nullable bindings) {
+                                              return [evaluatedObject valueForKey:propertyName] &&
+                                                     [evaluatedObject valueForKey:propertyName] ==
+                                                         [object valueForKey:propertyName];
+                                            }]];
         [intersection addObjectsFromArray:filteredArray];
     }
 

--- a/playground/ios/NavigationTests/NSArray+utilsTest.m
+++ b/playground/ios/NavigationTests/NSArray+utilsTest.m
@@ -1,0 +1,30 @@
+#import <ReactNativeNavigation/NSArray+utils.h>
+#import <XCTest/XCTest.h>
+
+@interface NSArray_utilsTest : XCTestCase
+@property(nonatomic, retain) NSArray *uut;
+@end
+
+@implementation NSArray_utilsTest
+
+- (void)testIntersectByValue {
+    NSArray *uut = @[ @{@"test" : @(1)} ];
+    NSArray *intersection = [uut intersect:@[ @{@"test" : @(1)} ] withPropertyName:@"test"];
+    XCTAssertTrue(intersection.count > 0);
+}
+
+- (void)testIntersectByReference {
+    NSObject *byRef = [NSObject new];
+    NSArray *uut = @[ @{@"test" : byRef} ];
+    NSArray *intersection = [uut intersect:@[ @{@"test" : byRef} ] withPropertyName:@"test"];
+    XCTAssertTrue(intersection.count > 0);
+}
+
+- (void)testDifference {
+    NSObject *byRef = [NSObject new];
+    NSArray *uut = @[ @{@"test" : byRef}, @{@"test" : [NSObject new]} ];
+    NSArray *difference = [uut difference:@[ @{@"test" : byRef} ] withPropertyName:@"test"];
+    XCTAssertTrue(difference.count == 1);
+}
+
+@end

--- a/playground/ios/playground.xcodeproj/project.pbxproj
+++ b/playground/ios/playground.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		5041897D250788AE004A6BC7 /* UIImage+Compare.m in Sources */ = {isa = PBXBuildFile; fileRef = 50418972250788AE004A6BC7 /* UIImage+Compare.m */; };
 		5041897E250788AE004A6BC7 /* UIImage+Diff.m in Sources */ = {isa = PBXBuildFile; fileRef = 50418973250788AE004A6BC7 /* UIImage+Diff.m */; };
 		50647FE323E3196800B92025 /* RNNExternalViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 50647FE223E3196800B92025 /* RNNExternalViewControllerTests.m */; };
+		5064A388256A85EB00D7AC84 /* NSArray+utilsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5064A387256A85EB00D7AC84 /* NSArray+utilsTest.m */; };
 		50650A23242FB0F800688104 /* CommandsHandlerCreator.m in Sources */ = {isa = PBXBuildFile; fileRef = 50650A22242FB0F800688104 /* CommandsHandlerCreator.m */; };
 		5078DF39242BE8AA007B0B4F /* TestingAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 5078DF38242BE8AA007B0B4F /* TestingAppDelegate.m */; };
 		507C80E5242912AD00F765F7 /* RNNTestRootViewCreator.m in Sources */ = {isa = PBXBuildFile; fileRef = E58D263D2385888C003F36BA /* RNNTestRootViewCreator.m */; };
@@ -138,6 +139,7 @@
 		50418975250788AE004A6BC7 /* UIImage+Snapshot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+Snapshot.h"; sourceTree = "<group>"; };
 		50418976250788AE004A6BC7 /* FBSnapshotTestController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSnapshotTestController.h; sourceTree = "<group>"; };
 		50647FE223E3196800B92025 /* RNNExternalViewControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNExternalViewControllerTests.m; sourceTree = "<group>"; };
+		5064A387256A85EB00D7AC84 /* NSArray+utilsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSArray+utilsTest.m"; sourceTree = "<group>"; usesTabs = 0; };
 		50650A21242FB0F800688104 /* CommandsHandlerCreator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CommandsHandlerCreator.h; sourceTree = "<group>"; };
 		50650A22242FB0F800688104 /* CommandsHandlerCreator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CommandsHandlerCreator.m; sourceTree = "<group>"; };
 		5078DF37242BE8AA007B0B4F /* TestingAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestingAppDelegate.h; sourceTree = "<group>"; };
@@ -402,6 +404,7 @@
 				E58D262C2385888B003F36BA /* RNNOptionsTest.h */,
 				E58D262D2385888B003F36BA /* RNNOverlayManagerTest.m */,
 				E58D26262385888B003F36BA /* RNNRootViewControllerTest.m */,
+				5064A387256A85EB00D7AC84 /* NSArray+utilsTest.m */,
 				E58D26372385888B003F36BA /* RNNSideMenuControllerTest.m */,
 				E58D262B2385888B003F36BA /* RNNSideMenuParserTest.m */,
 				E58D26362385888B003F36BA /* RNNSideMenuPresenterTest.m */,
@@ -866,6 +869,7 @@
 				E58D26602385888C003F36BA /* RNNModalManagerTest.m in Sources */,
 				E58D26502385888C003F36BA /* RNNNavigationOptionsTest.m in Sources */,
 				E58D264E2385888C003F36BA /* RNNTestBase.m in Sources */,
+				5064A388256A85EB00D7AC84 /* NSArray+utilsTest.m in Sources */,
 				5022EDCE2405524700852BA6 /* RNNBottomTabsAppearancePresenterTest.m in Sources */,
 				503F775C24D19D96005E596D /* RNNModalManagerEventHandlerTest.m in Sources */,
 				500E9FE72406A52100C61231 /* BottomTabPresenterTest.m in Sources */,

--- a/playground/src/screens/RoundedButton.tsx
+++ b/playground/src/screens/RoundedButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, View, TouchableOpacity, Text, Alert } from 'react-native';
+import { StyleSheet, View, TouchableOpacity, Text } from 'react-native';
 import { Navigation, NavigationComponentProps } from 'react-native-navigation';
 import Colors from '../commons/Colors';
 
@@ -21,7 +21,8 @@ export default class RoundedButton extends React.Component<Props> {
       <View style={styles.container}>
         <View style={styles.button}>
           <TouchableOpacity
-            onPress={() => Alert.alert(this.props.title, `Times created: ${timesCreated}`)}
+            // @ts-ignore
+            onPress={() => alert(this.props.title, `Times created: ${timesCreated}`)}
           >
             <Text style={styles.text}>{this.props.title}</Text>
           </TouchableOpacity>


### PR DESCRIPTION
When calling mergeOptions to set a right button, the button was recreated even if the component specifies an `id`.