### PR TITLE
Fix statusBar blur option in dark mode

### DIFF
--- a/lib/ios/UIViewController+RNNOptions.m
+++ b/lib/ios/UIViewController+RNNOptions.m
@@ -134,7 +134,7 @@ const NSInteger BLUR_STATUS_TAG = 78264801;
     if (blur) {
         if (!curBlurView) {
             UIVisualEffectView *blur = [[UIVisualEffectView alloc]
-                initWithEffect:[UIBlurEffect effectWithStyle:UIBlurEffectStyleLight]];
+                initWithEffect:[UIBlurEffect effectWithStyle:UIBlurEffectStyleRegular]];
             blur.frame = [[UIApplication sharedApplication] statusBarFrame];
             blur.tag = BLUR_STATUS_TAG;
             [self.view addSubview:blur];


### PR DESCRIPTION
Until now we used `UIBlurEffectStyleLight` effect on the `statusBar` background. In order to support dark mode blur color, we need to use `UIBlurEffectStyleRegular` so the system can automatically decide which style to use.

Closes #7346