### PR TITLE
Bottom tabs shadow default visibility

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/BottomTabsContainer.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/BottomTabsContainer.kt
@@ -35,6 +35,7 @@ class BottomTabsContainer(context: Context, val bottomTabs: BottomTabs) : Shadow
         }
 
     init {
+        this.isShadowed = false
         this.id = View.generateViewId()
         shadowAngle = DEFAULT_SHADOW_ANGLE
         shadowDistance = DEFAULT_SHADOW_DISTANCE

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/ShadowLayout.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/ShadowLayout.kt
@@ -5,6 +5,7 @@ import android.graphics.*
 import android.graphics.Paint.ANTI_ALIAS_FLAG
 import android.view.View
 import android.widget.FrameLayout
+import com.reactnativenavigation.utils.logd
 import kotlin.math.cos
 import kotlin.math.sin
 
@@ -43,6 +44,7 @@ open class ShadowLayout constructor(context: Context) : FrameLayout(context) {
     var isShadowed: Boolean = false
         set(isShadowed) {
             field = isShadowed
+            this.updatePadding()
             postInvalidate()
         }
 
@@ -75,9 +77,13 @@ open class ShadowLayout constructor(context: Context) : FrameLayout(context) {
     private fun resetShadow() {
         shadowDx = (shadowDistance * cos(shadowAngle / 180.0f * Math.PI)).toFloat()
         shadowDy = (shadowDistance * sin(shadowAngle / 180.0f * Math.PI)).toFloat()
-        val padding = (shadowDistance + shadowRadius).toInt()
-        setPadding(0, padding, 0, 0)
+        updatePadding()
         requestLayout()
+    }
+
+    private fun updatePadding() {
+        val padding = if (isShadowed) (shadowDistance + shadowRadius).toInt() else 0
+        setPadding(0, padding, 0, 0)
     }
 
     private fun adjustShadowAlpha(adjust: Boolean): Int {
@@ -100,6 +106,7 @@ open class ShadowLayout constructor(context: Context) : FrameLayout(context) {
     }
 
     override fun dispatchDraw(canvas: Canvas) {
+        logd("Shadow $isShadowed","ShadowXX")
         if (isShadowed) {
             if (invalidateShadow) {
                 if (bounds.width() != 0 && bounds.height() != 0) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/ShadowLayout.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/ShadowLayout.kt
@@ -5,7 +5,6 @@ import android.graphics.*
 import android.graphics.Paint.ANTI_ALIAS_FLAG
 import android.view.View
 import android.widget.FrameLayout
-import com.reactnativenavigation.utils.logd
 import kotlin.math.cos
 import kotlin.math.sin
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/ShadowLayout.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/ShadowLayout.kt
@@ -106,7 +106,6 @@ open class ShadowLayout constructor(context: Context) : FrameLayout(context) {
     }
 
     override fun dispatchDraw(canvas: Canvas) {
-        logd("Shadow $isShadowed","ShadowXX")
         if (isShadowed) {
             if (invalidateShadow) {
                 if (bounds.width() != 0 && bounds.height() != 0) {


### PR DESCRIPTION
shadow was enabled by default, changed to opt-in, by having valid shadow options in the BottomTabsOptions