### PR TITLE
Fix buttons tint color on iOS 12

### DIFF
--- a/lib/ios/RNNUIBarButtonItem.m
+++ b/lib/ios/RNNUIBarButtonItem.m
@@ -125,6 +125,7 @@
     self.accessibilityLabel = [buttonOptions.accessibilityLabel withDefault:nil];
     self.enabled = [buttonOptions.enabled withDefault:YES];
     self.accessibilityIdentifier = [buttonOptions.testID withDefault:nil];
+    self.tintColor = [buttonOptions.color withDefault:nil];
     [self applyTitleTextAttributes:buttonOptions];
     [self applyDisabledTitleTextAttributes:buttonOptions];
 }

--- a/playground/ios/NavigationTests/RNNUIBarButtonItemTest.m
+++ b/playground/ios/NavigationTests/RNNUIBarButtonItemTest.m
@@ -55,6 +55,20 @@
     XCTAssertTrue(CGSizeEqualToSize(button.frame.size, size));
 }
 
+- (void)testInitWithIcon_ShouldApplyTintColor {
+    UIColor *buttonColor = UIColor.redColor;
+
+    RNNButtonOptions *buttonOptions = RNNButtonOptions.new;
+    buttonOptions.icon = [Image withValue:UIImage.new];
+    buttonOptions.color = [Color withColor:buttonColor];
+    RNNUIBarButtonItem *barButtonItem =
+        [[RNNUIBarButtonItem alloc] initWithIcon:buttonOptions
+                                         onPress:^(NSString *buttonId){
+                                         }];
+
+    XCTAssertEqual(barButtonItem.tintColor, buttonColor);
+}
+
 - (UIImage *)imageWithSize:(CGSize)size {
     UIGraphicsBeginImageContextWithOptions(size, YES, 0);
     [[UIColor whiteColor] setFill];


### PR DESCRIPTION
Fixes a regression created in [this commit](8131ea7650b997cbaefa2665fcad039005ae6955) which caused buttons with icon to never receive a tint color on iOS 12.

Closes #6877 