### PR TITLE
#7560 removed componentName from ModalDismissedEvent

### DIFF
--- a/lib/src/interfaces/ComponentEvents.ts
+++ b/lib/src/interfaces/ComponentEvents.ts
@@ -26,7 +26,6 @@ export interface NavigationButtonPressedEvent extends ComponentEvent {
 }
 
 export interface ModalDismissedEvent extends ComponentEvent {
-  componentName: string;
   modalsDismissed: number;
 }
 


### PR DESCRIPTION
Solves #7560.

**componentName** is not filled since 2020 https://github.com/wix/react-native-navigation/issues/6605#issuecomment-701172387 ...