### PR TITLE
Fix issue BottomTabs Elevation not working on Android

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
@@ -8,6 +8,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.View;
+import android.widget.Toast;
 
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.PermissionAwareActivity;
@@ -47,6 +48,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
         );
         navigator.bindViews();
         getReactGateway().onActivityCreated(this);
+        Toast.makeText(this, "Hello Hanh!", Toast.LENGTH_LONG).show();
     }
 
     @Override

--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
@@ -8,7 +8,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.View;
-import android.widget.Toast;
 
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.PermissionAwareActivity;
@@ -48,7 +47,6 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
         );
         navigator.bindViews();
         getReactGateway().onActivityCreated(this);
-        Toast.makeText(this, "Hello Hanh!", Toast.LENGTH_LONG).show();
     }
 
     @Override

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsPresenter.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsPresenter.kt
@@ -175,7 +175,9 @@ class BottomTabsPresenter(
             }
         }
         if (bottomTabsOptions.elevation.hasValue()) {
-            bottomTabs.setUseElevation(true, bottomTabsOptions.elevation.get().toFloat())
+            val elevation = bottomTabsOptions.elevation.get().toFloat()
+            bottomTabsContainer.setPaddingTopForBottomTabWrapper(paddingTop = elevation.toInt())
+            bottomTabs.setUseElevation(true, elevation)
         }
 
         when {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/BottomTabsContainer.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/BottomTabsContainer.kt
@@ -93,12 +93,10 @@ class BottomTabsContainer(context: Context, val bottomTabs: BottomTabs) : Shadow
         topOutLineView.alpha = 0f
     }
 
-    // set padding top to show elevation of the bottom bar
     fun setPaddingTopForBottomTabWrapper(paddingTop: Int) {
         if (childCount > 0) {
             val child = getChildAt(0)
             if (child is LinearLayout) {
-                // set padding for the container of bottom tab
                 child.setPadding(
                     child.paddingLeft,
                     paddingTop,

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/BottomTabsContainer.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/BottomTabsContainer.kt
@@ -39,6 +39,7 @@ class BottomTabsContainer(context: Context, val bottomTabs: BottomTabs) : Shadow
         shadowColor = DEFAULT_SHADOW_COLOR
         val linearLayout = LinearLayout(context).apply {
             orientation = LinearLayout.VERTICAL
+            this.clipToPadding = false
             this.addView(topOutLineView, LayoutParams(LayoutParams.MATCH_PARENT, DEFAULT_TOP_OUTLINE_SIZE_PX))
             this.addView(bottomTabs, LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
         }
@@ -91,5 +92,20 @@ class BottomTabsContainer(context: Context, val bottomTabs: BottomTabs) : Shadow
     fun hideTopOutLine() {
         topOutLineView.alpha = 0f
     }
-}
 
+    // set padding top to show elevation of the bottom bar
+    fun setPaddingTopForBottomTabWrapper(paddingTop: Int) {
+        if (childCount > 0) {
+            val child = getChildAt(0)
+            if (child is LinearLayout) {
+                // set padding for the container of bottom tab
+                child.setPadding(
+                    child.paddingLeft,
+                    paddingTop,
+                    child.paddingRight,
+                    child.paddingBottom
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
This issue was raised on this link: https://github.com/wix/react-native-navigation/issues/7422

The code which sets bottomtabs elevation:
Navigation.setDefaultOptions({
    statusBar: {
        backgroundColor: '#4d089a'
    },
    topBar: {
        title: {
            color: 'white'
        },
        backButton: {
            color: 'white'
        },
        background: {
            color: '#4d089a'
        }
    },
    bottomTab: {
        fontSize: 14,
        selectedFontSize: 14,
        selectedTextColor: '#069A8E',
        selectedIconColor: '#069A8E'
    },
    bottomTabs: {
        titleDisplayMode: 'alwaysShow',
        iconWidth: 24,
        iconHeight: 24,
        elevation: 8,
    }
});

With the version "7.27.1", the android application doesn't show elevation like this picture:
![rnn_no_elevation](https://user-images.githubusercontent.com/22546252/166109236-8d603d04-03d7-4c5d-a5ec-01b31e25b543.png)

And if using the fixing code from my branch, it will show elevation:
![rnn_elevation](https://user-images.githubusercontent.com/22546252/166109271-8dfa1d2d-0fc9-4f86-9758-9a77ef181401.png)

Please check carefully, you can see the elevation in the second picture. 