### PR TITLE
Fix external component appearance events

### DIFF
--- a/lib/ios/RNNExternalViewController.m
+++ b/lib/ios/RNNExternalViewController.m
@@ -40,6 +40,20 @@
     [self readyForPresentation];
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    [self.eventEmitter sendComponentDidAppear:self.layoutInfo.componentId
+                                componentName:self.layoutInfo.name
+                                componentType:ComponentTypeScreen];
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
+    [self.eventEmitter sendComponentDidDisappear:self.layoutInfo.componentId
+                                   componentName:self.layoutInfo.name
+                                   componentType:ComponentTypeScreen];
+}
+
 #pragma mark - UIViewController overrides
 
 - (void)willMoveToParentViewController:(UIViewController *)parent {

--- a/playground/ios/NavigationTests/RNNExternalViewControllerTests.m
+++ b/playground/ios/NavigationTests/RNNExternalViewControllerTests.m
@@ -7,6 +7,8 @@
 
 @property(nonatomic, strong) RNNExternalViewController *uut;
 @property(nonatomic, strong) RNNCustomViewController *customViewController;
+@property(nonatomic, strong) id mockEventEmitter;
+@property(nonatomic, strong) RNNLayoutInfo *layoutInfo;
 
 @end
 
@@ -15,13 +17,15 @@
 - (void)setUp {
     [super setUp];
     self.customViewController = [[RNNCustomViewController alloc] init];
-    RNNLayoutInfo *layoutInfo = [[RNNLayoutInfo alloc] init];
-    layoutInfo.componentId = @"externalComponentId";
+    self.mockEventEmitter = [OCMockObject niceMockForClass:RNNEventEmitter.class];
+    _layoutInfo = [[RNNLayoutInfo alloc] init];
+    _layoutInfo.componentId = @"externalComponentId";
+    _layoutInfo.name = @"externalComponentName";
     RNNComponentPresenter *presenter =
         [[RNNComponentPresenter alloc] initWithComponentRegistry:nil defaultOptions:nil];
     self.uut =
-        [[RNNExternalViewController alloc] initWithLayoutInfo:layoutInfo
-                                                 eventEmitter:nil
+        [[RNNExternalViewController alloc] initWithLayoutInfo:_layoutInfo
+                                                 eventEmitter:self.mockEventEmitter
                                                     presenter:presenter
                                                       options:[RNNNavigationOptions emptyOptions]
                                                defaultOptions:nil
@@ -30,6 +34,22 @@
 
 - (void)testLoadView_withMainScreenBounds {
     XCTAssertTrue(CGRectEqualToRect(self.uut.view.bounds, UIScreen.mainScreen.bounds));
+}
+
+- (void)testViewDidAppear_shouldEmitEvent {
+    [[_mockEventEmitter expect] sendComponentDidAppear:_layoutInfo.componentId
+                                         componentName:_layoutInfo.name
+                                         componentType:ComponentTypeScreen];
+    [self.uut viewDidAppear:NO];
+    [_mockEventEmitter verify];
+}
+
+- (void)testViewDidDisappear_shouldEmitEvent {
+    [[_mockEventEmitter expect] sendComponentDidDisappear:_layoutInfo.componentId
+                                            componentName:_layoutInfo.name
+                                            componentType:ComponentTypeScreen];
+    [self.uut viewDidDisappear:NO];
+    [_mockEventEmitter verify];
 }
 
 @end


### PR DESCRIPTION
This PR fixes emitting `componentDidAppear` and `componentDidDisappear` events for external components.

Closes #6844