### PR TITLE
escape pipe to allow description cell to show

### DIFF
--- a/website/versioned_docs/version-7.28.0/api/api-component.mdx
+++ b/website/versioned_docs/version-7.28.0/api/api-component.mdx
@@ -42,7 +42,7 @@ Pass a function that will allow you to register a component lazily. When encount
 #### Parameters
 | Name   | Required | Type                | Description                                                                                                            |
 | ------ | -------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| lazyRegistratorFn | Yes      | (lazyComponentRequest: string | number) => void | A function that takes a componentName, will be called when encountering an unknown componentName |
+| lazyRegistratorFn | Yes      | (lazyComponentRequest: string \| number) => void | A function that takes a componentName, will be called when encountering an unknown componentName |
 
 #### Example
 ```js


### PR DESCRIPTION
A missing escape character for the `|` separating TS types for `` causes the markdown table rendering to swallow the description field. This should fix it and allow the description to show again.

Before:
<img width="960" alt="image" src="https://user-images.githubusercontent.com/6306291/170290063-2812690d-999d-4fab-9e64-40b9ef58baef.png">

After:
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/6306291/170291313-4b3d1d30-4158-41f7-8e55-fda8be9718c8.png">


