### PR TITLE
Fix bottomTabs background always being white

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/BottomTabs.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/BottomTabs.java
@@ -2,6 +2,7 @@ package com.reactnativenavigation.views.bottomtabs;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -28,6 +29,7 @@ public class BottomTabs extends AHBottomNavigation {
     public BottomTabs(Context context) {
         super(context);
         setId(R.id.bottomTabs);
+        setDefaultBackgroundColor(Color.TRANSPARENT);
     }
 
     public void disableItemsCreation() {


### PR DESCRIPTION
#7519 fixed missing elevation of bottomTabs by applying the background color on the bottomTabs container. While it fixed the elevation bug, it introduced a bug where the default background color of the bottomTabs overlapped the background color applied on the container.

This commit sets the default background color to transparent to fix the issue.