### PR TITLE
Use `maxByOrNull` instead of `maxBy`

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
@@ -19,7 +19,7 @@ class TitleBarReactView(context: Context?, reactInstanceManager: ReactInstanceMa
         // It's causing infinite measurements, that hung up the UI.
         // Intercepting largest child by width, and use its width as (parent) ReactRootView width fixed that.
         // See for more details https://github.com/wix/react-native-navigation/pull/7096
-        val measuredWidth = this.children.maxBy { it.measuredWidth }?.measuredWidth?:0
+        val measuredWidth = this.children.maxByOrNull { it.measuredWidth }?.measuredWidth?:0
         return if (measuredWidth > 0) MeasureSpec.makeMeasureSpec(measuredWidth, MeasureSpec.EXACTLY) else
             widthMeasureSpec
     }

--- a/playground/android/build.gradle
+++ b/playground/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        kotlinVersion = "1.3.72"
+        kotlinVersion = "1.4.0"
         RNNKotlinVersion = kotlinVersion
         detoxKotlinVersion = kotlinVersion
     }


### PR DESCRIPTION
It's a build error for newer kotlin versions:

```
e: /home/runner/work/react-native-vision-camera/react-native-vision-camera/example/node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt: (22, 43): Using 'maxBy((T) -> R): T?' is an error. Use maxByOrNull instead.
252
> Task :react-native-navigation:compileReactNative63DebugKotlin
253
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
254
    /home/runner/.gradle/caches/transforms-2/files-2.1/d65810e7e9ccba6782eaaaa935fff121/jetified-kotlin-stdlib-jdk8-1.3.61.jar (version 1.3)
255
    /home/runner/.gradle/caches/transforms-2/files-2.1/9ade639ed327baca76145aa01efaadc9/jetified-kotlin-stdlib-jdk7-1.3.61.jar (version 1.3)
256
    /home/runner/.gradle/caches/transforms-2/files-2.1/d0198dac042863f7ac0a4c575179177b/jetified-kotlin-stdlib-1.5.0.jar (version 1.5)
257
    /home/runner/.gradle/caches/transforms-2/files-2.1/32fd5ef6b950a9b76e764a490fa54ad8/jetified-kotlin-stdlib-common-1.5.0.jar (version 1.5)
258
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath
259

260

```