### PR TITLE
Avoid processing undefined colors

### DIFF
--- a/lib/src/commands/OptionsProcessor.test.ts
+++ b/lib/src/commands/OptionsProcessor.test.ts
@@ -462,6 +462,17 @@ describe('navigation options', () => {
         Platform.OS = 'android';
       });
 
+      it('should not process undefined color', () => {
+        const options: Options = {
+          topBar: { background: { color: undefined } },
+        };
+
+        uut.processOptions(options, CommandName.SetRoot);
+        expect(options).toEqual({
+          topBar: { background: { color: undefined } },
+        });
+      });
+
       it('PlatformColor should be passed to native as is', () => {
         const options: Options = {
           topBar: {
@@ -507,18 +518,12 @@ describe('navigation options', () => {
         const options: Options = {
           topBar: {
             background: { color: { light: 'blue', dark: 'red' } },
-            title: {
-              color: undefined,
-            },
           },
         };
         uut.processOptions(options, CommandName.SetRoot);
         expect(options).toEqual({
           topBar: {
             background: { color: { light: 0xff0000ff, dark: 0xffff0000 } },
-            title: {
-              color: { light: null, dark: null },
-            },
           },
         });
       });
@@ -539,6 +544,17 @@ describe('navigation options', () => {
         expect(options).toEqual({
           statusBar: { backgroundColor: 0xffff0000 },
           topBar: { background: { color: 0xff0000ff } },
+        });
+      });
+
+      it('should not process undefined color', () => {
+        const options: Options = {
+          topBar: { background: { color: undefined } },
+        };
+
+        uut.processOptions(options, CommandName.SetRoot);
+        expect(options).toEqual({
+          topBar: { background: { color: undefined } },
         });
       });
 
@@ -716,8 +732,8 @@ describe('navigation options', () => {
           hideOnScroll: false,
           hideTopBarOnFocus: false,
           obscuresBackgroundDuringPresentation: false,
-          backgroundColor: { light: null, dark: null },
-          tintColor: { light: null, dark: null },
+          backgroundColor: undefined,
+          tintColor: undefined,
           placeholder: '',
         });
       });

--- a/lib/src/commands/OptionsProcessor.ts
+++ b/lib/src/commands/OptionsProcessor.ts
@@ -136,7 +136,7 @@ export class OptionsProcessor {
         } else {
           options[key] = DynamicColorIOS({
             light: this.colorService.toNativeColor(value.light) as ColorValue,
-            dark: this.colorService.toNativeColor(value.dark) as ColorValue
+            dark: this.colorService.toNativeColor(value.dark) as ColorValue,
           });
         }
       } else {
@@ -146,24 +146,26 @@ export class OptionsProcessor {
   }
 
   private processColorAndroid(key: string, value: any, options: Record<string, any>) {
-    const newColorObj: Record<string, any> = { dark: 'NoColor', light: 'NoColor' };
-    if (value === null) {
-      options[key] = newColorObj;
-    } else if (value instanceof Object) {
-      if ('semantic' in value || 'resource_paths' in value) {
-        options[key] = value;
-        return;
-      } else {
-        for (let keyColor in value) {
-          newColorObj[keyColor] = this.colorService.toNativeColor(value[keyColor]);
+    if (value !== undefined) {
+      const newColorObj: Record<string, any> = { dark: 'NoColor', light: 'NoColor' };
+      if (value === null) {
+        options[key] = newColorObj;
+      } else if (value instanceof Object) {
+        if ('semantic' in value || 'resource_paths' in value) {
+          options[key] = value;
+          return;
+        } else {
+          for (let keyColor in value) {
+            newColorObj[keyColor] = this.colorService.toNativeColor(value[keyColor]);
+          }
+          options[key] = newColorObj;
         }
+      } else {
+        let parsedColor = this.colorService.toNativeColor(value);
+        newColorObj.light = parsedColor;
+        newColorObj.dark = parsedColor;
         options[key] = newColorObj;
       }
-    } else {
-      let parsedColor = this.colorService.toNativeColor(value);
-      newColorObj.light = parsedColor;
-      newColorObj.dark = parsedColor;
-      options[key] = newColorObj;
     }
   }
 


### PR DESCRIPTION
When passing undefined colors, we don't want to parse that as Null as it will reset the current visible colors.