### PR TITLE
[Android] Wrong user's tap area in overlay

### DIFF
--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -73,43 +73,43 @@ android {
     productFlavors {
         reactNative51 {
             dimension "RNN.reactNativeVersion"
-            buildConfigField("int", "REACT_NATVE_VERSION_MINOR", "51")
+            buildConfigField("int", "REACT_NATIVE_VERSION_MINOR", "51")
         }
         reactNative55 {
             dimension "RNN.reactNativeVersion"
-            buildConfigField("int", "REACT_NATVE_VERSION_MINOR", "55")
+            buildConfigField("int", "REACT_NATIVE_VERSION_MINOR", "55")
         }
         reactNative56 {
             dimension "RNN.reactNativeVersion"
-            buildConfigField("int", "REACT_NATVE_VERSION_MINOR", "56")
+            buildConfigField("int", "REACT_NATIVE_VERSION_MINOR", "56")
         }
         reactNative57 {
             dimension "RNN.reactNativeVersion"
-            buildConfigField("int", "REACT_NATVE_VERSION_MINOR", "57")
+            buildConfigField("int", "REACT_NATIVE_VERSION_MINOR", "57")
         }
         reactNative57_5 {
             dimension "RNN.reactNativeVersion"
-            buildConfigField("int", "REACT_NATVE_VERSION_MINOR", "57")
+            buildConfigField("int", "REACT_NATIVE_VERSION_MINOR", "57")
         }
         reactNative60 {
             dimension "RNN.reactNativeVersion"
-            buildConfigField("int", "REACT_NATVE_VERSION_MINOR", "60")
+            buildConfigField("int", "REACT_NATIVE_VERSION_MINOR", "60")
         }
         reactNative62 {
             dimension "RNN.reactNativeVersion"
-            buildConfigField("int", "REACT_NATVE_VERSION_MINOR", "62")
+            buildConfigField("int", "REACT_NATIVE_VERSION_MINOR", "62")
         }
         reactNative63 {
             dimension "RNN.reactNativeVersion"
-            buildConfigField("int", "REACT_NATVE_VERSION_MINOR", "63")
+            buildConfigField("int", "REACT_NATIVE_VERSION_MINOR", "63")
         }
         reactNative68 {
             dimension "RNN.reactNativeVersion"
-            buildConfigField("int", "REACT_NATVE_VERSION_MINOR", "68")
+            buildConfigField("int", "REACT_NATIVE_VERSION_MINOR", "68")
         }
         reactNative71 {
             dimension "RNN.reactNativeVersion"
-            buildConfigField("int", "REACT_NATVE_VERSION_MINOR", "71")
+            buildConfigField("int", "REACT_NATIVE_VERSION_MINOR", "71")
         }
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/DevPermissionRequest.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/DevPermissionRequest.java
@@ -22,7 +22,7 @@ public class DevPermissionRequest {
 	public boolean shouldAskPermission(Activity activity) {
 		return isDebug &&
                Build.VERSION.SDK_INT >= 23 &&
-               BuildConfig.REACT_NATVE_VERSION_MINOR <= 51 &&
+               BuildConfig.REACT_NATIVE_VERSION_MINOR <= 51 &&
                !Settings.canDrawOverlays(activity);
 	}
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/MotionEvent.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/MotionEvent.kt
@@ -9,14 +9,7 @@ import com.reactnativenavigation.BuildConfig
 val hitRect = Rect()
 
 fun MotionEvent.coordinatesInsideView(view: View?): Boolean {
-    if (BuildConfig.REACT_NATVE_VERSION_MINOR < 71) {
-        view ?: return false
-        view.getHitRect(hitRect)
-        return hitRect.contains(x.toInt(), y.toInt())
-    } else {
-        val viewGroup = (view as? ViewGroup)?.getChildAt(0) as? ViewGroup ?: view
-
-        viewGroup?.getHitRect(hitRect)
-        return hitRect.contains(x.toInt(), y.toInt())
-    }
+    view ?: return false
+    view.getHitRect(hitRect)
+    return hitRect.contains(x.toInt(), y.toInt())
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/MotionEvent.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/MotionEvent.kt
@@ -3,8 +3,6 @@ package com.reactnativenavigation.utils
 import android.graphics.Rect
 import android.view.MotionEvent
 import android.view.View
-import android.view.ViewGroup
-import com.reactnativenavigation.BuildConfig
 
 val hitRect = Rect()
 


### PR DESCRIPTION
Hi!

**I use:
    "react-native": "0.72.4",
    "react-native-navigation": "^7.37.0",**

I faced an annoying problem with `overlays` on `Android`. I show an overlay with a not full-screen view with `interceptTouchOutside: false`. For example, this view is `{x: 0, y: 500, width: 100, height: 100}`

When the user tries to tap the overlay the app receives a tap through the overlay (under it). Also, when the user tries to tap an area `{x: 0, y: 0, width: 100, height: 100}` through overlay (using `interceptTouchOutside: false`) it is blocked for taps.

It works well on iOS. Also, it worked well on older versions of react-native and react-native-navigation.

I found a problem in `react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/utils/MotionEvent.kt`

When we use the old version of the code our not full-screen overlay view performs `getHitRect` in the full-screen parent, so it works correctly.

```
view ?: return false
view.getHitRect(hitRect)
return hitRect.contains(x.toInt(), y.toInt())
```

However, when we started to use the new version of the code, we had an issue. It happens cause we use a child of this view from `getChildAt` instead of the original view for the `getHitRect` method.

```
val viewGroup = (view as? ViewGroup)?.getChildAt(0) as? ViewGroup ?: view
viewGroup?.getHitRect(hitRect)
return hitRect.contains(x.toInt(), y.toInt())
```
[Android View getHitRect](https://developer.android.com/reference/android/view/View#getHitRect(android.graphics.Rect))
The documentation says that `getHitRect - Hit rectangle in parent's coordinates`.

Therefore, when we use the original view for `getHitRect`, it calculates the hit for his full-screen parent, but when we use a view's child, it calculates the hit for the original view as a parent.

So, when the user taps on `{x: 50, y: 550}` coordinates on the screen, it will be just `{x:50, y:50}` in the not full-screen parent, and the blocking tap area for overlay will be translated to the top of the screen in the wrong place.

Additional changes: typo in `REACT_NATVE_VERSION_MINOR`

I prepared changes to fix this issue. Let's review and apply ones.