### PR TITLE
Change applying options order for scrollEdgeAppearance border properties

### DIFF
--- a/lib/ios/TopBarAppearancePresenter.m
+++ b/lib/ios/TopBarAppearancePresenter.m
@@ -23,12 +23,12 @@
     [self setLargeTitleAttributes:options.largeTitle];
     [self setBorderColor:[options.borderColor withDefault:nil]];
     [self showBorder:![options.noBorder withDefault:NO]];
-    [self setScrollEdgeBorderColor:[options.scrollEdgeAppearance.borderColor withDefault:nil]];
-    [self showScrollEdgeBorder:![options.scrollEdgeAppearance.noBorder withDefault:NO]];
     [self setBackButtonOptions:options.backButton];
     if ([options.scrollEdgeAppearance.active withDefault:NO]) {
         [self updateScrollEdgeAppearance];
     }
+    [self setScrollEdgeBorderColor:[options.scrollEdgeAppearance.borderColor withDefault:nil]];
+    [self showScrollEdgeBorder:![options.scrollEdgeAppearance.noBorder withDefault:NO]];
 }
 
 - (void)applyOptionsBeforePopping:(RNNTopBarOptions *)options {


### PR DESCRIPTION
Fixes `topBar` border visibility and color in `scrollEdge` appearance mode.
closes: [#6754](https://github.com/wix/react-native-navigation/issues/6754)

Calling `[self updateScrollEdgeAppearance]` as the latest part of applying options overrides `scrollEdge` properties since it applies predefined config with border by default:

```objc
- (void)updateScrollEdgeAppearance {
    if (self.scrollEdgeTransparent) {
        [self.getScrollEdgeAppearance configureWithTransparentBackground];
    } else if (self.scrollEdgeAppearanceColor) {
        [self.getScrollEdgeAppearance configureWithOpaqueBackground];
        [self.getScrollEdgeAppearance setBackgroundColor:self.scrollEdgeAppearanceColor];
    } else if (self.scrollEdgeTranslucent) {
        [self.getScrollEdgeAppearance configureWithDefaultBackground];
    } else {
        [self.getScrollEdgeAppearance configureWithOpaqueBackground];
        if (self.backgroundColor) {
            [self.getScrollEdgeAppearance setBackgroundColor:self.backgroundColor];
        }
    }
}
```