### PR TITLE
Fix title component measurement on Android

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleAndButtonsContainer.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleAndButtonsContainer.kt
@@ -153,6 +153,10 @@ class TitleAndButtonsContainer(context: Context) : ViewGroup(context) {
         val isCenter = titleComponentAlignment == Alignment.Center
         val titleHeightMeasureSpec = MeasureSpec.makeMeasureSpec(containerHeight, MeasureSpec.AT_MOST)
         val titleWidthMeasureSpec = makeTitleAtMostWidthMeasureSpec(containerWidth, rightBarWidth, leftBarWidth, isCenter)
+        if (titleComponent is TitleBarReactView) {
+            titleComponent.centered = isCenter
+        }
+
         titleComponent.measure(titleWidthMeasureSpec, titleHeightMeasureSpec)
     }
 

--- a/lib/android/app/src/reactNative51/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
+++ b/lib/android/app/src/reactNative51/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
@@ -9,6 +9,7 @@ import com.reactnativenavigation.react.ReactView
 @SuppressLint("ViewConstructor")
 class TitleBarReactView(context: Context?, reactInstanceManager: ReactInstanceManager?, componentId: String?,
                         componentName: String?) : ReactView(context, reactInstanceManager, componentId, componentName) {
+    var centered: Boolean = false
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(interceptReactRootViewMeasureSpec(widthMeasureSpec), heightMeasureSpec)
     }

--- a/lib/android/app/src/reactNative55/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
+++ b/lib/android/app/src/reactNative55/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
@@ -9,6 +9,7 @@ import com.reactnativenavigation.react.ReactView
 @SuppressLint("ViewConstructor")
 class TitleBarReactView(context: Context?, reactInstanceManager: ReactInstanceManager?, componentId: String?,
                         componentName: String?) : ReactView(context, reactInstanceManager, componentId, componentName) {
+    var centered: Boolean = false
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(interceptReactRootViewMeasureSpec(widthMeasureSpec), heightMeasureSpec)
     }

--- a/lib/android/app/src/reactNative56/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
+++ b/lib/android/app/src/reactNative56/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
@@ -9,6 +9,7 @@ import com.reactnativenavigation.react.ReactView
 @SuppressLint("ViewConstructor")
 class TitleBarReactView(context: Context?, reactInstanceManager: ReactInstanceManager?, componentId: String?,
                         componentName: String?) : ReactView(context, reactInstanceManager, componentId, componentName) {
+    var centered: Boolean = false
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(interceptReactRootViewMeasureSpec(widthMeasureSpec), heightMeasureSpec)
     }

--- a/lib/android/app/src/reactNative57/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
+++ b/lib/android/app/src/reactNative57/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
@@ -9,6 +9,7 @@ import com.reactnativenavigation.react.ReactView
 @SuppressLint("ViewConstructor")
 class TitleBarReactView(context: Context?, reactInstanceManager: ReactInstanceManager?, componentId: String?,
                         componentName: String?) : ReactView(context, reactInstanceManager, componentId, componentName) {
+    var centered: Boolean = false
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(interceptReactRootViewMeasureSpec(widthMeasureSpec), heightMeasureSpec)
     }

--- a/lib/android/app/src/reactNative57_5/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
+++ b/lib/android/app/src/reactNative57_5/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
@@ -9,6 +9,7 @@ import com.reactnativenavigation.react.ReactView
 @SuppressLint("ViewConstructor")
 class TitleBarReactView(context: Context?, reactInstanceManager: ReactInstanceManager?, componentId: String?,
                         componentName: String?) : ReactView(context, reactInstanceManager, componentId, componentName) {
+    var centered: Boolean = false
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(interceptReactRootViewMeasureSpec(widthMeasureSpec), heightMeasureSpec)
     }

--- a/lib/android/app/src/reactNative60/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
+++ b/lib/android/app/src/reactNative60/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
@@ -9,6 +9,7 @@ import com.reactnativenavigation.react.ReactView
 @SuppressLint("ViewConstructor")
 class TitleBarReactView(context: Context?, reactInstanceManager: ReactInstanceManager?, componentId: String?,
                         componentName: String?) : ReactView(context, reactInstanceManager, componentId, componentName) {
+    var centered: Boolean = false
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(interceptReactRootViewMeasureSpec(widthMeasureSpec), heightMeasureSpec)
     }

--- a/lib/android/app/src/reactNative62/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
+++ b/lib/android/app/src/reactNative62/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
@@ -9,6 +9,7 @@ import com.reactnativenavigation.react.ReactView
 @SuppressLint("ViewConstructor")
 class TitleBarReactView(context: Context?, reactInstanceManager: ReactInstanceManager?, componentId: String?,
                         componentName: String?) : ReactView(context, reactInstanceManager, componentId, componentName) {
+    var centered: Boolean = false
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(interceptReactRootViewMeasureSpec(widthMeasureSpec), heightMeasureSpec)
     }

--- a/lib/android/app/src/reactNative63/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
+++ b/lib/android/app/src/reactNative63/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
@@ -9,6 +9,7 @@ import com.reactnativenavigation.react.ReactView
 @SuppressLint("ViewConstructor")
 class TitleBarReactView(context: Context?, reactInstanceManager: ReactInstanceManager?, componentId: String?,
                         componentName: String?) : ReactView(context, reactInstanceManager, componentId, componentName) {
+    var centered: Boolean = false
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(interceptReactRootViewMeasureSpec(widthMeasureSpec), heightMeasureSpec)
     }

--- a/lib/android/app/src/reactNative68/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
+++ b/lib/android/app/src/reactNative68/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
@@ -9,6 +9,7 @@ import com.reactnativenavigation.react.ReactView
 @SuppressLint("ViewConstructor")
 class TitleBarReactView(context: Context?, reactInstanceManager: ReactInstanceManager?, componentId: String?,
                         componentName: String?) : ReactView(context, reactInstanceManager, componentId, componentName) {
+    var centered: Boolean = false
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(interceptReactRootViewMeasureSpec(widthMeasureSpec), heightMeasureSpec)
     }

--- a/lib/android/app/src/reactNative71/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
+++ b/lib/android/app/src/reactNative71/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactView.kt
@@ -11,78 +11,17 @@ import com.reactnativenavigation.react.ReactView
 @SuppressLint("ViewConstructor")
 class TitleBarReactView(context: Context?, reactInstanceManager: ReactInstanceManager?, componentId: String?,
                         componentName: String?) : ReactView(context, reactInstanceManager, componentId, componentName) {
+    var centered: Boolean = false
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        super.onMeasure(interceptReactRootViewMeasureSpecWidth(widthMeasureSpec), interceptReactRootViewMeasureSpecHeight(heightMeasureSpec))
-    }
-
-    private fun interceptReactRootViewMeasureSpecWidth(widthMeasureSpec: Int): Int {
-        // This is a HACK.
-        // ReactRootView has problematic behavior when setting width to WRAP_CONTENT,
-        // It's causing infinite measurements, that hung up the UI.
-        // Intercepting largest child by width, and use its width as (parent) ReactRootView width fixed that.
-        // See for more details https://github.com/wix/react-native-navigation/pull/7096
-        val measuredWidth = this.getLastRootViewChildMaxWidth()
-
-        return if (measuredWidth != null)  MeasureSpec.makeMeasureSpec(measuredWidth, MeasureSpec.EXACTLY) else
-            widthMeasureSpec
-    }
-
-    private fun interceptReactRootViewMeasureSpecHeight(heightMeasureSpec: Int): Int {
-        // This is a HACK.
-        // ReactRootView has problematic behavior when setting width to WRAP_CONTENT,
-        // It's causing infinite measurements, that hung up the UI.
-        // Intercepting largest child by height, and use its height as (parent) ReactRootView width fixed that.
-        // See for more details https://github.com/wix/react-native-navigation/pull/7096
-        val measuredHeight = this.getLastRootViewChildMaxHeight()
-
-        return if (measuredHeight != null) MeasureSpec.makeMeasureSpec(measuredHeight, MeasureSpec.EXACTLY) else
-            heightMeasureSpec
-    }
-
-    private fun getLastRootViewChildMaxWidth(): Int {
-        if (rootViewGroup.children.count() == 0) {
-            return 0
+        var titleHeightMeasureSpec: Int
+        var titleWidthMeasureSpec: Int
+        if (centered) {
+            titleHeightMeasureSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
+            titleWidthMeasureSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
+        } else {
+            titleHeightMeasureSpec = heightMeasureSpec
+            titleWidthMeasureSpec = widthMeasureSpec
         }
-        var maxWidth = rootViewGroup.width
-        var next = rootViewGroup as Any
-        while(next is ViewGroup) { //try {
-            if (next.width > maxWidth) {
-                maxWidth = next.width
-            }
-            if (next.children.count() == 0) break
-            next.children.first().also { next = it }
-        }
-        return maxWidth
-    }
-
-    private fun getLastRootViewChildMaxHeight(): Int {
-        if (rootViewGroup.children.count() == 0) {
-            return 0
-        }
-        var maxHeight = rootViewGroup.height
-        var next = rootViewGroup as Any
-        while(next is ViewGroup) { //try {
-            if (next.height > maxHeight) {
-                maxHeight = next.height
-            }
-            if (next.children.count() == 0) break
-            next.children.first().also { next = it }
-        }
-        return maxHeight
-    }
-
-    private fun getLastRootViewChild(): View? {
-        if (rootViewGroup.children.count() == 0) {
-            return null
-        }
-        var rootViewGroupLastChild: View = rootViewGroup
-        var next = rootViewGroup as Any
-        while(next is ViewGroup) { //try {
-            rootViewGroupLastChild = next
-            if (next.children.count() == 0) break
-            next.children.first().also { next = it }
-        }
-        @Suppress("UNREACHABLE_CODE")
-        return rootViewGroupLastChild
+        super.onMeasure(titleWidthMeasureSpec, titleHeightMeasureSpec)
     }
 }


### PR DESCRIPTION
Remove the hack and let ReactRootView measure itself when view is centered