### PR TITLE
Use getConstants on main thread

### DIFF
--- a/lib/ios/RNNBridgeModule.m
+++ b/lib/ios/RNNBridgeModule.m
@@ -245,7 +245,11 @@ RCT_EXPORT_METHOD(getNavigationConstants
 }
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getNavigationConstantsSync) {
-    return [Constants getConstants];
+    __block NSDictionary *c;
+    RCTUnsafeExecuteOnMainQueueSync(^{
+      c = [Constants getConstants];
+    });
+    return c;
 }
 
 @end


### PR DESCRIPTION
Solves
```
Main Thread Checker: UI API called on a background thread: -[UITabBarController tabBar]
```
warnings