### PR TITLE
Fix SET if image has not yet been loaded

### DIFF
--- a/lib/ios/AnimatedImageView.m
+++ b/lib/ios/AnimatedImageView.m
@@ -46,20 +46,27 @@
     CGFloat duration = [_transitionOptions.duration withDefault:300];
     id<Interpolator> interpolator = _transitionOptions.interpolator;
 
-    [animations addObject:[[BoundsTransition alloc] initWithView:_fromImageView
-                                                            from:_fromImageView.resolveBounds
-                                                              to:_toImageView.resolveBounds
-                                                      startDelay:startDelay
-                                                        duration:duration
-                                                    interpolator:interpolator]];
+    // assumes that from.image is equal (in bounds at least) to the to.image UIImage.
+    UIImage *fromImage = _fromImageView.image;
+    UIImage *toImage = _toImageView.image ?: fromImage;
+    if (fromImage != nil && toImage != nil) {
+        [animations
+            addObject:[[BoundsTransition alloc]
+                          initWithView:_fromImageView
+                                  from:[_fromImageView resolveBoundsWithImageSize:fromImage.size]
+                                    to:[_toImageView resolveBoundsWithImageSize:toImage.size]
+                            startDelay:startDelay
+                              duration:duration
+                          interpolator:interpolator]];
 
-    [animations addObject:[[CenterTransition alloc] initWithView:_fromImageView
-                                                            from:_fromImageView.center
-                                                              to:_toImageView.center
-                                                      startDelay:startDelay
-                                                        duration:duration
-                                                    interpolator:interpolator]];
-    _fromImageView.contentMode = UIViewContentModeScaleToFill;
+        [animations addObject:[[CenterTransition alloc] initWithView:_fromImageView
+                                                                from:_fromImageView.center
+                                                                  to:_toImageView.center
+                                                          startDelay:startDelay
+                                                            duration:duration
+                                                        interpolator:interpolator]];
+        _fromImageView.contentMode = UIViewContentModeScaleToFill;
+    }
 
     return animations;
 }

--- a/lib/ios/UIImageView+Transition.h
+++ b/lib/ios/UIImageView+Transition.h
@@ -2,6 +2,15 @@
 
 @interface UIImageView (Transition)
 
+/**
+ Returns the bounds of the actual underlying image transformed by the contentMode with a custom
+ imageSize.
+ */
+- (CGRect)resolveBoundsWithImageSize:(CGSize)imageSize;
+/**
+ Returns the bounds of the actual underlying image transformed by the contentMode, assuming the
+ underlying image has already been loaded.
+ */
 - (CGRect)resolveBounds;
 
 @end

--- a/lib/ios/UIImageView+Transition.m
+++ b/lib/ios/UIImageView+Transition.m
@@ -2,14 +2,12 @@
 
 @implementation UIImageView (Transition)
 
-- (CGRect)resolveBounds {
+- (CGRect)resolveBoundsWithImageSize:(CGSize)imageSize {
     switch (self.contentMode) {
     case UIViewContentModeCenter:
-        return CGRectMake(0, 0, self.image.size.width, self.image.size.height);
+        return CGRectMake(0, 0, imageSize.width, imageSize.height);
         break;
     case UIViewContentModeScaleAspectFill: {
-        CGSize imageSize = CGSizeMake(self.image.size.width, self.image.size.height);
-
         CGFloat widthRatio = imageSize.width / self.superview.bounds.size.width;
         CGFloat heightRatio = imageSize.height / self.superview.bounds.size.height;
 
@@ -22,9 +20,6 @@
         return CGRectMake(0, 0, imageSize.width, imageSize.height);
     }
     case UIViewContentModeScaleAspectFit: {
-        CGSize imageSize = CGSizeMake(self.image.size.width / self.image.scale,
-                                      self.image.size.height / self.image.scale);
-
         CGFloat widthRatio = imageSize.width / self.superview.bounds.size.width;
         CGFloat heightRatio = imageSize.height / self.superview.bounds.size.height;
 
@@ -41,6 +36,11 @@
     }
 
     return self.bounds;
+}
+
+- (CGRect)resolveBounds {
+    return [self resolveBoundsWithImageSize:CGSizeMake(self.image.size.width / self.image.scale,
+                                                       self.image.size.height / self.image.scale)];
 }
 
 @end


### PR DESCRIPTION
Fixes https://github.com/wix/react-native-navigation/issues/7078.

@yogevbd was there a specific reason to only account for the Image Scale in `UIViewContentModeScaleAspectFit`? All other contentModes just used the image width/height without dividing by it's scale. I changed it so that now every contentMode respects the scale.