### PR TITLE
Fix Build Error After Upgrading To Android Gradle Plugin 7.1.1

### DIFF
--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -161,16 +161,6 @@ List reactNativeVersionComponents(rnPackageJsonFile) {
     return reactNativeVersion.tokenize('-')[0].tokenize('.')
 }
 
-allprojects { p ->
-    p.afterEvaluate {
-        p.android.compileOptions.sourceCompatibility JavaVersion.VERSION_1_8
-        p.android.compileOptions.targetCompatibility JavaVersion.VERSION_1_8
-    }
-    p.repositories {
-        maven { url "https://jitpack.io" }
-    }
-}
-
 dependencies {
 
     implementation "androidx.core:core-ktx:1.6.0"


### PR DESCRIPTION
See [Issue 7463](https://github.com/wix/react-native-navigation/issues/7463)