### PR TITLE
Revert "Remove unneeded RCTUIManager setAvailableSize call (#7412)"

### DIFF
--- a/lib/ios/RNNComponentRootView.m
+++ b/lib/ios/RNNComponentRootView.m
@@ -2,6 +2,20 @@
 
 @implementation RNNComponentRootView
 
+- (instancetype)initWithBridge:(RCTBridge *)bridge
+                    moduleName:(NSString *)moduleName
+             initialProperties:(NSDictionary *)initialProperties
+                  eventEmitter:(RNNEventEmitter *)eventEmitter
+           reactViewReadyBlock:(RNNReactViewReadyCompletionBlock)reactViewReadyBlock {
+    self = [super initWithBridge:bridge
+                      moduleName:moduleName
+               initialProperties:initialProperties
+                    eventEmitter:eventEmitter
+             reactViewReadyBlock:reactViewReadyBlock];
+    [bridge.uiManager setAvailableSize:UIScreen.mainScreen.bounds.size forRootView:self];
+    return self;
+}
+
 - (NSString *)componentType {
     return ComponentTypeScreen;
 }


### PR DESCRIPTION
This reverts commit 345344a2c27611c6b3dc24f7a54742b2df25a7cc.

It seems like removing the setAvailableSize call has caused issues for some people (#7457). So I would recommend reverting this for now although I still don't think that the setAvailableSize call is really necessary here. It seems like the issues are caused by another problem thats just masked by this. We will need to investigate this further.