### PR TITLE
Add full screen image viewer page for Car Dealer

### DIFF
--- a/playground/src/screens/Screens.ts
+++ b/playground/src/screens/Screens.ts
@@ -15,6 +15,7 @@ const Screens = {
   CarDetailsScreen: 'CarDetailsScreen',
   CarStoryScreen: 'CarStoryScreen',
   CarsListScreen: 'CarsListScreen',
+  ImageFullScreenViewer: 'ImageFullScreenViewer',
   ContextScreen: 'ContextScreen',
   ExternalComponent: 'ExternalComponent',
   FullScreenModal: 'FullScreenModal',

--- a/playground/src/screens/index.tsx
+++ b/playground/src/screens/index.tsx
@@ -23,6 +23,9 @@ function registerScreens() {
   Navigation.registerComponent(Screens.CarStoryScreen, () =>
     gestureHandlerRootHOC(require('./sharedElementCarDealer/CarStoryScreen').default)
   );
+  Navigation.registerComponent(Screens.ImageFullScreenViewer, () =>
+    gestureHandlerRootHOC(require('./sharedElementCarDealer/ImageFullScreenViewer').default)
+  );
   Navigation.registerComponent(
     Screens.ImageGalleryListScreen,
     () => require('./imageGallery/ImageGalleryListScreen').default

--- a/playground/src/screens/sharedElementCarDealer/CarDetailsScreen.tsx
+++ b/playground/src/screens/sharedElementCarDealer/CarDetailsScreen.tsx
@@ -11,7 +11,7 @@ import FastImage from 'react-native-fast-image';
 import Reanimated, { Easing, useValue } from 'react-native-reanimated';
 import DismissableView from './DismissableView';
 import useDismissGesture from './useDismissGesture';
-import { SET_DURATION } from './Constants';
+import { buildFullScreenSharedElementAnimations, SET_DURATION } from './Constants';
 import PressableScale from '../../components/PressableScale';
 import colors from '../../commons/Colors';
 
@@ -63,6 +63,21 @@ const CarDetailsScreen: NavigationFunctionComponent<Props> = ({ car, componentId
     [dismissGesture.cardBorderRadius, headerY]
   );
 
+  const openImage = useCallback(() => {
+    Navigation.showModal({
+      component: {
+        name: 'ImageFullScreenViewer',
+        passProps: {
+          source: car.image,
+          sharedElementId: `image${car.id}Full`,
+        },
+        options: {
+          animations: buildFullScreenSharedElementAnimations(car),
+        },
+      },
+    });
+  }, [car]);
+
   useEffect(() => {
     setTimeout(() => {
       Reanimated.timing(dismissGesture.controlsOpacity, {
@@ -91,13 +106,15 @@ const CarDetailsScreen: NavigationFunctionComponent<Props> = ({ car, componentId
           <Text style={styles.buyText}>Buy</Text>
         </PressableScale>
       </Reanimated.ScrollView>
-      <ReanimatedFastImage
-        source={car.image}
-        // @ts-ignore nativeID isn't included in react-native-fast-image props.
-        nativeID={`image${car.id}Dest`}
-        style={imageStyle}
-        resizeMode="cover"
-      />
+      <ReanimatedTouchableOpacity style={imageStyle} onPress={openImage}>
+        <ReanimatedFastImage
+          source={car.image}
+          // @ts-ignore nativeID isn't included in react-native-fast-image props.
+          nativeID={`image${car.id}Dest`}
+          resizeMode="cover"
+          style={StyleSheet.absoluteFill}
+        />
+      </ReanimatedTouchableOpacity>
       <ReanimatedTouchableOpacity style={closeButtonStyle} onPress={onClosePressed}>
         <Text style={styles.closeButtonText}>x</Text>
       </ReanimatedTouchableOpacity>

--- a/playground/src/screens/sharedElementCarDealer/Constants.ts
+++ b/playground/src/screens/sharedElementCarDealer/Constants.ts
@@ -103,3 +103,38 @@ export function buildStorySharedElementAnimations(car: CarItem): AnimationOption
     },
   };
 }
+
+export function buildFullScreenSharedElementAnimations(car: CarItem): AnimationOptions {
+  return {
+    showModal: {
+      alpha: {
+        from: 0,
+        to: 1,
+        duration: SET_DURATION,
+      },
+      sharedElementTransitions: [
+        {
+          fromId: `image${car.id}Dest`,
+          toId: `image${car.id}Full`,
+          duration: SET_DURATION,
+          interpolation: { type: 'spring', ...SPRING_CONFIG },
+        },
+      ],
+    },
+    dismissModal: {
+      alpha: {
+        from: 1,
+        to: 0,
+        duration: SET_DURATION,
+      },
+      sharedElementTransitions: [
+        {
+          fromId: `image${car.id}Full`,
+          toId: `image${car.id}Dest`,
+          duration: SET_DURATION,
+          interpolation: { type: 'spring', ...SPRING_CONFIG },
+        },
+      ],
+    },
+  };
+}

--- a/playground/src/screens/sharedElementCarDealer/ImageFullScreenViewer.tsx
+++ b/playground/src/screens/sharedElementCarDealer/ImageFullScreenViewer.tsx
@@ -1,0 +1,61 @@
+import React, { useCallback } from 'react';
+import { StyleSheet, View, Text, Pressable } from 'react-native';
+import FastImage, { Source } from 'react-native-fast-image';
+import { Navigation, NavigationFunctionComponent } from 'react-native-navigation';
+
+interface Props {
+  source: Source;
+  sharedElementId: string;
+}
+
+const ImageFullScreenViewer: NavigationFunctionComponent<Props> = ({
+  source,
+  sharedElementId,
+  componentId,
+}): React.ReactElement => {
+  const onClose = useCallback(() => {
+    Navigation.dismissModal(componentId);
+  }, [componentId]);
+
+  return (
+    <View style={styles.container}>
+      <FastImage
+        // @ts-ignore nativeID isn't included in FastImage props.
+        nativeID={sharedElementId}
+        style={StyleSheet.absoluteFill}
+        source={source}
+        resizeMode="contain"
+      />
+
+      <Pressable onPress={onClose} style={styles.closeButton}>
+        <Text style={styles.closeText}>x</Text>
+      </Pressable>
+    </View>
+  );
+};
+
+export default ImageFullScreenViewer;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'black',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 50,
+    right: 15,
+    backgroundColor: 'white',
+    borderRadius: 15,
+    width: 30,
+    height: 30,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  closeText: {
+    color: 'black',
+    fontWeight: 'bold',
+  },
+});


### PR DESCRIPTION
Reproduction for Shared Element Transitions between different resize modes (`FastImage`)

![Simulator Screen Shot - iPhone 11 - 2020-12-09 at 11 40 51](https://user-images.githubusercontent.com/15199031/101619309-64829080-3a13-11eb-85ab-d725ec563be7.png)


