### PR TITLE
Remove duplicate disableIconTint option in API documentation.

### DIFF
--- a/website/versioned_docs/version-7.13.0/api/options-bottomTab.mdx
+++ b/website/versioned_docs/version-7.13.0/api/options-bottomTab.mdx
@@ -122,12 +122,6 @@ The height (in dp) of the icon.
 | ------- | -------- | -------- |
 | boolean | No       | Android  |
 
-## `disableIconTint`
-
-| Type    | Required | Platform |
-| ------- | -------- | -------- |
-| boolean | No       | Android  |
-
 ## `selectedTextColor`
 
 | Type  | Required | Platform |


### PR DESCRIPTION
This appears twice, and is applicable for both platforms, so I removed the "Android" specific version.