### PR TITLE
fix: update layout.orientation types to match iOS implementation

### DIFF
--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -34,8 +34,11 @@ type FontWeight =
   | '900'
   | FontWeightIOS;
 export type LayoutOrientation =
+  | 'all'
+  | 'default'
   | 'portrait'
   | 'landscape'
+  | 'upsideDown'
   | 'sensor'
   | 'sensorLandscape'
   | 'sensorPortrait';


### PR DESCRIPTION
Android doesn't have `upsideDown` or `all` (but does have `default`), but then again iOS doesn't have the `sensor*` ones.