### PR TITLE
Fix NullPointerException in NavigationModule

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
@@ -223,7 +223,8 @@ public class NavigationModule extends ReactContextBaseJavaModule {
 
     protected void handle(Runnable task) {
         UiThread.post(() -> {
-            if (getCurrentActivity() != null && !activity().isFinishing()) {
+            NavigationActivity activity = activity();
+            if (activity != null && !activity.isFinishing()) {
                 task.run();
             }
         });


### PR DESCRIPTION
We're seeing a crash that affects ~1% of our user base per month, that's caused by:
```
NullPointerException
Attempt to invoke virtual method 'boolean android.app.Activity.isFinishing()' on a null object reference
```

After looking into the code, we realised that that the null check and `.isFinishing()`  are not referencing the same activity.

Here's a screenshot with stack trace from Sentry:
<img width="1268" alt="Screenshot 2023-11-20 at 14 38 24" src="https://github.com/wix/react-native-navigation/assets/8324312/231ddbdd-d962-46e5-abea-b45eda66b81d">
