### PR TITLE
Fix onHostPause crash on Android

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
@@ -59,7 +59,9 @@ public class NavigationModule extends ReactContextBaseJavaModule {
             @Override
             public void onHostPause() {
                 super.onHostPause();
-                UiUtils.runOnMainThread(() -> navigator().onHostPause());
+                UiUtils.runOnMainThread(() -> {
+                    if (navigator() != null) navigator().onHostPause();
+                });
             }
 
             @Override

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
@@ -60,7 +60,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
             public void onHostPause() {
                 super.onHostPause();
                 UiUtils.runOnMainThread(() -> {
-                    if (navigator() != null) navigator().onHostPause();
+                    if (activity() != null) navigator().onHostPause();
                 });
             }
 


### PR DESCRIPTION
This fixes a crash happening in the Wix app, look like there's a race condition where the activity is destroyed and navigator.onHostPause() gets called too late and should always be called at front of queue. Most of times this shouldn't be delayed as it is called on the main thread.

This is the crash:
```
Location
NavigationModule.java line 213 in com.reactnativenavigation.react.NavigationModule.navigator
Exception
java.lang.NullPointerException
Message
Attempt to invoke virtual method 'com.reactnativenavigation.viewcontrollers.navigator.Navigator com.reactnativenavigation.NavigationActivity.getNavigator()' on a null object reference
```
