### PR TITLE
Check view.drawable for null before reading width/height

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/finder/ExistingViewFinder.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/finder/ExistingViewFinder.kt
@@ -56,6 +56,6 @@ class ExistingViewFinder : ViewFinder {
 
     private fun hasMeasuredDrawable(view: ImageView) = when (view.drawable) {
         is RootDrawable -> true
-        else -> with(view.drawable) { intrinsicWidth != -1 && intrinsicHeight != -1 }
+        else -> if (view.drawable != null) with(view.drawable) { intrinsicWidth != -1 && intrinsicHeight != -1 } else false
     }
 }


### PR DESCRIPTION
Not sure why, but we started seeing null pointer errors when running SETs.

@guyca could you please take a look and tell me if that fix is a good idea or just a lazy workaround?

```
                         E  Process: com.cuvent.experiences.friends, PID: 21034
                         E  java.lang.NullPointerException: Attempt to invoke virtual method 'int android.graphics.drawable.Drawable.getIntrinsicWidth()' on a null object reference
                         E      at com.reactnativenavigation.views.element.finder.ExistingViewFinder.hasMeasuredDrawable(ExistingViewFinder.kt:59)
                         E      at com.reactnativenavigation.views.element.finder.ExistingViewFinder.find(ExistingViewFinder.kt:21)
                         E      at com.reactnativenavigation.views.element.TransitionSetCreator$createSharedElementTransitions$2$invokeSuspend$$inlined$map$lambda$1.invokeSuspend(TransitionSetCreator.kt:33)
                         E      at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
                         E      at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
                         E      at kotlinx.coroutines.EventLoop.processUnconfinedEvent(EventLoop.common.kt:69)
                         E      at kotlinx.coroutines.internal.DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation.kt:349)
                         E      at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:30)
                         E      at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable$default(Cancellable.kt:27)
                         E      at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:109)
                         E      at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:158)
                         E      at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:56)
                         E      at kotlinx.coroutines.BuildersKt.launch(Unknown Source:1)
                         E      at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(Builders.common.kt:49)
                         E      at kotlinx.coroutines.BuildersKt.launch$default(Unknown Source:1)
                         E      at com.reactnativenavigation.viewcontrollers.modal.ModalAnimator.show(ModalAnimator.kt:29)
                         E      at com.reactnativenavigation.viewcontrollers.modal.ModalPresenter.animateShow(ModalPresenter.java:68)
                         E      at com.reactnativenavigation.viewcontrollers.modal.ModalPresenter.lambda$showModal$0$ModalPresenter(ModalPresenter.java:54)
                         E      at com.reactnativenavigation.viewcontrollers.modal.-$$Lambda$ModalPresenter$O-MRmuKmd9eTUP6wZGnLfpRFyaA.run(Unknown Source:10)
                         E      at com.reactnativenavigation.viewcontrollers.viewcontroller.-$$Lambda$WyAR0JEWmTiz3cWwZS9qp-P3Ddg.on(Unknown Source:2)
                         E      at com.reactnativenavigation.utils.CollectionUtils.forEach(CollectionUtils.java:133)
                         E      at com.reactnativenavigation.utils.CollectionUtils.forEach(CollectionUtils.java:127)
                         E      at com.reactnativenavigation.viewcontrollers.viewcontroller.ViewController.lambda$onViewWillAppear$3$ViewController(ViewController.java:248)
                         E      at com.reactnativenavigation.viewcontrollers.viewcontroller.-$$Lambda$ViewController$bfiHoKoA1KmT9QaA3BqT2KEB6CQ.run(Unknown Source:2)
                         E      at android.os.Handler.handleCallback(Handler.java:888)
                         E      at android.os.Handler.dispatchMessage(Handler.java:100)
                         E      at android.os.Looper.loop(Looper.java:213)
                         E      at android.app.ActivityThread.main(ActivityThread.java:8178)
                         E      at java.lang.reflect.Method.invoke(Native Method)
                         E      at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513)
                         E      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1101)
```