### PR TITLE
fix(bottomtabs): remove LAYER_TYPE_HARDWARE as view layer

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/ShadowLayout.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/bottomtabs/ShadowLayout.kt
@@ -31,7 +31,6 @@ open class ShadowLayout constructor(context: Context) : FrameLayout(context) {
 
     init {
         super.setWillNotDraw(false)
-        super.setLayerType(View.LAYER_TYPE_HARDWARE, paint)
     }
 
     override fun onDetachedFromWindow() {


### PR DESCRIPTION
The pull request resolve the bottomtabs shadow on Android 9:
https://github.com/wix/react-native-navigation/issues/7556