### PR TITLE
Fix crash in ButtonPresenter

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/ButtonPresenter.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/ButtonPresenter.kt
@@ -159,6 +159,7 @@ open class ButtonPresenter(private val context: Context, private val button: But
         iconResolver.resolve(button) { icon: Drawable ->
             setIconColor(icon)
             toolbar.setNavigationOnClickListener { onPress(button) }
+            toolbar.navigationIcon = null
             toolbar.navigationIcon = icon
             setLeftButtonTestId(toolbar)
             if (button.accessibilityLabel.hasValue()) toolbar.navigationContentDescription = button.accessibilityLabel.get()


### PR DESCRIPTION
#### Crash location
ButtonPresenter.java line 162 in com.reactnativenavigation.viewcontrollers.stack.topbar.button.ButtonPresenter.applyNavigationIcon$lambda-7()
#### EXCEPTION
java.lang.IllegalStateExceptionMESSAGEThe specified child already has a parent. You must call removeView() on the child's parent first.