### PR TITLE
Fix default button size with insets

### DIFF
--- a/lib/ios/RNNUIBarButtonItem.m
+++ b/lib/ios/RNNUIBarButtonItem.m
@@ -44,13 +44,15 @@
     CGFloat cornerRadius =
         [buttonOptions.iconBackground.cornerRadius getWithDefaultValue:@(0)].floatValue;
 
-    UIButton *button = [[UIButton alloc]
-        initWithFrame:CGRectMake(
-                          0, 0,
-                          [buttonOptions.iconBackground.width getWithDefaultValue:BUTTON_WIDTH]
-                              .floatValue,
-                          [buttonOptions.iconBackground.height getWithDefaultValue:BUTTON_HEIGHT]
-                              .floatValue)];
+    UIButton *button =
+        [[UIButton alloc] initWithFrame:CGRectMake(0, 0,
+                                                   [buttonOptions.iconBackground.width
+                                                       getWithDefaultValue:@(iconImage.size.width)]
+                                                       .floatValue,
+                                                   [buttonOptions.iconBackground.height
+                                                       getWithDefaultValue:@(iconImage.size.width)]
+                                                       .floatValue)];
+
     [button addTarget:self
                   action:@selector(onButtonPressed:)
         forControlEvents:UIControlEventTouchUpInside];

--- a/lib/ios/RNNUIBarButtonItem.m
+++ b/lib/ios/RNNUIBarButtonItem.m
@@ -4,9 +4,6 @@
 #import "UIImage+insets.h"
 #import "UIImage+tint.h"
 
-#define BUTTON_WIDTH @(40)
-#define BUTTON_HEIGHT @(40)
-
 @interface RNNUIBarButtonItem ()
 
 @property(nonatomic, strong) NSLayoutConstraint *widthConstraint;

--- a/playground/ios/NavigationTests/RNNUIBarButtonItemTest.m
+++ b/playground/ios/NavigationTests/RNNUIBarButtonItemTest.m
@@ -1,4 +1,5 @@
 #import <OCMock/OCMock.h>
+#import <ReactNativeNavigation/NullNumber.h>
 #import <ReactNativeNavigation/RNNUIBarButtonItem.h>
 #import <XCTest/XCTest.h>
 
@@ -28,6 +29,39 @@
     XCTAssertEqual(button.backgroundColor, backgroundColor);
     XCTAssertEqual(button.layer.cornerRadius, cornerRadius);
     XCTAssertTrue(CGSizeEqualToSize(button.frame.size, size));
+}
+
+- (void)testInitWithStyleOptions_shouldUseDefaultIconImageSize {
+    CGSize size = CGSizeMake(20, 20);
+    UIColor *backgroundColor = UIColor.redColor;
+    CGFloat cornerRadius = 10;
+    UIImage *image = [self imageWithSize:size];
+
+    RNNButtonOptions *buttonOptions = RNNButtonOptions.new;
+    buttonOptions.iconBackground = RNNIconBackgroundOptions.new;
+    buttonOptions.iconBackground.width = NullNumber.new;
+    buttonOptions.iconBackground.height = NullNumber.new;
+    buttonOptions.icon = [Image withValue:image];
+    buttonOptions.iconBackground.color = [Color withValue:backgroundColor];
+    buttonOptions.iconBackground.cornerRadius = [Number withValue:@(cornerRadius)];
+    RNNUIBarButtonItem *barButtonItem =
+        [[RNNUIBarButtonItem alloc] initCustomIcon:buttonOptions
+                                           onPress:^(NSString *buttonId){
+                                           }];
+
+    UIButton *button = barButtonItem.customView;
+    XCTAssertEqual(button.backgroundColor, backgroundColor);
+    XCTAssertEqual(button.layer.cornerRadius, cornerRadius);
+    XCTAssertTrue(CGSizeEqualToSize(button.frame.size, size));
+}
+
+- (UIImage *)imageWithSize:(CGSize)size {
+    UIGraphicsBeginImageContextWithOptions(size, YES, 0);
+    [[UIColor whiteColor] setFill];
+    UIRectFill(CGRectMake(0, 0, size.width, size.height));
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return image;
 }
 
 @end


### PR DESCRIPTION
[This commit](8131ea7650b997cbaefa2665fcad039005ae6955) created a bug where buttons received default size and not the original icon size which causes the insets to be bigger that it needed to be.