### PR TITLE
Fabric support android

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
@@ -3,16 +3,14 @@ package com.reactnativenavigation;
 import android.annotation.TargetApi;
 import android.content.Intent;
 import android.content.res.Configuration;
-import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.View;
-
+import com.facebook.react.ReactActivity;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.PermissionAwareActivity;
 import com.facebook.react.modules.core.PermissionListener;
-import com.reactnativenavigation.options.Options;
 import com.reactnativenavigation.viewcontrollers.overlay.OverlayManager;
 import com.reactnativenavigation.viewcontrollers.viewcontroller.RootPresenter;
 import com.reactnativenavigation.react.JsDevReloadHandler;
@@ -21,13 +19,11 @@ import com.reactnativenavigation.react.CommandListenerAdapter;
 import com.reactnativenavigation.viewcontrollers.child.ChildControllersRegistry;
 import com.reactnativenavigation.viewcontrollers.modal.ModalStack;
 import com.reactnativenavigation.viewcontrollers.navigator.Navigator;
-
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
 
-public class NavigationActivity extends AppCompatActivity implements DefaultHardwareBackBtnHandler, PermissionAwareActivity, JsDevReloadHandler.ReloadListener {
+public class NavigationActivity extends ReactActivity implements DefaultHardwareBackBtnHandler, PermissionAwareActivity, JsDevReloadHandler.ReloadListener {
     @Nullable
     private PermissionListener mPermissionListener;
 
@@ -100,7 +96,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     }
 
     @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         getReactGateway().onActivityResult(this, requestCode, resultCode, data);
     }
@@ -122,10 +118,11 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
         return navigator;
     }
 
+    @Override
     @TargetApi(Build.VERSION_CODES.M)
     public void requestPermissions(String[] permissions, int requestCode, PermissionListener listener) {
         mPermissionListener = listener;
-        requestPermissions(permissions, requestCode);
+        super.requestPermissions(permissions, requestCode);
     }
 
     @Override
@@ -134,6 +131,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
         if (mPermissionListener != null && mPermissionListener.onRequestPermissionsResult(requestCode, permissions, grantResults)) {
             mPermissionListener = null;
         }
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 
     @Override

--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
@@ -1,16 +1,13 @@
 package com.reactnativenavigation;
 
 import android.app.Application;
-
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.soloader.SoLoader;
 import com.reactnativenavigation.react.ReactGateway;
 import com.reactnativenavigation.viewcontrollers.externalcomponent.ExternalComponentCreator;
-
 import java.util.HashMap;
 import java.util.Map;
-
 import androidx.annotation.NonNull;
 
 public abstract class NavigationApplication extends Application implements ReactApplication {

--- a/lib/android/app/src/reactNative71/java/com/reactnativenavigation/react/NavigationReactNativeHost.java
+++ b/lib/android/app/src/reactNative71/java/com/reactnativenavigation/react/NavigationReactNativeHost.java
@@ -1,0 +1,65 @@
+package com.reactnativenavigation.react;
+
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.common.LifecycleState;
+import com.facebook.react.defaults.DefaultReactNativeHost;
+import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+import com.reactnativenavigation.NavigationApplication;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public abstract class NavigationReactNativeHost extends DefaultReactNativeHost implements BundleDownloadListenerProvider {
+
+    private @Nullable NavigationDevBundleDownloadListener bundleListener;
+    private final DevBundleDownloadListener bundleListenerMediator = new DevBundleDownloadListenerAdapter() {
+        @Override
+        public void onSuccess() {
+            if (bundleListener != null) {
+                bundleListener.onSuccess();
+            }
+        }
+    };
+
+    public NavigationReactNativeHost(NavigationApplication application) {
+        super(application);
+    }
+
+    @Override
+    public void setBundleLoaderListener(NavigationDevBundleDownloadListener listener) {
+        bundleListener = listener;
+    }
+
+    protected ReactInstanceManager createReactInstanceManager() {
+        ReactInstanceManagerBuilder builder = ReactInstanceManager.builder()
+                .setApplication(getApplication())
+                .setJSMainModulePath(getJSMainModuleName())
+                .setUseDeveloperSupport(getUseDeveloperSupport())
+                .setRedBoxHandler(getRedBoxHandler())
+                .setJavaScriptExecutorFactory(getJavaScriptExecutorFactory())
+                .setInitialLifecycleState(LifecycleState.BEFORE_CREATE)
+                .setJSIModulesPackage(getJSIModulePackage())
+                .setDevBundleDownloadListener(getDevBundleDownloadListener());
+
+        for (ReactPackage reactPackage : getPackages()) {
+            builder.addPackage(reactPackage);
+        }
+
+        String jsBundleFile = getJSBundleFile();
+        if (jsBundleFile != null) {
+            builder.setJSBundleFile(jsBundleFile);
+        } else {
+            builder.setBundleAssetName(Assertions.assertNotNull(getBundleAssetName()));
+        }
+        return builder.build();
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    @NonNull
+    protected DevBundleDownloadListener getDevBundleDownloadListener() {
+        return bundleListenerMediator;
+    }
+}

--- a/playground/android/app/src/main/java/com/reactnativenavigation/playground/MainActivity.java
+++ b/playground/android/app/src/main/java/com/reactnativenavigation/playground/MainActivity.java
@@ -3,15 +3,19 @@ package com.reactnativenavigation.playground;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.ImageView;
-
 import com.facebook.react.ReactActivityDelegate;
-import com.facebook.react.ReactRootView;
-
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
+import com.facebook.react.defaults.DefaultReactActivityDelegate;
 import com.reactnativenavigation.NavigationActivity;
 
 import androidx.annotation.Nullable;
 
 public class MainActivity extends NavigationActivity {
+
+    @Override
+    protected String getMainComponentName() {
+        return "PlaygroundApp";
+    }
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -23,5 +27,22 @@ public class MainActivity extends NavigationActivity {
         ImageView img = new ImageView(this);
         img.setImageDrawable(getDrawable(R.drawable.ic_android));
         setContentView(img);
+    }
+
+    /**
+     * Returns the instance of the {@link ReactActivityDelegate}. Here we use a util class {@link
+     * DefaultReactActivityDelegate} which allows you to easily enable Fabric and Concurrent React
+     * (aka React 18) with two boolean flags.
+     */
+    @Override
+    protected ReactActivityDelegate createReactActivityDelegate() {
+        return new DefaultReactActivityDelegate(
+                this,
+                getMainComponentName(),
+                // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+                DefaultNewArchitectureEntryPoint.getFabricEnabled(), // fabricEnabled
+                // If you opted-in for the New Architecture, we enable Concurrent React (i.e. React 18).
+                DefaultNewArchitectureEntryPoint.getConcurrentReactEnabled() // concurrentRootEnabled
+        );
     }
 }

--- a/playground/android/app/src/main/java/com/reactnativenavigation/playground/MainApplication.java
+++ b/playground/android/app/src/main/java/com/reactnativenavigation/playground/MainApplication.java
@@ -3,6 +3,7 @@ package com.reactnativenavigation.playground;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
 import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.react.NavigationPackage;
 import com.reactnativenavigation.react.NavigationReactNativeHost;
@@ -30,6 +31,15 @@ public class MainApplication extends NavigationApplication {
                     packages.add(new NavigationPackage(mReactNativeHost));
                     return packages;
                 }
+
+                @Override
+                protected boolean isNewArchEnabled() {
+                    return BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+                }
+                @Override
+                protected Boolean isHermesEnabled() {
+                    return BuildConfig.IS_HERMES_ENABLED;
+                }
             };
     private final ReactNativeHost mNewArchitectureNativeHost =
             new MainApplicationReactNativeHost(this);
@@ -38,6 +48,11 @@ public class MainApplication extends NavigationApplication {
     public void onCreate() {
         super.onCreate();
         registerExternalComponent("RNNCustomComponent", new FragmentCreator());
+
+        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+            // If you opted-in for the New Architecture, we load the native entry point for this app.
+            DefaultNewArchitectureEntryPoint.load();
+        }
     }
 
     @Override


### PR DESCRIPTION
Attempt to add fabric support for Android.

- Makes `NavigationActivity` extend `ReactActivity`
- Makes `NavigationReactNativeHost` extend `DefaultReactNativeHost`
- Adds fabric fabric overrides


The changes are minor, but his branch was created on top of [RN71](https://github.com/wix/react-native-navigation/tree/RN71) PR [here](https://github.com/wix/react-native-navigation/pull/7717).