### PR TITLE
Add synchronous constants call

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
@@ -78,15 +78,24 @@ public class NavigationModule extends ReactContextBaseJavaModule {
         promise.resolve(LaunchArgsParser.parse(activity()));
     }
 
-    @ReactMethod
-    public void getNavigationConstants(Promise promise) {
+    private WritableMap createNavigationConstantsMap() {
         ReactApplicationContext ctx = getReactApplicationContext();
         WritableMap constants = Arguments.createMap();
         constants.putString(Constants.BACK_BUTTON_JS_KEY, Constants.BACK_BUTTON_ID);
         constants.putDouble(Constants.BOTTOM_TABS_HEIGHT_KEY, Constants.BOTTOM_TABS_HEIGHT);
         constants.putDouble(Constants.STATUS_BAR_HEIGHT_KEY, pxToDp(ctx, StatusBarUtils.getStatusBarHeight(ctx)));
         constants.putDouble(Constants.TOP_BAR_HEIGHT_KEY, pxToDp(ctx, UiUtils.getTopBarHeight(ctx)));
-        promise.resolve(constants);
+        return constants;
+    }
+
+    @ReactMethod
+    public void getNavigationConstants(Promise promise) {
+        promise.resolve(createNavigationConstantsMap());
+    }
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    public WritableMap getNavigationConstantsSync() {
+        return createNavigationConstantsMap();
     }
 
     @ReactMethod

--- a/lib/ios/RNNBridgeModule.m
+++ b/lib/ios/RNNBridgeModule.m
@@ -244,4 +244,8 @@ RCT_EXPORT_METHOD(getNavigationConstants
     });
 }
 
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getNavigationConstantsSync) {
+    return [Constants getConstants];
+}
+
 @end

--- a/lib/src/Navigation.ts
+++ b/lib/src/Navigation.ts
@@ -293,4 +293,11 @@ export class NavigationRoot {
   public async constants(): Promise<NavigationConstants> {
     return await Constants.get();
   }
+
+  /**
+   * Constants coming from native (synchronized call)
+   */
+  public constantsSync(): NavigationConstants {
+    return Constants.getSync();
+  }
 }

--- a/lib/src/adapters/Constants.ts
+++ b/lib/src/adapters/Constants.ts
@@ -13,6 +13,10 @@ export class Constants {
     return new Constants(constants);
   }
 
+  static getSync(): NavigationConstants {
+    return new Constants(NativeModules.RNNBridgeModule.getNavigationConstantsSync());
+  }
+
   public readonly statusBarHeight: number;
   public readonly backButtonId: string;
   public readonly topBarHeight: number;


### PR DESCRIPTION
Allows getting the `NavigationConstants` synchronously. Useful wherever async waiting is not possible.