### PR TITLE
Resolve android crash on device rotate

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/Presenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/Presenter.java
@@ -97,7 +97,7 @@ public class Presenter {
             int top = view.resolveCurrentOptions().statusBar.drawBehind.isTrue() ? 0 : SystemUiUtils.getStatusBarHeight(view.getActivity());
             if (!(view instanceof ParentController)) {
                 MarginLayoutParams lp = (MarginLayoutParams) view.getView().getLayoutParams();
-                if (lp.topMargin != 0) top = 0;
+                if (lp != null && lp.topMargin != 0) top = 0;
             }
             ld.setLayerInset(0, 0, top, 0, 0);
             view.getView().setBackground(ld);


### PR DESCRIPTION
`getLayoutParams()` can return null if the view is not currently attached. This may occur during device rotation.

Fixes #7473