### PR TITLE
Update api-events.mdx

### DIFF
--- a/website/versioned_docs/version-7.16.0/api/api-events.mdx
+++ b/website/versioned_docs/version-7.16.0/api/api-events.mdx
@@ -177,7 +177,7 @@ modalDismissedListener.remove();
 
 ## registerModalAttemptedToDismissListener(iOS 13+ only)
 
-Invoked only on iOS pageSheet modal when `swipeToDismiss` flag is set to true and modal was swiped down to dismiss.
+Invoked only on iOS pageSheet modal when `swipeToDismiss` flag is set to false and modal was swiped down to dismiss.
 
 ```js
 // Subscribe


### PR DESCRIPTION
When testing the `registerModalAttemptedToDismissListener` event, I noticed that I had to set the `swipeToDismiss` flag to false. The docs currently falsely indicate it should be `true`