### PR TITLE
Add minimal iOS scrollEdgeAppearance supported version, minor formatting fixes

### DIFF
--- a/website/docs/api/options-scrollEdgeAppearance.mdx
+++ b/website/docs/api/options-scrollEdgeAppearance.mdx
@@ -21,9 +21,10 @@ const options = {
 
 Since this might be considered as a breaking change (meaning that previous configs might behave different), you'll need to
 pass active `true/false` to activate this option.
-| Type | Required | Platform |
-| ----- | -------- | -------- |
-| Bool | No | iOS |
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | iOS      |
 
 ### `color`
 
@@ -47,7 +48,7 @@ Change the topBar border color.
 
 | Type  | Required | Platform |
 | ----- | -------- | -------- |
-| Color | No       | Both     |
+| Color | No       | iOS      |
 
 ### `noBorder`
 

--- a/website/docs/api/options-stack.mdx
+++ b/website/docs/api/options-stack.mdx
@@ -72,7 +72,7 @@ Controls the appearance settings when the scrollable content reaches the matchin
 
 | Type                              | Required | Platform |
 | --------------------------------- | -------- | -------- |
-| [Scroll Edge Background](options-scrollEdgeAppearance.mdx) | No       | iOS     |
+| [Scroll Edge Background](options-scrollEdgeAppearance.mdx) | No       | iOS 13+     |
 
 ### `barStyle`
 

--- a/website/versioned_docs/version-7.7.0/api/options-scrollEdgeAppearance.mdx
+++ b/website/versioned_docs/version-7.7.0/api/options-scrollEdgeAppearance.mdx
@@ -21,9 +21,10 @@ const options = {
 
 Since this might be considered as a breaking change (meaning that previous configs might behave different), you'll need to
 pass active `true/false` to activate this option.
-| Type | Required | Platform |
-| ----- | -------- | -------- |
-| Bool | No | iOS |
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | iOS      |
 
 ### `color`
 
@@ -47,7 +48,7 @@ Change the topBar border color.
 
 | Type  | Required | Platform |
 | ----- | -------- | -------- |
-| Color | No       | Both     |
+| Color | No       | iOS      |
 
 ### `noBorder`
 

--- a/website/versioned_docs/version-7.7.0/api/options-stack.mdx
+++ b/website/versioned_docs/version-7.7.0/api/options-stack.mdx
@@ -72,7 +72,7 @@ Controls the appearance settings when the scrollable content reaches the matchin
 
 | Type                              | Required | Platform |
 | --------------------------------- | -------- | -------- |
-| [Scroll Edge Background](options-scrollEdgeAppearance.mdx) | No       | iOS     |
+| [Scroll Edge Background](options-scrollEdgeAppearance.mdx) | No       | iOS 13+     |
 
 ### `barStyle`
 

--- a/website/versioned_docs/version-7.8.1/api/options-scrollEdgeAppearance.mdx
+++ b/website/versioned_docs/version-7.8.1/api/options-scrollEdgeAppearance.mdx
@@ -21,9 +21,10 @@ const options = {
 
 Since this might be considered as a breaking change (meaning that previous configs might behave different), you'll need to
 pass active `true/false` to activate this option.
-| Type | Required | Platform |
-| ----- | -------- | -------- |
-| Bool | No | iOS |
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | iOS      |
 
 ### `color`
 
@@ -47,7 +48,7 @@ Change the topBar border color.
 
 | Type  | Required | Platform |
 | ----- | -------- | -------- |
-| Color | No       | Both     |
+| Color | No       | iOS      |
 
 ### `noBorder`
 

--- a/website/versioned_docs/version-7.8.1/api/options-stack.mdx
+++ b/website/versioned_docs/version-7.8.1/api/options-stack.mdx
@@ -72,7 +72,7 @@ Controls the appearance settings when the scrollable content reaches the matchin
 
 | Type                              | Required | Platform |
 | --------------------------------- | -------- | -------- |
-| [Scroll Edge Background](options-scrollEdgeAppearance.mdx) | No       | iOS     |
+| [Scroll Edge Background](options-scrollEdgeAppearance.mdx) | No       | iOS 13+     |
 
 ### `barStyle`
 


### PR DESCRIPTION
Add specific (iOS 13+) version info regarding scrollEdgeAppearance.
Fix incorrect formatting of  `active` property.