### PR TITLE
Fix shared element crash on Android

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/ElementTransitions.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/ElementTransitions.kt
@@ -1,6 +1,5 @@
 package com.reactnativenavigation.options
 
-import org.json.JSONException
 import org.json.JSONObject
 
 class ElementTransitions {
@@ -9,14 +8,10 @@ class ElementTransitions {
     companion object {
         fun parse(json: JSONObject): ElementTransitions {
             val result = ElementTransitions()
-            try {
-                val elementTransitions = json.getJSONArray("elementTransitions")
-                if (elementTransitions.length() == 0) return result
-                for (i in 0..elementTransitions.length()) {
-                    result.transitions.add(ElementTransitionOptions(elementTransitions.getJSONObject(i)))
-                }
-            } catch (e: JSONException) {
-
+            val elementTransitions = json.optJSONArray("elementTransitions")
+            if (elementTransitions == null || elementTransitions.length() == 0) return result
+            for (i in 0 until elementTransitions.length()) {
+                result.transitions.add(ElementTransitionOptions(elementTransitions.getJSONObject(i)))
             }
             return result
         }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/SharedElements.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/SharedElements.kt
@@ -1,6 +1,5 @@
 package com.reactnativenavigation.options
 
-import org.json.JSONException
 import org.json.JSONObject
 import java.util.*
 
@@ -28,16 +27,12 @@ class SharedElements {
         @JvmStatic
         fun parse(json: JSONObject): SharedElements {
             val result = SharedElements()
-            return try {
-                val sharedElements = json.getJSONArray("sharedElementTransitions")
-                if (sharedElements == null || sharedElements.length() == 0) return result
-                for (i in 0 until sharedElements.length()) {
-                    result.add(SharedElementTransitionOptions.parse(sharedElements.getJSONObject(i)))
-                }
-                result
-            } catch (e: JSONException) {
-                result
+            val sharedElementsJSONArray = json.optJSONArray("sharedElementTransitions")
+            if (sharedElementsJSONArray == null || sharedElementsJSONArray.length() == 0) return result
+            for (i in 0 until sharedElementsJSONArray.length()) {
+                result.add(SharedElementTransitionOptions.parse(sharedElementsJSONArray.getJSONObject(i)))
             }
+            return result
         }
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/TransitionAnimationOptions.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/TransitionAnimationOptions.kt
@@ -11,12 +11,10 @@ fun parseTransitionAnimationOptions(jsonObject: JSONObject?): TransitionAnimatio
                 AnimationOptions(jsonObject.optJSONObject("exit"))
         )
         if (jsonObject.has("sharedElementTransitions")) {
-            val json = jsonObject.getJSONObject("sharedElementTransitions")
-            modalAnimationOptions.sharedElements = SharedElements.parse(json)
+            modalAnimationOptions.sharedElements = SharedElements.parse(jsonObject)
         }
         if (jsonObject.has("elementTransitions")) {
-            val json = jsonObject.getJSONObject("elementTransitions")
-            modalAnimationOptions.elementTransitions = ElementTransitions.parse(json)
+            modalAnimationOptions.elementTransitions = ElementTransitions.parse(jsonObject)
         }
         modalAnimationOptions
     } ?: TransitionAnimationOptions()


### PR DESCRIPTION
# Issue:

Crashing over parsing the wrong types for modal animations.

# Fix:

Ensure that animations are parsed with the correct type.

Closes #7020 
