### PR TITLE
Avoid returning modal that is being dismissed as the top presented viewController

### DIFF
--- a/lib/ios/RNNModalManager.m
+++ b/lib/ios/RNNModalManager.m
@@ -191,7 +191,7 @@
 
 - (UIViewController *)topPresentedVC {
     UIViewController *root = [self rootViewController];
-    while (root.presentedViewController) {
+    while (root.presentedViewController && !root.presentedViewController.isBeingDismissed) {
         root = root.presentedViewController;
     }
     return root;


### PR DESCRIPTION
This caused a bug in our Wix app when presenting a modal while another one is dismissed. The presented modal was dismissed as well along with the one that was being dismissed.