### PR TITLE
Fix dot indicator location on iOS

### DIFF
--- a/lib/ios/RNNDotIndicatorPresenter.m
+++ b/lib/ios/RNNDotIndicatorPresenter.m
@@ -54,7 +54,7 @@
 
     UITabBarController *bottomTabs = [self getTabBarController:child];
     int index = (int)[[bottomTabs childViewControllers] indexOfObject:child];
-    [[bottomTabs getTabView:index] addSubview:indicator];
+    [[bottomTabs getTabIcon:index] addSubview:indicator];
     [self applyConstraints:options badge:indicator tabBar:bottomTabs index:index];
 }
 
@@ -92,7 +92,7 @@
 - (UIView *)getCurrentIndicator:(UIViewController *)child {
     UITabBarController *bottomTabs = [self getTabBarController:child];
     int tabIndex = (int)[[bottomTabs childViewControllers] indexOfObject:child];
-    return [[bottomTabs getTabView:tabIndex] viewWithTag:[child tabBarItem].tag];
+    return [[bottomTabs getTabIcon:tabIndex] viewWithTag:[child tabBarItem].tag];
 }
 
 - (BOOL)hasIndicator:(UIViewController *)child {

--- a/lib/ios/RNNDotIndicatorPresenter.m
+++ b/lib/ios/RNNDotIndicatorPresenter.m
@@ -49,12 +49,18 @@
     if ([self hasIndicator:child])
         [self remove:child];
 
+    UITabBarController *bottomTabs = [self getTabBarController:child];
+    int index = (int)[[bottomTabs childViewControllers] indexOfObject:child];
+    UIView *tabIcon = [bottomTabs getTabIcon:index];
+
+    if (!tabIcon) {
+        return;
+    }
+
     UIView *indicator = [self createIndicator:options];
     [child tabBarItem].tag = indicator.tag;
 
-    UITabBarController *bottomTabs = [self getTabBarController:child];
-    int index = (int)[[bottomTabs childViewControllers] indexOfObject:child];
-    [[bottomTabs getTabIcon:index] addSubview:indicator];
+    [tabIcon addSubview:indicator];
     [self applyConstraints:options badge:indicator tabBar:bottomTabs index:index];
 }
 

--- a/lib/ios/RNNDotIndicatorPresenter.m
+++ b/lib/ios/RNNDotIndicatorPresenter.m
@@ -92,7 +92,7 @@
         return NO;
     UIView *currentIndicator = [self getCurrentIndicator:child];
 
-    return [[currentIndicator backgroundColor] isEqual:[options.color withDefault:[UIColor redColor]]] && [[currentIndicator widthAnchor] isEqual:[options.size withDefault:@6]];
+    return [[currentIndicator backgroundColor] isEqual:[options.color withDefault:[UIColor redColor]]];
 }
 
 - (UIView *)getCurrentIndicator:(UIViewController *)child {

--- a/lib/ios/RNNDotIndicatorPresenter.m
+++ b/lib/ios/RNNDotIndicatorPresenter.m
@@ -85,8 +85,8 @@
     if (![self hasIndicator:child])
         return NO;
     UIView *currentIndicator = [self getCurrentIndicator:child];
-    return
-        [[currentIndicator backgroundColor] isEqual:[options.color withDefault:[UIColor redColor]]];
+
+    return [[currentIndicator backgroundColor] isEqual:[options.color withDefault:[UIColor redColor]]] && [[currentIndicator widthAnchor] isEqual:[options.size withDefault:@6]];
 }
 
 - (UIView *)getCurrentIndicator:(UIViewController *)child {

--- a/playground/ios/NavigationTests/RNNDotIndicatorPresenterTest.m
+++ b/playground/ios/NavigationTests/RNNDotIndicatorPresenterTest.m
@@ -75,17 +75,17 @@
 - (void)testApply_itAddsIndicatorToCorrectTabView {
     [self applyIndicator];
     UIView *indicator1 = [self getIndicator];
-    XCTAssertEqualObjects([indicator1 superview], [_bottomTabs getTabView:0]);
+    XCTAssertEqualObjects([indicator1 superview], [_bottomTabs getTabIcon:0]);
 }
 
 - (void)testApply_itRemovesPreviousDotIndicator {
-    NSUInteger childCountBeforeApplyingIndicator = [[_bottomTabs getTabView:0] subviews].count;
+    NSUInteger childCountBeforeApplyingIndicator = [[_bottomTabs getTabIcon:0] subviews].count;
     [self applyIndicator];
-    NSUInteger childCountAfterApplyingIndicatorOnce = [[_bottomTabs getTabView:0] subviews].count;
+    NSUInteger childCountAfterApplyingIndicatorOnce = [[_bottomTabs getTabIcon:0] subviews].count;
     XCTAssertEqual(childCountBeforeApplyingIndicator + 1, childCountAfterApplyingIndicatorOnce);
 
     [self applyIndicator:[UIColor greenColor]];
-    NSUInteger childCountAfterApplyingIndicatorTwice = [[_bottomTabs getTabView:0] subviews].count;
+    NSUInteger childCountAfterApplyingIndicatorTwice = [[_bottomTabs getTabIcon:0] subviews].count;
     XCTAssertEqual([[self getIndicator] backgroundColor], [UIColor greenColor]);
     XCTAssertEqual(childCountAfterApplyingIndicatorOnce, childCountAfterApplyingIndicatorTwice);
 }
@@ -112,7 +112,7 @@
     UIView *indicator = [self getIndicator];
     UIView *icon = [_bottomTabs getTabIcon:0];
 
-    NSArray<NSLayoutConstraint *> *alignmentConstraints = [_bottomTabs getTabView:0].constraints;
+    NSArray<NSLayoutConstraint *> *alignmentConstraints = [_bottomTabs getTabIcon:0].constraints;
     XCTAssertEqual([alignmentConstraints count], 2);
     XCTAssertEqual([alignmentConstraints[0] constant], -4);
     XCTAssertEqual([alignmentConstraints[0] firstItem], indicator);


### PR DESCRIPTION
- Fixes #6411 
- Fixes the crash if `dotIndicator` is applied without `icon` in tab

<img width="502" alt="image" src="https://user-images.githubusercontent.com/14828004/135261158-eec0d640-9220-4e1c-bbd1-46939b7b54de.png">