### PR TITLE
Fix bottomTabs More tab not clickable

### DIFF
--- a/lib/ios/RNNBottomTabsController.m
+++ b/lib/ios/RNNBottomTabsController.m
@@ -169,9 +169,11 @@
 - (BOOL)tabBarController:(UITabBarController *)tabBarController
     shouldSelectViewController:(UIViewController *)viewController {
     NSUInteger _index = [tabBarController.viewControllers indexOfObject:viewController];
+    BOOL isMoreTab = ![tabBarController.viewControllers containsObject:viewController];
+
     [self.eventEmitter sendBottomTabPressed:@(_index)];
 
-    if ([[viewController resolveOptions].bottomTab.selectTabOnPress withDefault:YES]) {
+    if ([[viewController resolveOptions].bottomTab.selectTabOnPress withDefault:YES] || isMoreTab) {
         return YES;
     }
 

--- a/playground/ios/NavigationTests/BottomTabsControllerTest.m
+++ b/playground/ios/NavigationTests/BottomTabsControllerTest.m
@@ -299,4 +299,30 @@
     [dotIndicator verify];
 }
 
+- (void)testShouldSelectViewController_returnTrueForMoreTab {
+    XCTAssertTrue([self.uut tabBarController:self.uut
+                  shouldSelectViewController:UIViewController.new]);
+}
+
+- (void)testShouldSelectViewController_returnTrueByDefault {
+    [self.uut viewWillAppear:NO];
+    XCTAssertTrue([self.uut tabBarController:self.uut
+                  shouldSelectViewController:self.uut.childViewControllers[0]]);
+}
+
+- (void)testShouldSelectViewController_selectTabOnPressFalse {
+    [self.uut viewWillAppear:NO];
+    self.uut.childViewControllers[0].options.bottomTab.selectTabOnPress = [Bool withValue:NO];
+    XCTAssertFalse([self.uut tabBarController:self.uut
+                   shouldSelectViewController:self.uut.childViewControllers[0]]);
+}
+
+- (void)testShouldSelectViewController_emitEvent {
+    [self.uut viewWillAppear:NO];
+    [[self.mockEventEmitter expect] sendBottomTabPressed:@(0)];
+    [self.uut tabBarController:self.uut
+        shouldSelectViewController:self.uut.childViewControllers[0]];
+    [self.mockEventEmitter verify];
+}
+
 @end


### PR DESCRIPTION
On iOS, when there are more than 5 tabs, the fifth tab becomes "more" tab. This tab is not clickable since we added `selectTabOnPress`. This PR fixes it.