### PR TITLE
Remove yellowBox observer on dealloc

### DIFF
--- a/lib/ios/RNNComponentView.m
+++ b/lib/ios/RNNComponentView.m
@@ -44,6 +44,14 @@
         }
     }
 }
+
+- (void)dealloc {
+    if (_observeLayerChange) {
+        [self.subviews.firstObject.subviews.firstObject.layer removeObserver:self
+                                                                  forKeyPath:@"sublayers"];
+    }
+}
+
 #endif
 
 @end


### PR DESCRIPTION
This PR fixes a crash caused by a KVO observer that isn't cleared.

Closes #7009