### PR TITLE
Android context crash when parsing options

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/Options.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/Options.java
@@ -15,7 +15,7 @@ public class Options {
     public static final Options EMPTY = new Options();
 
     @NonNull
-    public static Options parse(Context context, TypefaceLoader typefaceManager, JSONObject json) {
+    public static Options parse(@NonNull Context context, TypefaceLoader typefaceManager, JSONObject json) {
         Options result = new Options();
         if (json == null) return result;
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/utils/LayoutFactoryTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/utils/LayoutFactoryTest.java
@@ -15,14 +15,19 @@ import org.mockito.Mockito;
 import java.util.HashMap;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Java6Assertions.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class LayoutFactoryTest extends BaseTest {
     private LayoutFactory uut;
+    private ReactInstanceManager mockReactInstanceManager;
 
     @Override
     public void beforeEach() {
-        uut = new LayoutFactory(mock(ReactInstanceManager.class));
+        super.beforeEach();
+        mockReactInstanceManager = mock(ReactInstanceManager.class);
+        uut = new LayoutFactory(mockReactInstanceManager);
         uut.init(
                 newActivity(),
                 Mockito.mock(EventEmitter.class),
@@ -34,6 +39,16 @@ public class LayoutFactoryTest extends BaseTest {
     @Test
     public void sanity() throws JSONException {
         assertThat(uut.create(component())).isNotNull();
+    }
+
+    @Test
+    public void shouldParseOptionsWhenReactContextIsNull() {
+        when(mockReactInstanceManager.getCurrentReactContext()).thenReturn(null);
+        try {
+            uut.create(component());
+        } catch (Exception e) {
+            fail("Create should not fail! when react instance has null context");
+        }
     }
 
     @Test
@@ -50,6 +65,14 @@ public class LayoutFactoryTest extends BaseTest {
     }
 
     private LayoutNode component() throws JSONException {
-        return new LayoutNode("Component1", LayoutNode.Type.Component, new JSONObject().put("name", "com.component"), null);
+        final JSONObject component = new JSONObject();
+        final JSONObject layout = new JSONObject();
+        final JSONObject backgroundColor = new JSONObject();
+        backgroundColor.put("dark",0);
+        backgroundColor.put("light",1);
+        layout.put("backgroundColor",backgroundColor );
+        component.put("name", "com.component");
+        component.put("options",new JSONObject().put("layout", layout));
+        return new LayoutNode("Component1", LayoutNode.Type.Component, component, null);
     }
 }


### PR DESCRIPTION
# Issue:

When parsing options, `ReactInstanceManager.getCurrentContext()` might return null, which caused color parsing to throw null exception since it assumes that context is not null.

# Diagnose:

This can be the case when Activity was killed but the Application still alive (Don't keep activity for example), and since js is bound to the Application lifecycle, opening the activity triggers recreating context in bg, in the meantime calling a command that requires reactContext can cause such crashes to unwanted behaviours when react context is needed.
This happens internally and it looks like it is some flow where calling navigation command when react is not ready. 

# Fix:
 
Since the issue did not happen before, and the crash occurred in parsing options that are independent of `ReactContext`, we can use Activity or Application as the context for such a case.
