### PR TITLE
Support constants in Navigation mocks

### DIFF
--- a/lib/Mock/mocks/NativeCommandsSender.tsx
+++ b/lib/Mock/mocks/NativeCommandsSender.tsx
@@ -4,6 +4,7 @@ import { LayoutNode } from '../../src/commands/LayoutTreeCrawler';
 import { events } from '../Stores/EventsStore';
 import _ from 'lodash';
 import ComponentNode from '../Layouts/ComponentNode';
+import { Constants } from '../../src/adapters/Constants';
 
 export class NativeCommandsSender {
   constructor() {}
@@ -115,4 +116,22 @@ export class NativeCommandsSender {
   }
 
   getLaunchArgs(_commandId: string) {}
+
+  getNavigationConstants(): Promise<Constants> {
+    return Promise.resolve({
+      topBarHeight: 0,
+      backButtonId: 'RNN.back',
+      bottomTabsHeight: 0,
+      statusBarHeight: 0,
+    });
+  }
+
+  getNavigationConstantsSync(): Constants {
+    return {
+      topBarHeight: 0,
+      backButtonId: 'RNN.back',
+      bottomTabsHeight: 0,
+      statusBarHeight: 0,
+    };
+  }
 }

--- a/lib/src/Navigation.ts
+++ b/lib/src/Navigation.ts
@@ -248,7 +248,7 @@ export class NavigationRoot {
     componentId: string,
     layout: Layout<P> | Array<Layout<P>>
   ): Promise<string> {
-    const children: Layout[] = isArray(layout) ? layout : [layout];
+    const children: Layout<P | []>[] = isArray(layout) ? layout : [layout];
     return this.commands.setStackRoot(componentId, children);
   }
 
@@ -291,13 +291,13 @@ export class NavigationRoot {
    * Constants coming from native
    */
   public async constants(): Promise<NavigationConstants> {
-    return await Constants.get();
+    return await Constants.get(this.nativeCommandsSender);
   }
 
   /**
    * Constants coming from native (synchronized call)
    */
   public constantsSync(): NavigationConstants {
-    return Constants.getSync();
+    return Constants.getSync(this.nativeCommandsSender);
   }
 }

--- a/lib/src/adapters/Constants.ts
+++ b/lib/src/adapters/Constants.ts
@@ -1,4 +1,3 @@
-// import { NativeModules } from 'react-native';
 import { NativeCommandsSender } from './NativeCommandsSender';
 
 export interface NavigationConstants {

--- a/lib/src/adapters/Constants.ts
+++ b/lib/src/adapters/Constants.ts
@@ -1,4 +1,5 @@
-import { NativeModules } from 'react-native';
+// import { NativeModules } from 'react-native';
+import { NativeCommandsSender } from './NativeCommandsSender';
 
 export interface NavigationConstants {
   statusBarHeight: number;
@@ -8,13 +9,14 @@ export interface NavigationConstants {
 }
 
 export class Constants {
-  static async get(): Promise<NavigationConstants> {
-    const constants: NavigationConstants = await NativeModules.RNNBridgeModule.getNavigationConstants();
+  static async get(nativeCommandSender: NativeCommandsSender): Promise<NavigationConstants> {
+    const constants: NavigationConstants = await nativeCommandSender.getNavigationConstants();
     return new Constants(constants);
   }
 
-  static getSync(): NavigationConstants {
-    return new Constants(NativeModules.RNNBridgeModule.getNavigationConstantsSync());
+  static getSync(nativeCommandSender: NativeCommandsSender): NavigationConstants {
+    const constants: NavigationConstants = nativeCommandSender.getNavigationConstantsSync();
+    return new Constants(constants);
   }
 
   public readonly statusBarHeight: number;

--- a/lib/src/adapters/NativeCommandsSender.ts
+++ b/lib/src/adapters/NativeCommandsSender.ts
@@ -1,4 +1,5 @@
 import { NativeModules } from 'react-native';
+import { NavigationConstants } from './Constants';
 
 interface NativeCommandsModule {
   setRoot(commandId: string, layout: { root: any; modals: any[]; overlays: any[] }): Promise<any>;
@@ -16,6 +17,8 @@ interface NativeCommandsModule {
   dismissOverlay(commandId: string, componentId: string): Promise<any>;
   dismissAllOverlays(commandId: string): Promise<any>;
   getLaunchArgs(commandId: string): Promise<any>;
+  getNavigationConstants(): Promise<NavigationConstants>;
+  getNavigationConstantsSync(): NavigationConstants;
 }
 
 export class NativeCommandsSender {
@@ -82,5 +85,13 @@ export class NativeCommandsSender {
 
   getLaunchArgs(commandId: string) {
     return this.nativeCommandsModule.getLaunchArgs(commandId);
+  }
+
+  getNavigationConstants() {
+    return this.nativeCommandsModule.getNavigationConstants();
+  }
+
+  getNavigationConstantsSync() {
+    return this.nativeCommandsModule.getNavigationConstantsSync();
   }
 }

--- a/lib/src/commands/Commands.ts
+++ b/lib/src/commands/Commands.ts
@@ -91,7 +91,7 @@ export class Commands {
     this.commandsObserver.notify(CommandName.UpdateProps, { componentId, props });
   }
 
-  public showModal(layout: Layout) {
+  public showModal<P>(layout: Layout<P>) {
     const layoutCloned = cloneLayout(layout);
     this.optionsCrawler.crawl(layoutCloned);
     const layoutProcessed = this.layoutProcessor.process(layoutCloned, CommandName.ShowModal);
@@ -125,7 +125,7 @@ export class Commands {
     return result;
   }
 
-  public push(componentId: string, simpleApi: Layout) {
+  public push<P>(componentId: string, simpleApi: Layout<P>) {
     const input = cloneLayout(simpleApi);
     this.optionsCrawler.crawl(input);
     const layoutProcessed = this.layoutProcessor.process(input, CommandName.Push);
@@ -163,7 +163,7 @@ export class Commands {
     return result;
   }
 
-  public setStackRoot(componentId: string, children: Layout[]) {
+  public setStackRoot<P>(componentId: string, children: Layout<P>[]) {
     const input = map(cloneLayout(children), (simpleApi) => {
       this.optionsCrawler.crawl(simpleApi);
       const layoutProcessed = this.layoutProcessor.process(simpleApi, CommandName.SetStackRoot);
@@ -185,7 +185,7 @@ export class Commands {
     return result;
   }
 
-  public showOverlay(simpleApi: Layout) {
+  public showOverlay<P>(simpleApi: Layout<P>) {
     const input = cloneLayout(simpleApi);
     this.optionsCrawler.crawl(input);
     const layoutProcessed = this.layoutProcessor.process(input, CommandName.ShowOverlay);

--- a/lib/src/commands/OptionsCrawler.ts
+++ b/lib/src/commands/OptionsCrawler.ts
@@ -22,7 +22,7 @@ export class OptionsCrawler {
     this.crawl = this.crawl.bind(this);
   }
 
-  crawl(api?: Layout): void {
+  crawl(api?: Layout<any>): void {
     if (!api) return;
     if (api.topTabs) {
       this.topTabs(api.topTabs);

--- a/lib/src/processors/LayoutProcessor.ts
+++ b/lib/src/processors/LayoutProcessor.ts
@@ -6,7 +6,7 @@ import { CommandName } from '../interfaces/CommandName';
 export class LayoutProcessor {
   constructor(private layoutProcessorsStore: LayoutProcessorsStore) {}
 
-  public process(layout: Layout, commandName: CommandName): Layout {
+  public process(layout: Layout<any>, commandName: CommandName): Layout {
     const processors: ILayoutProcessor[] = this.layoutProcessorsStore.getProcessors();
     processors.forEach((processor) => {
       layout = processor(layout, commandName);


### PR DESCRIPTION
Until now, invoking `Navigation.constants()` and `Navigation.constantsSync()` failed in our headless tests.
This PR fix this and some lint issues.