### PR TITLE
disabling `rootViewController = nil` in Release Mode

### DIFF
--- a/lib/ios/RNNBridgeManager.mm
+++ b/lib/ios/RNNBridgeManager.mm
@@ -134,7 +134,9 @@
     [_overlayManager dismissAllOverlays];
     [_modalManager dismissAllModalsSynchronosly];
     [_componentRegistry clear];
+#ifdef DEBUG
     UIApplication.sharedApplication.delegate.window.rootViewController = nil;
+#endif
 }
 
 @end


### PR DESCRIPTION
In Release mode, when using `expo-updates` (as in [expo-rnn-starter](https://github.com/kanzitelli/expo-rnn-starter)) and want to update an app with the up-to-date bundle when it's active, the app crashes because it "loses" rootViewController in Release Mode. This PR doesn't anyhow affect an app in Debug or Release Mode, it just enables it to work with `expo-updates` and, I guess, as well as for `code-push`.

I have tested it already in production with [this app](https://apps.apple.com/ru/app/id1446775875) which I got released today and everything works good.