### PR TITLE
[Android] fix: Tab index out of number of tabs range

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -269,10 +269,11 @@ public class BottomTabsController extends ParentController<BottomTabsLayout> imp
     }
 
     private void selectTab(int newIndex, boolean enableSelectionHistory) {
-        saveTabSelection(newIndex, enableSelectionHistory);
-        tabsAttacher.onTabSelected(tabs.get(newIndex));
+        final int nextIndex = Math.max(0, Math.min(newIndex, tabs.size() - 1));
+        saveTabSelection(nextIndex, enableSelectionHistory);
+        tabsAttacher.onTabSelected(tabs.get(nextIndex));
         getCurrentView().setVisibility(View.INVISIBLE);
-        bottomTabs.setCurrentItem(newIndex, false);
+        bottomTabs.setCurrentItem(nextIndex, false);
         getCurrentView().setVisibility(View.VISIBLE);
         getCurrentChild().onViewWillAppear();
         getCurrentChild().onViewDidAppear();


### PR DESCRIPTION
I found many cases which crash app when the bottom tab index is out of the number of tabs range. Then screenshot is from crashlytic
![Screenshot 2023-10-14 at 17 40 16](https://github.com/wix/react-native-navigation/assets/16474293/99cfdb57-29b6-4f96-9285-315e3f19e6af)
