### PR TITLE
Fix icon color being applied to all instances of the same icon in release mode

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/ImageLoader.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/ImageLoader.kt
@@ -72,7 +72,7 @@ open class ImageLoader {
             }
         }
         if (drawable == null) throw RuntimeException("Could not load image $source")
-        return drawable
+        return drawable.mutate()
     }
 
     @Throws(IOException::class)


### PR DESCRIPTION
As @guyca suggested, this fix an issue where the icon color was modified in release mode, because resources are bundled in release. RNN was changing the Drawable's color, but wasn't mutating the drawable.