### PR TITLE
Keyboard autofocus android FIX

### DIFF
--- a/e2e/Keyboard.test.js
+++ b/e2e/Keyboard.test.js
@@ -25,6 +25,13 @@ describe.e2e('Keyboard', () => {
     await expect(elementById(testIDs.MAIN_BOTTOM_TABS)).toBeVisible();
   });
 
+  it.only('focus keyboard continue to resize content', async () => {
+        await elementById(TestIDs.TEXT_INPUT2).typeText("Hello");
+        await elementById(TestIDs.TEXT_INPUT2).tapReturnKey();
+        await expect(elementById(TestIDs.TEXT_INPUT1)).toBeFocused();
+        await expect(elementById(TestIDs.TEXT_INPUT1)).toBeVisible();
+  });
+
   it('focus keyboard on push', async () => {
     await elementById(TestIDs.PUSH_FOCUSED_KEYBOARD_SCREEN).tap();
     await expect(elementById(TestIDs.TEXT_INPUT1)).toBeFocused();

--- a/e2e/Keyboard.test.js
+++ b/e2e/Keyboard.test.js
@@ -25,7 +25,7 @@ describe.e2e('Keyboard', () => {
     await expect(elementById(testIDs.MAIN_BOTTOM_TABS)).toBeVisible();
   });
 
-  it.only('focus keyboard continue to resize content', async () => {
+  it('focus keyboard continue to resize content', async () => {
         await elementById(TestIDs.TEXT_INPUT2).typeText("Hello");
         await elementById(TestIDs.TEXT_INPUT2).tapReturnKey();
         await expect(elementById(TestIDs.TEXT_INPUT1)).toBeFocused();

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/component/ComponentViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/component/ComponentViewController.java
@@ -2,6 +2,7 @@ package com.reactnativenavigation.viewcontrollers.component;
 
 import android.app.Activity;
 import android.content.res.Configuration;
+import android.util.Log;
 import android.view.View;
 
 import com.reactnativenavigation.utils.LogKt;
@@ -78,6 +79,7 @@ public class ComponentViewController extends ChildController<ComponentLayout> {
         if (view != null)
             view.sendComponentWillStart();
         super.onViewDidAppear();
+        view.requestApplyInsets();
         if (view != null && lastVisibilityState == VisibilityState.Disappear) view.sendComponentStart();
         lastVisibilityState = VisibilityState.Appear;
     }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/component/ComponentViewControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/component/ComponentViewControllerTest.java
@@ -128,6 +128,13 @@ public class ComponentViewControllerTest extends BaseTest {
     }
 
     @Test
+    public void shouldCallApplyWindowInsetsWhenViewFullyAppeared(){
+        uut.ensureViewIsCreated();
+        uut.onViewDidAppear();
+        Mockito.verify(view).requestApplyInsets();
+    }
+
+    @Test
     public void isViewShownOnlyIfComponentViewIsReady() {
         Java6Assertions.assertThat(uut.isViewShown()).isFalse();
         uut.ensureViewIsCreated();

--- a/playground/src/screens/KeyboardScreen.tsx
+++ b/playground/src/screens/KeyboardScreen.tsx
@@ -99,7 +99,7 @@ export default class KeyboardScreen extends NavigationComponent<Props> {
               onBlur={this.showTabs}
               onSubmitEditing={async (event) => {
                 if (event.nativeEvent.text || event.nativeEvent.text.trim().length > 0)
-                  await this.openPushedKeyboard(event.nativeEvent.text);
+                  await this.openPushedKeyboard(event.nativeEvent.text, true);
               }}
             />
           </View>
@@ -165,7 +165,7 @@ const styles = StyleSheet.create({
     margin: 4,
   },
   image: {
-    height: 300,
+    height: 220,
     width: screenWidth,
     resizeMode: 'cover',
   },


### PR DESCRIPTION
#Issue:

When requesting autofocus on a screen that is being pushed with **animation**, insets will be applied once the view added to the view hierarchy, but when having animation the focus will be delayed until the view is fully visible in order for the edit text to take action and has a focus which will miss the first insets measurements.

#Fix:

Apply insets once the view is finished with the animation in order to resize/pan content when the view receives focus, once autofocus is passed to an EditText.