### PR TITLE
Fix issue with bottom-tabs being obscured on cold launch on android 13

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import android.content.res.Configuration;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
+import android.os.Build;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -112,8 +113,11 @@ public class BottomTabsController extends ParentController<BottomTabsLayout> imp
 
     @Override
     protected WindowInsetsCompat onApplyWindowInsets(View view, WindowInsetsCompat insets) {
-        ViewCompat.onApplyWindowInsets(view, insets);
-        return insets;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ViewCompat.onApplyWindowInsets(view, insets);
+            return insets;
+        }
+        return super.onApplyWindowInsets(view, insets);
     }
 
     @NonNull

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -3,6 +3,8 @@ package com.reactnativenavigation.viewcontrollers.bottomtabs;
 import android.animation.Animator;
 import android.app.Activity;
 import android.content.res.Configuration;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -106,6 +108,12 @@ public class BottomTabsController extends ParentController<BottomTabsLayout> imp
             initialTabIndex = resolveCurrentOptions.bottomTabsOptions.currentTabIndex.get();
         }
         bottomTabs.setCurrentItem(initialTabIndex, false);
+    }
+
+    @Override
+    protected WindowInsetsCompat onApplyWindowInsets(View view, WindowInsetsCompat insets) {
+        ViewCompat.onApplyWindowInsets(view, insets);
+        return insets;
     }
 
     @NonNull


### PR DESCRIPTION
Starting with Android 13, it seems like there has been a change in the order of events being fired for layout of the system navigationBars and systemBars.  This results in what appears to be a race condition of sorts, which leads to the bottom tabs not accounting for the OS navigationBar height when the app is initially launched, causing them to render 'behind' the OS controls.
<img width="449" alt="Screen Shot 2023-01-07 at 10 52 59 AM" src="https://user-images.githubusercontent.com/1091291/211159267-e715cd57-b5b1-4acc-bf7b-7ea44b653baf.png">

Upon backgrounding and relaunching the app, or interacting with the TINY bar there, this would be fixed:
<img width="461" alt="Screen Shot 2023-01-07 at 10 53 32 AM" src="https://user-images.githubusercontent.com/1091291/211159331-83437b43-3aa9-45a6-b0af-0fe91fb7d791.png">


I don't know if this is the optimal way to fix it, but adding this override appears to at least trigger an additional redraw and fixes the issue so that the bar is visible at the start.

Note: in order to see this behavior on an emulator, you need to set the `hw.mainKeys=no` in the config.ini field as well as turning off the gesture navigation system in System settings.
