### PR TITLE
Fix systemItem buttons

### DIFF
--- a/lib/ios/RNNButtonOptions.m
+++ b/lib/ios/RNNButtonOptions.m
@@ -21,6 +21,7 @@
     self.selectTabOnPress = [BoolParser parse:dict key:@"selectTabOnPress"];
     self.iconBackground = [[RNNIconBackgroundOptions alloc] initWithDict:dict[@"iconBackground"]
                                                                  enabled:self.enabled];
+    self.systemItem = [TextParser parse:dict key:@"systemItem"];
 
     return self;
 }
@@ -42,6 +43,7 @@
     newOptions.enabled = self.enabled.copy;
     newOptions.selectTabOnPress = self.selectTabOnPress.copy;
     newOptions.iconBackground = self.iconBackground.copy;
+    newOptions.systemItem = self.systemItem.copy;
     return newOptions;
 }
 
@@ -75,6 +77,8 @@
     }
     if (options.selectTabOnPress.hasValue)
         self.selectTabOnPress = options.selectTabOnPress;
+    if (options.systemItem.hasValue)
+        self.systemItem = options.systemItem;
 }
 
 - (BOOL)shouldCreateCustomView {


### PR DESCRIPTION
Setting buttons with `systemItem` stopped working in [this commit](https://github.com/wix/react-native-navigation/commit/08a9630220c7d1a166b99bfe3c42ff7cc1cbdfd0).

Closes #6924, #6911