### PR TITLE
Title react view crash

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/ViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/ViewController.java
@@ -6,6 +6,13 @@ import android.view.ViewGroup;
 import android.view.ViewManager;
 import android.view.ViewTreeObserver;
 
+import androidx.annotation.CallSuper;
+import androidx.annotation.CheckResult;
+import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+import androidx.annotation.VisibleForTesting;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+
 import com.reactnativenavigation.options.Options;
 import com.reactnativenavigation.options.params.Bool;
 import com.reactnativenavigation.options.params.NullBool;
@@ -24,13 +31,7 @@ import com.reactnativenavigation.views.component.Renderable;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.CallSuper;
-import androidx.annotation.CheckResult;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
-
-import static com.reactnativenavigation.utils.CollectionUtils.*;
+import static com.reactnativenavigation.utils.CollectionUtils.forEach;
 import static com.reactnativenavigation.utils.ObjectUtils.perform;
 
 public abstract class ViewController<T extends ViewGroup> implements ViewTreeObserver.OnGlobalLayoutListener,
@@ -59,6 +60,7 @@ public abstract class ViewController<T extends ViewGroup> implements ViewTreeObs
 
     private final Activity activity;
     private final String id;
+    private int viewIdTracker = View.NO_ID;
     private final YellowBoxDelegate yellowBoxDelegate;
     @Nullable protected T view;
     @Nullable private ParentController<? extends ViewGroup> parentController;
@@ -196,6 +198,7 @@ public abstract class ViewController<T extends ViewGroup> implements ViewTreeObs
                 throw new RuntimeException("Tried to create view after it has already been destroyed");
             }
             view = createView();
+            viewIdTracker = view.getId();
             view.setOnHierarchyChangeListener(this);
             view.getViewTreeObserver().addOnGlobalLayoutListener(this);
         }
@@ -280,6 +283,7 @@ public abstract class ViewController<T extends ViewGroup> implements ViewTreeObs
             if (view.getParent() instanceof ViewGroup) {
                 ((ViewManager) view.getParent()).removeView(view);
             }
+            this.viewIdTracker = view.getId();
             view = null;
             isDestroyed = true;
         }
@@ -373,5 +377,10 @@ public abstract class ViewController<T extends ViewGroup> implements ViewTreeObs
 
     public int getBottomInset() {
         return perform(parentController, 0, p -> p.getBottomInset(this));
+    }
+
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    final public int getViewIdTracker(){
+        return viewIdTracker;
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/MainToolBar.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/MainToolBar.kt
@@ -21,8 +21,6 @@ const val DEFAULT_LEFT_MARGIN = 16
 class MainToolBar(context: Context) : RelativeLayout(context) {
 
     private var component: View? = null
-    private val componentViewId = CompatUtils.generateViewId()
-    private var componentViewIdBackup = View.NO_ID
     private val centerFrameLayout = FrameLayout(context).apply {
         id = CompatUtils.generateViewId()
     }
@@ -62,8 +60,6 @@ class MainToolBar(context: Context) : RelativeLayout(context) {
         if (this.component == component) return
         clear()
         this.component = component
-        this.componentViewIdBackup = this.component?.id ?: View.NO_ID
-        this.component?.id = componentViewId
         if (alignment == Alignment.Center) {
             this.centerFrameLayout.addView(this.component, FrameLayout.LayoutParams(FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT).apply {
                 this.gravity = Gravity.CENTER
@@ -165,7 +161,7 @@ class MainToolBar(context: Context) : RelativeLayout(context) {
     }
 
 
-    private fun clearComponent() = this.component?.let { it.id = View.NO_ID; ViewUtils.removeFromParent(it); this.component = null; }
+    private fun clearComponent() = this.component?.let { ViewUtils.removeFromParent(it); this.component = null; }
 
     @RestrictTo(RestrictTo.Scope.TESTS, RestrictTo.Scope.LIBRARY)
     fun getTitleComponent() = this.component ?: this.titleSubTitleBar

--- a/lib/android/app/src/test/java/com/reactnativenavigation/mocks/SimpleViewController.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/mocks/SimpleViewController.java
@@ -4,19 +4,19 @@ import android.app.Activity;
 import android.content.Context;
 import android.view.MotionEvent;
 
+import androidx.annotation.NonNull;
+
 import com.facebook.react.ReactInstanceManager;
-import com.reactnativenavigation.viewcontrollers.viewcontroller.ScrollEventListener;
 import com.reactnativenavigation.options.Options;
-import com.reactnativenavigation.viewcontrollers.component.ComponentPresenterBase;
-import com.reactnativenavigation.viewcontrollers.viewcontroller.Presenter;
 import com.reactnativenavigation.react.ReactView;
 import com.reactnativenavigation.viewcontrollers.child.ChildController;
 import com.reactnativenavigation.viewcontrollers.child.ChildControllersRegistry;
+import com.reactnativenavigation.viewcontrollers.component.ComponentPresenterBase;
+import com.reactnativenavigation.viewcontrollers.viewcontroller.Presenter;
+import com.reactnativenavigation.viewcontrollers.viewcontroller.ScrollEventListener;
 import com.reactnativenavigation.views.component.ReactComponent;
 
 import org.mockito.Mockito;
-
-import androidx.annotation.NonNull;
 
 import static com.reactnativenavigation.utils.ObjectUtils.perform;
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/NavigatorTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/NavigatorTest.java
@@ -5,6 +5,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
+import androidx.annotation.NonNull;
+
 import com.facebook.react.ReactInstanceManager;
 import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.TestActivity;
@@ -37,9 +39,7 @@ import com.reactnativenavigation.viewcontrollers.viewcontroller.Presenter;
 import com.reactnativenavigation.viewcontrollers.viewcontroller.RootPresenter;
 import com.reactnativenavigation.viewcontrollers.viewcontroller.ViewController;
 import com.reactnativenavigation.views.bottomtabs.BottomTabs;
-import com.reactnativenavigation.views.bottomtabs.BottomTabsContainer;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -49,8 +49,6 @@ import org.robolectric.annotation.Config;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -244,8 +242,10 @@ public class NavigatorTest extends BaseTest {
 
     @Test
     public void push_OnCorrectStackByFindingChildId() {
-        StackController stack1 = newStack(); stack1.ensureViewIsCreated();
-        StackController stack2 = newStack(); stack2.ensureViewIsCreated();
+        StackController stack1 = newStack();
+        stack1.ensureViewIsCreated();
+        StackController stack2 = newStack();
+        stack2.ensureViewIsCreated();
         stack1.push(child1, new CommandListenerAdapter());
         stack2.push(child2, new CommandListenerAdapter());
         BottomTabsController bottomTabsController = newTabs(Arrays.asList(stack1, stack2));
@@ -298,7 +298,8 @@ public class NavigatorTest extends BaseTest {
     public void pop_byStackId() {
         disablePushAnimation(child1, child2);
         disablePopAnimation(child2, child1);
-        StackController stack = newStack(child1, child2); stack.ensureViewIsCreated();
+        StackController stack = newStack(child1, child2);
+        stack.ensureViewIsCreated();
         uut.setRoot(stack, new CommandListenerAdapter(), reactInstanceManager);
 
         uut.pop(stack.getId(), Options.EMPTY, new CommandListenerAdapter());
@@ -640,6 +641,26 @@ public class NavigatorTest extends BaseTest {
 
         assertThat(uut.handleBack(new CommandListenerAdapter())).isTrue();
         assertThat(uut.handleBack(new CommandListenerAdapter())).isFalse();
+    }
+
+    @Test
+    public void destroy_shouldNotChangeViewIds() {
+        disablePushAnimation(child1);
+        disableShowModalAnimation(child1, child2, child3);
+
+        StackController spy = spy(parentController);
+        SimpleViewController.SimpleView view = child1.getView();
+        ViewGroup view1 = child2.getView();
+        view.setId(10);
+        view1.setId(11);
+        spy.options.animations.setRoot.enabled = new Bool(false);
+        uut.setRoot(spy, new CommandListenerAdapter(), reactInstanceManager);
+        spy.push(child1, new CommandListenerAdapter());
+        uut.showModal(child2, new CommandListenerAdapter());
+        activityController.destroy();
+        assertThat(child1.getViewId()).isEqualTo(10);
+        assertThat(child2.getViewId()).isEqualTo(11);
+        verify(spy, times(1)).destroy();
     }
 
     @Test

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/NavigatorTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/NavigatorTest.java
@@ -658,8 +658,8 @@ public class NavigatorTest extends BaseTest {
         spy.push(child1, new CommandListenerAdapter());
         uut.showModal(child2, new CommandListenerAdapter());
         activityController.destroy();
-        assertThat(child1.getViewId()).isEqualTo(10);
-        assertThat(child2.getViewId()).isEqualTo(11);
+        assertThat(child1.getViewIdTracker()).isEqualTo(10);
+        assertThat(child2.getViewIdTracker()).isEqualTo(11);
         verify(spy, times(1)).destroy();
     }
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/viewcontroller/ViewControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/viewcontroller/ViewControllerTest.java
@@ -7,6 +7,8 @@ import android.view.ViewParent;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+
 import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.TestUtils;
 import com.reactnativenavigation.mocks.SimpleViewController;
@@ -27,8 +29,6 @@ import org.mockito.Mockito;
 import org.robolectric.Shadows;
 
 import java.lang.reflect.Field;
-
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -276,6 +276,17 @@ public class ViewControllerTest extends BaseTest {
 
         uut.destroy();
         assertThat(parent.getChildCount()).withFailMessage("expected not to have children").isZero();
+    }
+
+    @Test
+    public void onDestroy_shouldKeepViewIdsStable() {
+        LinearLayout parent = new LinearLayout(activity);
+        ViewGroup view = uut.getView();
+        view.setId(10);
+        parent.addView(view);
+
+        uut.destroy();
+        assertThat(view.getId()).isEqualTo(10);
     }
 
     @Test

--- a/lib/android/app/src/test/java/com/reactnativenavigation/views/MainToolbarTest.kt
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/views/MainToolbarTest.kt
@@ -7,8 +7,6 @@ import android.view.View
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.RelativeLayout
-import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.view.marginTop
 import com.nhaarman.mockitokotlin2.verify
 import com.reactnativenavigation.BaseTest
@@ -24,7 +22,6 @@ import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.times
-import kotlin.math.roundToInt
 
 private const val UUT_WIDTH = 1000
 private const val UUT_HEIGHT = 100
@@ -38,6 +35,29 @@ class MainToolbarTest : BaseTest() {
         uut = MainToolBar(activity)
     }
 
+    @Test
+    fun `should maintain stable ids for guest component`(){
+        val component = View(activity).apply { id = 19 }
+        val component2 = View(activity).apply { id = 29 }
+        uut.setComponent(component)
+        assertThat(component.id).isEqualTo(19)
+
+        uut.setComponent(component2)
+        assertThat(component.id).isEqualTo(19)
+        assertThat(component2.id).isEqualTo(29)
+
+        uut.clear()
+        assertThat(component.id).isEqualTo(19)
+        assertThat(component2.id).isEqualTo(29)
+
+        uut.setComponent(component2)
+        assertThat(component.id).isEqualTo(19)
+        assertThat(component2.id).isEqualTo(29)
+
+        uut.setTitle("title")
+        assertThat(component.id).isEqualTo(19)
+        assertThat(component2.id).isEqualTo(29)
+    }
     @Test
     fun `init- should Have Left Bar At Start`() {
         val layoutParams = uut.leftButtonsBar.layoutParams as RelativeLayout.LayoutParams
@@ -160,10 +180,13 @@ class MainToolbarTest : BaseTest() {
         assertThat(layoutParams.rules[RelativeLayout.CENTER_IN_PARENT]).isNotEqualTo(RelativeLayout.TRUE)
     }
 
+
     @Test
     fun setComponent_doesNothingIfComponentIsAlreadyAdded() {
         val component = View(activity)
+        component.id = 19
         uut.setComponent(component)
+        idleMainLooper()
         val firstCompId = component.id
         assertThat(uut.findViewById<View?>(firstCompId)).isNotNull()
         uut.setComponent(component)


### PR DESCRIPTION
# Issue:
![Screen Shot 2021-03-10 at 14 05 36](https://user-images.githubusercontent.com/7227793/110626678-b325ff00-81a9-11eb-8408-16972728ed8a.png)

Apps using RNN with `title.component` defined as a react component, might get this crash.

I'll share my insights as a logical flow:

- The crash itself is about casting the [`ReactClippingViewGroupManager.getChildCount(T parent)`](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactClippingViewManager.java#L53) template param, `parent` that is declared to extend `ReactViewGroup`.
- `parent` in this case is a `TitleBarReactView`, which is a `ReactRootView` but it isn't a `ReactViewGroup`.
- Since the stack trace indicates **line 19** in the [`ReactClippingViewGroupManager`](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactClippingViewManager.java) it is mostly about template type, templates in java pass a phase where it strips constraints to the base and in this case the base type was `ReactViewGroup`.
- The stack trace indicates that when destroying the activity, it fails on [dropView](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java#L620):
![Screen Shot 2021-03-10 at 14 11 55](https://user-images.githubusercontent.com/7227793/110627444-a8b83500-81aa-11eb-9c6c-e8cad6bbebe2.png)
- ReactNative, as it seems, is using view ids to maintain its react component native views within [`NativeViewHierarchyManager`](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java#L620)
- `TitleBarReactView` is a ReactRootView, a FrameLayout, which is a `ViewGroup` at the base.
- That is why it was being called in `NativeViewHierarchyManager.dropView` since the check for view type is only for ViewGroup type.
- In `TitleBarReactView` the view id was set to `View.NO_ID` before its being removed in `clearComponent()`
- That means since [`NativeViewHierarchyManager`](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java) uses view ids to maintain and call their `viewManagers` to drop them.
- There is a chance that ReactNative lost track of this `view.id` that was changed before its being destroyed, and fetched a view by id that is `NO_ID` in the wrong place, hence, calling drop with wrong view manager view types.
- By Inspecting `NativeViewHierarchyManager` it seems like there is a really high chance that ReactNative uses `view.id` to manage their lifecycle and their managers. (for now)

# Fix

- Add tests to make sure when view got removed from the hierarchy, but still, RN hold a ref for it, the ids still as is, stable.
- Remove id manipulation in `TitleBarReactView`.
