### PR TITLE
pass componentName prop to screens

### DIFF
--- a/lib/src/components/ComponentWrapper.test.tsx
+++ b/lib/src/components/ComponentWrapper.test.tsx
@@ -117,6 +117,7 @@ describe('ComponentWrapper', () => {
     renderer.create(<NavigationComponent componentId={'component123'} />);
     expect(myComponentProps).toEqual({
       componentId: 'component123',
+      componentName,
       numberProp: 1,
       stringProp: 'hello',
       objectProp: { a: 2 },
@@ -251,7 +252,10 @@ describe('ComponentWrapper', () => {
     const NavigationComponent = uut.wrap(componentName, generator, store, componentEventsObserver);
     const tree = renderer.create(<NavigationComponent componentId={'component123'} />);
     expect(tree.root.findByType(View)).toBeDefined();
-    expect(tree.root.findByType(MyComponent).props).toEqual({ componentId: 'component123' });
+    expect(tree.root.findByType(MyComponent).props).toEqual({
+      componentId: 'component123',
+      componentName,
+    });
   });
 
   it('sets component instance in store when constructed', () => {

--- a/lib/src/components/ComponentWrapper.tsx
+++ b/lib/src/components/ComponentWrapper.tsx
@@ -79,7 +79,11 @@ export class ComponentWrapper {
 
       render() {
         return (
-          <GeneratedComponentClass {...this.state.allProps} componentId={this.state.componentId} />
+          <GeneratedComponentClass
+            {...this.state.allProps}
+            componentId={this.state.componentId}
+            componentName={componentName}
+          />
         );
       }
 

--- a/lib/src/interfaces/NavigationComponentProps.ts
+++ b/lib/src/interfaces/NavigationComponentProps.ts
@@ -1,3 +1,4 @@
 export interface NavigationComponentProps {
   componentId: string;
+  componentName: string;
 }


### PR DESCRIPTION
Currently we inject only the `componentId` to screens, this PR add `componentName` as well.