### PR TITLE
Fix a leak in shared element animation

### DIFF
--- a/lib/ios/TransitionDelegate.m
+++ b/lib/ios/TransitionDelegate.m
@@ -113,4 +113,8 @@
     return self;
 }
 
+- (void)animationEnded:(BOOL)transitionCompleted {
+    _transitionContext = nil;
+}
+
 @end


### PR DESCRIPTION
The shared element animation `transitionContext` is strongly held by the `transitionDelegate` which resulted in a leak. 
@mrousavy Awesome finding!

Closes #6929