### PR TITLE
Expose when setNavigationRoot is called on RootPresenter

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
@@ -31,6 +31,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     private PermissionListener mPermissionListener;
 
     protected Navigator navigator;
+    protected RootPresenter rootPresenter;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -39,11 +40,12 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
             return;
         }
         addDefaultSplashLayout();
+        rootPresenter = new RootPresenter();
         navigator = new Navigator(this,
                 new ChildControllersRegistry(),
                 new ModalStack(this),
                 new OverlayManager(),
-                new RootPresenter()
+                rootPresenter
         );
         navigator.bindViews();
         getReactGateway().onActivityCreated(this);

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/RootPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/RootPresenter.java
@@ -19,6 +19,7 @@ public class RootPresenter {
     private final RootAnimator animator;
     private CoordinatorLayout rootLayout;
     private final LayoutDirectionApplier layoutDirectionApplier;
+    private boolean setRootCalled = false;
 
     public void setRootContainer(CoordinatorLayout rootLayout) {
         this.rootLayout = rootLayout;
@@ -28,6 +29,10 @@ public class RootPresenter {
         this(new RootAnimator(), new LayoutDirectionApplier());
     }
 
+    public boolean setRootCalled() {
+        return setRootCalled;
+    }
+
     @VisibleForTesting
     public RootPresenter(RootAnimator animator, LayoutDirectionApplier layoutDirectionApplier) {
         this.animator = animator;
@@ -35,6 +40,7 @@ public class RootPresenter {
     }
 
     public void setRoot(ViewController appearingRoot, ViewController<?> disappearingRoot, Options defaultOptions, CommandListener listener, ReactInstanceManager reactInstanceManager) {
+        setRootCalled = true;
         layoutDirectionApplier.apply(appearingRoot, defaultOptions, reactInstanceManager);
         rootLayout.addView(appearingRoot.getView(), matchParentWithBehaviour(new BehaviourDelegate(appearingRoot)));
         Options options = appearingRoot.resolveCurrentOptions(defaultOptions);


### PR DESCRIPTION
This change exposes when `setNavigationRoot` is called by the javascript application on the RootPresenter class. 

This is needed to implement the new Android 12 style splash screen (discussion here: https://github.com/wix/react-native-navigation/discussions/7363), so that the screen can persist until the application is ready to show real content.