### PR TITLE
Fix typo: Corrected duplicated "the" in the sentence.

### DIFF
--- a/website/docs/docs/docs-Installing.mdx
+++ b/website/docs/docs/docs-Installing.mdx
@@ -39,7 +39,7 @@ If one of the steps failed or you can't run (or are not comfortable with) the au
 
 ### CocoaPods
 
-After the the automatic scripts completed successfully, run pod install:
+After the automatic scripts completed successfully, run pod install:
 
 ```sh
 pod install --project-directory=ios

--- a/website/versioned_docs/version-7.11.2/docs/docs-Installing.mdx
+++ b/website/versioned_docs/version-7.11.2/docs/docs-Installing.mdx
@@ -39,7 +39,7 @@ If one of the steps failed or you can't run (or are not comfortable with) the au
 
 ### CocoaPods
 
-After the the automatic scripts completed successfully, run pod install:
+After the automatic scripts completed successfully, run pod install:
 
 ```sh
 pod install --project-directory=ios

--- a/website/versioned_docs/version-7.25.4/docs/docs-Installing.mdx
+++ b/website/versioned_docs/version-7.25.4/docs/docs-Installing.mdx
@@ -39,7 +39,7 @@ If one of the steps failed or you can't run (or are not comfortable with) the au
 
 ### CocoaPods
 
-After the the automatic scripts completed successfully, run pod install:
+After the automatic scripts completed successfully, run pod install:
 
 ```sh
 pod install --project-directory=ios

--- a/website/versioned_docs/version-7.32.1/docs/docs-Installing.mdx
+++ b/website/versioned_docs/version-7.32.1/docs/docs-Installing.mdx
@@ -39,7 +39,7 @@ If one of the steps failed or you can't run (or are not comfortable with) the au
 
 ### CocoaPods
 
-After the the automatic scripts completed successfully, run pod install:
+After the automatic scripts completed successfully, run pod install:
 
 ```sh
 pod install --project-directory=ios

--- a/website/versioned_docs/version-7.37.0/docs/docs-Installing.mdx
+++ b/website/versioned_docs/version-7.37.0/docs/docs-Installing.mdx
@@ -39,7 +39,7 @@ If one of the steps failed or you can't run (or are not comfortable with) the au
 
 ### CocoaPods
 
-After the the automatic scripts completed successfully, run pod install:
+After the automatic scripts completed successfully, run pod install:
 
 ```sh
 pod install --project-directory=ios

--- a/website/versioned_docs/version-7.7.0/docs/docs-Installing.mdx
+++ b/website/versioned_docs/version-7.7.0/docs/docs-Installing.mdx
@@ -39,7 +39,7 @@ If one of the steps failed or you can't run (or are not comfortable with) the au
 
 ### CocoaPods
 
-After the the automatic scripts completed successfully, run pod install:
+After the automatic scripts completed successfully, run pod install:
 
 ```sh
 pod install --project-directory=ios


### PR DESCRIPTION
Changed:
- After the the automatic scripts completed successfully, run pod install:

To:
- After the automatic scripts completed successfully, run pod install: