### PR TITLE
docs: fix order of tabs in Orientation 

### DIFF
--- a/website/docs/docs/style-orientation.mdx
+++ b/website/docs/docs/style-orientation.mdx
@@ -31,24 +31,6 @@ Navigation.setDefaultOptions({
 ```
 
 </TabItem>
-<TabItem value="modal">
-
-The following example demonstrates how to show a modal in landscape orientation.
-
-```js
-Navigation.showModal({
-  component: {
-    name: 'VideoPlayer'
-    options: {
-      layout: {
-        orientation: ['landscape']
-      }
-    }
-  }
-});
-```
-
-</TabItem>
 <TabItem value="root">
 
 Applying orientation in the root level will affect all screens in the root hierarchy level. It **will not** apply to modals.
@@ -65,6 +47,24 @@ Navigation.setRoot({
       children: [
         ...
       ]
+    }
+  }
+});
+```
+
+</TabItem>
+<TabItem value="modal">
+
+The following example demonstrates how to show a modal in landscape orientation.
+
+```js
+Navigation.showModal({
+  component: {
+    name: 'VideoPlayer'
+    options: {
+      layout: {
+        orientation: ['landscape']
+      }
     }
   }
 });

--- a/website/versioned_docs/version-6.12.2/docs/style-orientation.mdx
+++ b/website/versioned_docs/version-6.12.2/docs/style-orientation.mdx
@@ -31,24 +31,6 @@ Navigation.setDefaultOptions({
 ```
 
 </TabItem>
-<TabItem value="modal">
-
-The following example demonstrates how to show a modal in landscape orientation.
-
-```js
-Navigation.showModal({
-  component: {
-    name: 'VideoPlayer'
-    options: {
-      layout: {
-        orientation: ['landscape']
-      }
-    }
-  }
-});
-```
-
-</TabItem>
 <TabItem value="root">
 
 Applying orientation in the root level will affect all screens in the root hierarchy level. It **will not** apply to modals.
@@ -65,6 +47,24 @@ Navigation.setRoot({
       children: [
         ...
       ]
+    }
+  }
+});
+```
+
+</TabItem>
+<TabItem value="modal">
+
+The following example demonstrates how to show a modal in landscape orientation.
+
+```js
+Navigation.showModal({
+  component: {
+    name: 'VideoPlayer'
+    options: {
+      layout: {
+        orientation: ['landscape']
+      }
     }
   }
 });

--- a/website/versioned_docs/version-7.11.2/docs/style-orientation.mdx
+++ b/website/versioned_docs/version-7.11.2/docs/style-orientation.mdx
@@ -31,24 +31,6 @@ Navigation.setDefaultOptions({
 ```
 
 </TabItem>
-<TabItem value="modal">
-
-The following example demonstrates how to show a modal in landscape orientation.
-
-```js
-Navigation.showModal({
-  component: {
-    name: 'VideoPlayer'
-    options: {
-      layout: {
-        orientation: ['landscape']
-      }
-    }
-  }
-});
-```
-
-</TabItem>
 <TabItem value="root">
 
 Applying orientation in the root level will affect all screens in the root hierarchy level. It **will not** apply to modals.
@@ -65,6 +47,24 @@ Navigation.setRoot({
       children: [
         ...
       ]
+    }
+  }
+});
+```
+
+</TabItem>
+<TabItem value="modal">
+
+The following example demonstrates how to show a modal in landscape orientation.
+
+```js
+Navigation.showModal({
+  component: {
+    name: 'VideoPlayer'
+    options: {
+      layout: {
+        orientation: ['landscape']
+      }
     }
   }
 });

--- a/website/versioned_docs/version-7.13.0/docs/style-orientation.mdx
+++ b/website/versioned_docs/version-7.13.0/docs/style-orientation.mdx
@@ -31,24 +31,6 @@ Navigation.setDefaultOptions({
 ```
 
 </TabItem>
-<TabItem value="modal">
-
-The following example demonstrates how to show a modal in landscape orientation.
-
-```js
-Navigation.showModal({
-  component: {
-    name: 'VideoPlayer'
-    options: {
-      layout: {
-        orientation: ['landscape']
-      }
-    }
-  }
-});
-```
-
-</TabItem>
 <TabItem value="root">
 
 Applying orientation in the root level will affect all screens in the root hierarchy level. It **will not** apply to modals.
@@ -65,6 +47,24 @@ Navigation.setRoot({
       children: [
         ...
       ]
+    }
+  }
+});
+```
+
+</TabItem>
+<TabItem value="modal">
+
+The following example demonstrates how to show a modal in landscape orientation.
+
+```js
+Navigation.showModal({
+  component: {
+    name: 'VideoPlayer'
+    options: {
+      layout: {
+        orientation: ['landscape']
+      }
     }
   }
 });

--- a/website/versioned_docs/version-7.7.0/docs/style-orientation.mdx
+++ b/website/versioned_docs/version-7.7.0/docs/style-orientation.mdx
@@ -31,24 +31,6 @@ Navigation.setDefaultOptions({
 ```
 
 </TabItem>
-<TabItem value="modal">
-
-The following example demonstrates how to show a modal in landscape orientation.
-
-```js
-Navigation.showModal({
-  component: {
-    name: 'VideoPlayer'
-    options: {
-      layout: {
-        orientation: ['landscape']
-      }
-    }
-  }
-});
-```
-
-</TabItem>
 <TabItem value="root">
 
 Applying orientation in the root level will affect all screens in the root hierarchy level. It **will not** apply to modals.
@@ -65,6 +47,24 @@ Navigation.setRoot({
       children: [
         ...
       ]
+    }
+  }
+});
+```
+
+</TabItem>
+<TabItem value="modal">
+
+The following example demonstrates how to show a modal in landscape orientation.
+
+```js
+Navigation.showModal({
+  component: {
+    name: 'VideoPlayer'
+    options: {
+      layout: {
+        orientation: ['landscape']
+      }
     }
   }
 });


### PR DESCRIPTION
This fix makes tabs in the [ Orientation](https://wix.github.io/react-native-navigation/docs/style-orientation) part of the docs in correct order: `defaultOptions` -> `root` -> `modal`.
Putting tabs not in order introduced a bug where clicking on one tab opened the other. 
## Before

https://user-images.githubusercontent.com/39658211/114007352-8f65df80-9861-11eb-8ac1-0323fea14c66.mov

## After

https://user-images.githubusercontent.com/39658211/114007372-942a9380-9861-11eb-961a-25ae307fbd04.mov

