### PR TITLE
docs: Fix wrong API in example for custom button

### DIFF
--- a/website/docs/docs/docs-stack.mdx
+++ b/website/docs/docs/docs-stack.mdx
@@ -100,9 +100,12 @@ Now you can create buttons which use the component registered with `'ButtonCompo
 topBar: {
   rightButtons: [
     {
-      component: 'ButtonComponent',
-      passProps: {
-        // Pass initial props to the button here
+      id: 'custom',
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          // Pass initial props to the button here
+        },
       },
     },
   ];
@@ -121,9 +124,11 @@ topBar: {
   rightButtons: [
     {
       id: 'SomeUniqueId',
-      component: 'ButtonComponent',
-      passProps: {
-        count: 0,
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          count: 0,
+        },
       },
     },
   ];

--- a/website/docs/docs/stack-buttons.mdx
+++ b/website/docs/docs/stack-buttons.mdx
@@ -40,9 +40,11 @@ Now you can create buttons which use the component registered with `'ButtonCompo
 topBar: {
   rightButtons: [
     {
-      component: 'ButtonComponent',
-      passProps: {
-        // Pass initial props to the button here
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          // Pass initial props to the button here
+        },
       },
     },
   ];
@@ -61,10 +63,12 @@ topBar: {
   rightButtons: [
     {
       id: 'SomeUniqueId',
-      component: 'ButtonComponent',
-      passProps: {
-        count: 0,
-      },
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          count: 0
+        },
+      },,
     },
   ];
 }

--- a/website/versioned_docs/version-6.12.2/docs/docs-stack.mdx
+++ b/website/versioned_docs/version-6.12.2/docs/docs-stack.mdx
@@ -26,6 +26,7 @@ The stack manages the TopBar at the top of the stack. The TopBar displays the cu
 }>
 <TabItem value="single">
 
+
 A stack declared with a single child.
 
 ```js
@@ -42,6 +43,7 @@ const stack = {
 
 </TabItem>
 <TabItem value="multiple">
+
 
 A stack can be initialized with more than one child, in which case the last child will be the currently displayed child and the first child will be hidden. In this case the back button will be visible automatically, clicking it will go back in the stack revealing the first (previous) child.
 Once the root child becomes visible, the back button is hidden.
@@ -65,6 +67,7 @@ const stack = {
 
 </TabItem>
 </Tabs>
+
 
 ## TopBar Buttons
 
@@ -108,9 +111,11 @@ Now you can create buttons which use the component registered with `'ButtonCompo
 topBar: {
   rightButtons: [
     {
-      component: 'ButtonComponent',
-      passProps: {
-        // Pass initial props to the button here
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          // Pass initial props to the button here
+        },
       },
     },
   ];
@@ -129,10 +134,12 @@ topBar: {
   rightButtons: [
     {
       id: 'SomeUniqueId',
-      component: 'ButtonComponent',
-      passProps: {
-        count: 0,
-      },
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          count: 0
+        },
+      },,
     },
   ];
 }

--- a/website/versioned_docs/version-6.12.2/docs/stack-buttons.mdx
+++ b/website/versioned_docs/version-6.12.2/docs/stack-buttons.mdx
@@ -40,9 +40,11 @@ Now you can create buttons which use the component registered with `'ButtonCompo
 topBar: {
   rightButtons: [
     {
-      component: 'ButtonComponent',
-      passProps: {
-        // Pass initial props to the button here
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          // Pass initial props to the button here
+        },
       },
     },
   ];
@@ -61,10 +63,12 @@ topBar: {
   rightButtons: [
     {
       id: 'SomeUniqueId',
-      component: 'ButtonComponent',
-      passProps: {
-        count: 0,
-      },
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          count: 0
+        },
+      },,
     },
   ];
 }

--- a/website/versioned_docs/version-7.11.2/docs/docs-stack.mdx
+++ b/website/versioned_docs/version-7.11.2/docs/docs-stack.mdx
@@ -100,9 +100,11 @@ Now you can create buttons which use the component registered with `'ButtonCompo
 topBar: {
   rightButtons: [
     {
-      component: 'ButtonComponent',
-      passProps: {
-        // Pass initial props to the button here
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          // Pass initial props to the button here
+        },
       },
     },
   ];
@@ -121,10 +123,12 @@ topBar: {
   rightButtons: [
     {
       id: 'SomeUniqueId',
-      component: 'ButtonComponent',
-      passProps: {
-        count: 0,
-      },
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          count: 0
+        },
+      },,
     },
   ];
 }

--- a/website/versioned_docs/version-7.11.2/docs/stack-buttons.mdx
+++ b/website/versioned_docs/version-7.11.2/docs/stack-buttons.mdx
@@ -40,9 +40,11 @@ Now you can create buttons which use the component registered with `'ButtonCompo
 topBar: {
   rightButtons: [
     {
-      component: 'ButtonComponent',
-      passProps: {
-        // Pass initial props to the button here
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          // Pass initial props to the button here
+        },
       },
     },
   ];
@@ -61,10 +63,12 @@ topBar: {
   rightButtons: [
     {
       id: 'SomeUniqueId',
-      component: 'ButtonComponent',
-      passProps: {
-        count: 0,
-      },
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          count: 0
+        },
+      },,
     },
   ];
 }

--- a/website/versioned_docs/version-7.16.0/docs/docs-stack.mdx
+++ b/website/versioned_docs/version-7.16.0/docs/docs-stack.mdx
@@ -100,9 +100,11 @@ Now you can create buttons which use the component registered with `'ButtonCompo
 topBar: {
   rightButtons: [
     {
-      component: 'ButtonComponent',
-      passProps: {
-        // Pass initial props to the button here
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          // Pass initial props to the button here
+        },
       },
     },
   ];
@@ -121,10 +123,12 @@ topBar: {
   rightButtons: [
     {
       id: 'SomeUniqueId',
-      component: 'ButtonComponent',
-      passProps: {
-        count: 0,
-      },
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          count: 0
+        },
+      },,
     },
   ];
 }

--- a/website/versioned_docs/version-7.16.0/docs/stack-buttons.mdx
+++ b/website/versioned_docs/version-7.16.0/docs/stack-buttons.mdx
@@ -40,9 +40,12 @@ Now you can create buttons which use the component registered with `'ButtonCompo
 topBar: {
   rightButtons: [
     {
-      component: 'ButtonComponent',
-      passProps: {
-        // Pass initial props to the button here
+      id: 'custom',
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          // Pass initial props to the button here
+        },
       },
     },
   ];

--- a/website/versioned_docs/version-7.16.0/docs/stack-buttons.mdx
+++ b/website/versioned_docs/version-7.16.0/docs/stack-buttons.mdx
@@ -64,10 +64,12 @@ topBar: {
   rightButtons: [
     {
       id: 'SomeUniqueId',
-      component: 'ButtonComponent',
-      passProps: {
-        count: 0,
-      },
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          count: 0
+        },
+      },,
     },
   ];
 }

--- a/website/versioned_docs/version-7.7.0/docs/docs-stack.mdx
+++ b/website/versioned_docs/version-7.7.0/docs/docs-stack.mdx
@@ -100,9 +100,11 @@ Now you can create buttons which use the component registered with `'ButtonCompo
 topBar: {
   rightButtons: [
     {
-      component: 'ButtonComponent',
-      passProps: {
-        // Pass initial props to the button here
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          // Pass initial props to the button here
+        },
       },
     },
   ];
@@ -121,10 +123,12 @@ topBar: {
   rightButtons: [
     {
       id: 'SomeUniqueId',
-      component: 'ButtonComponent',
-      passProps: {
-        count: 0,
-      },
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          count: 0
+        },
+      },,
     },
   ];
 }

--- a/website/versioned_docs/version-7.7.0/docs/stack-buttons.mdx
+++ b/website/versioned_docs/version-7.7.0/docs/stack-buttons.mdx
@@ -40,9 +40,11 @@ Now you can create buttons which use the component registered with `'ButtonCompo
 topBar: {
   rightButtons: [
     {
-      component: 'ButtonComponent',
-      passProps: {
-        // Pass initial props to the button here
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          // Pass initial props to the button here
+        },
       },
     },
   ];
@@ -61,10 +63,12 @@ topBar: {
   rightButtons: [
     {
       id: 'SomeUniqueId',
-      component: 'ButtonComponent',
-      passProps: {
-        count: 0,
-      },
+      component: {
+        name: 'ButtonComponent',
+        passProps: {
+          count: 0
+        },
+      },,
     },
   ];
 }


### PR DESCRIPTION
This took me some time. For searchability, using a string instead of the object for component throws "Attempted to assign to readonly property.". Leaving out the id freezes the app (it's marked as mandatory in the button docs).