### PR TITLE
add missing TopBar Height documentation 

### DIFF
--- a/website/docs/api/options-stack.mdx
+++ b/website/docs/api/options-stack.mdx
@@ -82,6 +82,14 @@ Control the TopBar blur style. Requires `translucent: true`.
 | ----------------------- | -------- | -------- |
 | enum('default','black') | No       | iOS      |
 
+### `height`
+
+Set TopBar height, in dp units, on Android only. For iOS use `largeTitle` see [Options](options-largeTitle.mdx).
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| number | No       | Android  |
+
 ### `borderColor`
 
 Change the topBar border color.


### PR DESCRIPTION
Add missing documentation about `TopBarOptions.height`, stating about android only, and on iOS referring to `largeTitle` Option.

Closes #6983 