### PR TITLE
Add scrollEdgeAppearance border options

### DIFF
--- a/lib/ios/RNNScrollEdgeAppearanceOptions.h
+++ b/lib/ios/RNNScrollEdgeAppearanceOptions.h
@@ -6,5 +6,7 @@
 
 @property(nonatomic, strong) RNNScrollEdgeAppearanceBackgroundOptions *background;
 @property(nonatomic, strong) Bool *active;
+@property(nonatomic, strong) Bool *noBorder;
+@property(nonatomic, strong) Color *borderColor;
 
 @end

--- a/lib/ios/RNNScrollEdgeAppearanceOptions.m
+++ b/lib/ios/RNNScrollEdgeAppearanceOptions.m
@@ -7,6 +7,8 @@
     self.background =
         [[RNNScrollEdgeAppearanceBackgroundOptions alloc] initWithDict:dict[@"background"]];
     self.active = [BoolParser parse:dict key:@"active"];
+    self.noBorder = [BoolParser parse:dict key:@"noBorder"];
+    self.borderColor = [ColorParser parse:dict key:@"borderColor"];
 
     return self;
 }
@@ -16,6 +18,10 @@
 
     if (options.active.hasValue)
         self.active = options.active;
+    if (options.noBorder.hasValue)
+        self.noBorder = options.noBorder;
+    if (options.borderColor.hasValue)
+        self.borderColor = options.borderColor;
 }
 
 @end

--- a/lib/ios/TopBarAppearancePresenter.h
+++ b/lib/ios/TopBarAppearancePresenter.h
@@ -5,7 +5,8 @@ API_AVAILABLE(ios(13.0))
 @interface TopBarAppearancePresenter : TopBarPresenter
 
 @property(nonatomic, strong) UIColor *borderColor;
-
 @property(nonatomic) BOOL showBorder;
+@property(nonatomic, strong) UIColor *scrollEdgeBorderColor;
+@property(nonatomic) BOOL showScrollEdgeBorder;
 
 @end

--- a/lib/ios/TopBarAppearancePresenter.m
+++ b/lib/ios/TopBarAppearancePresenter.m
@@ -9,6 +9,7 @@
 @implementation TopBarAppearancePresenter
 
 @synthesize borderColor = _borderColor;
+@synthesize scrollEdgeBorderColor = _scrollEdgeBorderColor;
 
 - (void)applyOptions:(RNNTopBarOptions *)options {
     [self setTranslucent:[options.background.translucent getWithDefaultValue:NO]];
@@ -22,6 +23,9 @@
     [self setLargeTitleAttributes:options.largeTitle];
     [self setBorderColor:[options.borderColor getWithDefaultValue:nil]];
     [self showBorder:![options.noBorder getWithDefaultValue:NO]];
+    [self setScrollEdgeBorderColor:[options.scrollEdgeAppearance.borderColor
+                                       getWithDefaultValue:nil]];
+    [self showScrollEdgeBorder:![options.scrollEdgeAppearance.noBorder getWithDefaultValue:NO]];
     [self setBackButtonOptions:options.backButton];
     if ([options.scrollEdgeAppearance.active getWithDefaultValue:NO]) {
         [self updateScrollEdgeAppearance];
@@ -36,6 +40,14 @@
 
     if (options.borderColor.hasValue) {
         [self setBorderColor:options.borderColor.get];
+    }
+
+    if (options.scrollEdgeAppearance.borderColor.hasValue) {
+        [self setScrollEdgeBorderColor:options.scrollEdgeAppearance.borderColor.get];
+    }
+
+    if (options.scrollEdgeAppearance.noBorder.hasValue) {
+        [self showScrollEdgeBorder:options.scrollEdgeAppearance.noBorder.get];
     }
 }
 
@@ -91,6 +103,11 @@
     [self updateBorder];
 }
 
+- (void)showScrollEdgeBorder:(BOOL)showScrollEdgeBorder {
+    _showScrollEdgeBorder = showScrollEdgeBorder;
+    [self updateScrollEdgeBorder];
+}
+
 - (void)setBorderColor:(UIColor *)borderColor {
     _borderColor = borderColor;
     [self updateBorder];
@@ -100,9 +117,17 @@
     return _borderColor ?: [[UINavigationBarAppearance new] shadowColor];
 }
 
+- (UIColor *)scrollEdgeBorderColor {
+    return _scrollEdgeBorderColor ?: [[UINavigationBarAppearance new] shadowColor];
+}
+
 - (void)updateBorder {
     self.getAppearance.shadowColor = self.showBorder ? self.borderColor : nil;
-    self.getScrollEdgeAppearance.shadowColor = self.showBorder ? self.borderColor : nil;
+}
+
+- (void)updateScrollEdgeBorder {
+    self.getScrollEdgeAppearance.shadowColor =
+        self.scrollEdgeBorderColor ? self.scrollEdgeBorderColor : nil;
 }
 
 - (void)setBackIndicatorImage:(UIImage *)image withColor:(UIColor *)color {

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -393,6 +393,16 @@ export interface OptionsTopBarScrollEdgeAppearanceBackground {
 export interface OptionsTopBarScrollEdgeAppearance {
   background?: OptionsTopBarScrollEdgeAppearanceBackground;
   active: boolean;
+  /**
+   * Disable the border on bottom of the navbar
+   * #### (iOS specific)
+   * @default false
+   */
+  noBorder?: boolean;
+  /**
+   * Change the navbar border color
+   */
+  borderColor?: Color;
 }
 
 export interface OptionsTopBarBackground {

--- a/playground/ios/NavigationTests/RNNNavigationStackManagerTest.m
+++ b/playground/ios/NavigationTests/RNNNavigationStackManagerTest.m
@@ -29,7 +29,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Testing Async Method"];
     XCTAssertTrue([self.nvc.topViewController isEqual:self.vc3]);
     [_nvc popTo:self.vc2
-          animated:YES
+          animated:NO
         completion:^(NSArray *poppedViewControllers) {
           XCTAssertTrue([self.nvc.topViewController isEqual:self.vc2]);
           [expectation fulfill];

--- a/playground/ios/NavigationTests/TopBarAppearancePresenterTest.m
+++ b/playground/ios/NavigationTests/TopBarAppearancePresenterTest.m
@@ -127,4 +127,40 @@
                    21);
 }
 
+- (void)testMergeOptions_shouldShowScrollEdgeBorder {
+    RNNNavigationOptions *mergeOptions = [RNNNavigationOptions emptyOptions];
+    RNNNavigationOptions *defaultOptions = [RNNNavigationOptions emptyOptions];
+
+    mergeOptions.topBar.scrollEdgeAppearance.noBorder = [Bool withValue:NO];
+    RNNNavigationOptions *withDefault = [mergeOptions withDefault:defaultOptions];
+    [_uut mergeOptions:mergeOptions.topBar withDefault:withDefault.topBar];
+    XCTAssertEqual(
+        _stack.childViewControllers.lastObject.navigationItem.scrollEdgeAppearance.shadowColor,
+        [[UINavigationBarAppearance new] shadowColor]);
+}
+
+- (void)testMergeOptions_shouldHideScrollEdgeBorder {
+    RNNNavigationOptions *mergeOptions = [RNNNavigationOptions emptyOptions];
+    RNNNavigationOptions *defaultOptions = [RNNNavigationOptions emptyOptions];
+
+    mergeOptions.topBar.noBorder = [Bool withValue:YES];
+    RNNNavigationOptions *withDefault = [mergeOptions withDefault:defaultOptions];
+    [_uut mergeOptions:mergeOptions.topBar withDefault:withDefault.topBar];
+    XCTAssertEqual(
+        _stack.childViewControllers.lastObject.navigationItem.standardAppearance.shadowColor, nil);
+}
+
+- (void)testMergeOptions_shouldSetScrollEdgeBorderColor {
+    RNNNavigationOptions *mergeOptions = [RNNNavigationOptions emptyOptions];
+    RNNNavigationOptions *defaultOptions = [RNNNavigationOptions emptyOptions];
+
+    mergeOptions.topBar.scrollEdgeAppearance.noBorder = [Bool withValue:NO];
+    mergeOptions.topBar.scrollEdgeAppearance.borderColor = [Color withValue:UIColor.blueColor];
+    RNNNavigationOptions *withDefault = [mergeOptions withDefault:defaultOptions];
+    [_uut mergeOptions:mergeOptions.topBar withDefault:withDefault.topBar];
+    XCTAssertEqual(
+        _stack.childViewControllers.lastObject.navigationItem.scrollEdgeAppearance.shadowColor,
+        UIColor.blueColor);
+}
+
 @end

--- a/website/docs/api/options-scrollEdgeAppearance.mdx
+++ b/website/docs/api/options-scrollEdgeAppearance.mdx
@@ -10,22 +10,20 @@ Controls the top bar background styling.
 const options = {
   topBar: {
     scrollEdgeAppearance: {
-        background: {},
-        active: true
-    }
-  }
+      background: {},
+      active: true,
+    },
+  },
 };
 ```
-
 
 ### `active`
 
 Since this might be considered as a breaking change (meaning that previous configs might behave different), you'll need to
 pass active `true/false` to activate this option.
-| Type  | Required | Platform |
+| Type | Required | Platform |
 | ----- | -------- | -------- |
-| Bool | No       | iOS     |
-
+| Bool | No | iOS |
 
 ### `color`
 
@@ -33,12 +31,27 @@ Set the background color.
 
 | Type  | Required | Platform |
 | ----- | -------- | -------- |
-| Color | No       | iOS     |
-
+| Color | No       | iOS      |
 
 ### `translucent`
 
 Allows the Scroll Edge Appearance to be translucent (blurred).
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | iOS      |
+
+### `borderColor`
+
+Change the topBar border color.
+
+| Type  | Required | Platform |
+| ----- | -------- | -------- |
+| Color | No       | Both     |
+
+### `noBorder`
+
+Disables border at the bottom of the TopBar.
 
 | Type    | Required | Platform |
 | ------- | -------- | -------- |


### PR DESCRIPTION
Add control over the `topBar` border in [scrollEdge](https://developer.apple.com/documentation/uikit/uinavigationbar/3198027-scrolledgeappearance) appearance mode.

Closes #6754 