### PR TITLE
Bootstrap with user created bridge

### DIFF
--- a/lib/ios/RNNBridgeManager.h
+++ b/lib/ios/RNNBridgeManager.h
@@ -5,11 +5,7 @@ typedef UIViewController * (^RNNExternalViewCreator)(NSDictionary *props, RCTBri
 
 @interface RNNBridgeManager : NSObject
 
-- (instancetype)initWithLaunchOptions:(NSDictionary *)launchOptions
-                    andBridgeDelegate:(id<RCTBridgeDelegate>)delegate
-                           mainWindow:(UIWindow *)mainWindow;
-
-- (void)initializeBridge;
+- (instancetype)initWithBridge:(RCTBridge *)bridge mainWindow:(UIWindow *)mainWindow;
 
 - (void)registerExternalComponent:(NSString *)name callback:(RNNExternalViewCreator)callback;
 

--- a/lib/ios/RNNBridgeManager.mm
+++ b/lib/ios/RNNBridgeManager.mm
@@ -3,10 +3,6 @@
 #import <React/RCTBridge.h>
 #import <React/RCTUIManager.h>
 
-#ifdef RN_FABRIC_ENABLED
-#import <React/RCTSurfacePresenter.h>
-#endif
-
 #import "RNNBridgeModule.h"
 #import "RNNComponentViewCreator.h"
 #import "RNNEventEmitter.h"
@@ -15,11 +11,7 @@
 #import "RNNReactRootViewCreator.h"
 #import "RNNSplashScreen.h"
 
-@interface RNNBridgeManager () {
-#ifdef RN_FABRIC_ENABLED
-    RCTSurfacePresenter *_surfacePresenter;
-#endif
-}
+@interface RNNBridgeManager ()
 
 @property(nonatomic, strong, readwrite) RCTBridge *bridge;
 @property(nonatomic, strong, readwrite) RNNExternalComponentStore *store;
@@ -31,8 +23,6 @@
 @end
 
 @implementation RNNBridgeManager {
-    NSDictionary *_launchOptions;
-    id<RCTBridgeDelegate> _delegate;
     RCTBridge *_bridge;
     UIWindow *_mainWindow;
 
@@ -41,13 +31,10 @@
     RNNCommandsHandler *_commandsHandler;
 }
 
-- (instancetype)initWithLaunchOptions:(NSDictionary *)launchOptions
-                    andBridgeDelegate:(id<RCTBridgeDelegate>)delegate
-                           mainWindow:(UIWindow *)mainWindow {
+- (instancetype)initWithBridge:(RCTBridge *)bridge mainWindow:(UIWindow *)mainWindow {
     if (self = [super init]) {
+        _bridge = bridge;
         _mainWindow = mainWindow;
-        _launchOptions = launchOptions;
-        _delegate = delegate;
 
         _overlayManager = [RNNOverlayManager new];
 
@@ -67,15 +54,6 @@
                                                    object:nil];
     }
     return self;
-}
-
-- (void)initializeBridge {
-    _bridge = [[RCTBridge alloc] initWithDelegate:_delegate launchOptions:_launchOptions];
-
-#ifdef RN_FABRIC_ENABLED
-    _surfacePresenter = [[RCTSurfacePresenter alloc] initWithBridge:_bridge config:nil];
-    _bridge.surfacePresenter = _surfacePresenter;
-#endif
 }
 
 - (void)registerExternalComponent:(NSString *)name callback:(RNNExternalViewCreator)callback {

--- a/lib/ios/ReactNativeNavigation.h
+++ b/lib/ios/ReactNativeNavigation.h
@@ -7,8 +7,11 @@ typedef UIViewController * (^RNNExternalViewCreator)(NSDictionary *props, RCTBri
 
 @interface ReactNativeNavigation : NSObject
 
++ (void)bootstrapWithBridge:(RCTBridge *)bridge;
+
 + (void)bootstrapWithDelegate:(id<RCTBridgeDelegate>)bridgeDelegate
-                launchOptions:(NSDictionary *)launchOptions;
+                launchOptions:(NSDictionary *)launchOptions
+    __attribute__((deprecated("Use bootstrapWithBridge: instead")));
 
 + (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge;
 

--- a/lib/ios/ReactNativeNavigation.m
+++ b/lib/ios/ReactNativeNavigation.m
@@ -16,10 +16,15 @@
 
 #pragma mark - public API
 
++ (void)bootstrapWithBridge:(RCTBridge *)bridge {
+    [[ReactNativeNavigation sharedInstance] bootstrapWithBridge:bridge];
+}
+
 + (void)bootstrapWithDelegate:(id<RCTBridgeDelegate>)bridgeDelegate
                 launchOptions:(NSDictionary *)launchOptions {
-    [[ReactNativeNavigation sharedInstance] bootstrapWithDelegate:bridgeDelegate
-                                                    launchOptions:launchOptions];
+    RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:bridgeDelegate
+                                              launchOptions:launchOptions];
+    [[ReactNativeNavigation sharedInstance] bootstrapWithBridge:bridge];
 }
 
 + (void)registerExternalComponent:(NSString *)name callback:(RNNExternalViewCreator)callback {
@@ -53,14 +58,11 @@
     return instance;
 }
 
-- (void)bootstrapWithDelegate:(id<RCTBridgeDelegate>)bridgeDelegate
-                launchOptions:(NSDictionary *)launchOptions {
+- (void)bootstrapWithBridge:(RCTBridge *)bridge {
     UIWindow *mainWindow = [self initializeKeyWindowIfNeeded];
 
-    self.bridgeManager = [[RNNBridgeManager alloc] initWithLaunchOptions:launchOptions
-                                                       andBridgeDelegate:bridgeDelegate
-                                                              mainWindow:mainWindow];
-    [self.bridgeManager initializeBridge];
+    self.bridgeManager = [[RNNBridgeManager alloc] initWithBridge:bridge mainWindow:mainWindow];
+
     [RNNSplashScreen showOnWindow:mainWindow];
 }
 

--- a/playground/ios/playground/AppDelegate.m
+++ b/playground/ios/playground/AppDelegate.m
@@ -13,6 +13,9 @@
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+
+    RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+
     self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     if (@available(iOS 13.0, *)) {
         self.window.backgroundColor = [UIColor systemBackgroundColor];
@@ -21,7 +24,7 @@
     }
     [self.window makeKeyWindow];
 
-    [ReactNativeNavigation bootstrapWithDelegate:self launchOptions:launchOptions];
+    [ReactNativeNavigation bootstrapWithBridge:bridge];
     [ReactNativeNavigation
         registerExternalComponent:@"RNNCustomComponent"
                          callback:^UIViewController *(NSDictionary *props, RCTBridge *bridge) {


### PR DESCRIPTION
To better align with the iOS react-native template, we should bootstrap with a user created bridge as this is created in the template. Bootstrapping rnn will then be migrated to:
```objc
[ReactNativeNavigation bootstrapWithBridge:bridge];
```
The old bootstrap method will be deprecated.

This also means that enabling fabric is passed back to user land on creation of the bridge (see RNTester example).