### PR TITLE
downgrade kotlin 

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleAndButtonsMeasurer.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleAndButtonsMeasurer.kt
@@ -25,7 +25,7 @@ fun makeTitleAtMostWidthMeasureSpec(containerWidth: Int, rightBarWidth: Int, lef
 
 fun resolveVerticalTitleBoundsLimit(
         parentHeight: Int,
-        titleHeight: Int,
+        titleHeight: Int
 ): Pair<TitleTop, TitleBottom> {
     return (parentHeight / 2f - titleHeight / 2f).roundToInt() to (parentHeight / 2f + titleHeight / 2f).roundToInt()
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
@@ -19,7 +19,7 @@ class TitleBarReactView(context: Context?, reactInstanceManager: ReactInstanceMa
         // It's causing infinite measurements, that hung up the UI.
         // Intercepting largest child by width, and use its width as (parent) ReactRootView width fixed that.
         // See for more details https://github.com/wix/react-native-navigation/pull/7096
-        val measuredWidth = this.children.maxByOrNull { it.measuredWidth }?.measuredWidth ?: 0
+        val measuredWidth = this.children.maxBy { it.measuredWidth }?.measuredWidth?:0
         return if (measuredWidth > 0) MeasureSpec.makeMeasureSpec(measuredWidth, MeasureSpec.EXACTLY) else
             widthMeasureSpec
     }

--- a/playground/android/build.gradle
+++ b/playground/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        kotlinVersion = "1.4.20"
+        kotlinVersion = "1.3.72"
         RNNKotlinVersion = kotlinVersion
         detoxKotlinVersion = kotlinVersion
     }


### PR DESCRIPTION
Moving to Kortlin 1.4 is a breaking change, applying proper changes, delaying 1.4 to RNN v8 #7034.

CC: @yogevbd 