### PR TITLE
Fix 'Contribution Guidelines' links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -8,7 +8,7 @@ labels: 'triage: bug, needs triage'
 
 (A clear and concise description of what the bug is)
 
-### Have you read the [Contributing Guidelines on issues](https://wix.github.io/react-native-navigation/docs/meta-contributing)?
+### Have you read the [Contributing Guidelines on issues](https://wix.github.io/react-native-navigation/docs/meta-contributing/)?
 
 (Write your answer here.)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See https://wix.github.io/react-native-navigation/docs/meta-contributing
+See https://wix.github.io/react-native-navigation/docs/meta-contributing/


### PR DESCRIPTION
Fix 'Contribution Guidelines' links, without slash link is not working.