### PR TITLE
Fix SET default fade animation

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/FadeInAnimation.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/FadeInAnimation.kt
@@ -10,11 +10,13 @@ class FadeInAnimation : StackAnimationOptions() {
             alpha.put("from", 0)
             alpha.put("to", 1)
             alpha.put("duration", 300)
-            val content = JSONObject()
-            content.put("alpha", alpha)
+            val enter = JSONObject()
+            enter.put("alpha", alpha)
             val animation = JSONObject()
-            animation.put("content", content)
-            mergeWith(StackAnimationOptions(animation))
+            animation.put("enter", enter)
+            val content = JSONObject()
+            content.put("content", animation)
+            mergeWith(StackAnimationOptions(content))
         } catch (e: JSONException) {
             e.printStackTrace()
         }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/FadeOutAnimation.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/FadeOutAnimation.kt
@@ -10,11 +10,13 @@ class FadeOutAnimation : StackAnimationOptions() {
             alpha.put("from", 0)
             alpha.put("to", 1)
             alpha.put("duration", 300)
-            val content = JSONObject()
-            content.put("alpha", alpha)
+            val enter = JSONObject()
+            enter.put("alpha", alpha)
             val animation = JSONObject()
-            animation.put("content", content)
-            mergeWith(StackAnimationOptions(animation))
+            animation.put("enter", enter)
+            val content = JSONObject()
+            content.put("content", animation)
+            mergeWith(StackAnimationOptions(content))
         } catch (e: JSONException) {
             e.printStackTrace()
         }


### PR DESCRIPTION
Fix shared element transition is broken when `content` property is missing. It should fallback to the default fade animation.
Closes #6957