### PR TITLE
Declarative  modals

### DIFF
--- a/lib/src/components/RNNModal.tsx
+++ b/lib/src/components/RNNModal.tsx
@@ -18,11 +18,22 @@ let incID = 0;
 export class RNNModal extends React.Component<RNNModalProps> {
   private displayed: boolean;
   private modalId: string;
+  private dismissEventListener?: any;
   constructor(props: RNNModalProps) {
     super(props);
     this.modalId = `RNNModal${++incID}`;
     this.displayed = false;
     this.registerModalComponent();
+  }
+  componentDidMount() {
+    this.dismissEventListener = Navigation.events().registerModalDismissedListener((event) => {
+      if (event.componentId === this.modalId) {
+        this.displayed = false;
+      }
+    });
+  }
+  componentWillUnmount() {
+    this.dismissEventListener?.remove();
   }
   registerModalComponent() {
     let component: NavigationFunctionComponent<RNNModalProps> = (modalProps) => {
@@ -34,7 +45,7 @@ export class RNNModal extends React.Component<RNNModalProps> {
     };
     Navigation.registerComponent(this.modalId, () => component);
   }
-  render() {
+  componentDidUpdate() {
     if (this.props.visible === true && !this.displayed) {
       Navigation.showModal({
         component: {
@@ -49,7 +60,9 @@ export class RNNModal extends React.Component<RNNModalProps> {
       }
       this.displayed = false;
     }
-    return null;
+  }
+  render() {
+    return <></>;
   }
 }
 

--- a/lib/src/components/RNNModal.tsx
+++ b/lib/src/components/RNNModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ViewProps, StyleSheet, View, BackHandler } from 'react-native';
+import { ViewProps, StyleSheet, BackHandler, SafeAreaView } from 'react-native';
 import { Navigation } from '..'; // this is cyclic we must have a fix!!
 import { NavigationFunctionComponent } from '../interfaces/NavigationFunctionComponent';
 
@@ -37,9 +37,9 @@ export class RNNModal extends React.Component<RNNModalProps> {
   registerModalComponent() {
     let component: NavigationFunctionComponent<RNNModalProps> = (modalProps) => {
       return (
-        <View style={styles.container} {...modalProps}>
+        <SafeAreaView style={styles.container} {...modalProps}>
           {this.props.children}
-        </View>
+        </SafeAreaView>
       );
     };
     Navigation.registerComponent(this.modalId, () => component);
@@ -71,6 +71,6 @@ const styles = StyleSheet.create({
   },
   container: {
     // top: 0,
-    // flex: 1,
+    flex: 1,
   },
 });

--- a/lib/src/components/RNNModal.tsx
+++ b/lib/src/components/RNNModal.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { ViewProps, StyleSheet, View } from 'react-native';
+import { Navigation } from '..'; // this is cyclic we must have a fix!!
+import { NavigationFunctionComponent } from '../interfaces/NavigationFunctionComponent';
+
+export interface RNNModalProps extends ViewProps {
+  animationType?: 'none' | 'slide' | 'fade' | null;
+  presentationStyle?: 'fullScreen' | 'pageSheet' | 'formSheet' | 'overFullScreen' | null;
+  transparent?: boolean;
+  statusBarTranslucent?: boolean;
+  hardwareAccelerated?: boolean;
+  visible?: boolean;
+  //TODO extend to have more of ModalOptions
+}
+
+let incID = 0;
+
+export class RNNModal extends React.Component<RNNModalProps> {
+  private displayed: boolean;
+  private modalId: string;
+  constructor(props: RNNModalProps) {
+    super(props);
+    this.modalId = `RNNModal${++incID}`;
+    this.displayed = false;
+    this.registerModalComponent();
+  }
+  registerModalComponent() {
+    let component: NavigationFunctionComponent<RNNModalProps> = (modalProps) => {
+      return (
+        <View style={styles.container} {...modalProps}>
+          {this.props.children}
+        </View>
+      );
+    };
+    Navigation.registerComponent(this.modalId, () => component);
+  }
+  render() {
+    if (this.props.visible === true && !this.displayed) {
+      Navigation.showModal({
+        component: {
+          id: this.modalId,
+          name: this.modalId,
+        },
+      });
+      this.displayed = true;
+    } else {
+      if (this.displayed) {
+        Navigation.dismissModal(this.modalId);
+      }
+      this.displayed = false;
+    }
+    return null;
+  }
+}
+
+const styles = StyleSheet.create({
+  modal: {
+    //s: 'absolute',
+  },
+  container: {
+    top: 0,
+    flex: 1,
+  },
+});

--- a/lib/src/components/RNNModal.tsx
+++ b/lib/src/components/RNNModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ViewProps, StyleSheet, View } from 'react-native';
+import { ViewProps, StyleSheet, View, BackHandler } from 'react-native';
 import { Navigation } from '..'; // this is cyclic we must have a fix!!
 import { NavigationFunctionComponent } from '../interfaces/NavigationFunctionComponent';
 
@@ -18,7 +18,7 @@ let incID = 0;
 export class RNNModal extends React.Component<RNNModalProps> {
   private displayed: boolean;
   private modalId: string;
-  private dismissEventListener?: any;
+  private backHandler?: any;
   constructor(props: RNNModalProps) {
     super(props);
     this.modalId = `RNNModal${++incID}`;
@@ -26,14 +26,13 @@ export class RNNModal extends React.Component<RNNModalProps> {
     this.registerModalComponent();
   }
   componentDidMount() {
-    this.dismissEventListener = Navigation.events().registerModalDismissedListener((event) => {
-      if (event.componentId === this.modalId) {
-        this.displayed = false;
-      }
+    this.backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
+      this.displayed = false;
+      return false;
     });
   }
   componentWillUnmount() {
-    this.dismissEventListener?.remove();
+    this.backHandler?.remove();
   }
   registerModalComponent() {
     let component: NavigationFunctionComponent<RNNModalProps> = (modalProps) => {
@@ -45,8 +44,8 @@ export class RNNModal extends React.Component<RNNModalProps> {
     };
     Navigation.registerComponent(this.modalId, () => component);
   }
-  componentDidUpdate() {
-    if (this.props.visible === true && !this.displayed) {
+  componentDidUpdate(prevProps: RNNModalProps) {
+    if (this.props.visible !== prevProps.visible && !this.displayed) {
       Navigation.showModal({
         component: {
           id: this.modalId,
@@ -71,7 +70,7 @@ const styles = StyleSheet.create({
     //s: 'absolute',
   },
   container: {
-    top: 0,
-    flex: 1,
+    // top: 0,
+    // flex: 1,
   },
 });

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -3,6 +3,7 @@ const navigationDelegate = new NavigationDelegate();
 
 export const Navigation = navigationDelegate;
 export * from './events/EventsRegistry';
+export * from './components/RNNModal';
 export * from './adapters/Constants';
 export * from './interfaces/ComponentEvents';
 export * from './interfaces/Events';

--- a/playground/src/screens/LayoutsScreen.tsx
+++ b/playground/src/screens/LayoutsScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  RNNModal,
   Options,
   OptionsModalPresentationStyle,
   NavigationComponent,
@@ -25,6 +26,7 @@ const {
 
 interface State {
   componentDidAppear: boolean;
+  declaredModalVisible: boolean;
 }
 
 export default class LayoutsScreen extends NavigationComponent<NavigationComponentProps, State> {
@@ -33,6 +35,7 @@ export default class LayoutsScreen extends NavigationComponent<NavigationCompone
     Navigation.events().bindComponent(this);
     this.state = {
       componentDidAppear: false,
+      declaredModalVisible: false,
     };
   }
 
@@ -60,6 +63,12 @@ export default class LayoutsScreen extends NavigationComponent<NavigationCompone
         <Button label="Stack" testID={STACK_BTN} onPress={this.stack} />
         <Button label="BottomTabs" testID={BOTTOM_TABS_BTN} onPress={this.bottomTabs} />
         <Button label="SideMenu" testID={SIDE_MENU_BTN} onPress={this.sideMenu} />
+        <Button label="DeclaredModal" onPress={this.toggleDeclaredModal} />
+        <RNNModal visible={this.state.declaredModalVisible}>
+          <Button label="Dismiss" onPress={this.toggleDeclaredModal} />
+          <Button label="Dismiss" onPress={this.toggleDeclaredModal} />
+          <Button label="Dismiss" onPress={this.toggleDeclaredModal} />
+        </RNNModal>
         <Button
           label="SplitView"
           testID={SPLIT_VIEW_BUTTON}
@@ -124,6 +133,10 @@ export default class LayoutsScreen extends NavigationComponent<NavigationCompone
         },
       },
     });
+
+  toggleDeclaredModal = () => {
+    this.setState({ declaredModalVisible: !this.state.declaredModalVisible });
+  };
 
   splitView = () => {
     Navigation.setRoot({


### PR DESCRIPTION
## Motivation

We have our own declarative style modals, which can be used like ReactNative modals.
When using ReactNative modals it causes a problematic behaviour since those components are displayed out of our rules (order of modals and overlays), on Android they use Dialog which creates a DecorView on top of all views.

## Concept

We are defining a "Host" Component which will be the host, no render, and we will build a new component that "hunts" the host children and call `Navigation.registerComponent` , and manage visibility by calling `showModal/dismissModal`.

## Demo

https://user-images.githubusercontent.com/7227793/130560536-b79fb961-8c52-4ef1-ac60-4c70131a13ba.mov


https://user-images.githubusercontent.com/7227793/130591368-1554f374-62c4-4743-a16d-68f399749368.mov


# Missing stuff:

- Updating the declared modal code while showing (for devs) not working, the dev should dismiss and show.
- Adding more options that work with our modals system.
- Documentation.


