### PR TITLE
Fix runOnMainThread to postAtFrontOfQueue when already on the main thread

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/UiUtils.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/UiUtils.java
@@ -81,7 +81,11 @@ public class UiUtils {
     }
 
     public static void runOnMainThread(Runnable runnable) {
-        new Handler(Looper.getMainLooper()).post(runnable);
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            new Handler(Looper.getMainLooper()).postAtFrontOfQueue(runnable);
+        } else {
+            new Handler(Looper.getMainLooper()).post(runnable);
+        }
     }
 
     public static float getWindowHeight(Context context) {


### PR DESCRIPTION
This fixes a crash happening in the Wix app, look like there's a race condition where the activity is destroyed and `navigator.onHostPause()`gets called too late. Most of times this shouldn't be delayed as it is called on the main thread.