### PR TITLE
Export ProcessorSubscription

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -16,3 +16,4 @@ export * from './interfaces/NavigationComponentListener';
 export * from './interfaces/NavigationFunctionComponent';
 export * from './interfaces/CommandName';
 export * from './interfaces/Processors';
+export * from './interfaces/ProcessorSubscription';


### PR DESCRIPTION
ProcessorSubscription is returned when registering an options or a layout processor. It wasn't exported by mistake.