### PR TITLE
 Fix undefined passProps.componentId in static options

### DIFF
--- a/lib/src/Navigation.ts
+++ b/lib/src/Navigation.ts
@@ -78,7 +78,7 @@ export class NavigationRoot {
     this.layoutTreeCrawler = new LayoutTreeCrawler(this.store, optionsProcessor);
     this.nativeCommandsSender = new NativeCommandsSender();
     this.commandsObserver = new CommandsObserver(this.uniqueIdProvider);
-    this.optionsCrawler = new OptionsCrawler(this.store);
+    this.optionsCrawler = new OptionsCrawler(this.store, this.uniqueIdProvider);
     this.commands = new Commands(
       this.store,
       this.nativeCommandsSender,

--- a/lib/src/commands/Commands.test.ts
+++ b/lib/src/commands/Commands.test.ts
@@ -50,7 +50,7 @@ describe('Commands', () => {
       uniqueIdProvider,
       optionsProcessor,
       layoutProcessor,
-      new OptionsCrawler(instance(mockedStore))
+      new OptionsCrawler(instance(mockedStore), uniqueIdProvider)
     );
   });
 
@@ -138,7 +138,7 @@ describe('Commands', () => {
         root: { component: { name: 'com.example.MyScreen' } },
       });
       expect(layoutProcessor.process).toBeCalledWith(
-        { component: { name: 'com.example.MyScreen', options: {} } },
+        { component: { name: 'com.example.MyScreen', options: {}, id: 'Component+UNIQUE_ID' } },
         CommandName.SetRoot
       );
     });
@@ -161,7 +161,13 @@ describe('Commands', () => {
         root: { component: { name: 'com.example.MyScreen' } },
       });
       expect(layoutProcessor.process).toBeCalledWith(
-        { component: { name: 'com.example.MyScreen', options: { topBar: { visible: false } } } },
+        {
+          component: {
+            id: 'Component+UNIQUE_ID',
+            name: 'com.example.MyScreen',
+            options: { topBar: { visible: false } },
+          },
+        },
         CommandName.SetRoot
       );
     });
@@ -234,7 +240,7 @@ describe('Commands', () => {
     it('process layout with layoutProcessor', () => {
       uut.showModal({ component: { name: 'com.example.MyScreen' } });
       expect(layoutProcessor.process).toBeCalledWith(
-        { component: { name: 'com.example.MyScreen', options: {} } },
+        { component: { id: 'Component+UNIQUE_ID', name: 'com.example.MyScreen', options: {} } },
         CommandName.ShowModal
       );
     });
@@ -319,7 +325,7 @@ describe('Commands', () => {
     it('process layout with layoutProcessor', () => {
       uut.push('theComponentId', { component: { name: 'com.example.MyScreen' } });
       expect(layoutProcessor.process).toBeCalledWith(
-        { component: { name: 'com.example.MyScreen', options: {} } },
+        { component: { id: 'Component+UNIQUE_ID', name: 'com.example.MyScreen', options: {} } },
         CommandName.Push
       );
     });
@@ -416,7 +422,7 @@ describe('Commands', () => {
     it('process layout with layoutProcessor', () => {
       uut.setStackRoot('theComponentId', [{ component: { name: 'com.example.MyScreen' } }]);
       expect(layoutProcessor.process).toBeCalledWith(
-        { component: { name: 'com.example.MyScreen', options: {} } },
+        { component: { id: 'Component+UNIQUE_ID', name: 'com.example.MyScreen', options: {} } },
         CommandName.SetStackRoot
       );
     });
@@ -462,7 +468,7 @@ describe('Commands', () => {
     it('process layout with layoutProcessor', () => {
       uut.showOverlay({ component: { name: 'com.example.MyScreen' } });
       expect(layoutProcessor.process).toBeCalledWith(
-        { component: { name: 'com.example.MyScreen', options: {} } },
+        { component: { id: 'Component+UNIQUE_ID', name: 'com.example.MyScreen', options: {} } },
         CommandName.ShowOverlay
       );
     });
@@ -495,7 +501,6 @@ describe('Commands', () => {
     let cb: any;
     let mockedLayoutTreeParser: LayoutTreeParser;
     let mockedLayoutTreeCrawler: LayoutTreeCrawler;
-    let anotherMockedUniqueIdProvider: UniqueIdProvider;
 
     beforeEach(() => {
       cb = jest.fn();
@@ -503,10 +508,6 @@ describe('Commands', () => {
       mockedLayoutTreeCrawler = mock(LayoutTreeCrawler);
       commandsObserver.register(cb);
       const mockedOptionsProcessor = mock(OptionsProcessor) as OptionsProcessor;
-      anotherMockedUniqueIdProvider = mock(UniqueIdProvider);
-      when(anotherMockedUniqueIdProvider.generate(anything())).thenCall(
-        (prefix) => `${prefix}+UNIQUE_ID`
-      );
 
       uut = new Commands(
         mockedStore,
@@ -514,10 +515,10 @@ describe('Commands', () => {
         instance(mockedLayoutTreeParser),
         instance(mockedLayoutTreeCrawler),
         commandsObserver,
-        instance(anotherMockedUniqueIdProvider),
+        instance(mockedUniqueIdProvider),
         instance(mockedOptionsProcessor),
         new LayoutProcessor(new LayoutProcessorsStore()),
-        new OptionsCrawler(instance(mockedStore))
+        new OptionsCrawler(instance(mockedStore), mockedUniqueIdProvider)
       );
     });
 

--- a/lib/src/commands/OptionsCrawler.test.ts
+++ b/lib/src/commands/OptionsCrawler.test.ts
@@ -289,6 +289,19 @@ describe('OptionsCrawler', () => {
     });
   });
 
+  it('Components: options default obj', () => {
+    when(mockedStore.getComponentClassForName('theComponentName')).thenReturn(
+      () => class extends React.Component {}
+    );
+
+    const node = {
+      component: { name: 'theComponentName', options: {}, id: 'testId' },
+      children: [],
+    };
+    uut.crawl(node);
+    expect(node.component.options).toEqual({});
+  });
+
   it('Components: should generate component id', () => {
     let componentIdInProps: String = '';
     when(mockedStore.getComponentClassForName('theComponentName')).thenReturn(

--- a/lib/src/commands/OptionsCrawler.test.ts
+++ b/lib/src/commands/OptionsCrawler.test.ts
@@ -1,18 +1,23 @@
 import * as React from 'react';
 
 import { Store } from '../components/Store';
-import { mock, instance, when } from 'ts-mockito';
+import { mock, instance, when, anything } from 'ts-mockito';
 import { Options } from '../interfaces/Options';
 import { OptionsCrawler } from './OptionsCrawler';
 import { Layout } from '../interfaces/Layout';
+import { UniqueIdProvider } from '../adapters/UniqueIdProvider';
 
 describe('OptionsCrawler', () => {
   let uut: OptionsCrawler;
   let mockedStore: Store;
+  let mockedUniqueIdProvider: UniqueIdProvider;
 
   beforeEach(() => {
     mockedStore = mock(Store);
-    uut = new OptionsCrawler(instance(mockedStore));
+    mockedUniqueIdProvider = mock(UniqueIdProvider);
+    when(mockedUniqueIdProvider.generate(anything())).thenCall((prefix) => `${prefix}+UNIQUE_ID`);
+    const uniqueIdProvider = instance(mockedUniqueIdProvider);
+    uut = new OptionsCrawler(instance(mockedStore), uniqueIdProvider);
   });
 
   it('Components: injects options object', () => {
@@ -284,17 +289,23 @@ describe('OptionsCrawler', () => {
     });
   });
 
-  it('Components: options default obj', () => {
+  it('Components: should generate component id', () => {
+    let componentIdInProps: String = '';
     when(mockedStore.getComponentClassForName('theComponentName')).thenReturn(
-      () => class extends React.Component {}
+      () =>
+        class extends React.Component {
+          static options(props: any) {
+            componentIdInProps = props.componentId;
+          }
+        }
     );
 
     const node = {
-      component: { name: 'theComponentName', options: {}, id: 'testId' },
+      component: { name: 'theComponentName', options: {}, id: undefined },
       children: [],
     };
     uut.crawl(node);
-    expect(node.component.options).toEqual({});
+    expect(componentIdInProps).toEqual('Component+UNIQUE_ID');
   });
 
   it('componentId is included in props passed to options generator', () => {

--- a/lib/src/commands/OptionsCrawler.ts
+++ b/lib/src/commands/OptionsCrawler.ts
@@ -11,11 +11,13 @@ import {
   LayoutStack,
   LayoutTopTabs,
 } from '../interfaces/Layout';
+import { UniqueIdProvider } from 'react-native-navigation/adapters/UniqueIdProvider';
+import { LayoutType } from './LayoutType';
 
 type ComponentWithOptions = React.ComponentType<any> & { options(passProps: any): Options };
 
 export class OptionsCrawler {
-  constructor(public readonly store: Store) {
+  constructor(public readonly store: Store, public readonly uniqueIdProvider: UniqueIdProvider) {
     this.crawl = this.crawl.bind(this);
   }
 
@@ -60,7 +62,11 @@ export class OptionsCrawler {
   }
 
   private component(component: LayoutComponent): void {
+    this.applyComponentId(component);
     this.applyStaticOptions(component);
+  }
+  private applyComponentId(component: LayoutComponent): void {
+    component.id = component.id || this.uniqueIdProvider.generate(LayoutType.Component);
   }
 
   private isComponentWithOptions(component: any): component is ComponentWithOptions {


### PR DESCRIPTION
Generate `componentId` before calling static options function with passProps that should contain the `componentId`.

Closes #6916