### PR TITLE
Android SearchBar implementation kick off

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/SearchBarOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/SearchBarOptions.java
@@ -1,0 +1,32 @@
+package com.reactnativenavigation.options;
+
+import android.content.Context;
+
+import com.reactnativenavigation.options.params.Bool;
+import com.reactnativenavigation.options.params.NullBool;
+import com.reactnativenavigation.options.params.NullText;
+import com.reactnativenavigation.options.params.Text;
+import com.reactnativenavigation.options.parsers.BoolParser;
+import com.reactnativenavigation.options.parsers.TextParser;
+import com.reactnativenavigation.options.parsers.TypefaceLoader;
+
+import org.json.JSONObject;
+
+public class SearchBarOptions {
+    public static SearchBarOptions parse(Context context, TypefaceLoader typefaceManager, JSONObject json) {
+        SearchBarOptions options = new SearchBarOptions();
+
+        if (json == null) return options;
+
+        options.visible = BoolParser.parse(json, "visible");
+        options.focus = BoolParser.parse(json, "focus");
+        options.placeholder = TextParser.parse(json, "placeholder");
+
+        return options;
+    }
+
+    public Bool visible = new NullBool();
+    public Bool focus = new NullBool();
+    public Text placeholder = new NullText();
+
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/TopBarOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/TopBarOptions.java
@@ -50,6 +50,8 @@ public class TopBarOptions {
         options.leftButtonDisabledColor = ColorParser.parse(context, json, "leftButtonDisabledColor");
         options.rightButtonDisabledColor = ColorParser.parse(context, json, "rightButtonDisabledColor");
 
+
+        options.searchBar = SearchBarOptions.parse(context, typefaceLoader, json.optJSONObject("searchBar"));
         options.validate();
         return options;
     }
@@ -57,6 +59,7 @@ public class TopBarOptions {
     public TitleOptions title = new TitleOptions();
     public SubtitleOptions subtitle = new SubtitleOptions();
     public TopBarButtons buttons = new TopBarButtons();
+    public SearchBarOptions searchBar = new SearchBarOptions();
     public Text testId = new NullText();
     public TopBarBackgroundOptions background = new TopBarBackgroundOptions();
     public Bool visible = new NullBool();
@@ -102,6 +105,8 @@ public class TopBarOptions {
         if (other.rightButtonDisabledColor.hasValue()) rightButtonDisabledColor = other.rightButtonDisabledColor;
         if (other.leftButtonDisabledColor.hasValue()) leftButtonDisabledColor = other.leftButtonDisabledColor;
 
+        if (other.searchBar.visible.hasValue()) searchBar = other.searchBar;
+
         validate();
     }
 
@@ -125,6 +130,8 @@ public class TopBarOptions {
         if (!leftButtonColor.hasValue()) leftButtonColor = defaultOptions.leftButtonColor;
         if (!rightButtonDisabledColor.hasValue()) rightButtonDisabledColor = defaultOptions.rightButtonDisabledColor;
         if (!leftButtonDisabledColor.hasValue()) leftButtonDisabledColor = defaultOptions.leftButtonDisabledColor;
+
+        if (defaultOptions.searchBar.visible.hasValue()) searchBar = defaultOptions.searchBar;
 
         validate();
         return this;

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/Constants.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/Constants.java
@@ -3,6 +3,7 @@ package com.reactnativenavigation.react;
 public class Constants {
     public static final String BACK_BUTTON_JS_KEY = "backButtonId";
     public static final String BACK_BUTTON_ID = "RNN.back";
+    public static final String SEARCH_BUTTON_ID = "RNN.search";
     public static final String STATUS_BAR_HEIGHT_KEY = "statusBarHeight";
     public static final String TOP_BAR_HEIGHT_KEY = "topBarHeight";
     public static final String BOTTOM_TABS_HEIGHT_KEY = "bottomTabsHeight";

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/ImageLoader.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/ImageLoader.kt
@@ -29,6 +29,10 @@ open class ImageLoader {
         return ContextCompat.getDrawable(context, if (isRTL) R.drawable.ic_arrow_back_black_rtl_24dp else R.drawable.ic_arrow_back_black_24dp)
     }
 
+    open fun getSearchButtonIcon(context: Activity): Drawable? {
+        return ContextCompat.getDrawable(context, R.drawable.ic_baseline_search_24)
+    }
+
     open fun loadIcon(context: Context, uri: String?): Drawable? {
         if (uri == null) return null
         try {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenter.java
@@ -227,6 +227,12 @@ public class StackPresenter {
             topBar.clearBackgroundComponent();
         }
 
+        if (topBarOptions.searchBar.visible.hasValue()) {
+            topBar.setSearchBarWithOptions(topBarOptions.searchBar);
+        } else {
+            topBar.removeSearchBar();
+        }
+
         applyTopBarVisibility(topBarOptions, animationOptions, componentOptions, stack, child);
         if (topBarOptions.hideOnScroll.isTrue()) {
             if (component instanceof IReactView) {
@@ -464,6 +470,7 @@ public class StackPresenter {
                 topBar.setBackgroundComponent(controller.getView());
             }
         }
+        
 
         if (topBarOptions.testId.hasValue()) topBar.setTestId(topBarOptions.testId.get());
 
@@ -487,6 +494,12 @@ public class StackPresenter {
         }
         if (topBarOptions.hideOnScroll.isFalse()) {
             topBar.disableCollapse();
+        }
+
+        if (topBarOptions.searchBar.visible.hasValue()) {
+            topBar.setSearchBarWithOptions(topBarOptions.searchBar);
+        } else {
+            topBar.removeSearchBar();
         }
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/IconResolver.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/IconResolver.java
@@ -37,6 +37,8 @@ public class IconResolver {
             });
         } else if (Constants.BACK_BUTTON_ID.equals(button.id)) {
             onSuccess.run(imageLoader.getBackButtonIcon(context));
+        } else if (Constants.SEARCH_BUTTON_ID.equals(button.id)) {
+            onSuccess.run(imageLoader.getSearchButtonIcon(context));
         } else {
             Log.w("RNN", "Left button needs to have an icon");
         }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/SearchBar.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/SearchBar.java
@@ -1,0 +1,102 @@
+package com.reactnativenavigation.views.stack.topbar;
+
+import android.content.Context;
+import android.media.Image;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.util.AttributeSet;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.EditText;
+import android.widget.ImageView;
+
+import com.reactnativenavigation.R;
+import com.reactnativenavigation.options.params.Text;
+
+public class SearchBar extends EditText implements TextWatcher {
+
+
+    public SearchBar(Context context) {
+        super(context);
+        setBackgroundResource(R.color.transparent);
+        this.setFocusableInTouchMode(true);
+        this.setFocusable(true);
+        this.setOnKeyListener(new OnKeyListener() {
+            @Override
+            public boolean onKey(View view, int keyCode, KeyEvent keyEvent) {
+                if (keyCode == KeyEvent.KEYCODE_ENTER) {
+                    //send submit action
+                    hideKeyboard(context);
+                    return true;
+                }
+                return false;
+            }
+        });
+
+        this.setOnFocusChangeListener(new OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View view, boolean hasFocus) {
+                if (!hasFocus) {
+                    hideKeyboard(context);
+                }
+            }
+        });
+
+
+    }
+
+    public void hideKeyboard(Context context) {
+        InputMethodManager imm = (InputMethodManager)context.getSystemService(Context.INPUT_METHOD_SERVICE);
+        imm.hideSoftInputFromWindow(this.getWindowToken(), 0);
+    }
+
+    public SearchBar(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        setKeyListener();
+    }
+
+    public SearchBar(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        setKeyListener();
+    }
+
+    @Override
+    public boolean onKeyPreIme(int keyCode, KeyEvent ev) {
+        if (ev.getKeyCode() == KeyEvent.KEYCODE_BACK) {
+            //this.onKeyboardDismissed();
+        }
+
+        return super.onKeyPreIme(keyCode, ev);
+    }
+
+    private void setKeyListener() {
+        //setOnKeyListener(onKeyListener);
+    }
+
+    public void setFocus() {
+        this.requestFocus();
+    }
+
+    public void setPlaceholder(Text placeholder) {
+        if (placeholder.hasValue()) {
+            this.setHint(placeholder.toString());
+        }
+    }
+
+
+    @Override
+    public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+    }
+
+    @Override
+    public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+        System.out.println("TEXT");
+    }
+
+    @Override
+    public void afterTextChanged(Editable editable) {
+
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/TopBar.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/TopBar.java
@@ -10,14 +10,18 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 
 import com.google.android.material.appbar.AppBarLayout;
 import com.reactnativenavigation.R;
+import com.reactnativenavigation.options.ButtonOptions;
 import com.reactnativenavigation.options.FontOptions;
+import com.reactnativenavigation.options.SearchBarOptions;
 import com.reactnativenavigation.options.parsers.TypefaceLoader;
 import com.reactnativenavigation.viewcontrollers.stack.topbar.TopBarCollapseBehavior;
+import com.reactnativenavigation.viewcontrollers.stack.topbar.button.ButtonPresenter;
 import com.reactnativenavigation.viewcontrollers.viewcontroller.ScrollEventListener;
 import com.reactnativenavigation.options.Alignment;
 import com.reactnativenavigation.options.LayoutDirection;
@@ -27,6 +31,7 @@ import com.reactnativenavigation.utils.CompatUtils;
 import com.reactnativenavigation.utils.UiUtils;
 import com.reactnativenavigation.viewcontrollers.stack.topbar.button.ButtonController;
 import com.reactnativenavigation.views.stack.topbar.titlebar.TitleBar;
+import com.reactnativenavigation.views.stack.topbar.titlebar.TitleBarButtonCreator;
 import com.reactnativenavigation.views.toptabs.TopTabs;
 
 import java.util.Collections;
@@ -46,6 +51,8 @@ public class TopBar extends AppBarLayout implements ScrollEventListener.ScrollAw
     private final TopBarCollapseBehavior collapsingBehavior;
     private TopTabs topTabs;
     private FrameLayout root;
+    private SearchBar searchBar;
+    private ImageView leftIcon;
     private View border;
     private View component;
     private float elevation = -1;
@@ -69,6 +76,7 @@ public class TopBar extends AppBarLayout implements ScrollEventListener.ScrollAw
         titleBar = createTitleBar(getContext());
         topTabs = createTopTabs();
         border = createBorder();
+        searchBar = createSearchBar();
         LinearLayout content = createContentLayout();
 
         root = new FrameLayout(getContext());
@@ -103,6 +111,14 @@ public class TopBar extends AppBarLayout implements ScrollEventListener.ScrollAw
         lp.gravity = Gravity.BOTTOM;
         border.setLayoutParams(lp);
         return border;
+    }
+
+    private SearchBar createSearchBar() {
+        SearchBar searchBar = new SearchBar(getContext());
+        RelativeLayout.LayoutParams lp = new RelativeLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT);
+        lp.addRule(RelativeLayout.LAYOUT_DIRECTION_RTL);
+        searchBar.setLayoutParams(lp);
+        return searchBar;
     }
 
     protected TitleBar createTitleBar(Context context) {
@@ -302,5 +318,30 @@ public class TopBar extends AppBarLayout implements ScrollEventListener.ScrollAw
 
     public boolean containsRightButton(ButtonController button) {
         return titleBar.containsRightButton(button);
+    }
+    
+    public void setSearchBarWithOptions(SearchBarOptions searchBarOptions) {
+        searchBar.setPlaceholder(searchBarOptions.placeholder);
+        if (searchBarOptions.focus.isTrue()) {
+            searchBar.setFocus();
+        }
+
+        leftIcon = new ImageView(getContext());
+
+        leftIcon.setImageResource(R.drawable.ic_arrow_back_black_24dp);
+        leftIcon.setVisibility(View.VISIBLE);
+        titleBar.addView(leftIcon);
+        leftIcon.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                searchBar.hideKeyboard(getContext());
+                leftIcon.setVisibility(View.GONE);
+            }
+        });
+        titleBar.addView(searchBar);
+    }
+
+    public void removeSearchBar() {
+        titleBar.removeView(searchBar);
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBar.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBar.java
@@ -226,7 +226,8 @@ public class TitleBar extends Toolbar {
         setLeftButton(button);
     }
 
-    public void setLeftButtons(List<ButtonController> leftButtons) {
+    public void
+    setLeftButtons(List<ButtonController> leftButtons) {
         if (leftButtons == null) return;
         if (leftButtons.isEmpty()) {
             clearLeftButton();

--- a/lib/android/app/src/main/res/drawable/ic_baseline_search_24.xml
+++ b/lib/android/app/src/main/res/drawable/ic_baseline_search_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+</vector>

--- a/lib/android/app/src/main/res/values/colors.xml
+++ b/lib/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="transparent">#00000000</color>
+</resources>

--- a/playground/src/screens/OptionsScreen.tsx
+++ b/playground/src/screens/OptionsScreen.tsx
@@ -44,6 +44,7 @@ export default class Options extends React.Component<Props> {
         <Button label="Change title" testID={CHANGE_TITLE_BTN} onPress={this.changeTitle} />
         <Button label="Hide TopBar" testID={HIDE_TOP_BAR_BTN} onPress={this.hideTopBar} />
         <Button label="Show TopBar" testID={SHOW_TOP_BAR_BTN} onPress={this.showTopBar} />
+        <Button label="Show SearchBar" testID={SHOW_TOP_BAR_BTN} onPress={this.showSearchBar} />
         <Button label="Push" testID={PUSH_BTN} onPress={this.push} />
         <Button
           label="Hide TopBar in DefaultOptions"
@@ -95,6 +96,18 @@ export default class Options extends React.Component<Props> {
     Navigation.mergeOptions(this, {
       topBar: {
         visible: true,
+      },
+    });
+
+  showSearchBar = () =>
+    Navigation.mergeOptions(this, {
+      topBar: {
+        visible: true,
+        searchBar: {
+          visible: true,
+          focus: true,
+          placeholder: 'Search...',
+        },
       },
     });
 


### PR DESCRIPTION
## Dev plan

We should implement the following use cases outlined in the material.io docs: 

1. [Persistent search](https://material.io/design/navigation/search.html#persistent-search)

```
Use persistent search when search is the primary focus of your app. The search text field is presented inside of a search bar, ready to receive focus.
```

2. [Expandable search](https://material.io/design/navigation/search.html#expandable-search) 

```
Use expandable search when search is not the primary focus of your app. Expandable search displays a search icon in the toolbar, instead of an open search text box.
```

Android search bar should support almost all existing search bar options (enumerated below) when possible: 

- [x] visible
- [x] focus
- [ ] hideOnScroll
- [ ] hideTopBarOnFocus
- [ ] obscuresBackgroundDuringPresentation
- [ ] backgroundColor
- [ ] tintColor
- [x] searchBarPlaceholder 

Besides this, since this is a new API it should be opt in and require the following custom option for at least 1 major release (after that we can deprecate it), since it can break current implementations on Android:

- [ ] androidVisible


Fixes #6818