### PR TITLE
Fix options.bottomTabs.titleDisplayMode

### DIFF
--- a/website/docs/api/options-bottomTabs.mdx
+++ b/website/docs/api/options-bottomTabs.mdx
@@ -95,9 +95,9 @@ The options requires that the scrollable view will be the root view of the scree
 
 ## `titleDisplayMode`
 
-| Type                                             | Required | Android |
-| ------------------------------------------------ | -------- | ------- |
-| enum('alwaysShow','showWhenActive','alwaysHide') | No       | Both    |
+| Type                                             | Required | Platform |
+| ------------------------------------------------ | -------- | -------- |
+| enum('alwaysShow','showWhenActive','alwaysHide') | No       | Both     |
 
 ## `translucent`
 

--- a/website/versioned_docs/version-7.0.0/api/options-bottomTabs.mdx
+++ b/website/versioned_docs/version-7.0.0/api/options-bottomTabs.mdx
@@ -95,9 +95,9 @@ The options requires that the scrollable view will be the root view of the scree
 
 ## `titleDisplayMode`
 
-| Type                                             | Required | Android |
-| ------------------------------------------------ | -------- | ------- |
-| enum('alwaysShow','showWhenActive','alwaysHide') | No       | Both    |
+| Type                                             | Required | Platform |
+| ------------------------------------------------ | -------- | -------- |
+| enum('alwaysShow','showWhenActive','alwaysHide') | No       | Both     |
 
 ## `translucent`
 


### PR DESCRIPTION
`Android` was used instead of `Platform` in the header. I checked and `titleDisplayMode` is supported on both platforms, let's fix this.