### PR TITLE
Avoid calling AppRegistry.registerComponent in mocked mode

### DIFF
--- a/lib/src/Mock/mocks/AppRegistryService.ts
+++ b/lib/src/Mock/mocks/AppRegistryService.ts
@@ -1,0 +1,5 @@
+import { ComponentProvider } from 'react-native';
+
+export class AppRegistryService {
+  registerComponent(_appKey: string, _getComponentFunc: ComponentProvider) {}
+}

--- a/lib/src/Navigation.ts
+++ b/lib/src/Navigation.ts
@@ -48,7 +48,8 @@ export class NavigationRoot {
 
   constructor(
     private readonly nativeCommandsSender: NativeCommandsSender,
-    private readonly nativeEventsReceiver: NativeEventsReceiver
+    private readonly nativeEventsReceiver: NativeEventsReceiver,
+    private readonly appRegistryService: AppRegistryService
   ) {
     this.componentWrapper = new ComponentWrapper();
     this.store = new Store();
@@ -59,12 +60,12 @@ export class NavigationRoot {
       this.nativeEventsReceiver,
       this.store
     );
-    const appRegistryService = new AppRegistryService();
+
     this.componentRegistry = new ComponentRegistry(
       this.store,
       this.componentEventsObserver,
       this.componentWrapper,
-      appRegistryService
+      this.appRegistryService
     );
     this.layoutTreeParser = new LayoutTreeParser(this.uniqueIdProvider);
     const optionsProcessor = new OptionsProcessor(

--- a/lib/src/NavigationDelegate.ts
+++ b/lib/src/NavigationDelegate.ts
@@ -9,21 +9,24 @@ import { OptionsProcessor as OptionProcessor } from './interfaces/Processors';
 import { NavigationRoot } from './Navigation';
 import { NativeCommandsSender } from './adapters/NativeCommandsSender';
 import { NativeEventsReceiver } from './adapters/NativeEventsReceiver';
+import { AppRegistryService } from './adapters/AppRegistryService';
 
 export class NavigationDelegate {
   private concreteNavigation: NavigationRoot;
   constructor() {
     this.concreteNavigation = this.createConcreteNavigation(
       new NativeCommandsSender(),
-      new NativeEventsReceiver()
+      new NativeEventsReceiver(),
+      new AppRegistryService()
     );
   }
 
   private createConcreteNavigation(
     nativeCommandsSender: NativeCommandsSender,
-    nativeEventsReceiver: NativeEventsReceiver
+    nativeEventsReceiver: NativeEventsReceiver,
+    appRegistryService: AppRegistryService
   ) {
-    return new NavigationRoot(nativeCommandsSender, nativeEventsReceiver);
+    return new NavigationRoot(nativeCommandsSender, nativeEventsReceiver, appRegistryService);
   }
 
   /**
@@ -226,9 +229,11 @@ export class NavigationDelegate {
   public mockNativeComponents() {
     const { NativeCommandsSender } = require('./Mock/mocks/NativeCommandsSender');
     const { NativeEventsReceiver } = require('./Mock/mocks/NativeEventsReceiver');
+    const { AppRegistryService } = require('./Mock/mocks/AppRegistryService');
     this.concreteNavigation = this.createConcreteNavigation(
       new NativeCommandsSender(),
-      new NativeEventsReceiver()
+      new NativeEventsReceiver(),
+      new AppRegistryService()
     );
   }
 


### PR DESCRIPTION
We don't need to register the component using react-native's `AppRegistry` as in mocked mode we read it from our own store.