### PR TITLE
Fix ViewAnimationOptions not merging correctly

### DIFF
--- a/lib/ios/ViewAnimationOptions.m
+++ b/lib/ios/ViewAnimationOptions.m
@@ -17,10 +17,7 @@
 }
 
 - (void)mergeOptions:(ViewAnimationOptions *)options {
-    if (options.enable.hasValue)
-        self.enable = options.enable;
-    if (options.waitForRender.hasValue)
-        self.waitForRender = options.waitForRender;
+    [super mergeOptions:options];
     if (options.sharedElementTransitions)
         self.sharedElementTransitions = options.sharedElementTransitions;
     if (options.elementTransitions)

--- a/lib/ios/ViewAnimationOptions.m
+++ b/lib/ios/ViewAnimationOptions.m
@@ -17,6 +17,10 @@
 }
 
 - (void)mergeOptions:(ViewAnimationOptions *)options {
+    if (options.enable.hasValue)
+        self.enable = options.enable;
+    if (options.waitForRender.hasValue)
+        self.waitForRender = options.waitForRender;
     if (options.sharedElementTransitions)
         self.sharedElementTransitions = options.sharedElementTransitions;
     if (options.elementTransitions)


### PR DESCRIPTION
Adds missing enable and waitForRender props for copying. Allows for showModal/dismissModal to run without animation.