### PR TITLE
Fix SharedElementAnimator missing some animations

### DIFF
--- a/lib/ios/SharedElementAnimator.m
+++ b/lib/ios/SharedElementAnimator.m
@@ -39,7 +39,7 @@
             [RNNElementFinder findElementForId:transitionOptions.toId
                                         inView:_toVC.presentedComponentViewController.reactView];
         if (fromView == nil || toView == nil) {
-            break;
+            continue;
         }
 
         SharedElementTransition *sharedElementAnimator =


### PR DESCRIPTION
Previously if an element was not found, then it would break out of the loop looking for further (possibly valid) shared element transitions. Now it'll continue the loop, which is the expected behavior.