### PR TITLE
Fix sideMenu docs

### DIFF
--- a/website/docs/docs/docs-sideMenu.mdx
+++ b/website/docs/docs/docs-sideMenu.mdx
@@ -56,7 +56,7 @@ class SideMenuCenterScreen extends React.Component {
 
   navigationButtonPressed({ buttonId }) {
     if (buttonId === 'sideMenu') {
-      Navigation.mergeOptions(this, {
+      Navigation.mergeOptions(this.props.componentId, {
         sideMenu: {
           left: {
             visible: true


### PR DESCRIPTION
Updated the example using `Navigation.mergeOptions` to open the side menu with the correct first argument.