### PR TITLE
Status bar updates causes ui freeze on some devices

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/Presenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/Presenter.java
@@ -136,15 +136,21 @@ public class Presenter {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return;
 
         final View view = activity.getWindow().getDecorView();
+        //This is a HACK, in certain devices, posted to DecorView queue
+        //in order to prevent ui freeze on certain devices: Samsungs with Android 9.
+        //When calling mergeOptions inside useEffect that has fast enough fetch that
+        //resolves before window even got to change, this way we can grant changes for status bar
+        //will be called in the correct order.
+        view.post(()->{
+            int flags = view.getSystemUiVisibility();
+            if (isDarkTextColorScheme(statusBar)) {
+                flags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+            } else {
+                flags &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+            }
 
-        int flags = view.getSystemUiVisibility();
-        if (isDarkTextColorScheme(statusBar)) {
-            flags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
-        } else {
-            flags &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
-        }
-        
-        view.setSystemUiVisibility(flags);
+            view.setSystemUiVisibility(flags);
+        });
     }
 
     private void mergeStatusBarOptions(View view, StatusBarOptions statusBar) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/Presenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/Presenter.java
@@ -136,11 +136,8 @@ public class Presenter {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return;
 
         final View view = activity.getWindow().getDecorView();
-        //This is a HACK, in certain devices, posted to DecorView queue
-        //in order to prevent ui freeze on certain devices: Samsungs with Android 9.
-        //When calling mergeOptions inside useEffect that has fast enough fetch that
-        //resolves before window even got to change, this way we can grant changes for status bar
-        //will be called in the correct order.
+        //View.post is a Workaround, added to solve internal Samsung 
+        //Android 9 issues. For more info see https://github.com/wix/react-native-navigation/pull/7231
         view.post(()->{
             int flags = view.getSystemUiVisibility();
             if (isDarkTextColorScheme(statusBar)) {


### PR DESCRIPTION
Modify flags for DecorView in the global main thread handler caused ui to freeze when calling `mergeOptions` inside useEffect.
This happens on Samsung devices with Android 9, that seems it has issues internally since it is not reproduce on emulator and other devices including Samsungs with new android versions.

The workaround was to set the flags in a task to run in the DecorView MessageQueue in order to ensure flags are set when the DecorView is ready internally to accept changes.