### PR TITLE
Fix hardware back button event button id in docs

### DIFF
--- a/website/docs/docs/docs-customBackNavigation.mdx
+++ b/website/docs/docs/docs-customBackNavigation.mdx
@@ -59,11 +59,11 @@ options: {
 }
 ```
 
-Once the default behaviors are disabled, RNN will emit a [navigationButtonPress](../api/events#navigationbuttonpressed-event) with the `RNN.hardwareBack` id.
+Once the default behaviors are disabled, RNN will emit a [navigationButtonPress](../api/events#navigationbuttonpressed-event) with the `RNN.hardwareBackButton` id.
 
 ```js
 navigationButtonPressed({ buttonId }) {
-  if (buttonId === 'RNN.hardwareBack') {
+  if (buttonId === 'RNN.hardwareBackButton') {
     console.log('The hardware back button was pressed!');
   }
 }

--- a/website/versioned_docs/version-7.16.0/docs/docs-customBackNavigation.mdx
+++ b/website/versioned_docs/version-7.16.0/docs/docs-customBackNavigation.mdx
@@ -59,11 +59,11 @@ options: {
 }
 ```
 
-Once the default behaviors are disabled, RNN will emit a [navigationButtonPress](../api/events#navigationbuttonpressed-event) with the `RNN.hardwareBack` id.
+Once the default behaviors are disabled, RNN will emit a [navigationButtonPress](../api/events#navigationbuttonpressed-event) with the `RNN.hardwareBackButton` id.
 
 ```js
 navigationButtonPressed({ buttonId }) {
-  if (buttonId === 'RNN.hardwareBack') {
+  if (buttonId === 'RNN.hardwareBackButton') {
     console.log('The hardware back button was pressed!');
   }
 }


### PR DESCRIPTION
Actual buttonId for hardware back button event is `RNN.hardwareBackButton`, not `RNN.hardwareBack` :-)