### PR TITLE
Add missing displayMode from RNNBackButtonOptions

### DIFF
--- a/lib/ios/RNNBackButtonOptions.m
+++ b/lib/ios/RNNBackButtonOptions.m
@@ -45,6 +45,8 @@
         self.fontSize = options.fontSize;
     if (options.enableMenu.hasValue)
         self.enableMenu = options.enableMenu;
+    if (options.displayMode.hasValue)
+        self.displayMode = options.displayMode;
     if (options.popStackOnPress.hasValue)
         self.popStackOnPress = options.popStackOnPress;
 }


### PR DESCRIPTION
Fixes #7208 This allows displayMode on iOS to actually function (ish. The if clause in L192 of TopBarPresenter.m at least can enter now, but displayMode is not respected).

Note: L192 of TopBarPresenter.m needs reworking of the logic in order to accommodate for the showTitle option. For some reason, current implementation does not respect displayMode minimal. However, like what the original comment said, if you just comment out L199, it'll just "work". Additionally, if someone specifies a displayMode of "default" with some kind of color, then the backItem is not actually used in the current implementation and thus is an unexpected behavior.

So L199 always executes for some reason? This table summarizes how because L199 is executed, the title still appears: https://sarunw.com/posts/new-way-to-manage-back-button-title-in-ios14/#summary