### PR TITLE
[Android] Support bottom Tab and stack root page to respond to HWBackPress.

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -164,7 +164,9 @@ public class BottomTabsController extends ParentController<BottomTabsLayout> imp
         final boolean childBack = !tabs.isEmpty() && tabs.get(bottomTabs.getCurrentItem()).handleBack(listener);
         final Options options = resolveCurrentOptions();
         if (!childBack) {
-            if (options.hardwareBack.getBottomTabOnPress() instanceof HwBackBottomTabsBehaviour.PrevSelection) {
+            if (options.hardwareBack.popStackOnPress.isFalse()) {
+                return true;
+            } else if (options.hardwareBack.getBottomTabOnPress() instanceof HwBackBottomTabsBehaviour.PrevSelection) {
                 if (!selectionStack.isEmpty()) {
                     final int prevSelectedTabIndex = selectionStack.poll();
                     selectTab(prevSelectedTabIndex, false);

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
@@ -398,6 +398,9 @@ public class StackController extends ParentController<StackLayout> {
                 sendOnNavigationButtonPressed(HARDWARE_BACK_BUTTON_ID);
             }
             return true;
+        } else if (stack.size() == 1 && !presenter.shouldPopOnHardwareButtonPress(peek())) {
+            sendOnNavigationButtonPressed(HARDWARE_BACK_BUTTON_ID);
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
Support `popStackOnPress` in stack root page and bottomTab.
