### PR TITLE
Fix Kotlin 1.3 & 1.4 compatibility

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
@@ -19,7 +19,12 @@ class TitleBarReactView(context: Context?, reactInstanceManager: ReactInstanceMa
         // It's causing infinite measurements, that hung up the UI.
         // Intercepting largest child by width, and use its width as (parent) ReactRootView width fixed that.
         // See for more details https://github.com/wix/react-native-navigation/pull/7096
-        val measuredWidth = this.children.maxBy { it.measuredWidth }?.measuredWidth?:0
+        var measuredWidth = 0;
+        this.children.forEach {
+            if (it.measuredWidth > measuredWidth) {
+                measuredWidth = it.measuredWidth
+            }
+        }
         return if (measuredWidth > 0) MeasureSpec.makeMeasureSpec(measuredWidth, MeasureSpec.EXACTLY) else
             widthMeasureSpec
     }


### PR DESCRIPTION
`maxBy` was deprecated for Kotlin >= 1.4.x, while `maxByOrNull` is not supported in 1.3.x, so, for now, it's being replaced by Kotlin independent way to find child max measured width of react component.

RNN v8 may have a minimum requirement for Kotlin as 1.4 or 1.5.