### PR TITLE
Fix TypeScript error in the playground app

### DIFF
--- a/playground/src/screens/SideMenuCenterScreen.tsx
+++ b/playground/src/screens/SideMenuCenterScreen.tsx
@@ -17,6 +17,7 @@ const {
   CHANGE_RIGHT_SIDE_MENU_WIDTH_BTN,
 } = testIDs;
 
+// @ts-ignore TSC is unhappy as leftButtons is defined as an object instead of an array. Declaring buttons as a single object is not reflected in Options, but still supported.
 export default class SideMenuCenterScreen extends NavigationComponent {
   static options() {
     return {


### PR DESCRIPTION
TSC is unhappy as `leftButtons` is defined as an object instead of an array. Declaring buttons as a single object is not reflected in Options, but still supported. We should keep this options as is since it serves as some sort of sanity ensuring the old API is still supported.