### PR TITLE
Android mergeOptions subtitle center & margin fix

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenter.java
@@ -476,9 +476,9 @@ public class StackPresenter {
         if (resolveOptions.title.fontSize.hasValue()) topBar.setTitleFontSize(resolveOptions.title.fontSize.get());
         if (resolveOptions.title.font.hasValue()) topBar.setTitleTypeface(typefaceLoader, resolveOptions.title.font);
 
-        if (topBarOptions.subtitle.text.hasValue()) {
-            topBar.setSubtitle(topBarOptions.subtitle.text.get());
-            topBar.setSubtitleAlignment(topBarOptions.subtitle.alignment);
+        if (resolveOptions.subtitle.text.hasValue()) {
+            topBar.setSubtitle(resolveOptions.subtitle.text.get());
+            topBar.setSubtitleAlignment(resolveOptions.subtitle.alignment);
         }
         if (resolveOptions.subtitle.color.hasValue()) topBar.setSubtitleColor(resolveOptions.subtitle.color.get());
         if (resolveOptions.subtitle.fontSize.hasValue()) topBar.setSubtitleFontSize(resolveOptions.subtitle.fontSize.get());

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/TopBar.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/TopBar.java
@@ -159,6 +159,7 @@ public class TopBar extends AppBarLayout implements ScrollEventListener.ScrollAw
 
     public void setSubtitleAlignment(Alignment alignment) {
         mainToolBar.setSubTitleTextAlignment(alignment);
+        mainToolBar.setTitleBarAlignment(alignment);
     }
 
     public void setTestId(String testId) {

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenterTest.kt
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenterTest.kt
@@ -386,6 +386,43 @@ class StackPresenterTest : BaseTest() {
     }
 
     @Test
+    fun mergeOptions_shouldAlignTitleSubtitleAsOneOfThemChanges() {
+        fun String.asText() = Text(this)
+
+        val defaultOptions = Options()
+        defaultOptions.topBar = TopBarOptions().apply {
+            title = TitleOptions().apply {
+                alignment = Alignment.Center
+            }
+            subtitle = SubtitleOptions().apply {
+                alignment = Alignment.Center
+            }
+        }
+        uut.defaultOptions = defaultOptions
+        uut.applyChildOptions(defaultOptions, parent, child)
+
+        val titleSubtitleBar = topBar.mainToolBar.getTitleSubtitleBar()
+        val layoutParams = titleSubtitleBar.layoutParams as RelativeLayout.LayoutParams
+        assertThat(layoutParams.rules[RelativeLayout.CENTER_IN_PARENT]).isEqualTo(RelativeLayout.TRUE)
+        assertThat(layoutParams.marginStart).isEqualTo(0)
+        // do merge
+        val mergeOptions = Options().apply {
+            defaultOptions.topBar = TopBarOptions().apply {
+                title = TitleOptions().apply {
+                    text = "title".asText()
+                }
+                subtitle = SubtitleOptions().apply {
+                    text = "subtitle".asText()
+                }
+            }
+        }
+
+        uut.mergeOptions(mergeOptions, parent, child)
+        assertThat(layoutParams.rules[RelativeLayout.CENTER_IN_PARENT]).isEqualTo(RelativeLayout.TRUE)
+        assertThat(layoutParams.marginStart).isEqualTo(0)
+    }
+
+    @Test
     fun mergeOptions_resolvedSubtitleFontOptionsAreApplied() {
         val childOptions = Options()
         childOptions.topBar.subtitle.font.fontFamily = Text(SOME_FONT_FAMILY)


### PR DESCRIPTION
## Issue:

when setting default alignment in default options it wasn't being respected when `mergeOptions` called with options that do not include alignment, like updating the text or colour, it was resetting the alignment.

## Fix:

- Use the result of default options merged with requested options to update
- Ensure that alignment change should apply to the container when changing subtitle

CC: @danilobuerger 
