### PR TITLE
Render original top bar image when no color provided

### DIFF
--- a/lib/ios/RNNUIBarButtonItem.m
+++ b/lib/ios/RNNUIBarButtonItem.m
@@ -124,7 +124,9 @@
         [titleTextAttributes setValue:color forKey:NSForegroundColorAttributeName];
         [self setTitleTextAttributes:titleTextAttributes forState:UIControlStateNormal];
         [self setTitleTextAttributes:titleTextAttributes forState:UIControlStateHighlighted];
-    }
+    } else
+        self.image = [self.image imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+
     self.tintColor = color;
 }
 


### PR DESCRIPTION
Currently on iOS, adding top bar buttons with no color always fallbacks to the system default tint color. This behaviour makes rendering the original image impossible.

Closes #6934