### PR TITLE
Added `constantsSync` to delegate, updated docs

### DIFF
--- a/lib/src/NavigationDelegate.ts
+++ b/lib/src/NavigationDelegate.ts
@@ -215,6 +215,10 @@ export class NavigationDelegate {
     return await this.concreteNavigation.constants();
   }
 
+  public constantsSync(): NavigationConstants {
+    return this.concreteNavigation.constantsSync();
+  }
+
   get TouchablePreview() {
     return this.concreteNavigation.TouchablePreview;
   }

--- a/website/docs/docs/style-constants.mdx
+++ b/website/docs/docs/style-constants.mdx
@@ -12,11 +12,16 @@ Some of the values exposed through the constants API are actually evaluated only
 For example, if you need to get the height of the BottomTabs, you'll first need to have BottomTabs visible on the screen and only then retrieve their height via the constants API.
 
 :::important
-We recommend you don't cache the actual constants object returned by `await Navigation.constants()` as it might not be accurate later on when, for example, a new root is set or orientation changes.
+We recommend you don't cache the actual constants object returned by `await Navigation.constants()` or `Navigation.constantsSync()` as it might not be accurate later on when, for example, a new root is set or orientation changes.
 :::
 
 ## API
-As explained above, constants are evaluated in native each time the API is invoked. That's why `Navigation.constants()` returns a promise and the use is as follows:
+As explained above, constants are evaluated in native each time the API is invoked. There are two methods for accessing constants:
+
+- `Navigation.constants()`, which is async and thus returns a promise
+- `Navigation.constantsSync()`, which returns the constants synchronously, blocking the main thread
+
+Where possible, it is better to use the async method, since this will not block the main thread.
 
 ```js
 const { Navigation } = require('react-native-navigation');
@@ -25,4 +30,15 @@ const {
   topBarHeight,
   bottomTabsHeight
 } = await Navigation.constants();
+```
+
+But, if you need to access the constants synchronously (e.g. within the `render()` method of a React component), you can do so as follows:
+
+```js
+const { Navigation } = require('react-native-navigation');
+const {
+  statusBarHeight,
+  topBarHeight,
+  bottomTabsHeight
+} = Navigation.constantsSync();
 ```


### PR DESCRIPTION
`Navigation.constantsSync()` was introduced in [v7.17.1](https://github.com/wix/react-native-navigation/releases/tag/7.17.1) but is not accessible on the `Navigation` object. This PR fixes that, and adds some documentation for the new method.