### PR TITLE
Fix Icon bg color crash

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/ButtonPresenter.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/ButtonPresenter.kt
@@ -94,7 +94,7 @@ open class ButtonPresenter(private val context: Context, private val button: But
             loadIcon(object : ImageLoadingListenerAdapter() {
                 override fun onComplete(drawable: Drawable) {
                     setIconColor(drawable)
-                    menuItem.icon = if (button.iconBackground.hasValue()) IconBackgroundDrawable(context, drawable, button.iconBackground, getIconColor(), getBackgroundColor()) else drawable
+                    menuItem.icon = if (button.iconBackground.hasValue()) IconBackgroundDrawable(drawable, button.iconBackground, getIconColor(), getBackgroundColor()) else drawable
                 }
             })
         }
@@ -167,10 +167,28 @@ open class ButtonPresenter(private val context: Context, private val button: But
     }
 
     private fun getBackgroundColor(): Int {
-        return if (button.enabled.isTrueOrUndefined || !button.iconBackground.disabledColor.hasValue()) {
-            button.color.get()
+        if (button.enabled.isTrueOrUndefined) {
+            val hasIconAndIconBG = button.hasIcon()
+                    && button.iconBackground.hasValue()
+                    && button.iconBackground.color.hasValue()
+            return if (button.color.hasValue() && !hasIconAndIconBG) {
+                button.color.get()
+            } else if (hasIconAndIconBG) {
+                button.iconBackground.color.get()
+            } else {
+                Color.TRANSPARENT
+            }
         } else {
-            button.iconBackground.disabledColor[null]
+            val hasIconAndIconDisabledBG = button.hasIcon()
+                    && button.iconBackground.hasValue()
+                    && button.iconBackground.disabledColor.hasValue()
+            return if (button.disabledColor.hasValue() && !hasIconAndIconDisabledBG) {
+                button.disabledColor.get()
+            } else if (hasIconAndIconDisabledBG) {
+                button.iconBackground.disabledColor.get()
+            } else {
+                Color.TRANSPARENT
+            }
         }
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/ButtonPresenter.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/ButtonPresenter.kt
@@ -18,10 +18,9 @@ import androidx.core.view.doOnPreDraw
 import com.reactnativenavigation.options.ButtonOptions
 import com.reactnativenavigation.options.params.Colour
 import com.reactnativenavigation.utils.ArrayUtils
-import com.reactnativenavigation.utils.ImageLoader
-import com.reactnativenavigation.utils.ImageLoadingListenerAdapter
 import com.reactnativenavigation.utils.ViewUtils
 import com.reactnativenavigation.views.stack.topbar.titlebar.IconBackgroundDrawable
+import kotlin.math.max
 
 open class ButtonPresenter(private val context: Context, private val button: ButtonOptions, private val iconResolver: IconResolver) {
     companion object {
@@ -89,14 +88,29 @@ open class ButtonPresenter(private val context: Context, private val button: But
         menuItem.isEnabled = button.enabled.isTrueOrUndefined
     }
 
+    private fun applyIconBackgroundDrawable(srcDrawable: Drawable): Drawable? {
+        return if (button.iconBackground.hasValue()) {
+            val width = button.iconBackground.width.get(srcDrawable.intrinsicWidth).let { max(it, srcDrawable.intrinsicWidth) }
+            val height = button.iconBackground.height.get(srcDrawable.intrinsicHeight).let { max(it, srcDrawable.intrinsicHeight) }
+            val cornerRadius = button.iconBackground.cornerRadius
+            val backgroundColor = if (button.enabled.isTrueOrUndefined) {
+                button.iconBackground.color.get(null)
+            } else {
+                button.iconBackground.disabledColor.get(null)
+            }
+            IconBackgroundDrawable(srcDrawable, cornerRadius, width, height, getIconColor(), backgroundColor)
+        } else
+            srcDrawable
+    }
+
     private fun applyIcon(menuItem: MenuItem) {
         if (button.hasIcon()) {
-            loadIcon(object : ImageLoadingListenerAdapter() {
-                override fun onComplete(drawable: Drawable) {
+            iconResolver.resolve(button) { drawable: Drawable? ->
+                drawable?.let {
                     setIconColor(drawable)
-                    menuItem.icon = if (button.iconBackground.hasValue()) IconBackgroundDrawable(drawable, button.iconBackground, getIconColor(), getBackgroundColor()) else drawable
+                    menuItem.icon = applyIconBackgroundDrawable(drawable)
                 }
-            })
+            }
         }
     }
 
@@ -137,9 +151,6 @@ open class ButtonPresenter(private val context: Context, private val button: But
 
     private fun isIconButtonView(view: TextView, menuItem: MenuItem) = button.icon.hasValue() && ArrayUtils.contains(view.compoundDrawables, menuItem.icon)
     private fun isTextualButtonView(view: TextView) = button.text.hasValue() && button.text.get() == view.text.toString()
-    private fun loadIcon(callback: ImageLoader.ImagesLoadingListener) {
-        iconResolver.resolve(button) { drawable: Drawable? -> callback.onComplete(drawable!!) }
-    }
 
     fun applyNavigationIcon(toolbar: Toolbar, onPress: (String) -> Unit) {
         iconResolver.resolve(button) { icon: Drawable ->
@@ -164,32 +175,6 @@ open class ButtonPresenter(private val context: Context, private val button: But
         }
 
         return null
-    }
-
-    private fun getBackgroundColor(): Int {
-        if (button.enabled.isTrueOrUndefined) {
-            val hasIconAndIconBG = button.hasIcon()
-                    && button.iconBackground.hasValue()
-                    && button.iconBackground.color.hasValue()
-            return if (button.color.hasValue() && !hasIconAndIconBG) {
-                button.color.get()
-            } else if (hasIconAndIconBG) {
-                button.iconBackground.color.get()
-            } else {
-                Color.TRANSPARENT
-            }
-        } else {
-            val hasIconAndIconDisabledBG = button.hasIcon()
-                    && button.iconBackground.hasValue()
-                    && button.iconBackground.disabledColor.hasValue()
-            return if (button.disabledColor.hasValue() && !hasIconAndIconDisabledBG) {
-                button.disabledColor.get()
-            } else if (hasIconAndIconDisabledBG) {
-                button.iconBackground.disabledColor.get()
-            } else {
-                Color.TRANSPARENT
-            }
-        }
     }
 
     private fun setLeftButtonTestId(toolbar: Toolbar) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/IconResolver.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/IconResolver.java
@@ -11,6 +11,7 @@ import com.reactnativenavigation.utils.ImageLoader;
 import com.reactnativenavigation.utils.ImageLoadingListenerAdapter;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
 
 public class IconResolver {
 
@@ -40,5 +41,10 @@ public class IconResolver {
         } else {
             Log.w("RNN", "Left button needs to have an icon");
         }
+    }
+
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    public ImageLoader getImageLoader() {
+        return imageLoader;
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/IconBackgroundDrawable.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/IconBackgroundDrawable.kt
@@ -1,14 +1,14 @@
 package com.reactnativenavigation.views.stack.topbar.titlebar
 
-import android.content.Context
 import android.graphics.*
 import android.graphics.drawable.Drawable
+import androidx.annotation.RestrictTo
 import androidx.core.graphics.drawable.toBitmap
 import com.reactnativenavigation.options.IconBackgroundOptions
 import kotlin.math.max
 
 
-class IconBackgroundDrawable(private val context: Context, private val wrapped: Drawable, private val iconBackground: IconBackgroundOptions, private val iconColor: Int?, private val backgroundColor: Int) : Drawable() {
+class IconBackgroundDrawable(private val wrapped: Drawable, private val iconBackground: IconBackgroundOptions, private val iconColor: Int?, val backgroundColor: Int) : Drawable() {
     private val path: Path = Path()
     private val bitmapPaint = Paint().apply {
         isAntiAlias = true
@@ -24,8 +24,8 @@ class IconBackgroundDrawable(private val context: Context, private val wrapped: 
     private val cornerRadius = iconBackground.cornerRadius.get(0)
     private val bitmapWidth = wrapped.intrinsicWidth
     private val bitmapHeight = wrapped.intrinsicHeight
-    private val backgroundWidth =  iconBackground.width.get(bitmapWidth).let { max(it, bitmapWidth) }
-    private val backgroundHeight =  iconBackground.height.get(bitmapHeight).let { max(it, bitmapHeight) }
+    private val backgroundWidth = iconBackground.width.get(bitmapWidth).let { max(it, bitmapWidth) }
+    private val backgroundHeight = iconBackground.height.get(bitmapHeight).let { max(it, bitmapHeight) }
     private var backgroundRect = Rect()
     private var bitmapRect = Rect();
 
@@ -67,10 +67,10 @@ class IconBackgroundDrawable(private val context: Context, private val wrapped: 
                     (bounds.height() - backgroundHeight) / 2,
                     bounds.width() - (bounds.width() - backgroundWidth) / 2,
                     bounds.height() - (bounds.height() - backgroundHeight) / 2)
-            bitmapRect = Rect((bounds.width()-bitmapWidth) / 2,
-                    (bounds.height()-bitmapHeight) / 2,
-                    bounds.width() - (bounds.width()-bitmapWidth) / 2,
-                    bounds.height() - (bounds.height()-bitmapHeight) / 2)
+            bitmapRect = Rect((bounds.width() - bitmapWidth) / 2,
+                    (bounds.height() - bitmapHeight) / 2,
+                    bounds.width() - (bounds.width() - bitmapWidth) / 2,
+                    bounds.height() - (bounds.height() - bitmapHeight) / 2)
         }
         super.onBoundsChange(bounds)
     }
@@ -93,4 +93,6 @@ class IconBackgroundDrawable(private val context: Context, private val wrapped: 
             path.addRoundRect(r, cornerRadius.toFloat(), cornerRadius.toFloat(), Path.Direction.CW)
         }
     }
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    fun getWrappedDrawable():Drawable = this.wrapped
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/IconBackgroundDrawable.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/IconBackgroundDrawable.kt
@@ -4,11 +4,17 @@ import android.graphics.*
 import android.graphics.drawable.Drawable
 import androidx.annotation.RestrictTo
 import androidx.core.graphics.drawable.toBitmap
-import com.reactnativenavigation.options.IconBackgroundOptions
-import kotlin.math.max
+import com.reactnativenavigation.options.params.DensityPixel
 
 
-class IconBackgroundDrawable(private val wrapped: Drawable, private val iconBackground: IconBackgroundOptions, private val iconColor: Int?, val backgroundColor: Int) : Drawable() {
+class IconBackgroundDrawable(
+        private val wrapped: Drawable,
+        private val cornerRadius: DensityPixel,
+        private val backgroundWidth: Int,
+        private val backgroundHeight: Int,
+        private val iconColor: Int?,
+        val backgroundColor: Int?
+) : Drawable() {
     private val path: Path = Path()
     private val bitmapPaint = Paint().apply {
         isAntiAlias = true
@@ -18,14 +24,13 @@ class IconBackgroundDrawable(private val wrapped: Drawable, private val iconBack
     private val backgroundPaint = Paint().apply {
         isAntiAlias = true
         isFilterBitmap = true
-        color = backgroundColor
+        backgroundColor?.let {
+            color = it
+        }
     }
 
-    private val cornerRadius = iconBackground.cornerRadius.get(0)
     private val bitmapWidth = wrapped.intrinsicWidth
     private val bitmapHeight = wrapped.intrinsicHeight
-    private val backgroundWidth = iconBackground.width.get(bitmapWidth).let { max(it, bitmapWidth) }
-    private val backgroundHeight = iconBackground.height.get(bitmapHeight).let { max(it, bitmapHeight) }
     private var backgroundRect = Rect()
     private var bitmapRect = Rect();
 
@@ -36,11 +41,13 @@ class IconBackgroundDrawable(private val wrapped: Drawable, private val iconBack
     }
 
     private fun drawBackgroundColor(canvas: Canvas) {
-        canvas.drawRect(backgroundRect, backgroundPaint)
+        backgroundColor?.let {
+            canvas.drawRect(backgroundRect, backgroundPaint)
+        }
     }
 
     private fun drawPath(canvas: Canvas) {
-        if (iconBackground.cornerRadius.hasValue()) {
+        if (cornerRadius.hasValue()) {
             canvas.clipPath(path)
         }
     }
@@ -88,11 +95,13 @@ class IconBackgroundDrawable(private val wrapped: Drawable, private val iconBack
     }
 
     private fun updatePath(r: RectF) {
-        if (iconBackground.cornerRadius.hasValue()) {
+        if (cornerRadius.hasValue()) {
             path.reset()
-            path.addRoundRect(r, cornerRadius.toFloat(), cornerRadius.toFloat(), Path.Direction.CW)
+            val radius = cornerRadius.get(0).toFloat()
+            path.addRoundRect(r, radius, radius, Path.Direction.CW)
         }
     }
+
     @RestrictTo(RestrictTo.Scope.TESTS)
-    fun getWrappedDrawable():Drawable = this.wrapped
+    fun getWrappedDrawable(): Drawable = this.wrapped
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/fakes/IconResolverFake.kt
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/fakes/IconResolverFake.kt
@@ -2,6 +2,7 @@ package com.reactnativenavigation.fakes
 
 import android.app.Activity
 import com.reactnativenavigation.mocks.ImageLoaderMock
+import com.reactnativenavigation.utils.ImageLoader
 import com.reactnativenavigation.viewcontrollers.stack.topbar.button.IconResolver
 
-class IconResolverFake(activity: Activity) : IconResolver(activity, ImageLoaderMock.mock())
+class IconResolverFake(activity: Activity, imageLoader: ImageLoader = ImageLoaderMock.mock()) : IconResolver(activity, imageLoader)

--- a/lib/android/app/src/test/java/com/reactnativenavigation/mocks/ImageLoaderMock.kt
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/mocks/ImageLoaderMock.kt
@@ -12,7 +12,7 @@ import com.reactnativenavigation.utils.ImageLoader.ImagesLoadingListener
 import java.util.*
 
 object ImageLoaderMock {
-     val mockDrawable: Drawable = object : Drawable() {
+    val mockDrawable: Drawable = object : Drawable() {
         override fun draw(canvas: Canvas) {}
         override fun setAlpha(alpha: Int) {}
         override fun setColorFilter(colorFilter: ColorFilter?) {}
@@ -24,25 +24,11 @@ object ImageLoaderMock {
 
     @JvmStatic
     fun mock(): ImageLoader {
-        val imageLoader = mock<ImageLoader>()
-        doAnswer { invocation ->
-            val urlCount = (invocation.arguments[1] as Collection<*>).size
-            val drawables = Collections.nCopies(urlCount, mockDrawable)
-            (invocation.arguments[2] as ImagesLoadingListener).onComplete(drawables)
-            null
-        }.`when`(imageLoader).loadIcons(any(), any(), any())
-
-        doAnswer { invocation ->
-            (invocation.arguments[2] as ImagesLoadingListener).onComplete(mockDrawable)
-            null
-        }.`when`(imageLoader).loadIcon(any(), any(), any())
-
-        whenever(imageLoader.getBackButtonIcon(any())).thenReturn(backIcon)
-        return imageLoader
+        return this.mock(mockDrawable)
     }
 
     @JvmStatic
-    fun mock(returnDrawable:Drawable): ImageLoader {
+    fun mock(returnDrawable: Drawable = mockDrawable): ImageLoader {
         val imageLoader = mock<ImageLoader>()
         doAnswer { invocation ->
             val urlCount = (invocation.arguments[1] as Collection<*>).size

--- a/lib/android/app/src/test/java/com/reactnativenavigation/mocks/ImageLoaderMock.kt
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/mocks/ImageLoaderMock.kt
@@ -12,7 +12,7 @@ import com.reactnativenavigation.utils.ImageLoader.ImagesLoadingListener
 import java.util.*
 
 object ImageLoaderMock {
-    private val mockDrawable: Drawable = object : Drawable() {
+     val mockDrawable: Drawable = object : Drawable() {
         override fun draw(canvas: Canvas) {}
         override fun setAlpha(alpha: Int) {}
         override fun setColorFilter(colorFilter: ColorFilter?) {}
@@ -34,6 +34,25 @@ object ImageLoaderMock {
 
         doAnswer { invocation ->
             (invocation.arguments[2] as ImagesLoadingListener).onComplete(mockDrawable)
+            null
+        }.`when`(imageLoader).loadIcon(any(), any(), any())
+
+        whenever(imageLoader.getBackButtonIcon(any())).thenReturn(backIcon)
+        return imageLoader
+    }
+
+    @JvmStatic
+    fun mock(returnDrawable:Drawable): ImageLoader {
+        val imageLoader = mock<ImageLoader>()
+        doAnswer { invocation ->
+            val urlCount = (invocation.arguments[1] as Collection<*>).size
+            val drawables = Collections.nCopies(urlCount, returnDrawable)
+            (invocation.arguments[2] as ImagesLoadingListener).onComplete(drawables)
+            null
+        }.`when`(imageLoader).loadIcons(any(), any(), any())
+
+        doAnswer { invocation ->
+            (invocation.arguments[2] as ImagesLoadingListener).onComplete(returnDrawable)
             null
         }.`when`(imageLoader).loadIcon(any(), any(), any())
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/utils/ButtonPresenterTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/utils/ButtonPresenterTest.java
@@ -2,6 +2,9 @@ package com.reactnativenavigation.utils;
 
 import android.app.Activity;
 import android.graphics.Color;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
+import android.graphics.drawable.Drawable;
 import android.text.SpannableString;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -11,7 +14,9 @@ import androidx.appcompat.widget.ActionMenuView;
 
 import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.fakes.IconResolverFake;
+import com.reactnativenavigation.mocks.ImageLoaderMock;
 import com.reactnativenavigation.options.ButtonOptions;
+import com.reactnativenavigation.options.IconBackgroundOptions;
 import com.reactnativenavigation.options.params.Bool;
 import com.reactnativenavigation.options.params.Colour;
 import com.reactnativenavigation.options.params.Number;
@@ -19,6 +24,7 @@ import com.reactnativenavigation.options.params.Text;
 import com.reactnativenavigation.viewcontrollers.stack.topbar.button.ButtonController;
 import com.reactnativenavigation.viewcontrollers.stack.topbar.button.ButtonPresenter;
 import com.reactnativenavigation.views.stack.topbar.titlebar.ButtonsToolbar;
+import com.reactnativenavigation.views.stack.topbar.titlebar.IconBackgroundDrawable;
 import com.reactnativenavigation.views.stack.topbar.titlebar.TitleBarButtonCreator;
 
 import org.junit.Test;
@@ -28,6 +34,8 @@ import org.robolectric.shadows.ShadowLooper;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 @LooperMode(LooperMode.Mode.PAUSED)
 public class ButtonPresenterTest extends BaseTest {
@@ -37,15 +45,24 @@ public class ButtonPresenterTest extends BaseTest {
     private ButtonPresenter uut;
     private ButtonController buttonController;
     private ButtonOptions button;
+    private IconResolverFake iconResolver;
+    private Activity activity;
 
     @Override
     public void beforeEach() {
-        Activity activity = newActivity();
+        activity = newActivity();
         titleBar = new ButtonsToolbar(activity);
         activity.setContentView(titleBar);
         button = createButton();
+        ImageLoader imageLoaderMock;
 
-        uut = new ButtonPresenter(activity, button, new IconResolverFake(activity));
+        imageLoaderMock = ImageLoaderMock.mock();
+        initUUt(imageLoaderMock);
+    }
+
+    private void initUUt(ImageLoader imageLoaderMock) {
+        iconResolver = new IconResolverFake(activity, imageLoaderMock);
+        uut = new ButtonPresenter(activity, button, iconResolver);
         buttonController = new ButtonController(
                 activity,
                 uut,
@@ -83,6 +100,81 @@ public class ButtonPresenterTest extends BaseTest {
         Colour color = new Colour(Color.RED);
         uut.applyColor(titleBar, menuItem, color);
         assertThat(findButtonView().getCurrentTextColor()).isEqualTo(Color.RED);
+    }
+
+    @Test
+    public void applyOptions_shouldChangeIconColorTint() {
+        IconBackgroundDrawable mockD = mock(IconBackgroundDrawable.class);
+        initUUt(ImageLoaderMock.mock(mockD));
+        button.enabled = new Bool(true);
+        button.icon = new Text("icon");
+        button.color = new Colour(Color.RED);
+        MenuItem menuItem = spy(addMenuButton());
+        uut.applyOptions(titleBar, menuItem, buttonController::getView);
+
+        Drawable icon = menuItem.getIcon();
+        assertThat(icon).isNotNull();
+        verify(icon).setColorFilter(new PorterDuffColorFilter(Color.RED, PorterDuff.Mode.SRC_IN));
+    }
+
+    @Test
+    public void applyOptions_shouldChangeIconDisabledColorTint() {
+        IconBackgroundDrawable mockD = mock(IconBackgroundDrawable.class);
+        initUUt(ImageLoaderMock.mock(mockD));
+        button.enabled = new Bool(false);
+        button.icon = new Text("icon");
+        button.color = new Colour(Color.RED);
+        button.disabledColor = new Colour(Color.YELLOW);
+        MenuItem menuItem = spy(addMenuButton());
+        uut.applyOptions(titleBar, menuItem, buttonController::getView);
+
+        Drawable icon = menuItem.getIcon();
+        assertThat(icon).isNotNull();
+        verify(icon).setColorFilter(new PorterDuffColorFilter(Color.YELLOW, PorterDuff.Mode.SRC_IN));
+    }
+
+    @Test
+    public void applyOptions_shouldChangeIconColorBackground() {
+        IconBackgroundDrawable mockD = mock(IconBackgroundDrawable.class);
+        initUUt(ImageLoaderMock.mock(mockD));
+        button.enabled = new Bool(true);
+        button.icon = new Text("icon");
+        button.color = new Colour(Color.RED);
+        IconBackgroundOptions iconBackground = new IconBackgroundOptions();
+        iconBackground.color = new Colour(Color.GREEN);
+        button.iconBackground = iconBackground;
+        MenuItem menuItem = spy(addMenuButton());
+        uut.applyOptions(titleBar, menuItem, buttonController::getView);
+
+        Drawable icon = menuItem.getIcon();
+        assertThat(icon).isNotNull();
+        assertThat(icon).isInstanceOf(IconBackgroundDrawable.class);
+        IconBackgroundDrawable modifed = (IconBackgroundDrawable) icon;
+        verify(modifed.getWrappedDrawable()).setColorFilter(new PorterDuffColorFilter(Color.RED, PorterDuff.Mode.SRC_IN));
+        assertThat(modifed.getBackgroundColor()).isEqualTo(Color.GREEN);
+    }
+
+    @Test
+    public void applyOptions_shouldChangeIconDisabledColorBackground() {
+        IconBackgroundDrawable mockD = mock(IconBackgroundDrawable.class);
+        initUUt(ImageLoaderMock.mock(mockD));
+        button.enabled = new Bool(false);
+        button.icon = new Text("icon");
+        button.color = new Colour(Color.RED);
+        button.disabledColor = new Colour(Color.YELLOW);
+        IconBackgroundOptions iconBackground = new IconBackgroundOptions();
+        iconBackground.color = new Colour(Color.GREEN);
+        iconBackground.disabledColor = new Colour(Color.CYAN);
+        button.iconBackground = iconBackground;
+        MenuItem menuItem = spy(addMenuButton());
+        uut.applyOptions(titleBar, menuItem, buttonController::getView);
+
+        Drawable icon = menuItem.getIcon();
+        assertThat(icon).isNotNull();
+        assertThat(icon).isInstanceOf(IconBackgroundDrawable.class);
+        IconBackgroundDrawable modifed = (IconBackgroundDrawable) icon;
+        verify(modifed.getWrappedDrawable()).setColorFilter(new PorterDuffColorFilter(Color.YELLOW, PorterDuff.Mode.SRC_IN));
+        assertThat(modifed.getBackgroundColor()).isEqualTo(Color.CYAN);
     }
 
     @Test

--- a/lib/android/app/src/test/java/com/reactnativenavigation/utils/ButtonPresenterTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/utils/ButtonPresenterTest.java
@@ -45,7 +45,6 @@ public class ButtonPresenterTest extends BaseTest {
     private ButtonPresenter uut;
     private ButtonController buttonController;
     private ButtonOptions button;
-    private IconResolverFake iconResolver;
     private Activity activity;
 
     @Override
@@ -61,7 +60,7 @@ public class ButtonPresenterTest extends BaseTest {
     }
 
     private void initUUt(ImageLoader imageLoaderMock) {
-        iconResolver = new IconResolverFake(activity, imageLoaderMock);
+        IconResolverFake iconResolver = new IconResolverFake(activity, imageLoaderMock);
         uut = new ButtonPresenter(activity, button, iconResolver);
         buttonController = new ButtonController(
                 activity,

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/TopBarButtonControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/TopBarButtonControllerTest.java
@@ -7,6 +7,7 @@ import android.view.MenuItem;
 import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.TestUtils;
 import com.reactnativenavigation.fakes.IconResolverFake;
+import com.reactnativenavigation.mocks.ImageLoaderMock;
 import com.reactnativenavigation.mocks.TitleBarButtonCreatorMock;
 import com.reactnativenavigation.options.params.Bool;
 import com.reactnativenavigation.options.ButtonOptions;
@@ -47,7 +48,7 @@ public class TopBarButtonControllerTest extends BaseTest {
         stackController.getTopBar().layout(0, 0, 1080, 200);
         getTitleBar().layout(0, 0, 1080, 200);
 
-        optionsPresenter = spy(new ButtonPresenter(activity, button, new IconResolverFake(activity)));
+        optionsPresenter = spy(new ButtonPresenter(activity, button, new IconResolverFake(activity, ImageLoaderMock.mock())));
         uut = new ButtonController(activity, optionsPresenter, button, buttonCreatorMock, (buttonId) -> {});
 
         stackController.ensureViewIsCreated();


### PR DESCRIPTION
**Issue:**
#6938
Crashing when setting `iconBackground`, it was crashing because of missing conditions that yield different results of colours depending on the options.

**Fix:**
Added tests that simulate the wanted behaviour, fix the crash by checking that bg colour selection is done correctly as the options suggesting, make sure colours changing as expected.

