### PR TITLE
Add accessibilityRole to OptionsTopBarButton type interface

### DIFF
--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -535,6 +535,10 @@ export interface OptionsTopBarButton {
    */
   accessibilityLabel?: string;
   /**
+   * Communicates the purpose of a component to the user of an assistive technology
+   */
+  accessibilityRole?: string;
+  /**
    * Set the font family for the button's text
    */
   fontFamily?: FontFamily;


### PR DESCRIPTION
This PR adds the [accessibilityRole](https://reactnative.dev/docs/accessibility#accessibilityrole) prop to the `OptionsTopBarButton` type interface. 

This prop is used to communicate the purpose of a component to screen-reader users. 