### PR TITLE
Fix custom animations on iOS

### DIFF
--- a/lib/ios/RNNScreenTransition.m
+++ b/lib/ios/RNNScreenTransition.m
@@ -7,7 +7,7 @@
     self = [super initWithDict:dict];
 
     self.topBar = [[ElementTransitionOptions alloc] initWithDict:dict[@"topBar"]];
-    self.content = [[ElementTransitionOptions alloc] initWithDict:dict[@"content"]];
+    self.content = [[ElementTransitionOptions alloc] initWithDict:dict[@"content"][@"enter"]];
     self.bottomTabs = [[ElementTransitionOptions alloc] initWithDict:dict[@"bottomTabs"]];
     self.enable = [BoolParser parse:dict key:@"enabled"];
     self.waitForRender = [BoolParser parse:dict key:@"waitForRender"];


### PR DESCRIPTION
[This commit](https://github.com/wix/react-native-navigation/commit/17c82b456e0d6b0ee79f3d2a1643fe14054bf069) added exit screen animation option on Android and by that changed the object received in native. We should have update it on iOS as well. This PR fixes it.

Closes #6992