### PR TITLE
Timeout

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,6 +26,7 @@ steps:
     - "npm run test-unit-android -- --release"
     - "npm run test-e2e-android-multi -- --release --headless --verbose --ci"
     key: "android_build"
+    timeout_in_minutes: 60
 
   - label: ":ios: iOS - Unit"
     command:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,7 +26,7 @@ steps:
     - "npm run test-unit-android -- --release"
     - "npm run test-e2e-android-multi -- --release --headless --verbose --ci"
     key: "android_build"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 1
 
   - label: ":ios: iOS - Unit"
     command:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,6 +34,7 @@ steps:
     - "npm install"
     - "npm run test-unit-ios -- --release"
     key: "ios_unit"
+    timeout_in_minutes: 90
 
   - label: ":ios: iOS - E2E"
     command:
@@ -42,6 +43,7 @@ steps:
     - "npm run test-snapshot-ios -- --release"
     - "npm run test-e2e-ios -- --release --multi --ci"
     key: "ios_e2e"
+    timeout_in_minutes: 90
 
   - label: ":package: Publish"
     env:
@@ -54,3 +56,4 @@ steps:
     - "android_build"
     - "ios_unit"
     - "ios_e2e"
+    timeout_in_minutes: 90

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,7 +26,7 @@ steps:
     - "npm run test-unit-android -- --release"
     - "npm run test-e2e-android-multi -- --release --headless --verbose --ci"
     key: "android_build"
-    timeout_in_minutes: 1
+    timeout_in_minutes: 90
 
   - label: ":ios: iOS - Unit"
     command:


### PR DESCRIPTION
Buildkite right now don't have a convenient way to set a global timeout for whole build, so need to set it for every step separately.  