### PR TITLE
Fix Crash topBar merge empty buttons with color

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenter.java
@@ -198,7 +198,7 @@ public class StackPresenter {
             }
             topBarController.alignTitleComponent(topBarOptions.title.component.alignment);
         } else {
-            topBar.applyTitleOptions(topBarOptions.title,typefaceLoader);
+            topBar.applyTitleOptions(topBarOptions.title, typefaceLoader);
             topBar.applySubtitleOptions(topBarOptions.subtitle, typefaceLoader);
             topBarController.alignTitleComponent(topBarOptions.title.alignment);
         }
@@ -373,19 +373,25 @@ public class StackPresenter {
 
     private void mergeLeftButtonsColor(View child, Colour color, Colour disabledColor) {
         if (color.hasValue() || disabledColor.hasValue()) {
-            forEach(componentLeftButtons.get(child).values(), (btnController) -> {
-                if (color.hasValue()) btnController.applyColor(topBarController.getView().getLeftButtonsBar(), color);
-                if (disabledColor.hasValue()) btnController.applyDisabledColor(topBarController.getView().getLeftButtonsBar(), disabledColor);
-            });
+            Map<String, ButtonController> stringButtonControllerMap = componentLeftButtons.get(child);
+            if (stringButtonControllerMap != null) {
+                forEach(stringButtonControllerMap.values(), (btnController) -> {
+                    if (color.hasValue()) btnController.applyColor(topBarController.getView().getLeftButtonsBar(), color);
+                    if (disabledColor.hasValue()) btnController.applyDisabledColor(topBarController.getView().getLeftButtonsBar(), disabledColor);
+                });
+            }
         }
     }
 
     private void mergeRightButtonsColor(View child, Colour color, Colour disabledColor) {
         if (color.hasValue() || disabledColor.hasValue()) {
-            forEach(componentRightButtons.get(child).values(), (btnController) -> {
-                if (color.hasValue()) btnController.applyColor(topBarController.getView().getRightButtonsBar(), color);
-                if (disabledColor.hasValue()) btnController.applyDisabledColor(topBarController.getView().getRightButtonsBar(), disabledColor);
-            });
+            Map<String, ButtonController> stringButtonControllerMap = componentRightButtons.get(child);
+            if (stringButtonControllerMap != null) {
+                forEach(stringButtonControllerMap.values(), (btnController) -> {
+                    if (color.hasValue()) btnController.applyColor(topBarController.getView().getRightButtonsBar(), color);
+                    if (disabledColor.hasValue()) btnController.applyDisabledColor(topBarController.getView().getRightButtonsBar(), disabledColor);
+                });
+            }
         }
     }
 
@@ -470,7 +476,7 @@ public class StackPresenter {
         if (resolveOptions.title.fontSize.hasValue()) topBar.setTitleFontSize(resolveOptions.title.fontSize.get());
         if (resolveOptions.title.font.hasValue()) topBar.setTitleTypeface(typefaceLoader, resolveOptions.title.font);
 
-        if (topBarOptions.subtitle.text.hasValue()){
+        if (topBarOptions.subtitle.text.hasValue()) {
             topBar.setSubtitle(topBarOptions.subtitle.text.get());
             topBar.setSubtitleAlignment(topBarOptions.subtitle.alignment);
         }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenterTest.kt
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenterTest.kt
@@ -623,6 +623,37 @@ class StackPresenterTest : BaseTest() {
     }
 
     @Test
+    fun mergeChildOptions_ignoreColorWhenClearingButtons() {
+        val mergeOptions = Options()
+        val initialOptions = Options()
+        val rightButton = ButtonOptions()
+        val leftButton = ButtonOptions()
+
+
+        //add buttons
+        uut.applyChildOptions(initialOptions, parent, child)
+
+        //Merge color change for right and left buttons with clear buttons
+        mergeOptions.topBar.buttons.right = ArrayList()
+        mergeOptions.topBar.buttons.left = ArrayList()
+        mergeOptions.topBar.rightButtonColor = Colour(100)
+        mergeOptions.topBar.leftButtonColor = Colour(100)
+        mergeOptions.topBar.rightButtonDisabledColor = Colour(100)
+        mergeOptions.topBar.leftButtonDisabledColor = Colour(10)
+        val rightController = spy(ButtonController(activity, ButtonPresenter(activity, rightButton, iconResolver), rightButton, buttonCreator, mock { }))
+        val leftController = spy(ButtonController(activity, ButtonPresenter(activity, leftButton, iconResolver), leftButton, buttonCreator, mock { }))
+        uut.setComponentsButtonController(child.view, rightController, leftController)
+        uut.mergeChildOptions(mergeOptions, initialOptions, parent, child)
+
+        verify(rightController, never()).applyColor(any(), any());
+        verify(leftController, never()).applyColor(any(), any());
+        verify(leftController, never()).applyDisabledColor(any(), any());
+        verify(leftController, never()).applyDisabledColor(any(), any())
+
+    }
+
+
+    @Test
     fun mergeChildOptions_buttonColorIsResolvedFromAppliedOptions() {
         val appliedOptions = Options()
         appliedOptions.topBar.rightButtonColor = Colour(10)

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenterTest.kt
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenterTest.kt
@@ -631,6 +631,8 @@ class StackPresenterTest : BaseTest() {
 
 
         //add buttons
+        initialOptions.topBar.buttons.right = ArrayList()
+        initialOptions.topBar.buttons.left = ArrayList()
         uut.applyChildOptions(initialOptions, parent, child)
 
         //Merge color change for right and left buttons with clear buttons


### PR DESCRIPTION
### Issue:
When passing empty `rightButtons` with `rightButtonColors` it caused a crash.
example here: #6970

### Fix:
Checking for nulls when applying colours for empty buttons list, Right and left.
Added test that covers the flow.


Closes #6970