### PR TITLE
remove unneccessary netinfo package

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "@react-native-community/blur": "^3.6.0",
     "@react-native-community/datetimepicker": "^3.4.7",
     "@react-native-community/eslint-config": "2.0.0",
-    "@react-native-community/netinfo": "^5.9.4",
     "@testing-library/jest-native": "^4.0.1",
     "@testing-library/react-native": "^7.2.0",
     "@types/detox": "17.14.3",


### PR DESCRIPTION
remove unnecessary **@react-native-community/netinfo** declaration since it is not used.