### PR TITLE
Fix left and right top bar buttons with component crash on Android

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
@@ -24,7 +24,7 @@ public class TitleBarReactButtonView extends ReactView {
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        super.onMeasure(createSpec(widthMeasureSpec, component.width), createSpec(widthMeasureSpec, component.height));
+        super.onMeasure(createSpec(widthMeasureSpec, component.width), createSpec(heightMeasureSpec, component.height));
     }
 
     private int createSpec(int measureSpec, Number dimension) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
@@ -24,6 +24,10 @@ public class TitleBarReactButtonView extends ReactView {
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        if (!this.isAttachedToWindow() || this.getReactInstanceManager() == null) {
+            this.setId(View.NO_ID);
+        }
+
         super.onMeasure(createSpec(widthMeasureSpec, component.width), createSpec(heightMeasureSpec, component.height));
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
@@ -25,6 +25,9 @@ public class TitleBarReactButtonView extends ReactView {
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        
+        //This is a workaround, ReactNative throws exception when views have ids, On android MenuItems 
+        // With ActionViews like this got an id, see #7253
         if (!this.isAttachedToWindow() || this.getReactInstanceManager() == null) {
             this.setId(View.NO_ID);
         }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
@@ -2,6 +2,7 @@ package com.reactnativenavigation.views.stack.topbar.titlebar;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.view.View;
 
 import com.facebook.react.ReactInstanceManager;
 import com.reactnativenavigation.options.ComponentOptions;


### PR DESCRIPTION
Fixes #7229 

It also happens with left button.

Also noticed that width spec was used for the height measurement (probably typo).