### PR TITLE
Fix: Wrong options are set when onConfigurationChanged occurs

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/parent/ParentController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/parent/ParentController.java
@@ -208,7 +208,9 @@ public abstract class ParentController<T extends ViewGroup> extends ChildControl
         super.onConfigurationChanged(newConfig);
         Collection<? extends ViewController<?>> childControllers = getChildControllers();
         for(ViewController<?> controller: childControllers){
-            controller.onConfigurationChanged(newConfig);
+            if (controller.isViewShown()) {
+                controller.onConfigurationChanged(newConfig);
+            }
         }
     }
 }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/parent/ParentControllerTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/parent/ParentControllerTest.java
@@ -86,15 +86,18 @@ public class ParentControllerTest extends BaseTest {
     }
 
     @Test
-    public void onConfigurationChange_shouldCallConfigurationChangeForPresenterAndChildren() {
-        children.add(spy(new SimpleViewController(activity, childRegistry, "child1", new Options())));
-        children.add(spy(new SimpleViewController(activity, childRegistry, "child2", new Options())));
+    public void onConfigurationChange_shouldCallConfigurationChangeForPresenterAndVisibleChild() {
+        SimpleViewController child1 = spy(new SimpleViewController(activity, childRegistry, "child1", new Options()));
+        SimpleViewController child2 = spy(new SimpleViewController(activity, childRegistry, "child2", new Options()));
+        children.add(child1);
+        children.add(child2);
+        Mockito.when(child1.isViewShown()).thenReturn(true);
+        Mockito.when(child2.isViewShown()).thenReturn(false);
         ParentController<?> spyUUT = spy(uut);
         spyUUT.onConfigurationChanged(mockConfiguration);
         verify(presenter).onConfigurationChanged(any(),any());
-        for (ViewController<?> controller : children) {
-            verify(controller).onConfigurationChanged(any());
-        }
+        verify(child1).onConfigurationChanged(any());
+        verify(child2, never()).onConfigurationChanged(any());
     }
 
     @Test


### PR DESCRIPTION
## Repro steps
1. Set system theme to light.
2. Create stack root with multiple tabs
3. Set nav bar color to black on first tab.
```
Navigation.mergeOptions({
  navigationBar: {
    backgroundColor: '#000000',
  }
});
```
4. Change app orientation.


**Expected Result:** Nav bar stays black.
**Achieved Result:** Nav bar becomes white.

## Issue cause
As I've figured out during debugging, `mergeOptions` changes only option of controller with specified `componentId`. However, when `Navigator.onConfigurationChanged` is invoked the options of all existing controllers are being applied to presenter, therefore the last created controller's options are finally set.

## Solution
Check for `controller.isViewShown` before triggering it's `onConfigurationChanged`.