### PR TITLE
add missing Android RTL manifest attribute to docs

### DIFF
--- a/website/versioned_docs/version-7.11.0/api/options-layout.mdx
+++ b/website/versioned_docs/version-7.11.0/api/options-layout.mdx
@@ -56,6 +56,8 @@ Set language direction, only works with DefaultOptions. `locale` is an Android s
 | ---------------------------- | -------- | -------- |
 | enum('rtl', 'ltr', 'locale') | No       | Both     |
 
+On Android make sure your AndroidManifest.xml has this attribute: `android:supportsRtl="true"`.
+
 ### `autoHideHomeIndicator`
 
 Controls the application's preferred home indicator auto-hiding.


### PR DESCRIPTION
It's not clear when using `rtl` feature that in android, projects that want RTL support should declare that (`android:supportsRtl="true"`) in the `AndroidManifest.xml`, like in the playground.
Updated the docs about this note.

Closes #6974.

