### PR TITLE
Component title bar alignment fix

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBar.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBar.java
@@ -86,7 +86,6 @@ public class TitleBar extends Toolbar {
         clearTitle();
         clearSubtitle();
         this.component = component;
-        runOnMeasured(component, () -> component.setX((getWidth() - component.getWidth() - getStart()) / 2f));
         addView(component);
     }
 
@@ -143,35 +142,37 @@ public class TitleBar extends Toolbar {
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
         super.onLayout(changed, l, t, r, b);
-
-        centerComponent();
-
-        if (changed || isTitleChanged) {
-            TextView title = findTitleTextView();
-            if (title != null) {
-                alignTextView(titleAlignment, title);
+        if (component != null) {
+            alignComponent();
+        } else {
+            if (changed || isTitleChanged) {
+                TextView title = findTitleTextView();
+                if (title != null) {
+                    alignTextView(titleAlignment, title);
+                }
+                isTitleChanged = false;
             }
-            isTitleChanged = false;
-        }
 
-        if (changed || isSubtitleChanged) {
-            TextView subtitle = findSubtitleTextView();
-            if (subtitle != null) alignTextView(subtitleAlignment, subtitle);
-            isSubtitleChanged = false;
+            if (changed || isSubtitleChanged) {
+                TextView subtitle = findSubtitleTextView();
+                if (subtitle != null) alignTextView(subtitleAlignment, subtitle);
+                isSubtitleChanged = false;
+            }
         }
     }
 
-    private void centerComponent() {
-        if (component != null) {
-            runOnMeasured(component, () -> {
-                Toolbar.LayoutParams lp = (LayoutParams) component.getLayoutParams();
-                if (lp.gravity == Gravity.CENTER) {
-                    boolean isRTL = getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
-                    int direction = isRTL ? -1 : 1;
-                    component.setX((getWidth() - component.getWidth() - direction * getStart()) / 2f);
-                }
-            });
-        }
+    private void alignComponent() {
+        runOnMeasured(component, () -> {
+            Toolbar.LayoutParams lp = (LayoutParams) component.getLayoutParams();
+            if (lp.gravity == Gravity.CENTER) {
+                boolean isRTL = getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+                int direction = isRTL ? -1 : 1;
+                component.setX((getWidth() - component.getWidth() - direction * getStart()) / 2f);
+            } else if (lp.gravity == Gravity.START) {
+                boolean isRTL = getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+                component.setX(isRTL ? getWidth() - component.getWidth() - getStart() : 0);
+            }
+        });
     }
 
     @Override

--- a/lib/android/app/src/test/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarTest.java
@@ -5,6 +5,7 @@ import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
@@ -71,14 +72,40 @@ public class TitleBarTest extends BaseTest {
     }
 
     @Test
-    public void setComponent_alignedAfterMeasure() {
+    public void setComponent_alignedStartAfterMeasure() {
         uut.layout(0, 0, UUT_WIDTH, UUT_HEIGHT);
 
         View component = new View(activity);
         component.layout(0, 0, COMPONENT_WIDTH, COMPONENT_HEIGHT);
+        component.setLayoutParams(new Toolbar.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, Gravity.START));
         uut.setComponent(component);
+        uut.onLayout(true, 0, 0, 0, 0);
+        assertThat(component.getX()).isEqualTo(0);
+    }
 
-        dispatchOnGlobalLayout(component);
+    @Test
+    public void setComponent_alignedStartRTLAfterMeasure() {
+        ViewGroup parent = new FrameLayout(activity);
+        parent.layout(0, 0, UUT_WIDTH, UUT_HEIGHT);
+        when(uut.getParent()).thenReturn(parent);
+        uut.layout(0, 0, UUT_WIDTH, UUT_HEIGHT);
+        when(uut.getLayoutDirection()).thenReturn(View.LAYOUT_DIRECTION_RTL);
+        View component = new View(activity);
+        component.layout(0, 0, COMPONENT_WIDTH, COMPONENT_HEIGHT);
+        component.setLayoutParams(new Toolbar.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, Gravity.START));
+        uut.setComponent(component);
+        uut.onLayout(true, 0, 0, 0, 0);
+        assertThat(component.getX()).isEqualTo(UUT_WIDTH - COMPONENT_WIDTH);
+    }
+
+    @Test
+    public void setComponent_alignedCenterAfterMeasure() {
+        uut.layout(0, 0, UUT_WIDTH, UUT_HEIGHT);
+        View component = new View(activity);
+        component.layout(0, 0, COMPONENT_WIDTH, COMPONENT_HEIGHT);
+        component.setLayoutParams(new Toolbar.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, Gravity.CENTER));
+        uut.setComponent(component);
+        uut.onLayout(true, 0, 0, 0, 0);
         assertThat(component.getX()).isEqualTo((UUT_WIDTH - COMPONENT_WIDTH) / 2f);
     }
 
@@ -91,7 +118,7 @@ public class TitleBarTest extends BaseTest {
         uut.setComponent(component);
         ((Toolbar.LayoutParams) component.getLayoutParams()).gravity = Gravity.CENTER;
 
-        uut.onLayout(true, 0, 0, 0 ,0);
+        uut.onLayout(true, 0, 0, 0, 0);
         assertThat(component.getX()).isEqualTo((UUT_WIDTH - COMPONENT_WIDTH) / 2f);
     }
 
@@ -108,7 +135,7 @@ public class TitleBarTest extends BaseTest {
         uut.setComponent(component);
         ((Toolbar.LayoutParams) component.getLayoutParams()).gravity = Gravity.CENTER;
 
-        uut.onLayout(true, 0, 0, 0 ,0);
+        uut.onLayout(true, 0, 0, 0, 0);
         component.layout(0, 0, COMPONENT_WIDTH, COMPONENT_HEIGHT);
         dispatchOnGlobalLayout(component);
         assertThat(component.getX()).isEqualTo((UUT_WIDTH - COMPONENT_WIDTH + (PARENT_WIDTH - UUT_WIDTH)) / 2f);

--- a/playground/src/screens/CustomTopBar.tsx
+++ b/playground/src/screens/CustomTopBar.tsx
@@ -25,13 +25,11 @@ export default class CustomTopBar extends React.Component<Props> {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
-    flexDirection: 'column',
-    justifyContent: 'center',
-    alignSelf: 'center',
+    alignSelf: 'baseline',
+    padding: 8,
   },
   text: {
-    alignSelf: 'center',
+    alignSelf: 'flex-start',
     color: 'black',
     fontSize: 16,
   },

--- a/playground/src/screens/OptionsScreen.tsx
+++ b/playground/src/screens/OptionsScreen.tsx
@@ -52,7 +52,7 @@ export default class Options extends React.Component<Props> {
           onPress={this.hideTopBarInDefaultOptions}
         />
         <Button
-          label="Set React Title View"
+          label="Set React Title View x"
           testID={SET_REACT_TITLE_VIEW}
           onPress={this.setReactTitleView}
         />
@@ -159,8 +159,9 @@ export default class Options extends React.Component<Props> {
         title: {
           component: {
             name: Screens.ReactTitleView,
-            alignment: 'center',
+            alignment: 'fill',
             passProps: {
+              clickable: true,
               text: 'Press Me',
             },
           },

--- a/playground/src/screens/OptionsScreen.tsx
+++ b/playground/src/screens/OptionsScreen.tsx
@@ -52,7 +52,7 @@ export default class Options extends React.Component<Props> {
           onPress={this.hideTopBarInDefaultOptions}
         />
         <Button
-          label="Set React Title View x"
+          label="Set React Title View"
           testID={SET_REACT_TITLE_VIEW}
           onPress={this.setReactTitleView}
         />


### PR DESCRIPTION
**Issue:**
Closes #6883 
setting Component ignores alignment, works only on centre.

**Fix:**
- use-case tests added.
- rename `centerComponent` to `alignComponent`.
- calculate X where the component should be as the wanted alignment value set before in LayoutParams (alignment - gravity)
- support RTL into calculations (The component must be aware of this and adapt, RNN just change horizontal position)

