### PR TITLE
Fix types passProps does not require componentId

### DIFF
--- a/lib/src/interfaces/Layout.ts
+++ b/lib/src/interfaces/Layout.ts
@@ -16,7 +16,7 @@ export interface LayoutComponent<P = {}> {
   /**
    * Properties to pass down to the component
    */
-  passProps?: P;
+  passProps?: Omit<P, 'componentId'>;
 }
 
 export interface LayoutStackChildren {


### PR DESCRIPTION
RNN generates `componentId`.  If using typesafe screen navigation, this results in error:
```ts
Navigation.showOverlay<MyProps>({
  component: {
    name: 'overlay.MyOverlay',
    passProps: { // Error, requires `componentId`.
      foo: 'bar',
    },
  },
});
```