### PR TITLE
Disable button animations on iOS by default

### DIFF
--- a/lib/ios/RNNComponentPresenter.m
+++ b/lib/ios/RNNComponentPresenter.m
@@ -92,14 +92,15 @@
         [_buttonsPresenter applyLeftButtons:withDefault.topBar.leftButtons
                                defaultColor:withDefault.topBar.leftButtonColor
                        defaultDisabledColor:withDefault.topBar.leftButtonDisabledColor
-                                   animated:withDefault.topBar.animateLeftButtons];
+                                   animated:[withDefault.topBar.animateLeftButtons withDefault:NO]];
     }
 
     if (withDefault.topBar.rightButtons) {
-        [_buttonsPresenter applyRightButtons:withDefault.topBar.rightButtons
-                                defaultColor:withDefault.topBar.rightButtonColor
-                        defaultDisabledColor:withDefault.topBar.rightButtonDisabledColor
-                                    animated:withDefault.topBar.animateRightButtons];
+        [_buttonsPresenter
+               applyRightButtons:withDefault.topBar.rightButtons
+                    defaultColor:withDefault.topBar.rightButtonColor
+            defaultDisabledColor:withDefault.topBar.rightButtonDisabledColor
+                        animated:[withDefault.topBar.animateRightButtons withDefault:NO]];
     }
 }
 
@@ -196,14 +197,15 @@
         [_buttonsPresenter applyLeftButtons:mergeOptions.topBar.leftButtons
                                defaultColor:withDefault.topBar.leftButtonColor
                        defaultDisabledColor:withDefault.topBar.leftButtonDisabledColor
-                                   animated:withDefault.topBar.animateLeftButtons];
+                                   animated:[withDefault.topBar.animateLeftButtons withDefault:NO]];
     }
 
     if (mergeOptions.topBar.rightButtons) {
-        [_buttonsPresenter applyRightButtons:mergeOptions.topBar.rightButtons
-                                defaultColor:withDefault.topBar.rightButtonColor
-                        defaultDisabledColor:withDefault.topBar.rightButtonDisabledColor
-                                    animated:withDefault.topBar.animateRightButtons];
+        [_buttonsPresenter
+               applyRightButtons:mergeOptions.topBar.rightButtons
+                    defaultColor:withDefault.topBar.rightButtonColor
+            defaultDisabledColor:withDefault.topBar.rightButtonDisabledColor
+                        animated:[withDefault.topBar.animateRightButtons withDefault:NO]];
     }
 
     if (mergeOptions.topBar.leftButtonColor.hasValue) {

--- a/playground/ios/NavigationTests/RNNComponentPresenterTest.m
+++ b/playground/ios/NavigationTests/RNNComponentPresenterTest.m
@@ -64,8 +64,30 @@
     XCTAssertFalse(self.boundViewController.navigationItem.hidesBackButton);
 }
 
+- (void)testApplyOptions_defaultAnimateLeftButtonsFalse {
+    RNNButtonOptions *button = [RNNButtonOptions new];
+    self.options.topBar.leftButtons = @[ button ];
+    [[self.buttonsPresenter expect] applyLeftButtons:self.options.topBar.leftButtons
+                                        defaultColor:OCMArg.any
+                                defaultDisabledColor:OCMArg.any
+                                            animated:NO];
+    [self.uut applyOptions:self.options];
+    [self.buttonsPresenter verify];
+}
+
+- (void)testApplyOptions_defaultAnimateRightButtonsFalse {
+    RNNButtonOptions *button = [RNNButtonOptions new];
+    self.options.topBar.rightButtons = @[ button ];
+    [[self.buttonsPresenter expect] applyRightButtons:self.options.topBar.rightButtons
+                                         defaultColor:OCMArg.any
+                                 defaultDisabledColor:OCMArg.any
+                                             animated:NO];
+    [self.uut applyOptions:self.options];
+    [self.buttonsPresenter verify];
+}
+
 - (void)testApplyOptions_animateLeftButtons {
-    self.options.topBar.animateLeftButtons = [Bool withValue:NO];
+    self.options.topBar.animateLeftButtons = [Bool withValue:YES];
     RNNButtonOptions *button = [RNNButtonOptions new];
     self.options.topBar.leftButtons = @[ button ];
     [[self.buttonsPresenter expect] applyLeftButtons:self.options.topBar.leftButtons


### PR DESCRIPTION
When we added button animations feature, our intention was to disable it by default for backward compatibility. 

Closes #7168