### PR TITLE
Bump kotlin version to 1.4.3 (multithreaded)

### DIFF
--- a/autolink/postlink/gradleLinker.js
+++ b/autolink/postlink/gradleLinker.js
@@ -1,9 +1,9 @@
 // @ts-check
 var path = require('./path');
 var fs = require('fs');
-var {warnn, errorn, logn, infon, debugn} = require('./log');
-var {insertString} = require('./stringUtils');
-var DEFAULT_KOTLIN_VERSION = '1.3.61';
+var { warnn, errorn, logn, infon, debugn } = require('./log');
+var { insertString } = require('./stringUtils');
+var DEFAULT_KOTLIN_VERSION = '1.4.31';
 // This should be the minSdkVersion required for RNN.
 var DEFAULT_MIN_SDK_VERSION = 21;
 

--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -14,7 +14,7 @@ def DEFAULT_MIN_SDK_VERSION = 19
 def DEFAULT_TARGET_SDK_VERSION = 29
 def kotlinVersion = rootProject.ext.get("RNNKotlinVersion")
 def kotlinStdlib = safeExtGet('RNNKotlinStdlib', 'kotlin-stdlib-jdk8')
-def kotlinCoroutinesCore = safeExtGet('RNNKotlinCoroutinesCore', '1.3.7')
+def kotlinCoroutinesCore = safeExtGet('RNNKotlinCoroutinesCore', '1.4.3-native-mt')
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
@@ -172,7 +172,6 @@ allprojects { p ->
 dependencies {
     implementation "androidx.core:core-ktx:1.3.0"
     implementation "org.jetbrains.kotlin:$kotlinStdlib:$kotlinVersion"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesCore"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesCore"
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
 

--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        RNNKotlinVersion = '1.3.61'
+        RNNKotlinVersion = '1.4.31'
     }
 
     repositories {
@@ -13,7 +13,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Bumps kotlin version from 1.3.61 to 1.4.31 and uses the native multithreaded build variant. See https://github.com/Kotlin/kotlinx.coroutines/issues/462 for more details about mt.