### PR TITLE
Fix (Types) - Icon type does not accept object

### DIFF
--- a/lib/src/adapters/AssetResolver.ts
+++ b/lib/src/adapters/AssetResolver.ts
@@ -1,7 +1,7 @@
-import { ImageRequireSource, Image } from 'react-native';
+import { Image, ImageSourcePropType } from 'react-native';
 
 export class AssetService {
-  resolveFromRequire(value: ImageRequireSource) {
+  resolveFromRequire(value: ImageSourcePropType) {
     return Image.resolveAssetSource(value);
   }
 }

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -1,5 +1,5 @@
 // tslint:disable jsdoc-format
-import { ImageRequireSource, Insets } from 'react-native';
+import { ImageRequireSource, ImageSourcePropType, Insets } from 'react-native';
 
 // TODO: Import ColorValue instead when upgrading @types/react-native to 0.63+
 // Only assign PlatformColor or DynamicColorIOS as a Color symbol!
@@ -826,7 +826,7 @@ export interface ImageSystemSource {
   fallback?: ImageRequireSource | string;
 }
 
-export type ImageResource = ImageRequireSource | string | ImageSystemSource;
+export type ImageResource = ImageSourcePropType | string | ImageSystemSource;
 
 export interface OptionsBottomTab {
   dotIndicator?: DotIndicatorOptions;


### PR DESCRIPTION
Closes #6099

Rationale: https://github.com/wix/react-native-navigation/issues/6099#issuecomment-702537239