### PR TITLE
Shared element android fix

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/modal/ModalAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/modal/ModalAnimator.kt
@@ -4,10 +4,13 @@ import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.AnimatorSet
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import com.reactnativenavigation.options.FadeInAnimation
 import com.reactnativenavigation.options.FadeOutAnimation
 import com.reactnativenavigation.options.TransitionAnimationOptions
+import com.reactnativenavigation.options.params.Bool
 import com.reactnativenavigation.utils.ScreenAnimationListener
+import com.reactnativenavigation.utils.awaitRender
 import com.reactnativenavigation.viewcontrollers.common.BaseAnimator
 import com.reactnativenavigation.viewcontrollers.viewcontroller.ViewController
 import com.reactnativenavigation.views.element.TransitionAnimatorCreator
@@ -23,7 +26,9 @@ open class ModalAnimator @JvmOverloads constructor(
     val isRunning: Boolean
         get() = runningAnimators.isNotEmpty()
 
-    private val runningAnimators: MutableMap<ViewController<*>, Animator?> = HashMap()
+    @VisibleForTesting
+    internal val runningAnimators: MutableMap<ViewController<*>, AnimatorSet?> = HashMap()
+
 
     open fun show(
             appearing: ViewController<*>,
@@ -31,21 +36,41 @@ open class ModalAnimator @JvmOverloads constructor(
             animationOptions: TransitionAnimationOptions,
             listener: ScreenAnimationListener
     ) {
+        val set = createShowModalAnimator(appearing, listener)
+        runningAnimators[appearing] = set
+        if (animationOptions.hasElementTransitions() && disappearing != null) {
+            showModalWithElementTransition(appearing, disappearing, animationOptions, set)
+        } else {
+            showModalWithoutElementTransition(appearing, disappearing, animationOptions, set)
+        }
+
+    }
+
+    private fun showModalWithElementTransition(appearing: ViewController<*>, disappearing: ViewController<*>, animationOptions: TransitionAnimationOptions, set: AnimatorSet) {
         GlobalScope.launch(Dispatchers.Main.immediate) {
-            val set = createShowModalAnimator(appearing, listener)
-            if (animationOptions.hasElementTransitions() && disappearing != null) {
-                setupShowModalWithSharedElementTransition(disappearing, appearing, animationOptions, set)
-            } else {
-                val appearingAnimation = if (animationOptions.enter.hasValue()) {
-                    animationOptions.enter.getAnimation(appearing.view)
-                } else getDefaultPushAnimation(appearing.view)
-                val disappearingAnimation = if (disappearing != null && animationOptions.exit.hasValue()) {
-                    animationOptions.exit.getAnimation(disappearing.view)
-                } else null
-                disappearingAnimation?.let {
-                    set.playTogether(appearingAnimation, disappearingAnimation)
-                } ?: set.playTogether(appearingAnimation)
-            }
+            appearing.setWaitForRender(Bool(true))
+            appearing.view.alpha = 0f
+            appearing.awaitRender()
+            val fade = if (animationOptions.enter.isFadeAnimation()) animationOptions.enter else FadeInAnimation().content.enter
+            val transitionAnimators = transitionAnimatorCreator.create(animationOptions, fade, disappearing, appearing)
+            set.playTogether(fade.getAnimation(appearing.view), transitionAnimators)
+            transitionAnimators.listeners.forEach { animatorListener: Animator.AnimatorListener -> set.addListener(animatorListener) }
+            transitionAnimators.removeAllListeners()
+            set.start()
+        }
+    }
+
+    private fun showModalWithoutElementTransition(appearing: ViewController<*>, disappearing: ViewController<*>?, animationOptions: TransitionAnimationOptions, set: AnimatorSet) {
+        GlobalScope.launch(Dispatchers.Main.immediate) {
+            val appearingAnimation = if (animationOptions.enter.hasValue()) {
+                animationOptions.enter.getAnimation(appearing.view)
+            } else getDefaultPushAnimation(appearing.view)
+            val disappearingAnimation = if (disappearing != null && animationOptions.exit.hasValue()) {
+                animationOptions.exit.getAnimation(disappearing.view)
+            } else null
+            disappearingAnimation?.let {
+                set.playTogether(appearingAnimation, disappearingAnimation)
+            } ?: set.playTogether(appearingAnimation)
             set.start()
         }
     }
@@ -60,10 +85,10 @@ open class ModalAnimator @JvmOverloads constructor(
                 if (animationOptions.hasElementTransitions() && appearing != null) {
                     setupDismissAnimationWithSharedElementTransition(disappearing, appearing, animationOptions, set)
                 } else {
-                    val appearingAnimation = if (appearing != null&&animationOptions.enter.hasValue()) {
+                    val appearingAnimation = if (appearing != null && animationOptions.enter.hasValue()) {
                         animationOptions.enter.getAnimation(appearing.view)
                     } else null
-                    val disappearingAnimation = if ( animationOptions.exit.hasValue()) {
+                    val disappearingAnimation = if (animationOptions.exit.hasValue()) {
                         animationOptions.exit.getAnimation(disappearing.view)
                     } else getDefaultPopAnimation(disappearing.view)
                     appearingAnimation?.let {
@@ -80,7 +105,6 @@ open class ModalAnimator @JvmOverloads constructor(
         set.addListener(object : AnimatorListenerAdapter() {
             private var isCancelled = false
             override fun onAnimationStart(animation: Animator) {
-                runningAnimators[appearing] = animation
                 listener.onStart()
             }
 
@@ -95,19 +119,6 @@ open class ModalAnimator @JvmOverloads constructor(
             }
         })
         return set
-    }
-
-    private suspend fun setupShowModalWithSharedElementTransition(
-            disappearing: ViewController<*>,
-            appearing: ViewController<*>,
-            show: TransitionAnimationOptions,
-            set: AnimatorSet
-    ) {
-        val fade = if (show.enter.isFadeAnimation()) show.enter else FadeInAnimation().content.enter
-        val transitionAnimators = transitionAnimatorCreator.create(show, fade, disappearing, appearing)
-        set.playTogether(fade.getAnimation(appearing.view), transitionAnimators)
-        transitionAnimators.listeners.forEach { listener: Animator.AnimatorListener -> set.addListener(listener) }
-        transitionAnimators.removeAllListeners()
     }
 
     private fun createDismissAnimator(disappearing: ViewController<*>, listener: ScreenAnimationListener): AnimatorSet {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/modal/ModalPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/modal/ModalPresenter.java
@@ -13,17 +13,19 @@ import com.reactnativenavigation.viewcontrollers.viewcontroller.ViewController;
 import androidx.annotation.Nullable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
+import org.jetbrains.annotations.NotNull;
+
 import static com.reactnativenavigation.utils.CoordinatorLayoutUtils.matchParentLP;
 
 public class ModalPresenter {
 
     private ViewGroup rootLayout;
     private CoordinatorLayout modalsLayout;
-    private final ModalAnimator animator;
+    private final ModalAnimator modalAnimator;
     private Options defaultOptions = new Options();
 
     ModalPresenter(ModalAnimator animator) {
-        this.animator = animator;
+        this.modalAnimator = animator;
     }
 
     void setRootLayout(ViewGroup rootLayout) {
@@ -38,36 +40,38 @@ public class ModalPresenter {
         this.defaultOptions = defaultOptions;
     }
 
-    void showModal(ViewController toAdd, ViewController toRemove, CommandListener listener) {
+    void showModal(ViewController<?> appearing, ViewController<?> disappearing, CommandListener listener) {
         if (modalsLayout == null) {
             listener.onError("Can not show modal before activity is created");
             return;
         }
 
-        Options options = toAdd.resolveCurrentOptions(defaultOptions);
+        Options options = appearing.resolveCurrentOptions(defaultOptions);
+
         AnimationOptions enterAnimationOptions = options.animations.showModal.getEnter();
-        toAdd.setWaitForRender(enterAnimationOptions.waitForRender);
+        appearing.setWaitForRender(enterAnimationOptions.waitForRender);
         modalsLayout.setVisibility(View.VISIBLE);
-        modalsLayout.addView(toAdd.getView(), matchParentLP());
+        modalsLayout.addView(appearing.getView(), matchParentLP());
 
         if (enterAnimationOptions.enabled.isTrueOrUndefined()) {
-            toAdd.getView().setAlpha(0);
             if (enterAnimationOptions.shouldWaitForRender().isTrue()) {
-                toAdd.addOnAppearedListener(() -> animateShow(toAdd, toRemove, listener, options));
+                appearing.addOnAppearedListener(() -> modalAnimator.show(appearing, disappearing, options.animations.showModal, createListener(appearing, disappearing, listener)));
             } else {
-                animateShow(toAdd, toRemove, listener, options);
+                modalAnimator.show(appearing, disappearing, options.animations.showModal, createListener(appearing, disappearing, listener));
             }
         } else {
             if (enterAnimationOptions.waitForRender.isTrue()) {
-                toAdd.addOnAppearedListener(() -> onShowModalEnd(toAdd, toRemove, listener));
+                appearing.addOnAppearedListener(() -> onShowModalEnd(appearing, disappearing, listener));
             } else {
-                onShowModalEnd(toAdd, toRemove, listener);
+                onShowModalEnd(appearing, disappearing, listener);
             }
         }
     }
 
-    private void animateShow(ViewController toAdd, ViewController toRemove, CommandListener listener, Options options) {
-        animator.show(toAdd, toRemove, options.animations.showModal, new ScreenAnimationListener() {
+
+    @NotNull
+    private ScreenAnimationListener createListener(ViewController toAdd, ViewController toRemove, CommandListener listener) {
+        return new ScreenAnimationListener() {
             @Override
             public void onStart() {
                 toAdd.getView().setAlpha(1);
@@ -82,7 +86,7 @@ public class ModalPresenter {
             public void onCancel() {
                 listener.onSuccess(toAdd.getId());
             }
-        });
+        };
     }
 
     private void onShowModalEnd(ViewController toAdd, @Nullable ViewController toRemove, CommandListener listener) {
@@ -104,7 +108,7 @@ public class ModalPresenter {
         }
         Options options = toDismiss.resolveCurrentOptions(defaultOptions);
         if (options.animations.dismissModal.getExit().enabled.isTrueOrUndefined()) {
-            animator.dismiss(toAdd, toDismiss, options.animations.dismissModal, new ScreenAnimationListener() {
+            modalAnimator.dismiss(toAdd, toDismiss, options.animations.dismissModal, new ScreenAnimationListener() {
                 @Override
                 public void onEnd() {
                     onDismissEnd(toDismiss, listener);

--- a/lib/android/app/src/test/java/com/reactnativenavigation/options/TransitionAnimationOptionsTest.kt
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/options/TransitionAnimationOptionsTest.kt
@@ -4,6 +4,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import com.reactnativenavigation.BaseTest
 import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Test
 
@@ -85,6 +86,20 @@ class TransitionAnimationOptionsTest : BaseTest() {
     }
 
 }
+
+fun newSharedElementAnimationOptionsJson() =
+        JSONArray().apply {
+            put(JSONObject().apply {
+                put("fromId", "1")
+                put("toId", "2")
+                put("duration", "30")
+            })
+            put(JSONObject().apply {
+                put("fromId", "3")
+                put("toId", "4")
+                put("duration", "30")
+            })
+        }
 
 fun newAnimationOptionsJson(enabled: Boolean) =
         JSONObject().apply {

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalAnimatorTest.kt
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalAnimatorTest.kt
@@ -3,10 +3,7 @@ package com.reactnativenavigation.viewcontrollers.modal
 import com.nhaarman.mockitokotlin2.*
 import com.reactnativenavigation.BaseTest
 import com.reactnativenavigation.mocks.SimpleViewController
-import com.reactnativenavigation.options.AnimationOptions
-import com.reactnativenavigation.options.TransitionAnimationOptions
-import com.reactnativenavigation.options.Options
-import com.reactnativenavigation.options.newAnimationOptionsJson
+import com.reactnativenavigation.options.*
 import com.reactnativenavigation.utils.ScreenAnimationListener
 import com.reactnativenavigation.viewcontrollers.child.ChildControllersRegistry
 import com.reactnativenavigation.viewcontrollers.viewcontroller.ViewController
@@ -43,6 +40,28 @@ class ModalAnimatorTest : BaseTest() {
     fun show_isRunning() {
         uut.show(modal1, root, TransitionAnimationOptions(), object : ScreenAnimationListener() {})
         assertThat(uut.isRunning).isTrue()
+    }
+
+    @Test
+    fun `show - should play shared transition if it has value`() {
+        val screenAnimationListener: ScreenAnimationListener = mock { }
+
+        val sharedElements = SharedElements.parse(newAnimationOptionsJson(true).apply {
+            put("sharedElementTransitions", newSharedElementAnimationOptionsJson())
+        })
+        val mockModal = spy(modal1)
+        uut.show(mockModal, root, TransitionAnimationOptions(sharedElements = sharedElements), screenAnimationListener)
+        idleMainLooper()
+        verify(mockModal).setWaitForRender(any())
+    }
+
+    @Test
+    fun `show - should not play shared transition if it does not has value`() {
+        val screenAnimationListener: ScreenAnimationListener = mock { }
+        val enter = spy(AnimationOptions(newAnimationOptionsJson(true)))
+        val mockModal = spy(modal1)
+        uut.show(mockModal, root, TransitionAnimationOptions(enter = enter), screenAnimationListener)
+        verify(mockModal, never()).setWaitForRender(any())
     }
 
     @Test


### PR DESCRIPTION
# Issue

Showing modal with shared element transition broke, in the opening direction, while it is working in the closing direction, like when opening a card in the Car dealer in the Playground, the shared card won't animate to the new position, fading instead.


https://user-images.githubusercontent.com/7227793/114307698-7cfdd700-9ae9-11eb-8f4c-d4ca4235e9db.mov


# Fix

Check and test that SharedElement transition is playing, matching `push` shared element behaviour, making `showModal` and `push` aligned since push does not suffer such misbehaving in shared element.


https://user-images.githubusercontent.com/7227793/114307791-c2ba9f80-9ae9-11eb-9068-8931a8238994.mov

Closes: #7070