### PR TITLE
Remove jcenter from android repositories

### DIFF
--- a/playground/android/build.gradle
+++ b/playground/android/build.gradle
@@ -11,7 +11,6 @@ buildscript {
         google()
         mavenLocal()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"

--- a/playground/android/build.gradle
+++ b/playground/android/build.gradle
@@ -33,5 +33,6 @@ allprojects {
         maven { url "$rootDir/../../node_modules/detox/Detox-android" }
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
         maven { url "$rootDir/../../node_modules/jsc-android/dist" }
+        mavenCentral()
     }
 }

--- a/playground/android/build.gradle
+++ b/playground/android/build.gradle
@@ -33,6 +33,5 @@ allprojects {
         maven { url "$rootDir/../../node_modules/detox/Detox-android" }
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
         maven { url "$rootDir/../../node_modules/jsc-android/dist" }
-        jcenter()
     }
 }


### PR DESCRIPTION
JCenter is no longer supported and should be replace in all projects with `mavenCentral`.
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/