### PR TITLE
Fix persenting react-native modals from overlays

### DIFF
--- a/lib/ios/RNNOverlayWindow.m
+++ b/lib/ios/RNNOverlayWindow.m
@@ -1,5 +1,6 @@
 #import "RNNOverlayWindow.h"
 #import "RNNReactView.h"
+#import <React/RCTModalHostView.h>
 
 @implementation RNNOverlayWindow
 
@@ -7,7 +8,8 @@
     UIView *hitTestResult = [super hitTest:point withEvent:event];
 
     if ([hitTestResult isKindOfClass:[UIWindow class]] ||
-        [hitTestResult.subviews.firstObject isKindOfClass:RNNReactView.class]) {
+        [hitTestResult.subviews.firstObject isKindOfClass:RNNReactView.class] ||
+        [hitTestResult isKindOfClass:[RCTModalHostView class]]) {
         return nil;
     }
 


### PR DESCRIPTION
Presenting react-native declarative modals from an overlay freeze the app as the overlay window didn't pass the touch event to the underlying window.