### PR TITLE
[docs] RNN Screens library info added

### DIFF
--- a/website/versioned_docs/version-7.16.0/docs/community-libraries.mdx
+++ b/website/versioned_docs/version-7.16.0/docs/community-libraries.mdx
@@ -14,6 +14,9 @@ A set of React hooks for React Native Navigation.
 [React Native Navigation Register Screens](https://github.com/karlmarxlopez/react-native-navigation-register-screens) : 
 Utility function to register array of screens instead of calling `Navigation.registerComponent` multiple times.
 
+[RNN Screens](https://github.com/kanzitelli/rnn-screens) :
+A set of methods to help build initial screens for RNN without hassle. Includes screens registration and predictable navigation between them.
+
 ## Extensions
 
 [React Native Navigation Drawer Extension](https://github.com/lukebrandonfarrell/react-native-navigation-drawer-extension) :


### PR DESCRIPTION
Hey guys! I have created a tiny library, [rnn-screens](https://github.com/kanzitelli/rnn-screens), around React Native Navigation which simplifies the way of building initial screens and layouts for an app. And as the concept was already tested for quite a long time in [rnn-starter](https://github.com/kanzitelli/rnn-starter), I decided to put the setup in one method. So maybe someone will find it useful :) 

Here is a quick example:

```tsx
import {generateRNNScreens, Root, Stack, Component, BottomTabs} from 'rnn-screens';

export const screens = generateRNNScreens({
  Main: {
    component: Main,
    options: {
      topBar: {
        title: {
          text: 'Home',
        },
      },
    },
  },
  // ...
});

// One screen app
screens.N.setRoot(Root(Stack(Component(screens.get('Main')))));

// Tab based app
screens.N.setRoot(
  Root(
    BottomTabs([
      Stack(Component(screens.get('Main'))),
      Stack(Component(screens.get('Settings'))),
    ]),
  ),
);

// push screen
screens.push(componentId, 'Example');

// show modal
screens.show('Example');

// push screen with passProps
screens.push<ExampleScreenProps>(
  componentId,
  'Example',
  { value: randomNum() },
)
```