### PR TITLE
Enable UIViewControllerBasedStatusBarAppearance on rnn-link

### DIFF
--- a/autolink/postlink/path.js
+++ b/autolink/postlink/path.js
@@ -1,5 +1,5 @@
 var glob = require('glob');
-var ignoreFolders = { ignore: ['node_modules/**', '**/build/**'] };
+var ignoreFolders = {ignore: ['node_modules/**', '**/build/**', '**/Build/**', '**/DerivedData/**', '**/*-tvOS*/**']};
 
 var manifestPath = glob.sync('**/AndroidManifest.xml', ignoreFolders)[0];
 
@@ -11,3 +11,4 @@ exports.rootGradle = mainApplicationJava.replace(/android\/app\/.*\.java/, 'andr
 
 exports.appDelegate = glob.sync('**/AppDelegate.m', ignoreFolders)[0];
 exports.podFile = glob.sync('**/Podfile', ignoreFolders)[0];
+exports.plist = glob.sync('**/info.plist', ignoreFolders)[0];

--- a/autolink/postlink/plistLinker.js
+++ b/autolink/postlink/plistLinker.js
@@ -1,0 +1,48 @@
+// @ts-check
+var fs = require('fs');
+var path = require('./path');
+var {logn, errorn} = require('./log');
+
+const viewControllerBasedStatusBar = /<key>UIViewControllerBasedStatusBarAppearance<\/key>(\s+|\n+)<(.*)\/>/;
+
+class plistLinker {
+  constructor() {
+    this.plistPath = path.plist;
+    console.log(this.plistPath)
+  }
+
+  link() {
+    if (!this.plistPath) {
+      errorn(
+        '   info.plist not found! Does the file exist in the correct folder?\n   Please check the manual installation docs:\n   https://wix.github.io/react-native-navigation/docs/installing#native-installation'
+      );
+      return;
+    }
+
+    logn('Linking info.plist...');
+
+    var plistContent = fs.readFileSync(this.plistPath, 'utf8');
+
+    if (this._viewControllerBasedStatusBarDefined(plistContent)) {
+      plistContent = this._updateViewControllerBasedStatusBar(plistContent);
+    } else {
+      plistContent = this._applyViewControllerBasedStatusBar(plistContent);
+    }
+
+    fs.writeFileSync(this.plistPath, plistContent);
+  }
+
+  _viewControllerBasedStatusBarDefined(content) {
+    return viewControllerBasedStatusBar.test(content);
+  }
+
+  _applyViewControllerBasedStatusBar(content) {
+    return content.replace(/<\/dict>\s<\/plist>/, '<key>UIViewControllerBasedStatusBarAppearance</key>\n<true/>\n<\/dict>\n<\/plist>')
+  }
+
+  _updateViewControllerBasedStatusBar(content) {
+    return content.replace(viewControllerBasedStatusBar, '<key>UIViewControllerBasedStatusBarAppearance</key>\n<true/>')
+  }
+}
+
+module.exports = plistLinker;

--- a/autolink/postlink/postLinkIOS.js
+++ b/autolink/postlink/postLinkIOS.js
@@ -1,10 +1,12 @@
 // @ts-check
-var { infon } = require('./log');
+var {infon} = require('./log');
 var AppDelegateLinker = require('./appDelegateLinker');
 var PodfileLinker = require('./podfileLinker');
+var PlistLinker = require('./plistLinker');
 
 module.exports = () => {
   infon('Running iOS postlink script.\n');
   new AppDelegateLinker().link();
   new PodfileLinker().link();
+  new PlistLinker().link();
 };


### PR DESCRIPTION
In order to control the `statusBar` appearance on iOS through RNN, adding `UIViewControllerBasedStatusBarAppearance` true to the project `info.plist` was a mandatory step. 
Now this step will no longer be needed as the link script will update it automatically.