### PR TITLE
Fix scrollEdgeAppearance border visibility

### DIFF
--- a/lib/ios/TopBarAppearancePresenter.m
+++ b/lib/ios/TopBarAppearancePresenter.m
@@ -47,7 +47,7 @@
     }
 
     if (options.scrollEdgeAppearance.noBorder.hasValue) {
-        [self showScrollEdgeBorder:options.scrollEdgeAppearance.noBorder.get];
+        [self showScrollEdgeBorder:!options.scrollEdgeAppearance.noBorder.get];
     }
 }
 
@@ -127,7 +127,7 @@
 
 - (void)updateScrollEdgeBorder {
     self.getScrollEdgeAppearance.shadowColor =
-        self.scrollEdgeBorderColor ? self.scrollEdgeBorderColor : nil;
+        self.showScrollEdgeBorder ? self.scrollEdgeBorderColor : nil;
 }
 
 - (void)setBackIndicatorImage:(UIImage *)image withColor:(UIColor *)color {

--- a/playground/ios/NavigationTests/TopBarAppearancePresenterTest.m
+++ b/playground/ios/NavigationTests/TopBarAppearancePresenterTest.m
@@ -106,7 +106,7 @@
         UIColor.blueColor);
 }
 
-- (void)testMergeOptions_shouldApplyTitleAppearance {
+- (void)testApplyOptions_shouldApplyTitleAppearance {
     RNNNavigationOptions *options = [RNNNavigationOptions emptyOptions];
     options.topBar.title.color = [Color withColor:UIColor.redColor];
     options.topBar.title.fontSize = [Number withValue:@(21)];
@@ -161,6 +161,38 @@
     XCTAssertEqual(
         _stack.childViewControllers.lastObject.navigationItem.scrollEdgeAppearance.shadowColor,
         UIColor.blueColor);
+}
+
+- (void)testApplyOptions_shouldHideScrollEdgeBorder {
+    RNNNavigationOptions *options = [RNNNavigationOptions emptyOptions];
+    options.topBar.scrollEdgeAppearance.noBorder = [Bool withValue:YES];
+    options.topBar.scrollEdgeAppearance.borderColor = [Color withColor:UIColor.redColor];
+
+    [_uut applyOptions:options.topBar];
+    XCTAssertEqual(
+        _stack.childViewControllers.lastObject.navigationItem.scrollEdgeAppearance.shadowColor,
+        nil);
+}
+
+- (void)testApplyOptions_shouldShowScrollEdgeBorderWithDefaultColor {
+    RNNNavigationOptions *options = [RNNNavigationOptions emptyOptions];
+    options.topBar.scrollEdgeAppearance.noBorder = [Bool withValue:NO];
+
+    [_uut applyOptions:options.topBar];
+    XCTAssertEqual(
+        _stack.childViewControllers.lastObject.navigationItem.scrollEdgeAppearance.shadowColor,
+        [[UINavigationBarAppearance new] shadowColor]);
+}
+
+- (void)testApplyOptions_shouldShowScrollEdgeBorderWithColor {
+    RNNNavigationOptions *options = [RNNNavigationOptions emptyOptions];
+    options.topBar.scrollEdgeAppearance.noBorder = [Bool withValue:NO];
+    options.topBar.scrollEdgeAppearance.borderColor = [Color withColor:UIColor.redColor];
+
+    [_uut applyOptions:options.topBar];
+    XCTAssertEqual(
+        _stack.childViewControllers.lastObject.navigationItem.scrollEdgeAppearance.shadowColor,
+        UIColor.redColor);
 }
 
 @end


### PR DESCRIPTION
Fixes `topBar` border visibility in [scrollEdge](https://developer.apple.com/documentation/uikit/uinavigationbar/3198027-scrolledgeappearance) appearance mode.
```js
scrollEdgeAppearance: {
  active: true,
  noBorder: true,
},
```
Closes #6754 