### PR TITLE
Bottom tab Badge style

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/BadgeOptions.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/BadgeOptions.kt
@@ -1,0 +1,39 @@
+package com.reactnativenavigation.options
+
+import android.content.Context
+import com.reactnativenavigation.options.params.Colour
+import com.reactnativenavigation.options.params.NullColor
+import com.reactnativenavigation.options.params.NullText
+import com.reactnativenavigation.options.params.Text
+import com.reactnativenavigation.options.parsers.ColorParser
+import com.reactnativenavigation.options.parsers.TextParser
+import org.json.JSONObject
+
+fun parseBadgeOptions(context: Context, json: JSONObject?): BadgeOptions {
+    return json?.let {
+        BadgeOptions(TextParser.parse(json, "text"), ColorParser.parse(context, json, "textColor"),
+                ColorParser.parse(context, json, "backgroundColor")
+        )
+    } ?: BadgeOptions()
+}
+
+class BadgeOptions(var text: Text = NullText(), var textColor: Colour = NullColor(), var backgroundColor: Colour = NullColor()) {
+    fun hasValue() = text.hasValue() || textColor.hasValue() || backgroundColor.hasValue()
+    fun mergeWith(other: BadgeOptions) {
+        if (other.text.hasValue())
+            this.text = other.text
+        if (other.textColor.hasValue())
+            this.textColor = other.textColor
+        if (other.backgroundColor.hasValue())
+            this.backgroundColor = other.backgroundColor
+    }
+
+    fun mergeWithDefaults(other: BadgeOptions) {
+        if (!this.text.hasValue())
+            this.text = other.text
+        if (!this.textColor.hasValue())
+            this.textColor = other.textColor
+        if (!this.backgroundColor.hasValue())
+            this.backgroundColor = other.backgroundColor
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/BottomTabOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/BottomTabOptions.java
@@ -35,8 +35,7 @@ public class BottomTabOptions {
         options.selectedIcon = IconParser.parse(json, "selectedIcon");
         options.iconColor = ColorParser.parse(context, json, "iconColor");
         options.selectedIconColor = ColorParser.parse(context, json, "selectedIconColor");
-        options.badge = TextParser.parse(json, "badge");
-        options.badgeColor = ColorParser.parse(context, json, "badgeColor");
+        options.badge = BadgeOptionsKt.parseBadgeOptions(context, json.optJSONObject("badge"));
         options.animateBadge = BoolParser.parse(json, "animateBadge");
         options.testId = TextParser.parse(json, "testID");
         options.font = FontParser.parse(json);
@@ -58,8 +57,7 @@ public class BottomTabOptions {
     public Colour iconColor = new NullColor();
     public Colour selectedIconColor = new NullColor();
     public Text testId = new NullText();
-    public Text badge = new NullText();
-    public Colour badgeColor = new NullColor();
+    public BadgeOptions badge = new BadgeOptions();
     public Bool animateBadge = new NullBool();
     public DotIndicatorOptions dotIndicator = new DotIndicatorOptions();
     public Number fontSize = new NullNumber();
@@ -78,8 +76,7 @@ public class BottomTabOptions {
         if (other.selectedIcon.hasValue()) selectedIcon = other.selectedIcon;
         if (other.iconColor.hasValue()) iconColor = other.iconColor;
         if (other.selectedIconColor.hasValue()) selectedIconColor = other.selectedIconColor;
-        if (other.badge.hasValue()) badge = other.badge;
-        if (other.badgeColor.hasValue()) badgeColor = other.badgeColor;
+        badge.mergeWith(other.badge);
         if (other.animateBadge.hasValue()) animateBadge = other.animateBadge;
         if (other.testId.hasValue()) testId = other.testId;
         if (other.fontSize.hasValue()) fontSize = other.fontSize;
@@ -99,8 +96,7 @@ public class BottomTabOptions {
         if (!selectedIcon.hasValue()) selectedIcon = defaultOptions.selectedIcon;
         if (!iconColor.hasValue()) iconColor = defaultOptions.iconColor;
         if (!selectedIconColor.hasValue()) selectedIconColor = defaultOptions.selectedIconColor;
-        if (!badge.hasValue()) badge = defaultOptions.badge;
-        if (!badgeColor.hasValue()) badgeColor = defaultOptions.badgeColor;
+        badge.mergeWithDefaults(defaultOptions.badge);
         if (!animateBadge.hasValue()) animateBadge = defaultOptions.animateBadge;
         if (!fontSize.hasValue()) fontSize = defaultOptions.fontSize;
         if (!selectedFontSize.hasValue()) selectedFontSize = defaultOptions.selectedFontSize;

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabPresenter.java
@@ -156,8 +156,8 @@ public class BottomTabPresenter {
                 builder.setBackgroundColor(oldOptions.badge.getBackgroundColor().get(0));
             if (tab.animateBadge.hasValue())
                 builder.animate(tab.animateBadge.get());
+            bottomTabs.perform(bottomTabs -> bottomTabs.setNotification(builder.build(), index));
         }
-        bottomTabs.perform(bottomTabs -> bottomTabs.setNotification(builder.build(), index));
     }
 
     private void mergeDotIndicator(int index, DotIndicatorOptions dotIndicator) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabPresenter.java
@@ -33,7 +33,7 @@ public class BottomTabPresenter {
     private final List<ViewController<?>> tabs;
     private final int defaultDotIndicatorSize;
 
-    public BottomTabPresenter(Context context, List<ViewController<?>> tabs, ImageLoader imageLoader,  TypefaceLoader typefaceLoader, Options defaultOptions) {
+    public BottomTabPresenter(Context context, List<ViewController<?>> tabs, ImageLoader imageLoader, TypefaceLoader typefaceLoader, Options defaultOptions) {
         this.tabs = tabs;
         this.context = context;
         this.bottomTabFinder = new BottomTabFinder(tabs);
@@ -65,7 +65,8 @@ public class BottomTabPresenter {
                 if (tab.fontSize.hasValue()) bottomTabs.setTitleInactiveTextSizeInSp(i, Float.valueOf(tab.fontSize.get()));
                 if (tab.selectedFontSize.hasValue()) bottomTabs.setTitleActiveTextSizeInSp(i, Float.valueOf(tab.selectedFontSize.get()));
                 if (tab.testId.hasValue()) bottomTabs.setTag(i, tab.testId.get());
-                if (shouldApplyDot(tab)) applyDotIndicator(i, tab.dotIndicator); else applyBadge(i, tab);
+                if (shouldApplyDot(tab)) applyDotIndicator(i, tab.dotIndicator);
+                else applyBadge(i, tab);
             }
         });
     }
@@ -104,16 +105,19 @@ public class BottomTabPresenter {
                     }
                 });
                 if (tab.testId.hasValue()) bottomTabs.setTag(index, tab.testId.get());
-                if (shouldApplyDot(tab)) mergeDotIndicator(index, tab.dotIndicator); else mergeBadge(index, tab);
+                if (shouldApplyDot(tab))
+                    mergeDotIndicator(index, tab.dotIndicator);
+                else
+                    mergeBadge(index, tab);
             }
         });
     }
 
     private void applyDotIndicator(int tabIndex, DotIndicatorOptions dotIndicator) {
-        if(dotIndicator.visible.isFalse()) return;
+        if (dotIndicator.visible.isFalse()) return;
         AHNotification.Builder builder = new AHNotification.Builder()
                 .setText("")
-                .setBackgroundColor(dotIndicator.color.get(null))
+                .setBackgroundColor(dotIndicator.color.get(0))
                 .setSize(dotIndicator.size.get(defaultDotIndicatorSize))
                 .animate(dotIndicator.animate.get(false));
         bottomTabs.perform(bottomTabs -> bottomTabs.setNotification(builder.build(), tabIndex));
@@ -122,20 +126,37 @@ public class BottomTabPresenter {
     private void applyBadge(int tabIndex, BottomTabOptions tab) {
         if (bottomTabs == null) return;
         AHNotification.Builder builder = new AHNotification.Builder()
-                .setText(tab.badge.get(""))
-                .setBackgroundColor(tab.badgeColor.get(null))
+                .setText(tab.badge.getText().get(""))
+                .setBackgroundColor(tab.badge.getBackgroundColor().get(0))
+                .setTextColor(tab.badge.getTextColor().get(0))
                 .animate(tab.animateBadge.get(false));
         bottomTabs.perform(bottomTabs -> bottomTabs.setNotification(builder.build(), tabIndex));
     }
 
     private void mergeBadge(int index, BottomTabOptions tab) {
         if (bottomTabs == null) return;
-        if (!tab.badge.hasValue()) return;
+
         AHNotification.Builder builder = new AHNotification.Builder();
-        if (tab.badge.hasValue()) builder.setText(tab.badge.get());
-        if (tab.badgeColor.hasValue()) builder.setBackgroundColor(tab.badgeColor.get());
-        if (tab.badgeColor.hasValue()) builder.setBackgroundColor(tab.badgeColor.get());
-        if (tab.animateBadge.hasValue()) builder.animate(tab.animateBadge.get());
+        if (tab.badge.hasValue()) {
+            BottomTabOptions oldOptions = tabs.get(index).resolveCurrentOptions(defaultOptions).bottomTabOptions;
+
+            if (tab.badge.getText().hasValue())
+                builder.setText(tab.badge.getText().get());
+            else
+                builder.setText(oldOptions.badge.getText().get(""));
+            if (tab.badge.getTextColor().hasValue())
+                builder.setTextColor(tab.badge.getTextColor().get());
+            else
+                builder.setTextColor(oldOptions.badge.getTextColor().get(0));
+
+
+            if (tab.badge.getBackgroundColor().hasValue())
+                builder.setBackgroundColor(tab.badge.getBackgroundColor().get());
+            else
+                builder.setBackgroundColor(oldOptions.badge.getBackgroundColor().get(0));
+            if (tab.animateBadge.hasValue())
+                builder.animate(tab.animateBadge.get());
+        }
         bottomTabs.perform(bottomTabs -> bottomTabs.setNotification(builder.build(), index));
     }
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/options/BadgeOptionsTest.kt
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/options/BadgeOptionsTest.kt
@@ -1,0 +1,79 @@
+package com.reactnativenavigation.options
+
+import android.graphics.Color
+import com.reactnativenavigation.BaseTest
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+
+class BadgeOptionsTest : BaseTest() {
+    lateinit var uut: BadgeOptions
+
+    @Test
+    fun `parse - should parse json options`() {
+        uut = parseBadgeOptions(newActivity(), JSONObject().apply {
+            put("text", "hello")
+            put("textColor", Color.RED)
+            put("backgroundColor", Color.RED)
+        })
+
+        assertThat(uut.text.get()).isEqualTo("hello")
+        assertThat(uut.textColor.get()).isEqualTo(Color.RED)
+        assertThat(uut.backgroundColor.get()).isEqualTo(Color.RED)
+    }
+
+    @Test
+    fun `parse - should parse null for missing json options`() {
+        uut = parseBadgeOptions(newActivity(), JSONObject().apply {
+            put("text", "hello")
+            put("backgroundColor", Color.RED)
+        })
+
+        assertThat(uut.text.get()).isEqualTo("hello")
+        assertThat(uut.textColor.hasValue()).isFalse()
+        assertThat(uut.backgroundColor.get()).isEqualTo(Color.RED)
+
+        uut = parseBadgeOptions(newActivity(), JSONObject().apply {
+        })
+
+        assertThat(uut.text.hasValue()).isFalse()
+        assertThat(uut.textColor.hasValue()).isFalse()
+        assertThat(uut.backgroundColor.hasValue()).isFalse()
+    }
+
+    @Test
+    fun `hasValue - true when one of the props has value false otherwhise`() {
+        uut = parseBadgeOptions(newActivity(), JSONObject().apply {
+            put("text", "hello")
+            put("backgroundColor", Color.RED)
+        })
+        assertThat(uut.hasValue()).isTrue()
+
+        uut = parseBadgeOptions(newActivity(), JSONObject().apply {
+            put("backgroundColor", Color.RED)
+        })
+        assertThat(uut.hasValue()).isTrue()
+
+        uut = parseBadgeOptions(newActivity(), JSONObject().apply {
+        })
+        assertThat(uut.hasValue()).isFalse()
+    }
+
+    @Test
+    fun `mergeWith - should merge changes only`() {
+        uut = parseBadgeOptions(newActivity(), JSONObject().apply {
+            put("text", "hello")
+            put("backgroundColor", Color.RED)
+        })
+
+        assertThat(uut.textColor.hasValue()).isFalse()
+        val uut2 = parseBadgeOptions(newActivity(), JSONObject().apply {
+            put("backgroundColor", Color.YELLOW)
+            put("textColor", Color.BLUE)
+        })
+        uut.mergeWith(uut2)
+
+        assertThat(uut.textColor.hasValue()).isTrue()
+        assertThat(uut.backgroundColor.get()).isEqualTo(Color.YELLOW)
+    }
+}

--- a/lib/src/commands/Deprecations.ts
+++ b/lib/src/commands/Deprecations.ts
@@ -75,6 +75,19 @@ export class Deprecations {
     if (key === 'interpolation' && typeof parentOptions[key] === 'string') {
       this.deprecateInterpolationOptions(parentOptions);
     }
+    if (key === 'badgeColor') {
+      console.warn(
+        `${key} is deprecated and will be removed in the next major version. For more information see https://github.com/wix/react-native-navigation/issues/6889`,
+        parentOptions
+      );
+    }
+
+    if (key === 'badge' && typeof parentOptions[key] === 'string') {
+      console.warn(
+        `${key} is deprecated as a string and will be removed in the next major version. For more information see https://github.com/wix/react-native-navigation/issues/6889`,
+        parentOptions
+      );
+    }
   }
 
   public onProcessDefaultOptions(_key: string, _parentOptions: Record<string, any>) {}

--- a/lib/src/commands/OptionsProcessor.test.ts
+++ b/lib/src/commands/OptionsProcessor.test.ts
@@ -619,4 +619,62 @@ describe('navigation options', () => {
       });
     });
   });
+
+  describe('BottomTabBadgeOptions', () => {
+    it('transform old options to new options', () => {
+      const options: Options = {
+        bottomTab: {
+          badgeColor: 'red',
+          badge: 'hello',
+        },
+      };
+      uut.processOptions(options, CommandName.MergeOptions);
+
+      expect(options).toEqual({
+        bottomTab: {
+          badge: {
+            text: 'hello',
+            textColor: undefined,
+            backgroundColor: 0xffff0000,
+          },
+        },
+      });
+    });
+
+    it('transform badge/Color to badge object with text/backgroundColor', () => {
+      const options: Options = {
+        bottomTab: {
+          badge: 'hello',
+        },
+      };
+      uut.processOptions(options, CommandName.MergeOptions);
+
+      expect(options).toEqual({
+        bottomTab: {
+          badge: {
+            text: 'hello',
+            textColor: undefined,
+            backgroundColor: null,
+          },
+        },
+      });
+
+      const colorOptions: Options = {
+        bottomTab: {
+          badgeColor: 'red',
+        },
+      };
+      uut.processOptions(colorOptions, CommandName.MergeOptions);
+
+      expect(colorOptions).toEqual({
+        bottomTab: {
+          badge: {
+            text: undefined,
+            textColor: undefined,
+            backgroundColor: 0xffff0000,
+          },
+        },
+      });
+    });
+  });
 });

--- a/lib/src/commands/OptionsProcessor.ts
+++ b/lib/src/commands/OptionsProcessor.ts
@@ -84,6 +84,7 @@ export class OptionsProcessor {
       this.processComponent(key, value, objectToProcess);
       this.processImage(key, value, objectToProcess);
       this.processButtonsPassProps(key, value);
+      this.processBottmTabBadge(key, parentOptions);
       this.processSearchBar(key, value, objectToProcess);
       this.processInterpolation(key, value, objectToProcess);
       this.processAnimation(key, value, objectToProcess);
@@ -297,6 +298,30 @@ export class OptionsProcessor {
       parentOptions.push!!.bottomTabs = {
         enter: animation.bottomTabs as ViewAnimationOptions,
       };
+    }
+  }
+
+  private processBottmTabBadge(key: string, parentOptions: any) {
+    if (key === 'bottomTab' && parentOptions.bottomTab) {
+      if (parentOptions.bottomTab.badge) {
+        if (typeof parentOptions.bottomTab.badge === 'string') {
+          let text = parentOptions.bottomTab.badge;
+          parentOptions.bottomTab.badge = {
+            text,
+            backgroundColor: parentOptions.bottomTab.badgeColor,
+          };
+        } else {
+          if (parentOptions.bottomTab.badgeColor)
+            parentOptions.bottomTab.badge.backgroundColor = parentOptions.bottomTab.badgeColor;
+        }
+      } else {
+        if (parentOptions.bottomTab.badgeColor) {
+          parentOptions.bottomTab.badge = {
+            backgroundColor: parentOptions.bottomTab.badgeColor,
+          };
+        }
+      }
+      if (parentOptions.bottomTab.badgeColor) delete parentOptions.bottomTab.badgeColor;
     }
   }
 }

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -871,6 +871,11 @@ export interface ImageSystemSource {
 
 export type ImageResource = ImageSourcePropType | string | ImageSystemSource;
 
+export interface BottomTabBadgeOptions {
+  text?: string;
+  textColor?: Color;
+  backgroundColor?: Color;
+}
 export interface OptionsBottomTab {
   dotIndicator?: DotIndicatorOptions;
 
@@ -879,11 +884,13 @@ export interface OptionsBottomTab {
    */
   text?: string;
   /**
-   * Set the text in a badge that is overlayed over the component
+   * Set the badge options
    */
-  badge?: string;
+  badge?: BottomTabBadgeOptions | string;
   /**
+   * Deprecated: use badge.backgroundColor
    * Set the background color of the badge that is overlayed over the component
+   * overrides  badge.backgroundColor value at options processor
    */
   badgeColor?: string;
   /**

--- a/website/docs/api/options-bottomTab.mdx
+++ b/website/docs/api/options-bottomTab.mdx
@@ -12,15 +12,40 @@ const options = {
 
 ## `badge`
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| string | No       | Both     |
+Text Badge in the top end (right) corner of the bottomTab, see the following example
+
+| Type                  | Required | Platform |
+| --------------------- | -------- | -------- |
+| BottomTabBadgeOptions | No       | Both     |
+
+```js
+const options = {
+  bottomTab: {
+  badge: {
+          text: 'content',
+          textColor: 'green',
+          backgroundColor: 'blue',
+    },
+  },
+};
+```
+:::warning Deprecation warning
+This option as string is currently deprecated and will be removed in a future release. Please use the BottomTabBadgeOptions option instead.
+Using string will be the same as BottomTabBadgeOptions with text.
+:::
 
 ## `badgeColor`
+
+Badge backgroundColor
 
 | Type  | Required | Platform |
 | ----- | -------- | -------- |
 | color | No       | Both     |
+
+:::warning Deprecation warning
+This option is currently deprecated and will be removed in a future release. Please use the BottomTabBadgeOptions option instead.
+Using this option will be the same as BottomTabBadgeOptions with backgroundColor.
+:::
 
 ## `animateBadge`
 


### PR DESCRIPTION
### Changes:
- transform old options for new badge options (backwards compatibility).
- add new Options with `textColor`, Closes: #6889.
- Android native side implemented. 
- IOS in progress...
Old way (deprecated):
```js
  Navigation.mergeOptions(this.props.componentId, {
      bottomTab: {
        badgeColor: 'red',
        badge: 'hello',
      },
    });
```

New way:
```js
  Navigation.mergeOptions(this.props.componentId, {
      bottomTab: {
        badge: {
          text: 'content',
          textColor: 'green',
          backgroundColor: 'blue',
        },
      },
    });
```

### Demo

https://user-images.githubusercontent.com/7227793/108303324-65bc0080-71ae-11eb-8fec-04b71a1dc703.mov

