### PR TITLE
Add bottomTab.accessibilityLabel

### DIFF
--- a/lib/ios/RNNBottomTabOptions.h
+++ b/lib/ios/RNNBottomTabOptions.h
@@ -12,6 +12,7 @@
 @property(nonatomic, strong) Text *fontFamily;
 @property(nonatomic, strong) Text *fontWeight;
 @property(nonatomic, strong) Text *testID;
+@property(nonatomic, strong) Text *accessibilityLabel;
 @property(nonatomic, strong) Image *icon;
 @property(nonatomic, strong) Image *selectedIcon;
 @property(nonatomic, strong) Color *iconColor;

--- a/lib/ios/RNNBottomTabOptions.m
+++ b/lib/ios/RNNBottomTabOptions.m
@@ -13,6 +13,7 @@
     self.fontFamily = [TextParser parse:dict key:@"fontFamily"];
     self.fontWeight = [TextParser parse:dict key:@"fontWeight"];
     self.testID = [TextParser parse:dict key:@"testID"];
+    self.accessibilityLabel = [TextParser parse:dict key:@"accessibilityLabel"];
     self.badgeColor = [ColorParser parse:dict key:@"badgeColor"];
 
     self.dotIndicator = [DotIndicatorParser parse:dict];
@@ -45,6 +46,8 @@
         self.fontWeight = options.fontWeight;
     if (options.testID.hasValue)
         self.testID = options.testID;
+    if (options.accessibilityLabel.hasValue)
+        self.accessibilityLabel = options.accessibilityLabel;
     if (options.badgeColor.hasValue)
         self.badgeColor = options.badgeColor;
     if (options.icon.hasValue)

--- a/lib/ios/RNNTabBarItemCreator.m
+++ b/lib/ios/RNNTabBarItemCreator.m
@@ -22,6 +22,7 @@
     tabItem.title = [bottomTabOptions.text withDefault:nil];
     tabItem.tag = bottomTabOptions.tag;
     tabItem.accessibilityIdentifier = [bottomTabOptions.testID withDefault:nil];
+    tabItem.accessibilityLabel = [bottomTabOptions.accessibilityLabel withDefault:nil];
 
     NSDictionary *iconInsets = [bottomTabOptions.iconInsets withDefault:nil];
     if (iconInsets && ![iconInsets isKindOfClass:[NSNull class]]) {

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -776,6 +776,11 @@ export interface OptionsBottomTabs {
    */
   testID?: string;
   /**
+   * Overrides the text that's read by the screen reader when the user interacts with the element
+   * #### (iOS specific)
+   */
+  accessibilityLabel?: string;
+  /**
    * Draw screen component under the tab bar
    */
   drawBehind?: boolean;

--- a/website/docs/api/options-bottomTab.mdx
+++ b/website/docs/api/options-bottomTab.mdx
@@ -140,6 +140,14 @@ The height (in dp) of the icon.
 | ------ | -------- | -------- |
 | string | No       | Both     |
 
+### `accessibilityLabel`
+
+Overrides the text that's read by the screen reader when the user interacts with the bottomTab button.
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| string | No       | iOS      |
+
 ## `text`
 
 | Type   | Required | Platform |


### PR DESCRIPTION
Overrides the text that's read by the screen reader when the user interacts with the `bottomTab` button.
