### PR TITLE
docs: Update option-processor rightButtons example

### DIFF
--- a/website/docs/docs/style-theme/option-processor-defaults.tsx
+++ b/website/docs/docs/style-theme/option-processor-defaults.tsx
@@ -2,9 +2,11 @@ import { CommandName, Navigation, OptionsTopBarButton } from 'react-native-navig
 
 Navigation.addOptionProcessor<OptionsTopBarButton>(
   'topBar.rightButtons',
-  (button: OptionsTopBarButton, commandName: CommandName): OptionsTopBarButton => {
-    button.fontFamily = 'helvetica';
-    button.color = 'red';
-    return button;
-  }
+  (rightButtons: OptionsTopBarButton[], commandName: CommandName): OptionsTopBarButton => {
+    return rightButtons.map((button) => ({
+		  ...button,
+			fontFamily: 'helvetica',
+			fontSize: 16,
+      color: 'red'
+		}));
 );

--- a/website/docs/docs/style-theme/option-processor-defaults.tsx
+++ b/website/docs/docs/style-theme/option-processor-defaults.tsx
@@ -4,9 +4,9 @@ Navigation.addOptionProcessor<OptionsTopBarButton>(
   'topBar.rightButtons',
   (rightButtons: OptionsTopBarButton[], commandName: CommandName): OptionsTopBarButton => {
     return rightButtons.map((button) => ({
-		  ...button,
-			fontFamily: 'helvetica',
-			fontSize: 16,
+      ...button,
+      fontFamily: 'helvetica',
+      fontSize: 16,
       color: 'red'
-		}));
+  }));
 );

--- a/website/versioned_docs/version-6.12.2/docs/style-theme/option-processor-defaults.tsx
+++ b/website/versioned_docs/version-6.12.2/docs/style-theme/option-processor-defaults.tsx
@@ -2,9 +2,11 @@ import { CommandName, Navigation, OptionsTopBarButton } from 'react-native-navig
 
 Navigation.addOptionProcessor<OptionsTopBarButton>(
   'topBar.rightButtons',
-  (button: OptionsTopBarButton, commandName: CommandName): OptionsTopBarButton => {
-    button.fontFamily = 'helvetica';
-    button.color = 'red';
-    return button;
-  }
+  (rightButtons: OptionsTopBarButton[], commandName: CommandName): OptionsTopBarButton => {
+    return rightButtons.map((button) => ({
+      ...button,
+      fontFamily: 'helvetica',
+      fontSize: 16,
+      color: 'red'
+  }));
 );

--- a/website/versioned_docs/version-7.11.2/docs/style-theme/option-processor-defaults.tsx
+++ b/website/versioned_docs/version-7.11.2/docs/style-theme/option-processor-defaults.tsx
@@ -2,9 +2,11 @@ import { CommandName, Navigation, OptionsTopBarButton } from 'react-native-navig
 
 Navigation.addOptionProcessor<OptionsTopBarButton>(
   'topBar.rightButtons',
-  (button: OptionsTopBarButton, commandName: CommandName): OptionsTopBarButton => {
-    button.fontFamily = 'helvetica';
-    button.color = 'red';
-    return button;
-  }
+  (rightButtons: OptionsTopBarButton[], commandName: CommandName): OptionsTopBarButton => {
+    return rightButtons.map((button) => ({
+      ...button,
+      fontFamily: 'helvetica',
+      fontSize: 16,
+      color: 'red'
+  }));
 );

--- a/website/versioned_docs/version-7.13.0/docs/style-theme/option-processor-defaults.tsx
+++ b/website/versioned_docs/version-7.13.0/docs/style-theme/option-processor-defaults.tsx
@@ -2,9 +2,11 @@ import { CommandName, Navigation, OptionsTopBarButton } from 'react-native-navig
 
 Navigation.addOptionProcessor<OptionsTopBarButton>(
   'topBar.rightButtons',
-  (button: OptionsTopBarButton, commandName: CommandName): OptionsTopBarButton => {
-    button.fontFamily = 'helvetica';
-    button.color = 'red';
-    return button;
-  }
+  (rightButtons: OptionsTopBarButton[], commandName: CommandName): OptionsTopBarButton => {
+    return rightButtons.map((button) => ({
+      ...button,
+      fontFamily: 'helvetica',
+      fontSize: 16,
+      color: 'red'
+  }));
 );

--- a/website/versioned_docs/version-7.7.0/docs/style-theme/option-processor-defaults.tsx
+++ b/website/versioned_docs/version-7.7.0/docs/style-theme/option-processor-defaults.tsx
@@ -2,9 +2,11 @@ import { CommandName, Navigation, OptionsTopBarButton } from 'react-native-navig
 
 Navigation.addOptionProcessor<OptionsTopBarButton>(
   'topBar.rightButtons',
-  (button: OptionsTopBarButton, commandName: CommandName): OptionsTopBarButton => {
-    button.fontFamily = 'helvetica';
-    button.color = 'red';
-    return button;
-  }
+  (rightButtons: OptionsTopBarButton[], commandName: CommandName): OptionsTopBarButton => {
+    return rightButtons.map((button) => ({
+      ...button,
+      fontFamily: 'helvetica',
+      fontSize: 16,
+      color: 'red'
+  }));
 );


### PR DESCRIPTION
Update option-processor-defaults example to work. The current example wouldn't work properly or do anything b/c an array of rightButtons is returned to the processor, not a single button.