### PR TITLE
Fix SET when pushing a screen from bottom tabs

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabPresenter.java
@@ -62,8 +62,8 @@ public class BottomTabPresenter {
                 if (tab.iconColor.canApplyValue()) bottomTabs.setIconInactiveColor(i, tab.iconColor.get(null));
                 bottomTabs.setTitleActiveColor(i, tab.selectedTextColor.get(null));
                 bottomTabs.setTitleInactiveColor(i, tab.textColor.get(null));
-                bottomTabs.setTitleInactiveTextSizeInSp(i, tab.fontSize.hasValue() ? Float.valueOf(tab.fontSize.get()) : null);
-                bottomTabs.setTitleActiveTextSizeInSp(i, tab.selectedFontSize.hasValue() ? Float.valueOf(tab.selectedFontSize.get()) : null);
+                if (tab.fontSize.hasValue()) bottomTabs.setTitleInactiveTextSizeInSp(i, Float.valueOf(tab.fontSize.get()));
+                if (tab.selectedFontSize.hasValue()) bottomTabs.setTitleActiveTextSizeInSp(i, Float.valueOf(tab.selectedFontSize.get()));
                 if (tab.testId.hasValue()) bottomTabs.setTag(i, tab.testId.get());
                 if (shouldApplyDot(tab)) applyDotIndicator(i, tab.dotIndicator); else applyBadge(i, tab);
             }


### PR DESCRIPTION
I see that this issue is kinda present in the issue backlog so I've decided to fix it (since it happened to me). 
This is the error that I'm encountering: 

```
java.lang.NullPointerException: Attempt to invoke virtual method 'float java.lang.Float.floatValue()' on a null object reference
        at com.aurelhubert.ahbottomnavigation.AHBottomNavigation.setTitleInactiveTextSizeInSp(AHBottomNavigation.java:1311)
        at com.reactnativenavigation.viewcontrollers.bottomtabs.BottomTabPresenter.lambda$applyOptions$0$BottomTabPresenter(BottomTabPresenter.java:65)
        at com.reactnativenavigation.viewcontrollers.bottomtabs.-$$Lambda$BottomTabPresenter$xw0BqWFLHJmeiaHq_MSiMyHoYmc.run(Unknown Source:4)
        at com.reactnativenavigation.utils.LateInit.perform(LateInit.java:19)
```

basically my assumption is that calling set on titleInactiveTextSize results in the error above.

This should fix it :D 
