### PR TITLE
Remove manually dismissing all modals on setRoot

### DIFF
--- a/lib/ios/RNNAssert.h
+++ b/lib/ios/RNNAssert.h
@@ -12,8 +12,8 @@ extern BOOL RNNIsMainQueue(void);
         if ((condition) == 0) {                                                                    \
             if (RNN_NSASSERT) {                                                                    \
                 [[NSAssertionHandler currentHandler]                                               \
-                    handleFailureInFunction:(NSString * _Nonnull) @(__func__)                      \
-                                       file:(NSString * _Nonnull) @(__FILE__)                      \
+                    handleFailureInFunction:(NSString *_Nonnull)@(__func__)                        \
+                                       file:(NSString *_Nonnull)@(__FILE__)                        \
                                  lineNumber:__LINE__                                               \
                                 description:__VA_ARGS__];                                          \
             }                                                                                      \

--- a/lib/ios/RNNBottomTabOptions.m
+++ b/lib/ios/RNNBottomTabOptions.m
@@ -84,7 +84,8 @@
            self.testID.hasValue || self.icon.hasValue || self.selectedIcon.hasValue ||
            self.iconColor.hasValue || self.selectedIconColor.hasValue ||
            self.selectedTextColor.hasValue || self.iconInsets.hasValue || self.textColor.hasValue ||
-           self.visible.hasValue || self.selectTabOnPress.hasValue || self.sfSymbol.hasValue || self.sfSelectedSymbol.hasValue;
+           self.visible.hasValue || self.selectTabOnPress.hasValue || self.sfSymbol.hasValue ||
+           self.sfSelectedSymbol.hasValue;
 }
 
 @end

--- a/lib/ios/RNNButtonBuilder.m
+++ b/lib/ios/RNNButtonBuilder.m
@@ -31,9 +31,9 @@
         return [[RNNUIBarButtonItem alloc] initCustomIcon:button
                                               iconCreator:_iconCreator
                                                   onPress:onPress];
-	} else if (button.sfSymbol.hasValue) {
-		return [[RNNUIBarButtonItem alloc] initWithSFSymbol:button onPress:onPress];
-	} else if (button.icon.hasValue) {
+    } else if (button.sfSymbol.hasValue) {
+        return [[RNNUIBarButtonItem alloc] initWithSFSymbol:button onPress:onPress];
+    } else if (button.icon.hasValue) {
         return [[RNNUIBarButtonItem alloc] initWithIcon:button onPress:onPress];
     } else if (button.text.hasValue) {
         return [[RNNUIBarButtonItem alloc] initWithTitle:button onPress:onPress];

--- a/lib/ios/RNNButtonOptions.m
+++ b/lib/ios/RNNButtonOptions.m
@@ -11,7 +11,7 @@
     self.fontWeight = [TextParser parse:dict key:@"fontWeight"];
     self.fontSize = [NumberParser parse:dict key:@"fontSize"];
     self.text = [TextParser parse:dict key:@"text"];
-	self.sfSymbol = [TextParser parse:dict key:@"sfSymbol"];
+    self.sfSymbol = [TextParser parse:dict key:@"sfSymbol"];
     self.testID = [TextParser parse:dict key:@"testID"];
     self.accessibilityLabel = [TextParser parse:dict key:@"accessibilityLabel"];
     self.color = [ColorParser parse:dict key:@"color"];
@@ -40,7 +40,7 @@
     newOptions.color = self.color.copy;
     newOptions.disabledColor = self.disabledColor.copy;
     newOptions.icon = self.icon.copy;
-	newOptions.sfSymbol = self.sfSymbol.copy;
+    newOptions.sfSymbol = self.sfSymbol.copy;
     newOptions.iconInsets = self.iconInsets.copy;
     newOptions.enabled = self.enabled.copy;
     newOptions.selectTabOnPress = self.selectTabOnPress.copy;
@@ -73,8 +73,8 @@
         self.disabledColor = options.disabledColor;
     if (options.icon.hasValue)
         self.icon = options.icon;
-	if (options.sfSymbol.hasValue)
-		self.sfSymbol = options.sfSymbol;
+    if (options.sfSymbol.hasValue)
+        self.sfSymbol = options.sfSymbol;
     if (options.enabled.hasValue) {
         self.enabled = options.enabled;
         [self.iconBackground setEnabled:self.enabled];

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -82,10 +82,7 @@ static NSString *const setDefaultOptions = @"setDefaultOptions";
         }
     }
 
-    [_modalManager dismissAllModalsAnimated:NO
-                                 completion:^{
-
-                                 }];
+    [_modalManager reset];
 
     UIViewController *vc = [_controllerFactory createLayout:layout[@"root"]];
     [_layoutManager addPendingViewController:vc];

--- a/lib/ios/RNNDotIndicatorPresenter.m
+++ b/lib/ios/RNNDotIndicatorPresenter.m
@@ -92,7 +92,8 @@
         return NO;
     UIView *currentIndicator = [self getCurrentIndicator:child];
 
-    return [[currentIndicator backgroundColor] isEqual:[options.color withDefault:[UIColor redColor]]];
+    return
+        [[currentIndicator backgroundColor] isEqual:[options.color withDefault:[UIColor redColor]]];
 }
 
 - (UIView *)getCurrentIndicator:(UIViewController *)child {

--- a/lib/ios/RNNModalManager.h
+++ b/lib/ios/RNNModalManager.h
@@ -24,4 +24,6 @@ typedef void (^RNNTransitionRejectionBlock)(NSString *_Nonnull code, NSString *_
 - (void)dismissAllModalsAnimated:(BOOL)animated completion:(void (^__nullable)(void))completion;
 - (void)dismissAllModalsSynchronosly;
 
+- (void)reset;
+
 @end

--- a/lib/ios/RNNModalManager.m
+++ b/lib/ios/RNNModalManager.m
@@ -143,6 +143,11 @@
     }
 }
 
+- (void)reset {
+    _presentedModals = [NSMutableArray new];
+    _pendingModalIdsToDismiss = [NSMutableArray new];
+}
+
 #pragma mark - private
 
 - (void)removePendingNextModalIfOnTop:(RNNTransitionCompletionBlock)completion

--- a/lib/ios/RNNModalManager.m
+++ b/lib/ios/RNNModalManager.m
@@ -144,8 +144,8 @@
 }
 
 - (void)reset {
-    _presentedModals = [NSMutableArray new];
-    _pendingModalIdsToDismiss = [NSMutableArray new];
+    [_presentedModals removeAllObjects];
+    [_pendingModalIdsToDismiss removeAllObjects];
 }
 
 #pragma mark - private

--- a/lib/ios/RNNSegmentedControl.h
+++ b/lib/ios/RNNSegmentedControl.h
@@ -1,5 +1,5 @@
-#import <HMSegmentedControl/HMSegmentedControl.h>
 #import <Foundation/Foundation.h>
+#import <HMSegmentedControl/HMSegmentedControl.h>
 
 @interface RNNSegmentedControl : HMSegmentedControl
 

--- a/lib/ios/RNNTabBarItemCreator.m
+++ b/lib/ios/RNNTabBarItemCreator.m
@@ -18,11 +18,12 @@
 
     if (@available(iOS 13.0, *)) {
         if (bottomTabOptions.sfSymbol.hasValue) {
-            icon = [UIImage systemImageNamed: [bottomTabOptions.sfSymbol withDefault:nil]];
+            icon = [UIImage systemImageNamed:[bottomTabOptions.sfSymbol withDefault:nil]];
         }
 
         if (bottomTabOptions.sfSelectedSymbol.hasValue) {
-            selectedIcon = [UIImage systemImageNamed: [bottomTabOptions.sfSelectedSymbol withDefault:nil]];
+            selectedIcon =
+                [UIImage systemImageNamed:[bottomTabOptions.sfSelectedSymbol withDefault:nil]];
         }
     }
 

--- a/lib/ios/RNNUIBarButtonItem.h
+++ b/lib/ios/RNNUIBarButtonItem.h
@@ -15,7 +15,7 @@ typedef void (^RNNButtonPressCallback)(NSString *buttonId);
                    iconCreator:(RNNIconCreator *)iconCreator
                        onPress:(RNNButtonPressCallback)onPress;
 - (instancetype)initWithSFSymbol:(RNNButtonOptions *)buttonOptions
-					onPress:(RNNButtonPressCallback)onPress;
+                         onPress:(RNNButtonPressCallback)onPress;
 - (instancetype)initWithIcon:(RNNButtonOptions *)buttonOptions
                      onPress:(RNNButtonPressCallback)onPress;
 - (instancetype)initWithTitle:(RNNButtonOptions *)buttonOptions

--- a/lib/ios/RNNUIBarButtonItem.m
+++ b/lib/ios/RNNUIBarButtonItem.m
@@ -21,12 +21,12 @@
 }
 
 - (instancetype)initWithSFSymbol:(RNNButtonOptions *)buttonOptions
-						 onPress:(RNNButtonPressCallback)onPress {
+                         onPress:(RNNButtonPressCallback)onPress {
     UIImage *iconImage = [UIImage alloc];
 
-	if (@available(iOS 13.0, *)) {
+    if (@available(iOS 13.0, *)) {
         iconImage = [UIImage systemImageNamed:[buttonOptions.sfSymbol withDefault:nil]];
-	}
+    }
 
     self = [super initWithImage:iconImage
                           style:UIBarButtonItemStylePlain

--- a/lib/ios/TopBarPresenter.m
+++ b/lib/ios/TopBarPresenter.m
@@ -160,17 +160,21 @@
     UIBarButtonItem *backItem = [[RNNUIBarBackButtonItem alloc] initWithOptions:backButtonOptions];
     UINavigationItem *previousNavigationItem = previousViewControllerInStack.navigationItem;
 
-
     if (@available(iOS 13.0, *)) {
         UIImage *sfSymbol = [UIImage systemImageNamed:[backButtonOptions.sfSymbol withDefault:nil]];
         if (backButtonOptions.sfSymbol.hasValue) {
-            icon = color ? [sfSymbol imageWithTintColor:color renderingMode:UIImageRenderingModeAlwaysOriginal]
+            icon = color ? [sfSymbol imageWithTintColor:color
+                                          renderingMode:UIImageRenderingModeAlwaysOriginal]
                          : [sfSymbol imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
         } else {
-            icon = color ? [[icon withTintColor:color] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal] : icon;
+            icon = color ? [[icon withTintColor:color]
+                               imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal]
+                         : icon;
         }
     } else {
-        icon = color ? [[icon withTintColor:color] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal] : icon;
+        icon = color ? [[icon withTintColor:color]
+                           imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal]
+                     : icon;
     }
 
     [self setBackIndicatorImage:icon withColor:color];


### PR DESCRIPTION
Currently we manually dismiss all modals on `setRoot`, we should instead clear it from the modal manager so that those controllers will be automatically released by the reference count system.