### PR TITLE
Exclude android unit tests for non playground projects

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@ coverage/
 e2e/
 integration/
 playground/
+artifacts/
 scripts/
 website/
 .travis.yml
@@ -164,6 +165,7 @@ lib/android/out/
 lib/android/.gradle/
 lib/android/build/
 lib/android/app/build/
+lib/android/app/src/test
 
 # Local configuration file (sdk path, etc)
 local.properties

--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -172,6 +172,7 @@ allprojects { p ->
 }
 
 dependencies {
+
     implementation "androidx.core:core-ktx:1.6.0"
     implementation "org.jetbrains.kotlin:$kotlinStdlib:$kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesCore"
@@ -189,13 +190,15 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
 
-    // tests
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation "org.robolectric:robolectric:4.7.2"
-    testImplementation 'org.assertj:assertj-core:3.11.1'
-    testImplementation 'org.mockito:mockito-core:4.0.0'
-    testImplementation 'com.squareup.assertj:assertj-android:1.2.0'
-    testImplementation 'org.mockito:mockito-inline:3.4.0'
-    testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
-    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
+    if("Playground".toLowerCase() == rootProject.name.toLowerCase()){
+        // tests only for our playground
+        testImplementation 'junit:junit:4.13.2'
+        testImplementation "org.robolectric:robolectric:4.7.2"
+        testImplementation 'org.assertj:assertj-core:3.11.1'
+        testImplementation 'org.mockito:mockito-core:4.0.0'
+        testImplementation 'com.squareup.assertj:assertj-android:1.2.0'
+        testImplementation 'org.mockito:mockito-inline:3.4.0'
+        testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
+        testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
+    }
 }

--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -190,7 +190,7 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
 
-    if("Playground" == rootProject.name){
+    if("Playground".toLowerCase() == rootProject.name.toLowerCase()){
         // tests only for our playground
         testImplementation 'junit:junit:4.13.2'
         testImplementation "org.robolectric:robolectric:4.7.2"

--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -190,7 +190,7 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
 
-    if("Playground".toLowerCase() == rootProject.name.toLowerCase()){
+    if("Playground" == rootProject.name){
         // tests only for our playground
         testImplementation 'junit:junit:4.13.2'
         testImplementation "org.robolectric:robolectric:4.7.2"

--- a/scripts/test-unit.js
+++ b/scripts/test-unit.js
@@ -19,7 +19,7 @@ function runAndroidUnitTests() {
     exec.execSync(`yes | ${sdkmanager} --licenses`);
     // exec.execSync(`echo y | ${sdkmanager} --update && echo y | ${sdkmanager} --licenses`);
   }
-  exec.execSync(`cd lib/android && ./gradlew ${conf}`);
+  exec.execSync(`cd playground/android && ./gradlew ${conf}`);
 }
 
 function runIosUnitTests() {


### PR DESCRIPTION
Exclude android native unit tests and their dependencies from being passed to other projects.