### PR TITLE
Fix resolving dismissAllModals when there are no presented modals

### DIFF
--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -81,7 +81,10 @@ static NSString *const setDefaultOptions = @"setDefaultOptions";
         }
     }
 
-    [_modalManager dismissAllModalsAnimated:NO completion:nil];
+    [_modalManager dismissAllModalsAnimated:NO
+                                 completion:^{
+
+                                 }];
 
     UIViewController *vc = [_controllerFactory createLayout:layout[@"root"]];
     [_layoutManager addPendingViewController:vc];

--- a/lib/ios/RNNModalManager.m
+++ b/lib/ios/RNNModalManager.m
@@ -89,16 +89,14 @@
 }
 
 - (void)dismissAllModalsAnimated:(BOOL)animated completion:(void (^__nullable)(void))completion {
-    [CATransaction begin];
-    [CATransaction setCompletionBlock:completion];
-
     UIViewController *root = UIApplication.sharedApplication.delegate.window.rootViewController;
-    [root dismissViewControllerAnimated:animated completion:completion];
-    [_eventHandler dismissedMultipleModals:_presentedModals];
-    [_pendingModalIdsToDismiss removeAllObjects];
-    [_presentedModals removeAllObjects];
-
-    [CATransaction commit];
+    if (root.presentedViewController) {
+        [root dismissViewControllerAnimated:animated completion:completion];
+        [_eventHandler dismissedMultipleModals:_presentedModals];
+        [_pendingModalIdsToDismiss removeAllObjects];
+        [_presentedModals removeAllObjects];
+    } else
+        completion();
 }
 
 - (void)dismissAllModalsSynchronosly {

--- a/lib/ios/RNNModalManager.m
+++ b/lib/ios/RNNModalManager.m
@@ -89,7 +89,7 @@
 }
 
 - (void)dismissAllModalsAnimated:(BOOL)animated completion:(void (^__nullable)(void))completion {
-    UIViewController *root = UIApplication.sharedApplication.delegate.window.rootViewController;
+    UIViewController *root = [self rootViewController];
     if (root.presentedViewController) {
         [root dismissViewControllerAnimated:animated completion:completion];
         [_eventHandler dismissedMultipleModals:_presentedModals];
@@ -188,8 +188,12 @@
                                                .presentedComponentViewController];
 }
 
+- (UIViewController *)rootViewController {
+    return UIApplication.sharedApplication.delegate.window.rootViewController;
+}
+
 - (UIViewController *)topPresentedVC {
-    UIViewController *root = UIApplication.sharedApplication.delegate.window.rootViewController;
+    UIViewController *root = [self rootViewController];
     while (root.presentedViewController) {
         root = root.presentedViewController;
     }

--- a/lib/ios/RNNModalManager.m
+++ b/lib/ios/RNNModalManager.m
@@ -95,7 +95,7 @@
         [_eventHandler dismissedMultipleModals:_presentedModals];
         [_pendingModalIdsToDismiss removeAllObjects];
         [_presentedModals removeAllObjects];
-    } else
+    } else if (completion)
         completion();
 }
 

--- a/lib/ios/RNNModalManager.m
+++ b/lib/ios/RNNModalManager.m
@@ -89,11 +89,16 @@
 }
 
 - (void)dismissAllModalsAnimated:(BOOL)animated completion:(void (^__nullable)(void))completion {
+    [CATransaction begin];
+    [CATransaction setCompletionBlock:completion];
+
     UIViewController *root = UIApplication.sharedApplication.delegate.window.rootViewController;
     [root dismissViewControllerAnimated:animated completion:completion];
     [_eventHandler dismissedMultipleModals:_presentedModals];
     [_pendingModalIdsToDismiss removeAllObjects];
     [_presentedModals removeAllObjects];
+
+    [CATransaction commit];
 }
 
 - (void)dismissAllModalsSynchronosly {

--- a/playground/ios/NavigationTests/RNNModalManagerTest.m
+++ b/playground/ios/NavigationTests/RNNModalManagerTest.m
@@ -21,6 +21,7 @@
 @end
 
 @interface MockModalManager : RNNModalManager
+@property(nonatomic, strong) MockViewController *rootViewController;
 @property(nonatomic, strong) MockViewController *topPresentedVC;
 @end
 
@@ -57,6 +58,10 @@
 }
 
 - (void)testDismissMultipleModalsInvokeDelegateWithCorrectParameters {
+    _modalManager.rootViewController = [OCMockObject partialMockForObject:UIViewController.new];
+    OCMStub(_modalManager.rootViewController.presentedViewController)
+        .andReturn(UIViewController.new);
+
     [_modalManager showModal:_vc1 animated:NO completion:nil];
     [_modalManager showModal:_vc2 animated:NO completion:nil];
     [_modalManager showModal:_vc3 animated:NO completion:nil];
@@ -99,6 +104,10 @@
 }
 
 - (void)testDismissAllModals_AfterDismissingPreviousModal_InvokeDelegateWithCorrectParameters {
+    _modalManager.rootViewController = [OCMockObject partialMockForObject:UIViewController.new];
+    OCMStub(_modalManager.rootViewController.presentedViewController)
+        .andReturn(UIViewController.new);
+
     [_modalManager showModal:_vc1 animated:NO completion:nil];
     [_modalManager showModal:_vc2 animated:NO completion:nil];
     [_modalManager showModal:_vc3 animated:NO completion:nil];

--- a/playground/ios/NavigationTests/RNNModalManagerTest.m
+++ b/playground/ios/NavigationTests/RNNModalManagerTest.m
@@ -66,6 +66,18 @@
     [_modalManagerEventHandler verify];
 }
 
+- (void)testDismissAllModals_InvokeCompletionWhenNoModalsPresented {
+    XCTestExpectation *expectation =
+        [self expectationWithDescription:@"Should invoke completion block"];
+
+    [_modalManager dismissAllModalsAnimated:NO
+                                 completion:^{
+                                   [expectation fulfill];
+                                 }];
+
+    [self waitForExpectationsWithTimeout:10 handler:nil];
+}
+
 - (void)testDismissModal_InvokeDelegateWithCorrectParameters {
     [_modalManager showModal:_vc1 animated:NO completion:nil];
     [_modalManager showModal:_vc2 animated:NO completion:nil];


### PR DESCRIPTION
Calling `Navigation.dismissAllModals` promise never resolved when no modals are presented. 

Closes #6875 