### PR TITLE
Badge cleared dismissing modal Fix

### DIFF
--- a/e2e/BottomTabs.test.js
+++ b/e2e/BottomTabs.test.js
@@ -33,6 +33,16 @@ describe('BottomTabs', () => {
     await expect(element(by.text('NEW'))).toBeVisible();
   });
 
+  it.only('Badge not cleared after showing/dismissing modal', async () => {
+    await elementById(TestIDs.SECOND_TAB_BAR_BTN).tap();
+    await elementById(TestIDs.SET_BADGE_BTN).tap();
+    await expect(element(by.text('Badge'))).toBeVisible();
+    await elementById(TestIDs.MODAL_BTN).tap();
+    await elementById(TestIDs.MODAL_BTN).tap();
+    await elementById(TestIDs.DISMISS_MODAL_BTN).tap();
+    await expect(element(by.text('Badge'))).toBeVisible();
+  });
+
   it('set empty string badge on a current Tab should clear badge', async () => {
     await elementById(TestIDs.SET_BADGE_BTN).tap();
     await expect(element(by.text('NEW'))).toBeVisible();

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabPresenter.java
@@ -67,7 +67,8 @@ public class BottomTabPresenter {
                 if (tab.fontSize.hasValue()) bottomTabs.setTitleInactiveTextSizeInSp(i, Float.valueOf(tab.fontSize.get()));
                 if (tab.selectedFontSize.hasValue()) bottomTabs.setTitleActiveTextSizeInSp(i, Float.valueOf(tab.selectedFontSize.get()));
                 if (tab.testId.hasValue()) bottomTabs.setTag(i, tab.testId.get());
-                if (shouldApplyDot(tab)) applyDotIndicator(i, tab.dotIndicator); else applyBadge(i, tab);
+                if (shouldApplyDot(tab)) applyDotIndicator(i, tab.dotIndicator);
+                if (tab.badge.hasValue()) applyBadge(i, tab);
             }
         });
     }
@@ -131,11 +132,9 @@ public class BottomTabPresenter {
     }
 
     private void mergeBadge(int index, BottomTabOptions tab) {
-        if (bottomTabs == null) return;
-        if (!tab.badge.hasValue()) return;
+        if (bottomTabs == null || !tab.badge.hasValue()) return;
         AHNotification.Builder builder = new AHNotification.Builder();
         if (tab.badge.hasValue()) builder.setText(tab.badge.get());
-        if (tab.badgeColor.hasValue()) builder.setBackgroundColor(tab.badgeColor.get());
         if (tab.badgeColor.hasValue()) builder.setBackgroundColor(tab.badgeColor.get());
         if (tab.animateBadge.hasValue()) builder.animate(tab.animateBadge.get());
         bottomTabs.perform(bottomTabs -> bottomTabs.setNotification(builder.build(), index));
@@ -167,7 +166,8 @@ public class BottomTabPresenter {
                 if (tab.iconColor.canApplyValue()) bottomTabs.setIconInactiveColor(i, tab.iconColor.get(null));
                 bottomTabs.setTitleActiveColor(i, tab.selectedTextColor.get(null));
                 bottomTabs.setTitleInactiveColor(i, tab.textColor.get(null));
-                if (shouldApplyDot(tab)) applyDotIndicator(i, tab.dotIndicator); else applyBadge(i, tab);
+                if (shouldApplyDot(tab)) applyDotIndicator(i, tab.dotIndicator);
+                if (tab.badge.hasValue()) applyBadge(i, tab);
             }
         });
     }

--- a/playground/src/screens/SecondBottomTabScreen.tsx
+++ b/playground/src/screens/SecondBottomTabScreen.tsx
@@ -11,10 +11,12 @@ const {
   SIDE_MENU_INSIDE_BOTTOM_TABS_BTN,
   PUSH_BTN,
   PUSHED_BOTTOM_TABS,
+  MODAL_BTN,
   SIDE_MENU_TAB,
   FLAT_LIST_BTN,
   HIDE_TABS_PUSH_BTN,
   SECOND_TAB_BAR_BTN,
+  SET_BADGE_BTN,
 } = testIDs;
 
 export default class SecondBottomTabScreen extends React.Component<NavigationComponentProps> {
@@ -42,6 +44,9 @@ export default class SecondBottomTabScreen extends React.Component<NavigationCom
       <Root componentId={this.props.componentId}>
         <Button label="Push" onPress={this.push} />
         <Button label="Push BottomTabs" testID={PUSH_BTN} onPress={this.pushBottomTabs} />
+        <Button label="Push Modal" testID={MODAL_BTN} onPress={this.pushModal} />
+        <Button label="SetBadge" testID={SET_BADGE_BTN} onPress={this.setBadge} />
+
         <Button label="Push ScrollView" onPress={this.pushScrollView} />
         <Button
           label="SideMenu inside BottomTabs"
@@ -66,6 +71,15 @@ export default class SecondBottomTabScreen extends React.Component<NavigationCom
     );
 
   push = () => Navigation.push(this, Screens.Pushed);
+
+  pushModal = async () => await Navigation.push(this, Screens.Modal);
+
+  setBadge = () =>
+    Navigation.mergeOptions(this, {
+      bottomTab: {
+        badge: 'Badge',
+      },
+    });
 
   pushBottomTabs = () =>
     Navigation.push(this, {


### PR DESCRIPTION
# Issue:

Badge got cleared on this flow:
- set badge on a tab
- Push a screen
- open a modal from the pushed screen
- dismiss modal
- badge got cleared

# Fix:

Prevent applying empty badge when there is no value 