### PR TITLE
BackButton on stack root fix

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenter.java
@@ -353,7 +353,7 @@ public class StackPresenter {
     public void mergeChildOptions(Options toMerge, Options resolvedOptions, StackController stack, ViewController child) {
         TopBarOptions topBar = toMerge.copy().topBar.mergeWithDefault(resolvedOptions.topBar).mergeWithDefault(defaultOptions.topBar);
         mergeOrientation(toMerge.layout.orientation);
-        mergeButtons(topBar, toMerge.topBar, child.getView());
+        mergeButtons(topBar, toMerge.topBar, child.getView(), stack);
         mergeTopBarOptions(topBar, toMerge, stack, child);
         mergeTopTabsOptions(toMerge.topTabs);
         mergeTopTabOptions(toMerge.topTabOptions);
@@ -363,12 +363,12 @@ public class StackPresenter {
         if (orientationOptions.hasValue()) applyOrientation(orientationOptions);
     }
 
-    private void mergeButtons(TopBarOptions options, TopBarOptions optionsToMerge, View child) {
+    private void mergeButtons(TopBarOptions options, TopBarOptions optionsToMerge, View child, StackController stack) {
         mergeRightButtons(options, optionsToMerge.buttons, child);
         mergeLeftButton(options, optionsToMerge.buttons, child);
         mergeLeftButtonsColor(child, optionsToMerge.leftButtonColor, optionsToMerge.leftButtonDisabledColor);
         mergeRightButtonsColor(child, optionsToMerge.rightButtonColor, optionsToMerge.rightButtonDisabledColor);
-        mergeBackButton(optionsToMerge.buttons);
+        mergeBackButton(optionsToMerge.buttons, stack);
     }
 
     private void mergeLeftButtonsColor(View child, Colour color, Colour disabledColor) {
@@ -423,12 +423,13 @@ public class StackPresenter {
         }
     }
 
-    private void mergeBackButton(TopBarButtons buttons) {
+    private void mergeBackButton(TopBarButtons buttons, StackController stack) {
         if (buttons.back.hasValue() && isNullOrEmpty(buttons.left)) {
             if (buttons.back.visible.isFalse()) {
                 topBar.clearLeftButtons();
             } else {
-                topBar.setBackButton(createButtonController(buttons.back));
+                if (stack.size() > 1)
+                    topBar.setBackButton(createButtonController(buttons.back));
             }
         }
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenter.java
@@ -427,9 +427,8 @@ public class StackPresenter {
         if (buttons.back.hasValue() && isNullOrEmpty(buttons.left)) {
             if (buttons.back.visible.isFalse()) {
                 topBar.clearLeftButtons();
-            } else {
-                if (stack.size() > 1)
-                    topBar.setBackButton(createButtonController(buttons.back));
+            } else if (stack.size() > 1) {
+                topBar.setBackButton(createButtonController(buttons.back));
             }
         }
     }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenterTest.kt
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenterTest.kt
@@ -216,6 +216,16 @@ class StackPresenterTest : BaseTest() {
     }
 
     @Test
+    fun `mergeButtons - modify BackButton should not have effect on stack with with one child`() {
+        val options = Options()
+        options.topBar.buttons.back = BackButton.parse(activity, JSONObject().apply {
+            put("color", Color.RED)
+        })
+        uut.mergeChildOptions(options, EMPTY_OPTIONS, parent, child)
+        verify(topBar, times(0)).setBackButton(any())
+    }
+
+    @Test
     fun mergeButtons_previousRightButtonsAreDestroyed() {
         val options = Options()
         options.topBar.buttons.right = ArrayList(listOf(componentBtn1))


### PR DESCRIPTION
# Issue:

MergeOptions with `topBar.backButton.someProp` on a stack that has single child (nothing to pop) showed back button.


# Fix:

Make sure that no changes to the back button should apply to the Stack with one child