### PR TITLE
Warn when calling mergeOptions before component is mounted

### DIFF
--- a/lib/src/commands/Commands.ts
+++ b/lib/src/commands/Commands.ts
@@ -75,6 +75,12 @@ export class Commands {
     const input = cloneDeep(options);
     this.optionsProcessor.processOptions(input, CommandName.MergeOptions);
 
+    const component = this.store.getComponentInstance(componentId);
+    if (component && !component.isMounted)
+      console.warn(
+        `Navigation.mergeOptions was invoked on component with id: ${componentId} before it is mounted, this can cause UI issues and should be avoided.\n Use static options instead.`
+      );
+
     this.nativeCommandsSender.mergeOptions(componentId, input);
     this.commandsObserver.notify(CommandName.MergeOptions, { componentId, options });
   }

--- a/lib/src/components/ComponentWrapper.test.tsx
+++ b/lib/src/components/ComponentWrapper.test.tsx
@@ -286,4 +286,41 @@ describe('ComponentWrapper', () => {
       expect((NavigationComponent as any).options()).toEqual({ foo: 123 });
     });
   });
+
+  it('initialize isMounted with false value', () => {
+    const NavigationComponent = uut.wrap(
+      componentName,
+      () => MyComponent,
+      store,
+      componentEventsObserver
+    );
+    new NavigationComponent({ componentId: 'component123' });
+    expect(store.getComponentInstance('component123')?.isMounted).toEqual(false);
+  });
+
+  it('updates isMounted on componentDidMount', () => {
+    const NavigationComponent = uut.wrap(
+      componentName,
+      () => MyComponent,
+      store,
+      componentEventsObserver
+    );
+
+    renderer.create(<NavigationComponent componentId={'component123'} />);
+    expect(store.getComponentInstance('component123')?.isMounted).toEqual(true);
+  });
+
+  it('clears isMounted on componentDidUnmount', () => {
+    const NavigationComponent = uut.wrap(
+      componentName,
+      () => MyComponent,
+      store,
+      componentEventsObserver
+    );
+
+    const tree = renderer.create(<NavigationComponent componentId={'component123'} />);
+    expect(store.getComponentInstance('component123')?.isMounted).toEqual(true);
+    tree.unmount();
+    expect(store.getComponentInstance('component123')?.isMounted).toBeUndefined();
+  });
 });

--- a/lib/src/components/ComponentWrapper.tsx
+++ b/lib/src/components/ComponentWrapper.tsx
@@ -16,6 +16,7 @@ interface HocProps {
 
 export interface IWrappedComponent extends React.Component {
   setProps(newProps: Record<string, any>): void;
+  isMounted: boolean;
 }
 
 export class ComponentWrapper {
@@ -39,6 +40,12 @@ export class ComponentWrapper {
         };
       }
 
+      private _isMounted = false;
+
+      get isMounted() {
+        return this._isMounted;
+      }
+
       constructor(props: HocProps) {
         super(props);
         this._assertComponentId();
@@ -56,6 +63,10 @@ export class ComponentWrapper {
             ...newProps,
           },
         }));
+      }
+
+      componentDidMount() {
+        this._isMounted = true;
       }
 
       componentWillUnmount() {

--- a/lib/src/components/Store.ts
+++ b/lib/src/components/Store.ts
@@ -54,7 +54,7 @@ export class Store {
     this.componentsInstancesById[id] = component;
   }
 
-  getComponentInstance(id: string): IWrappedComponent {
+  getComponentInstance(id: string): IWrappedComponent | undefined {
     return this.componentsInstancesById[id];
   }
 


### PR DESCRIPTION
Invoking `Navigation.mergeOptions()` before the component is mounted is wrong and can cause flickering UI as it updates the native views while the screen is in the middle of the presentation animation.

For that we have the static options which should always be used when we want to initialise the screen with options.