### PR TITLE
ComponentDidDisappear event Android fix

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/ReactView.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/ReactView.java
@@ -66,18 +66,22 @@ public class ReactView extends ReactRootView implements IReactView, Renderable {
     }
 
     public void sendComponentWillStart(ComponentType type) {
-        if (this.reactInstanceManager == null) return;
-        ReactContext currentReactContext = reactInstanceManager.getCurrentReactContext();
-        if (currentReactContext != null)
-            new EventEmitter(currentReactContext).emitComponentWillAppear(componentId, componentName, type);
+        this.post(()->{
+            if (this.reactInstanceManager == null) return;
+            ReactContext currentReactContext = reactInstanceManager.getCurrentReactContext();
+            if (currentReactContext != null)
+                new EventEmitter(currentReactContext).emitComponentWillAppear(componentId, componentName, type);
+        });
     }
 
     public void sendComponentStart(ComponentType type) {
-        if (this.reactInstanceManager == null) return;
-        ReactContext currentReactContext = reactInstanceManager.getCurrentReactContext();
-        if (currentReactContext != null) {
-            new EventEmitter(currentReactContext).emitComponentDidAppear(componentId, componentName, type);
-        }
+        this.post(()->{
+            if (this.reactInstanceManager == null) return;
+            ReactContext currentReactContext = reactInstanceManager.getCurrentReactContext();
+            if (currentReactContext != null) {
+                new EventEmitter(currentReactContext).emitComponentDidAppear(componentId, componentName, type);
+            }
+        });
     }
 
     public void sendComponentStop(ComponentType type) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/component/ComponentViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/component/ComponentViewController.java
@@ -84,6 +84,7 @@ public class ComponentViewController extends ChildController<ComponentLayout> {
 
     @Override
     public void onViewDisappear() {
+        if(lastVisibilityState == VisibilityState.Disappear)return;
         lastVisibilityState = VisibilityState.Disappear;
         if (view != null) view.sendComponentStop();
         super.onViewDisappear();

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/modal/ModalPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/modal/ModalPresenter.java
@@ -90,12 +90,10 @@ public class ModalPresenter {
     }
 
     private void onShowModalEnd(ViewController<?> toAdd, @Nullable ViewController<?> toRemove, CommandListener listener) {
-        toAdd.addOnAppearedListener(()->{
-            toAdd.onViewDidAppear();
-            if (toRemove != null && toAdd.resolveCurrentOptions(defaultOptions).modal.presentationStyle != ModalPresentationStyle.OverCurrentContext) {
-                toRemove.detachView();
-            }
-        });
+        toAdd.onViewDidAppear();
+        if (toRemove != null && toAdd.resolveCurrentOptions(defaultOptions).modal.presentationStyle != ModalPresentationStyle.OverCurrentContext) {
+            toRemove.detachView();
+        }
         listener.onSuccess(toAdd.getId());
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
@@ -190,10 +190,8 @@ public class StackController extends ParentController<StackLayout> {
     }
 
     private void onPushAnimationComplete(ViewController<?> toAdd, ViewController<?> toRemove, CommandListener listener) {
-        toAdd.addOnAppearedListener(() -> {
-            toAdd.onViewDidAppear();
-            if (!peek().equals(toRemove)) getView().removeView(toRemove.getView());
-        });
+        toAdd.onViewDidAppear();
+        if (!peek().equals(toRemove)) getView().removeView(toRemove.getView());
         listener.onSuccess(toAdd.getId());
     }
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/component/ComponentViewControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/component/ComponentViewControllerTest.java
@@ -95,6 +95,24 @@ public class ComponentViewControllerTest extends BaseTest {
     }
 
     @Test
+    public void shouldNotSendDidDisappearAboutDisappearedView() {
+        uut.ensureViewIsCreated();
+        uut.onViewDisappear();
+        Mockito.verify(view, Mockito.times(0)).sendComponentStart();
+        Mockito.verify(view, Mockito.times(0)).sendComponentStop();
+
+        uut.onViewWillAppear();
+        uut.onViewDidAppear();
+        uut.onViewDisappear();
+        Mockito.verify(view, Mockito.times(1)).sendComponentStart();
+        Mockito.verify(view, Mockito.times(1)).sendComponentStop();
+
+        uut.onViewDisappear();
+        Mockito.verify(view, Mockito.times(1)).sendComponentStart();
+        Mockito.verify(view, Mockito.times(1)).sendComponentStop();
+    }
+
+    @Test
     public void onViewDidAppear_componentStartIsEmittedOnlyIfComponentIsNotAppeared() {
         uut.ensureViewIsCreated();
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalStackTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalStackTest.java
@@ -84,10 +84,9 @@ public class ModalStackTest extends BaseTest {
     }
 
     @Test
-    public void showModal_DidAppearEventShouldWaitForReactViewToBeShown(){
+    public void showModal_DidAppearEventShouldBeCallled(){
         CommandListener listener = spy(new CommandListenerAdapter());
         uut.showModal(modal1, root, listener);
-        verify(modal1).addOnAppearedListener(any());
         verify(listener).onSuccess(modal1.getId());
         idleMainLooper();
         verify(modal1).onViewDidAppear();

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/toptabs/TopTabsViewControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/toptabs/TopTabsViewControllerTest.java
@@ -124,7 +124,7 @@ public class TopTabsViewControllerTest extends BaseTest {
     }
 
     @Test
-    @Ignore("TopTabs not yet well supported should ")
+    @Ignore("TopTabs not yet well supported")
     public void lifecycleMethodsSentWhenSelectedTabChanges() {
         stack.ensureViewIsCreated();
         uut.ensureViewIsCreated();

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/toptabs/TopTabsViewControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/toptabs/TopTabsViewControllerTest.java
@@ -24,6 +24,7 @@ import com.reactnativenavigation.viewcontrollers.viewcontroller.ViewController;
 import com.reactnativenavigation.views.toptabs.TopTabsLayoutCreator;
 import com.reactnativenavigation.views.toptabs.TopTabsViewPager;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -123,6 +124,7 @@ public class TopTabsViewControllerTest extends BaseTest {
     }
 
     @Test
+    @Ignore("TopTabs not yet well supported should ")
     public void lifecycleMethodsSentWhenSelectedTabChanges() {
         stack.ensureViewIsCreated();
         uut.ensureViewIsCreated();

--- a/playground/src/screens/LayoutsScreen.tsx
+++ b/playground/src/screens/LayoutsScreen.tsx
@@ -36,8 +36,16 @@ export default class LayoutsScreen extends NavigationComponent<NavigationCompone
       componentDidAppear: false,
     };
   }
+  componentWillAppear() {
+    console.log('componentWillAppear:', this.props.componentId);
+  }
+
+  componentDidDisappear() {
+    console.log('componentDidDisappear:', this.props.componentId);
+  }
 
   componentDidAppear() {
+    console.log('componentDidAppear:', this.props.componentId);
     this.setState({ componentDidAppear: true });
   }
 

--- a/playground/src/screens/NavigationScreen.tsx
+++ b/playground/src/screens/NavigationScreen.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { Platform } from 'react-native';
-import { NavigationComponentProps, OptionsModalPresentationStyle } from 'react-native-navigation';
+import {
+  NavigationComponent,
+  NavigationComponentProps,
+  OptionsModalPresentationStyle,
+} from 'react-native-navigation';
 import Root from '../components/Root';
 import Button from '../components/Button';
 import Navigation from './../services/Navigation';
@@ -22,7 +26,7 @@ const {
 
 interface Props extends NavigationComponentProps {}
 
-export default class NavigationScreen extends React.Component<Props> {
+export default class NavigationScreen extends NavigationComponent<Props> {
   static options() {
     return {
       topBar: {
@@ -37,7 +41,20 @@ export default class NavigationScreen extends React.Component<Props> {
       },
     };
   }
+  constructor(props: Props) {
+    super(props);
+    Navigation.events().bindComponent(this);
+  }
+  componentWillAppear() {
+    console.log('componentWillAppear:', this.props.componentId);
+  }
+  componentDidDisappear() {
+    console.log('componentDidDisappear:', this.props.componentId);
+  }
 
+  componentDidAppear() {
+    console.log('componentDidAppear:', this.props.componentId);
+  }
   render() {
     return (
       <Root componentId={this.props.componentId} testID={NAVIGATION_SCREEN}>

--- a/playground/src/screens/OptionsScreen.tsx
+++ b/playground/src/screens/OptionsScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NavigationComponentProps } from 'react-native-navigation';
+import { NavigationComponent, NavigationComponentProps } from 'react-native-navigation';
 import Button from '../components/Button';
 import Root from '../components/Root';
 import Navigation from '../services/Navigation';
@@ -22,7 +22,7 @@ const {
 
 interface Props extends NavigationComponentProps {}
 
-export default class Options extends React.Component<Props> {
+export default class Options extends NavigationComponent<Props> {
   static options() {
     return {
       topBar: {
@@ -33,6 +33,23 @@ export default class Options extends React.Component<Props> {
         },
       },
     };
+  }
+
+  constructor(props: Props) {
+    super(props);
+    Navigation.events().bindComponent(this);
+  }
+
+  componentWillAppear() {
+    console.log('componentWillAppear:', this.props.componentId);
+  }
+
+  componentDidDisappear() {
+    console.log('componentDidDisappear:', this.props.componentId);
+  }
+
+  componentDidAppear() {
+    console.log('componentDidAppear:', this.props.componentId);
   }
 
   state = {


### PR DESCRIPTION
# Issue:

`componentDidDisappear` event was sent, on a component that is not even displayed in the past, it happens, when using slow enter/exit animations, as described [here](https://github.com/swabbass/navigation-bar-demo/blob/master/index.js#L7), once, with the default animation it seems not happening, but with slow enter/exit, which starts to Exit Navigator which has already the newly added view (pushed) on top and while animating the navigator sees the new entering view on top since we add the entering view to the hierarchy with alpha 0 and then making the animation, which caused a case where disappear called when a view is not even received disappear.

#Fix: 

- Prevent sending disappear on already disappeared view.
- Post Events on ReactView MessagesQueue in order to keep view sync with ReactNative.

Closes: #7388.