### PR TITLE
Fix Navigation bottomTabs and topBar height constants

### DIFF
--- a/lib/ios/UINavigationController+RNNOptions.m
+++ b/lib/ios/UINavigationController+RNNOptions.m
@@ -72,7 +72,7 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 }
 
 - (CGFloat)getTopBarHeight {
-    return self.navigationBar.frame.size.height;
+    return self.navigationBar.frame.origin.y + self.navigationBar.frame.size.height;
 }
 
 @end

--- a/lib/ios/UIViewController+LayoutProtocol.m
+++ b/lib/ios/UIViewController+LayoutProtocol.m
@@ -146,23 +146,11 @@
 }
 
 - (CGFloat)getTopBarHeight {
-    for (UIViewController *child in [self childViewControllers]) {
-        CGFloat childTopBarHeight = [child getTopBarHeight];
-        if (childTopBarHeight > 0)
-            return childTopBarHeight;
-    }
-
-    return 0;
+    return [self.presentedComponentViewController.navigationController getTopBarHeight];
 }
 
 - (CGFloat)getBottomTabsHeight {
-    for (UIViewController *child in [self childViewControllers]) {
-        CGFloat childBottomTabsHeight = [child getBottomTabsHeight];
-        if (childBottomTabsHeight > 0)
-            return childBottomTabsHeight;
-    }
-
-    return 0;
+    return [self.presentedComponentViewController.tabBarController getBottomTabsHeight];
 }
 
 - (void)screenPopped {

--- a/playground/ios/NavigationTests/UIViewController+LayoutProtocolTest.m
+++ b/playground/ios/NavigationTests/UIViewController+LayoutProtocolTest.m
@@ -1,4 +1,5 @@
 #import "RNNComponentPresenter.h"
+#import "RNNComponentViewController+Utils.h"
 #import "RNNStackController.h"
 #import "UIViewController+LayoutProtocol.h"
 #import "UIViewController+RNNOptions.h"
@@ -222,6 +223,86 @@
     XCTAssertTrue(component.extendedLayoutIncludesOpaqueBars);
     XCTAssertTrue(stack.extendedLayoutIncludesOpaqueBars);
     XCTAssertTrue(tabBar.extendedLayoutIncludesOpaqueBars);
+}
+
+- (void)testConstants_shouldReturnNavigationBarHeight_visible {
+    RNNNavigationOptions *options = [RNNNavigationOptions emptyOptions];
+    options.topBar.largeTitle.visible = [Bool withValue:YES];
+    UIViewController *vc1 = [RNNComponentViewController createWithComponentId:@"vc1"];
+    UIViewController *vc2 = [RNNComponentViewController createWithComponentId:@"vc2"
+                                                               initialOptions:options];
+    RNNStackController *stack =
+        [[RNNStackController alloc] initWithLayoutInfo:nil
+                                               creator:nil
+                                               options:options
+                                        defaultOptions:nil
+                                             presenter:[[RNNStackPresenter alloc] init]
+                                          eventEmitter:nil
+                                  childViewControllers:@[ vc1 ]];
+    RNNStackController *stack2 =
+        [[RNNStackController alloc] initWithLayoutInfo:nil
+                                               creator:nil
+                                               options:options
+                                        defaultOptions:nil
+                                             presenter:[[RNNStackPresenter alloc] init]
+                                          eventEmitter:nil
+                                  childViewControllers:@[ vc2 ]];
+
+    RNNBottomTabsController *bottomTabs =
+        [[RNNBottomTabsController alloc] initWithLayoutInfo:nil
+                                                    creator:nil
+                                                    options:nil
+                                             defaultOptions:nil
+                                                  presenter:RNNBasePresenter.new
+                                         bottomTabPresenter:nil
+                                      dotIndicatorPresenter:nil
+                                               eventEmitter:nil
+                                       childViewControllers:@[ stack, stack2 ]
+                                         bottomTabsAttacher:nil];
+
+    XCTAssertEqual([bottomTabs getTopBarHeight], stack.navigationBar.frame.size.height);
+}
+
+- (void)testConstants_shouldReturnNavigationBarHeight_invisible {
+    RNNNavigationOptions *options = [RNNNavigationOptions emptyOptions];
+    options.topBar.visible = [Bool withValue:NO];
+    UIViewController *vc1 = [RNNComponentViewController createWithComponentId:@"vc1"];
+    UIViewController *vc2 = [RNNComponentViewController createWithComponentId:@"vc2"
+                                                               initialOptions:options];
+    RNNStackController *stack =
+        [[RNNStackController alloc] initWithLayoutInfo:nil
+                                               creator:nil
+                                               options:RNNNavigationOptions.emptyOptions
+                                        defaultOptions:RNNNavigationOptions.emptyOptions
+                                             presenter:[[RNNStackPresenter alloc] init]
+                                          eventEmitter:nil
+                                  childViewControllers:@[ vc1 ]];
+    RNNStackController *stack2 =
+        [[RNNStackController alloc] initWithLayoutInfo:nil
+                                               creator:nil
+                                               options:RNNNavigationOptions.emptyOptions
+                                        defaultOptions:RNNNavigationOptions.emptyOptions
+                                             presenter:[[RNNStackPresenter alloc] init]
+                                          eventEmitter:nil
+                                  childViewControllers:@[ vc2 ]];
+
+    RNNBottomTabsController *bottomTabs =
+        [[RNNBottomTabsController alloc] initWithLayoutInfo:nil
+                                                    creator:nil
+                                                    options:nil
+                                             defaultOptions:nil
+                                                  presenter:RNNBasePresenter.new
+                                         bottomTabPresenter:nil
+                                      dotIndicatorPresenter:nil
+                                               eventEmitter:nil
+                                       childViewControllers:@[ stack, stack2 ]
+                                         bottomTabsAttacher:nil];
+    [vc1 viewWillAppear:NO];
+    XCTAssertNotEqual([bottomTabs getTopBarHeight], 0);
+
+    [bottomTabs setSelectedIndex:1];
+    [vc2 viewWillAppear:NO];
+    XCTAssertEqual([bottomTabs getTopBarHeight], 0);
 }
 
 @end


### PR DESCRIPTION
`bottomTabs` and `topBar` height constants resolved incorrectly, fixed it to be resolved from the current visible screen.

Closes #7514