### PR TITLE
Android 14 support

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/JsDevReloadHandler.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/JsDevReloadHandler.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.view.KeyEvent;
 import android.widget.EditText;
+import android.os.Build;
 
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.reactnativenavigation.utils.UiUtils;
@@ -49,7 +50,11 @@ public class JsDevReloadHandler extends JsDevReloadHandlerFacade {
     }
 
 	public void onActivityResumed(Activity activity) {
-		activity.registerReceiver(reloadReceiver, new IntentFilter(RELOAD_BROADCAST));
+		if (Build.VERSION.SDK_INT >= 34 && activity.getApplicationInfo().targetSdkVersion >= 34) {
+            activity.registerReceiver(reloadReceiver, new IntentFilter(RELOAD_BROADCAST), Context.RECEIVER_EXPORTED);
+        } else {
+            activity.registerReceiver(reloadReceiver, new IntentFilter(RELOAD_BROADCAST));
+        }
 	}
 
 	public void onActivityPaused(Activity activity) {


### PR DESCRIPTION
From react native [pr](https://github.com/facebook/react-native/pull/38256)
> Summary:
> Add RECEIVER_EXPORTED/RECEIVER_NOT_EXPORTED flag support to DevSupportManagerBase for Android 14 change. See
> https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported for details.
> 
> Without this fix, app crashes during launch because of :
> SecurityException: {package name here}: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts