### PR TITLE
[iOS] Fix: the bottomTab dotIndicator is sometimes displayed at a wrong tab button

### DIFF
--- a/lib/ios/Utils/UITabBarController+RNNUtils.m
+++ b/lib/ios/Utils/UITabBarController+RNNUtils.m
@@ -1,17 +1,10 @@
+#import "UITabBar+utils.h"
 #import "UITabBarController+RNNUtils.h"
 #import "UIView+Utils.h"
 
 @implementation UITabBarController (RNNUtils)
 - (UIView *)getTabView:(int)tabIndex {
-    int index = 0;
-    for (UIView *view in [[self tabBar] subviews]) {
-        if ([NSStringFromClass([view class]) isEqualToString:@"UITabBarButton"]) {
-            if (index == tabIndex)
-                return view;
-            index++;
-        }
-    }
-    return nil;
+    return [[self tabBar] tabBarItemViewAtIndex:tabIndex];
 }
 
 - (UIView *)getTabIcon:(int)tabIndex {

--- a/playground/src/screens/FirstBottomTabScreen.tsx
+++ b/playground/src/screens/FirstBottomTabScreen.tsx
@@ -38,7 +38,6 @@ export default class FirstBottomTabScreen extends React.Component<NavigationComp
     };
   }
 
-  dotVisible = true;
   badgeVisible = true;
   bottomTabPressedListener = Navigation.events().registerBottomTabPressedListener((event) => {
     if (event.tabIndex == 2) {
@@ -61,7 +60,8 @@ export default class FirstBottomTabScreen extends React.Component<NavigationComp
         />
         <Button label="Set Badge" testID={SET_BADGE_BTN} onPress={() => this.setBadge('NEW')} />
         <Button label="Clear Badge" testID={CLEAR_BADGE_BTN} onPress={() => this.setBadge('')} />
-        <Button label="Set Notification Dot" onPress={this.setNotificationDot} />
+        <Button label="Show Notification Dot" onPress={() => this.setNotificationDot(true)} />
+        <Button label="Hide Notification Dot" onPress={() => this.setNotificationDot(false)} />
         <Button label="Hide Tabs" testID={HIDE_TABS_BTN} onPress={() => this.toggleTabs(false)} />
         <Button label="Show Tabs" testID={SHOW_TABS_BTN} onPress={() => this.toggleTabs(true)} />
         <Button
@@ -109,17 +109,16 @@ export default class FirstBottomTabScreen extends React.Component<NavigationComp
 
   setBadge = (badge: string) => {
     this.badgeVisible = !!badge;
-    if (this.badgeVisible) this.dotVisible = false;
     Navigation.mergeOptions(this, {
       bottomTab: { badge, animateBadge: true },
     });
   };
 
-  setNotificationDot = () => {
-    this.dotVisible = !this.dotVisible;
+  setNotificationDot = (visible: boolean) => {
     Navigation.mergeOptions(this, {
       bottomTab: {
-        dotIndicator: { visible: this.dotVisible },
+        ...(visible ? { badge: '' } : {}),
+        dotIndicator: { visible },
       },
     });
   };

--- a/playground/src/screens/SecondBottomTabScreen.tsx
+++ b/playground/src/screens/SecondBottomTabScreen.tsx
@@ -47,7 +47,8 @@ export default class SecondBottomTabScreen extends React.Component<NavigationCom
         <Button label="Push BottomTabs" testID={PUSH_BTN} onPress={this.pushBottomTabs} />
         <Button label="Push Modal" testID={MODAL_BTN} onPress={this.pushModal} />
         <Button label="SetBadge" testID={SET_BADGE_BTN} onPress={this.setBadge} />
-
+        <Button label="Show Notification Dot" onPress={() => this.setNotificationDot(true)} />
+        <Button label="Hide Notification Dot" onPress={() => this.setNotificationDot(false)} />
         <Button label="Push ScrollView" onPress={this.pushScrollView} />
         <Button
           label="SideMenu inside BottomTabs"
@@ -86,6 +87,15 @@ export default class SecondBottomTabScreen extends React.Component<NavigationCom
         badge: 'Badge',
       },
     });
+
+  setNotificationDot = (visible: boolean) => {
+    Navigation.mergeOptions(this, {
+      bottomTab: {
+        ...(visible ? { badge: '' } : {}),
+        dotIndicator: { visible, color: 'green' },
+      },
+    });
+  };
 
   pushBottomTabs = () =>
     Navigation.push(this, {


### PR DESCRIPTION
Fix the bottomTab dotIndicator is displayed at a wrong tab button after changing the badge state.

Related issue: https://github.com/wix/react-native-navigation/issues/7146

### Repro

It happens after we modify the badge option by calling `mergeOptions` .

https://user-images.githubusercontent.com/25456520/218294543-57d214ec-322f-40c2-9dce-bd4a86fd8354.mp4

### Solution

Fix `getTabView` to return the correct view at the given index.
It currently uses `subviews` to find the view at index, but it doesn't work after tab bar buttons are modified.
Fixed it by using `tabBarItemViewAtIndex` which is already implemented.