### PR TITLE
fix popTo so promise get resolved

### DIFF
--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -309,11 +309,11 @@ static NSString *const setDefaultOptions = @"setDefaultOptions";
 
     if (vc) {
         [vc.stack popTo:vc
-              animated:[vc.resolveOptionsWithDefault.animations.pop.enable withDefault:YES]
-            completion:^(NSArray *poppedViewControllers) {
-              [self->_eventEmitter sendOnNavigationCommandCompletion:popTo commandId:commandId];
-              completion();
-            }
+               animated:[vc.resolveOptionsWithDefault.animations.pop.enable withDefault:YES]
+             completion:^(NSArray *poppedViewControllers) {
+               [self->_eventEmitter sendOnNavigationCommandCompletion:popTo commandId:commandId];
+               completion();
+             }
               rejection:rejection];
     } else {
         [RNNErrorHandler

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -307,13 +307,22 @@ static NSString *const setDefaultOptions = @"setDefaultOptions";
     RNNNavigationOptions *options = [[RNNNavigationOptions alloc] initWithDict:mergeOptions];
     [vc mergeOptions:options];
 
-    [vc.stack popTo:vc
-           animated:[vc.resolveOptionsWithDefault.animations.pop.enable withDefault:YES]
-         completion:^(NSArray *poppedViewControllers) {
-           [self->_eventEmitter sendOnNavigationCommandCompletion:popTo commandId:commandId];
-           completion();
-         }
-          rejection:rejection];
+    if (vc) {
+        [vc.stack popTo:vc
+              animated:[vc.resolveOptionsWithDefault.animations.pop.enable withDefault:YES]
+            completion:^(NSArray *poppedViewControllers) {
+              [self->_eventEmitter sendOnNavigationCommandCompletion:popTo commandId:commandId];
+              completion();
+            }
+              rejection:rejection];
+    } else {
+        [RNNErrorHandler
+                      reject:rejection
+               withErrorCode:1012
+            errorDescription:
+                [NSString stringWithFormat:@"PopTo component failed - componentId '%@' not found",
+                                           componentId]];
+    }
 }
 
 - (void)popToRoot:(NSString *)componentId


### PR DESCRIPTION
This should resolve the promise even if you add a none existing componentId to `popTo`.

More context: https://github.com/wix/react-native-navigation/issues/7152