### PR TITLE
Revert "Fix disabling modal animations on iOS"

### DIFF
--- a/lib/ios/RNNAnimationsOptions.m
+++ b/lib/ios/RNNAnimationsOptions.m
@@ -7,8 +7,8 @@
 
     self.push = [[RNNScreenTransition alloc] initWithDict:dict[@"push"]];
     self.pop = [[RNNScreenTransition alloc] initWithDict:dict[@"pop"]];
-    self.showModal = [[ViewAnimationOptions alloc] initWithDict:dict[@"showModal"][@"enter"]];
-    self.dismissModal = [[ViewAnimationOptions alloc] initWithDict:dict[@"dismissModal"][@"exit"]];
+    self.showModal = [[ViewAnimationOptions alloc] initWithDict:dict[@"showModal"]];
+    self.dismissModal = [[ViewAnimationOptions alloc] initWithDict:dict[@"dismissModal"]];
     self.setStackRoot = [[RNNScreenTransition alloc] initWithDict:dict[@"setStackRoot"]];
     self.setRoot = [[TransitionOptions alloc] initWithDict:dict[@"setRoot"]];
 

--- a/lib/ios/ViewAnimationOptions.m
+++ b/lib/ios/ViewAnimationOptions.m
@@ -12,7 +12,7 @@
     self.elementTransitions = [OptionsArrayParser parse:dict
                                                     key:@"elementTransitions"
                                                 ofClass:ElementTransitionOptions.class];
-    self.enable = [BoolParser parse:dict key:@"enabled"];
+    self.enable = [BoolParser parse:dict key:@"enable"];
     self.waitForRender = [BoolParser parse:dict key:@"waitForRender"];
 
     return self;
@@ -24,10 +24,6 @@
         self.sharedElementTransitions = options.sharedElementTransitions;
     if (options.elementTransitions)
         self.elementTransitions = options.elementTransitions;
-    if (options.enable.hasValue)
-        self.enable = options.enable;
-    if (options.waitForRender.hasValue)
-        self.waitForRender = options.waitForRender;
 }
 
 - (BOOL)hasAnimation {


### PR DESCRIPTION
Reverts wix/react-native-navigation#7091 as it broke shared element transitions on iOS.