### PR TITLE
Add more information on how to run playground

### DIFF
--- a/website/docs/docs/docs-playground-app.mdx
+++ b/website/docs/docs/docs-playground-app.mdx
@@ -8,11 +8,12 @@ sidebar_label: Playground app
 
 If you want to have a quick look around and test things out, you can run the playground app, bundled with this repo.
 
-1. Install dependencies via `npm install` (if you haven't already) and `npm run pod-install` (for iOS)
-2. Run the playground project on Android and iOS
+1. Install correct version of node/npm: `nvm install` _(important step)_
+2. Install dependencies via `npm install` (if you haven't already) and `npm run pod-install` (for iOS)
+3. Run the playground project on Android and iOS
     - `npm run start` to get the packager running in the terminal, leave it open
     - **iOS**: open `./playground/ios` in Xcode and run it
     - **Android**: open `./playground/android` in Android Studio and run it
-3. You can run tests if / when you need to (list of scripts [available here](meta-contributing#scripts)). Before
+4. You can run tests if / when you need to (list of scripts [available here](meta-contributing#scripts)). Before
 you start changing things, make sure everything works.
 	- To easily run all tests in parallel `npm run test-all`


### PR DESCRIPTION
npm install will fail if nodejs is not in the correct version. (somehow fix or related to #7604 )