### PR TITLE
Pass component props to option processors

### DIFF
--- a/lib/src/Navigation.ts
+++ b/lib/src/Navigation.ts
@@ -27,6 +27,7 @@ import { LayoutProcessor } from './processors/LayoutProcessor';
 import { LayoutProcessorsStore } from './processors/LayoutProcessorsStore';
 import { CommandName } from './interfaces/CommandName';
 import { OptionsCrawler } from './commands/OptionsCrawler';
+import { OptionsProcessor as OptionProcessor } from './interfaces/Processors';
 
 export class NavigationRoot {
   public readonly TouchablePreview = TouchablePreview;
@@ -120,7 +121,7 @@ export class NavigationRoot {
    */
   public addOptionProcessor<T>(
     optionPath: string,
-    processor: (value: T, commandName: CommandName) => T
+    processor: OptionProcessor<T>
   ): ProcessorSubscription {
     return this.optionProcessorsStore.addProcessor(optionPath, processor);
   }

--- a/lib/src/commands/OptionsCrawler.ts
+++ b/lib/src/commands/OptionsCrawler.ts
@@ -65,6 +65,7 @@ export class OptionsCrawler {
     this.applyComponentId(component);
     this.applyStaticOptions(component);
   }
+
   private applyComponentId(component: LayoutComponent): void {
     component.id = component.id || this.uniqueIdProvider.generate(LayoutType.Component);
   }

--- a/lib/src/commands/OptionsProcessor.test.ts
+++ b/lib/src/commands/OptionsProcessor.test.ts
@@ -12,6 +12,7 @@ import { ColorService } from '../adapters/ColorService';
 import { AssetService } from '../adapters/AssetResolver';
 import { Deprecations } from './Deprecations';
 import { CommandName } from '../interfaces/CommandName';
+import { OptionsProcessor as Processor } from '../interfaces/Processors';
 
 describe('navigation options', () => {
   let uut: OptionsProcessor;
@@ -127,6 +128,24 @@ describe('navigation options', () => {
     });
 
     uut.processOptions(options, CommandName.SetRoot);
+  });
+
+  it('passes passProps to registered processor', () => {
+    const options: Options = {
+      topBar: {
+        visible: false,
+      },
+    };
+    const props = {
+      prop: 'prop',
+    };
+    const processor: Processor<boolean> = (_value, _commandName, passProps) => {
+      expect(passProps).toEqual(props);
+      return _value;
+    };
+
+    optionProcessorsRegistry.addProcessor('topBar.visible', processor);
+    uut.processOptions(options, CommandName.SetRoot, props);
   });
 
   it('supports multiple registered processors', () => {
@@ -284,7 +303,7 @@ describe('navigation options', () => {
 
   it('show warning on iOS when toggling bottomTabs visibility through mergeOptions', () => {
     jest.spyOn(console, 'warn');
-    uut.processOptions({ bottomTabs: { visible: false } }, CommandName.MergeOptions);
+    uut.processOptions({ bottomTabs: { visible: false } }, CommandName.MergeOptions, undefined);
     expect(console.warn).toBeCalledWith(
       'toggling bottomTabs visibility is deprecated on iOS. For more information see https://github.com/wix/react-native-navigation/issues/6416',
       {

--- a/lib/src/commands/OptionsProcessor.test.ts
+++ b/lib/src/commands/OptionsProcessor.test.ts
@@ -130,7 +130,7 @@ describe('navigation options', () => {
     uut.processOptions(options, CommandName.SetRoot);
   });
 
-  it('passes passProps to registered processor', () => {
+  it('passes props to registered processor', () => {
     const options: Options = {
       topBar: {
         visible: false,
@@ -303,7 +303,7 @@ describe('navigation options', () => {
 
   it('show warning on iOS when toggling bottomTabs visibility through mergeOptions', () => {
     jest.spyOn(console, 'warn');
-    uut.processOptions({ bottomTabs: { visible: false } }, CommandName.MergeOptions, undefined);
+    uut.processOptions({ bottomTabs: { visible: false } }, CommandName.MergeOptions);
     expect(console.warn).toBeCalledWith(
       'toggling bottomTabs visibility is deprecated on iOS. For more information see https://github.com/wix/react-native-navigation/issues/6416',
       {

--- a/lib/src/commands/OptionsProcessor.ts
+++ b/lib/src/commands/OptionsProcessor.ts
@@ -33,7 +33,7 @@ export class OptionsProcessor {
     private deprecations: Deprecations
   ) {}
 
-  public processOptions(options: Options, commandName: CommandName) {
+  public processOptions(options: Options, commandName: CommandName, passProps?: any) {
     this.processObject(
       options,
       clone(options),
@@ -41,7 +41,8 @@ export class OptionsProcessor {
         this.deprecations.onProcessOptions(key, parentOptions, commandName);
         this.deprecations.checkForDeprecatedOptions(parentOptions);
       },
-      commandName
+      commandName,
+      passProps
     );
   }
 
@@ -61,11 +62,19 @@ export class OptionsProcessor {
     parentOptions: object,
     onProcess: (key: string, parentOptions: object) => void,
     commandName: CommandName,
+    passProps?: any,
     parentPath?: string
   ) {
     forEach(objectToProcess, (value, key) => {
       const objectPath = this.resolveObjectPath(key, parentPath);
-      this.processWithRegisteredProcessor(key, value, objectToProcess, objectPath, commandName);
+      this.processWithRegisteredProcessor(
+        key,
+        value,
+        objectToProcess,
+        objectPath,
+        commandName,
+        passProps
+      );
       this.processColor(key, value, objectToProcess);
 
       if (!value) {
@@ -83,7 +92,14 @@ export class OptionsProcessor {
 
       const processedValue = objectToProcess[key];
       if (!isEqual(key, 'passProps') && (isObject(processedValue) || isArray(processedValue))) {
-        this.processObject(processedValue, parentOptions, onProcess, commandName, objectPath);
+        this.processObject(
+          processedValue,
+          parentOptions,
+          onProcess,
+          commandName,
+          passProps,
+          objectPath
+        );
       }
     });
   }
@@ -105,12 +121,13 @@ export class OptionsProcessor {
     value: string,
     options: Record<string, any>,
     path: string,
-    commandName: CommandName
+    commandName: CommandName,
+    passProps: any
   ) {
     const registeredProcessors = this.optionProcessorsRegistry.getProcessors(path);
     if (registeredProcessors) {
       registeredProcessors.forEach((processor) => {
-        options[key] = processor(value, commandName);
+        options[key] = processor(value, commandName, passProps);
       });
     }
   }

--- a/lib/src/commands/OptionsProcessor.ts
+++ b/lib/src/commands/OptionsProcessor.ts
@@ -33,7 +33,7 @@ export class OptionsProcessor {
     private deprecations: Deprecations
   ) {}
 
-  public processOptions(options: Options, commandName: CommandName, passProps?: any) {
+  public processOptions(options: Options, commandName: CommandName, props?: any) {
     this.processObject(
       options,
       clone(options),
@@ -42,7 +42,7 @@ export class OptionsProcessor {
         this.deprecations.checkForDeprecatedOptions(parentOptions);
       },
       commandName,
-      passProps
+      props
     );
   }
 
@@ -62,7 +62,7 @@ export class OptionsProcessor {
     parentOptions: object,
     onProcess: (key: string, parentOptions: object) => void,
     commandName: CommandName,
-    passProps?: any,
+    props?: any,
     parentPath?: string
   ) {
     forEach(objectToProcess, (value, key) => {
@@ -73,7 +73,7 @@ export class OptionsProcessor {
         objectToProcess,
         objectPath,
         commandName,
-        passProps
+        props
       );
       this.processColor(key, value, objectToProcess);
 
@@ -97,7 +97,7 @@ export class OptionsProcessor {
           parentOptions,
           onProcess,
           commandName,
-          passProps,
+          props,
           objectPath
         );
       }

--- a/lib/src/interfaces/Processors.ts
+++ b/lib/src/interfaces/Processors.ts
@@ -6,5 +6,5 @@ export interface LayoutProcessor {
 }
 
 export interface OptionsProcessor<T> {
-  (value: T, commandName: CommandName, passProps?: any): T;
+  (value: T, commandName: CommandName, props?: any): T;
 }

--- a/lib/src/interfaces/Processors.ts
+++ b/lib/src/interfaces/Processors.ts
@@ -6,5 +6,5 @@ export interface LayoutProcessor {
 }
 
 export interface OptionsProcessor<T> {
-  (value: T, commandName: CommandName): T;
+  (value: T, commandName: CommandName, passProps?: any): T;
 }

--- a/website/docs/docs/style-theme/option-processor.tsx
+++ b/website/docs/docs/style-theme/option-processor.tsx
@@ -7,7 +7,7 @@ import {
 
 Navigation.addOptionProcessor<OptionsTopBar>(
   'topBar',
-  (topBar: OptionsTopBar, commandName: CommandName): OptionsTopBar => {
+  (topBar: OptionsTopBar, commandName: CommandName, _props: any): OptionsTopBar => {
     if (commandName === CommandName.ShowModal) {
       if (!topBar.leftButtons) {
         topBar.leftButtons = [


### PR DESCRIPTION
This PR adds the ability to receive the component `passProps` in option processor.

```js
Navigation.addOptionProcessor<OptionsTopBar>(
  'topBar',
  (topBar: OptionsTopBar, commandName: string, props: any): OptionsTopBar => {
    return topBar;
  }
);
```