### PR TITLE
docs: updated community libraries.

### DIFF
--- a/website/docs/docs/community-libraries.mdx
+++ b/website/docs/docs/community-libraries.mdx
@@ -6,8 +6,15 @@ sidebar_label: Community libraries
 
 React Native Navigation has an active community with a bunch of support libraries.
 
+## Utilities
+
 [React Native Navigation Hooks](https://github.com/underscopeio/react-native-navigation-hooks) :
 A set of React hooks for React Native Navigation.
+
+[React Native Navigation Register Screens](https://github.com/karlmarxlopez/react-native-navigation-register-screens) : 
+Utility function to register array of screens instead of calling `Navigation.registerComponent` multiple times.
+
+## Extensions
 
 [React Native Navigation Drawer Extension](https://github.com/lukebrandonfarrell/react-native-navigation-drawer-extension) :
 Drawer API built on top of React Native Navigation for iOS and Android. 
@@ -15,5 +22,5 @@ Drawer API built on top of React Native Navigation for iOS and Android.
 [React Native Navigation Search Bar](https://github.com/lukebrandonfarrell/react-native-navigation-search-bar) :
 React Native Elements search bar with collapsible header built for React Native Navigation.
 
-[React Native Navigation Register Screens](https://github.com/karlmarxlopez/react-native-navigation-register-screens) : 
-Utility function to register array of screens instead of calling `Navigation.registerComponent` multiple times.
+[React Native Navigation Bottom Sheet Extension](https://github.com/CursedWizard/react-native-navigation-bottom-sheet) :
+A performant customizable bottom sheet component built on top of React Native Navigation.

--- a/website/versioned_docs/version-7.16.0/docs/community-libraries.mdx
+++ b/website/versioned_docs/version-7.16.0/docs/community-libraries.mdx
@@ -6,8 +6,15 @@ sidebar_label: Community libraries
 
 React Native Navigation has an active community with a bunch of support libraries.
 
+## Utilities
+
 [React Native Navigation Hooks](https://github.com/underscopeio/react-native-navigation-hooks) :
 A set of React hooks for React Native Navigation.
+
+[React Native Navigation Register Screens](https://github.com/karlmarxlopez/react-native-navigation-register-screens) : 
+Utility function to register array of screens instead of calling `Navigation.registerComponent` multiple times.
+
+## Extensions
 
 [React Native Navigation Drawer Extension](https://github.com/lukebrandonfarrell/react-native-navigation-drawer-extension) :
 Drawer API built on top of React Native Navigation for iOS and Android. 
@@ -15,5 +22,5 @@ Drawer API built on top of React Native Navigation for iOS and Android.
 [React Native Navigation Search Bar](https://github.com/lukebrandonfarrell/react-native-navigation-search-bar) :
 React Native Elements search bar with collapsible header built for React Native Navigation.
 
-[React Native Navigation Register Screens](https://github.com/karlmarxlopez/react-native-navigation-register-screens) : 
-Utility function to register array of screens instead of calling `Navigation.registerComponent` multiple times.
+[React Native Navigation Bottom Sheet Extension](https://github.com/CursedWizard/react-native-navigation-bottom-sheet) :
+A performant customizable bottom sheet component built on top of React Native Navigation.


### PR DESCRIPTION
Couldn't find a ready-to-use solution for a bottom sheet component that would work seamlessly with react-native-navigation, so decided to write my own - [React Native Navigation Bottom Sheet Extension](https://github.com/CursedWizard/react-native-navigation-bottom-sheet). Added it to community libraries in docs.

Also made the list of packages a little bit more organized.