### PR TITLE
Compile jsx to plain js

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "allowJs": false,
     "target": "esnext",
     "module": "commonjs",
-    "jsx": "react-native",
+    "jsx": "react",
     "declaration": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
When configured as `react-native`, jsx is not converted to function calls https://www.typescriptlang.org/tsconfig#jsx .  This means other tools (e.g. `jest`) must themselves be configured to transpile, instead of being able to consume the js directly.