### PR TITLE
Activity lifecycle send DidAppear & Disappear 

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
@@ -54,6 +54,12 @@ public class NavigationModule extends ReactContextBaseJavaModule {
         this.layoutFactory = layoutFactory;
         reactContext.addLifecycleEventListener(new LifecycleEventListenerAdapter() {
             @Override
+            public void onHostPause() {
+                super.onHostPause();
+                navigator().onHostPause();
+            }
+
+            @Override
             public void onHostResume() {
                 eventEmitter = new EventEmitter(reactContext);
                 navigator().setEventEmitter(eventEmitter);
@@ -63,6 +69,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                         navigator().getChildRegistry(),
                         ((NavigationApplication) activity().getApplication()).getExternalComponents()
                 );
+                navigator().onHostResume();
             }
         });
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/navigator/Navigator.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/navigator/Navigator.java
@@ -256,4 +256,11 @@ public class Navigator extends ParentController {
     CoordinatorLayout getOverlaysLayout() {
         return overlaysLayout;
     }
+
+    public void onHostPause() {
+        super.onViewDisappear();
+    }
+    public void onHostResume(){
+        super.onViewDidAppear();
+    }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/parent/ParentController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/parent/ParentController.java
@@ -45,7 +45,16 @@ public abstract class ParentController<T extends ViewGroup> extends ChildControl
 
     @Override
     public void onViewDidAppear() {
-        getCurrentChild().onViewDidAppear();
+        super.onViewDidAppear();
+        ViewController currentChild = getCurrentChild();
+        if (currentChild != null) currentChild.onViewDidAppear();
+    }
+
+    @Override
+    public void onViewDisappear() {
+        super.onViewDisappear();
+        ViewController currentChild = getCurrentChild();
+        if (currentChild != null) currentChild.onViewDisappear();
     }
 
     @Override

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/NavigatorTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/NavigatorTest.java
@@ -143,6 +143,22 @@ public class NavigatorTest extends BaseTest {
     }
 
     @Test
+    public void shouldCallOnViewDidAppearWhenHostResumes() {
+        SimpleViewController child1 = spy(this.child1);
+        uut.setRoot(child1, new CommandListenerAdapter(), reactInstanceManager);
+        uut.onHostResume();
+        verify(child1,times(2)).onViewDidAppear();
+    }
+
+    @Test
+    public void shouldCallOnViewDisappearWhenHostPauses() {
+        SimpleViewController child1 = spy(this.child1);
+        uut.setRoot(child1, new CommandListenerAdapter(), reactInstanceManager);
+        uut.onHostPause();
+        verify(child1).onViewDidAppear();
+    }
+
+    @Test
     public void setDefaultOptions() {
         uut.setDefaultOptions(new Options());
 
@@ -160,10 +176,9 @@ public class NavigatorTest extends BaseTest {
         CommandListenerAdapter listener = new CommandListenerAdapter();
         uut.setRoot(child1, listener, reactInstanceManager);
         ArgumentCaptor<CommandListenerAdapter> captor = ArgumentCaptor.forClass(CommandListenerAdapter.class);
-        verify(rootPresenter).setRoot(eq(child1), eq(null),eq(uut.getDefaultOptions()), captor.capture(), eq(reactInstanceManager));
+        verify(rootPresenter).setRoot(eq(child1), eq(null), eq(uut.getDefaultOptions()), captor.capture(), eq(reactInstanceManager));
         assertThat(captor.getValue().getListener()).isEqualTo(listener);
     }
-
 
 
     @Test

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/parent/ParentControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/parent/ParentControllerTest.java
@@ -30,6 +30,7 @@ import static com.reactnativenavigation.utils.CollectionUtils.*;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -83,6 +84,31 @@ public class ParentControllerTest extends BaseTest {
         });
     }
 
+    @Test
+    public void onViewDidAppearShouldCallCurrentChildDidAppear(){
+        SimpleViewController child1 = spy(new SimpleViewController(activity, childRegistry, "child1", new Options()));
+        SimpleViewController child2 = spy(new SimpleViewController(activity, childRegistry, "child2", new Options()));
+        children.add(child1);
+        children.add(child2);
+
+        uut.onViewDidAppear();
+
+        verify(child1).onViewDidAppear();
+        verify(child2,never()).onViewDidAppear();
+    }
+
+    @Test
+    public void onViewDisappearShouldCallCurrentChildDisAppear(){
+        SimpleViewController child1 = spy(new SimpleViewController(activity, childRegistry, "child1", new Options()));
+        SimpleViewController child2 = spy(new SimpleViewController(activity, childRegistry, "child2", new Options()));
+        children.add(child1);
+        children.add(child2);
+
+        uut.onViewDisappear();
+
+        verify(child1).onViewDisappear();
+        verify(child2,never()).onViewDisappear();
+    }
     @Test
     public void holdsViewGroup() {
         assertThat(uut.getView()).isInstanceOf(ViewGroup.class);


### PR DESCRIPTION
## Issue:
When the app switches to BG or a new activity is opened, appearance events did not get sent to the RN side, since it's logical to have them sent when the app is not visible, which means every visible component now is invisible, and vice versa.

## Fix:
Support sending `DidAppear/Disappear` events when activity changes visibility state, `OnPause` & `OnResume`.

Closes: #7158 