### PR TITLE
Fix runOnMainThread to run at front of queue

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/UiUtils.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/UiUtils.java
@@ -82,9 +82,9 @@ public class UiUtils {
 
     public static void runOnMainThread(Runnable runnable) {
         if (Looper.myLooper() == Looper.getMainLooper()) {
-            new Handler(Looper.getMainLooper()).postAtFrontOfQueue(runnable);
+            runnable.run();
         } else {
-            new Handler(Looper.getMainLooper()).post(runnable);
+            new Handler(Looper.getMainLooper()).postAtFrontOfQueue(runnable);
         }
     }
 


### PR DESCRIPTION
This fixes a crash happening in the Wix app, look like there's a race condition where the activity is destroyed and navigator.onHostPause() gets called too late and should always be called at front of queue. Most of times this shouldn't be delayed as it is called on the main thread.

This is the crash:
```
Location
NavigationModule.java line 213 in com.reactnativenavigation.react.NavigationModule.navigator
Exception
java.lang.NullPointerException
Message
Attempt to invoke virtual method 'com.reactnativenavigation.viewcontrollers.navigator.Navigator com.reactnativenavigation.NavigationActivity.getNavigator()' on a null object reference
```

Closes #7769