### PR TITLE
Fix setRoot animations on iOS

### DIFF
--- a/lib/src/commands/OptionsProcessor.test.ts
+++ b/lib/src/commands/OptionsProcessor.test.ts
@@ -13,6 +13,7 @@ import { AssetService } from '../adapters/AssetResolver';
 import { Deprecations } from './Deprecations';
 import { CommandName } from '../interfaces/CommandName';
 import { OptionsProcessor as Processor } from '../interfaces/Processors';
+import { Platform } from 'react-native';
 
 describe('navigation options', () => {
   let uut: OptionsProcessor;
@@ -52,7 +53,8 @@ describe('navigation options', () => {
     );
   });
 
-  it('processes old setRoot animation value to new enter exit format', () => {
+  it('processes old setRoot animation value to new enter exit format on Android', () => {
+    Platform.OS = 'android';
     const options: Options = {
       animations: {
         setRoot: {
@@ -84,6 +86,7 @@ describe('navigation options', () => {
     uut.processOptions(options, CommandName.SetRoot);
     expect(options).toEqual(expectedOptions);
   });
+
   describe('Modal Animation Options', () => {
     describe('Show Modal', () => {
       it('processes old options into new options,backwards compatibility ', () => {

--- a/lib/src/commands/OptionsProcessor.ts
+++ b/lib/src/commands/OptionsProcessor.ts
@@ -25,6 +25,7 @@ import {
 import { Deprecations } from './Deprecations';
 import { OptionProcessorsStore } from '../processors/OptionProcessorsStore';
 import { CommandName } from '../interfaces/CommandName';
+import { Platform } from 'react-native';
 
 export class OptionsProcessor {
   constructor(
@@ -284,10 +285,12 @@ export class OptionsProcessor {
     parentOptions: AnimationOptions
   ) {
     if (key !== 'setRoot') return;
-    if (!('enter' in animation)) {
+    if (Platform.OS === 'android' && !('enter' in animation)) {
       parentOptions.setRoot = {
         enter: animation,
       } as EnterExitAnimationOptions;
+    } else if (Platform.OS === 'ios' && 'enter' in animation) {
+      parentOptions.setRoot = animation;
     }
   }
 


### PR DESCRIPTION
Processing `setRoot` animations options for enter and exit animations on Android broke the iOS implementation.

Closes #7068, #7066