### PR TITLE
Busy-wait for activity on getLaunchArgs()

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
@@ -89,8 +89,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
     public void getLaunchArgs(String commandId, Promise promise) {
         // This is work-around for the RN problem described here:
         // https://github.com/facebook/react-native/issues/37518
-        Activity activity = activity();
-        if (activity == null) {
+        if (activity() == null) {
             NullRNActivityWorkaround.waitForActivity(getReactApplicationContext());
         }
         promise.resolve(LaunchArgsParser.parse(activity()));
@@ -120,7 +119,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void setRoot(String commandId, ReadableMap rawLayoutTree, Promise promise) {
         final LayoutNode layoutTree = LayoutNodeParser.parse(Objects.requireNonNull(jsonParser.parse(rawLayoutTree).optJSONObject("root")));
-        runOnUIThread(() -> {
+        handle(() -> {
             final ViewController<?> viewController = layoutFactory.create(layoutTree);
             navigator().setRoot(viewController, new NativeCommandListener("setRoot", commandId, promise, eventEmitter, now), reactInstanceManager);
         });
@@ -128,7 +127,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void setDefaultOptions(ReadableMap options) {
-        runOnUIThread(() -> {
+        handle(() -> {
             Options defaultOptions = parse(options);
             layoutFactory.setDefaultOptions(defaultOptions);
             navigator().setDefaultOptions(defaultOptions);
@@ -137,13 +136,13 @@ public class NavigationModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void mergeOptions(String onComponentId, @Nullable ReadableMap options) {
-        runOnUIThread(() -> navigator().mergeOptions(onComponentId, parse(options)));
+        handle(() -> navigator().mergeOptions(onComponentId, parse(options)));
     }
 
     @ReactMethod
     public void push(String commandId, String onComponentId, ReadableMap rawLayoutTree, Promise promise) {
         final LayoutNode layoutTree = LayoutNodeParser.parse(jsonParser.parse(rawLayoutTree));
-        runOnUIThread(() -> {
+        handle(() -> {
             final ViewController<?> viewController = layoutFactory.create(layoutTree);
             navigator().push(onComponentId, viewController, new NativeCommandListener("push", commandId, promise, eventEmitter, now));
         });
@@ -151,7 +150,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void setStackRoot(String commandId, String onComponentId, ReadableArray children, Promise promise) {
-        runOnUIThread(() -> {
+        handle(() -> {
             ArrayList<ViewController<?>> _children = new ArrayList<>();
             for (int i = 0; i < children.size(); i++) {
                 final LayoutNode layoutTree = LayoutNodeParser.parse(jsonParser.parse(children.getMap(i)));
@@ -163,23 +162,23 @@ public class NavigationModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void pop(String commandId, String componentId, @Nullable ReadableMap mergeOptions, Promise promise) {
-        runOnUIThread(() -> navigator().pop(componentId, parse(mergeOptions), new NativeCommandListener("pop", commandId, promise, eventEmitter, now)));
+        handle(() -> navigator().pop(componentId, parse(mergeOptions), new NativeCommandListener("pop", commandId, promise, eventEmitter, now)));
     }
 
     @ReactMethod
     public void popTo(String commandId, String componentId, @Nullable ReadableMap mergeOptions, Promise promise) {
-        runOnUIThread(() -> navigator().popTo(componentId, parse(mergeOptions), new NativeCommandListener("popTo", commandId, promise, eventEmitter, now)));
+        handle(() -> navigator().popTo(componentId, parse(mergeOptions), new NativeCommandListener("popTo", commandId, promise, eventEmitter, now)));
     }
 
     @ReactMethod
     public void popToRoot(String commandId, String componentId, @Nullable ReadableMap mergeOptions, Promise promise) {
-        runOnUIThread(() -> navigator().popToRoot(componentId, parse(mergeOptions), new NativeCommandListener("popToRoot", commandId, promise, eventEmitter, now)));
+        handle(() -> navigator().popToRoot(componentId, parse(mergeOptions), new NativeCommandListener("popToRoot", commandId, promise, eventEmitter, now)));
     }
 
     @ReactMethod
     public void showModal(String commandId, ReadableMap rawLayoutTree, Promise promise) {
         final LayoutNode layoutTree = LayoutNodeParser.parse(jsonParser.parse(rawLayoutTree));
-        runOnUIThread(() -> {
+        handle(() -> {
             final ViewController<?> viewController = layoutFactory.create(layoutTree);
             navigator().showModal(viewController, new NativeCommandListener("showModal", commandId, promise, eventEmitter, now));
         });
@@ -187,7 +186,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void dismissModal(String commandId, String componentId, @Nullable ReadableMap mergeOptions, Promise promise) {
-        runOnUIThread(() -> {
+        handle(() -> {
             navigator().mergeOptions(componentId, parse(mergeOptions));
             navigator().dismissModal(componentId, new NativeCommandListener("dismissModal", commandId, promise, eventEmitter, now));
         });
@@ -195,13 +194,13 @@ public class NavigationModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void dismissAllModals(String commandId, @Nullable ReadableMap mergeOptions, Promise promise) {
-        runOnUIThread(() -> navigator().dismissAllModals(parse(mergeOptions), new NativeCommandListener("dismissAllModals", commandId, promise, eventEmitter, now)));
+        handle(() -> navigator().dismissAllModals(parse(mergeOptions), new NativeCommandListener("dismissAllModals", commandId, promise, eventEmitter, now)));
     }
 
     @ReactMethod
     public void showOverlay(String commandId, ReadableMap rawLayoutTree, Promise promise) {
         final LayoutNode layoutTree = LayoutNodeParser.parse(jsonParser.parse(rawLayoutTree));
-        runOnUIThread(() -> {
+        handle(() -> {
             final ViewController<?> viewController = layoutFactory.create(layoutTree);
             navigator().showOverlay(viewController, new NativeCommandListener("showOverlay", commandId, promise, eventEmitter, now));
         });
@@ -209,12 +208,12 @@ public class NavigationModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void dismissOverlay(String commandId, String componentId, Promise promise) {
-        runOnUIThread(() -> navigator().dismissOverlay(componentId, new NativeCommandListener("dismissOverlay", commandId, promise, eventEmitter, now)));
+        handle(() -> navigator().dismissOverlay(componentId, new NativeCommandListener("dismissOverlay", commandId, promise, eventEmitter, now)));
     }
 
     @ReactMethod
     public void dismissAllOverlays(String commandId, Promise promise) {
-        runOnUIThread(() -> navigator().dismissAllOverlays(new NativeCommandListener("dismissAllOverlays", commandId, promise, eventEmitter, now)));
+        handle(() -> navigator().dismissAllOverlays(new NativeCommandListener("dismissAllOverlays", commandId, promise, eventEmitter, now)));
     }
 
     @Override
@@ -236,7 +235,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                 null ? Options.EMPTY : Options.parse(ctx, new TypefaceLoader(activity()), jsonParser.parse(mergeOptions));
     }
 
-    protected void runOnUIThread(Runnable task) {
+    protected void handle(Runnable task) {
         UiThread.post(() -> {
             if (getCurrentActivity() != null && !activity().isFinishing()) {
                 task.run();

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
@@ -44,6 +44,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
     private final JSONParser jsonParser;
     private final LayoutFactory layoutFactory;
     private EventEmitter eventEmitter;
+    private final NullRNActivityWorkaround nullRNActivityWorkaround;
 
     @SuppressWarnings("WeakerAccess")
     public NavigationModule(ReactApplicationContext reactContext, ReactInstanceManager reactInstanceManager, LayoutFactory layoutFactory) {
@@ -55,6 +56,8 @@ public class NavigationModule extends ReactContextBaseJavaModule {
         this.reactInstanceManager = reactInstanceManager;
         this.jsonParser = jsonParser;
         this.layoutFactory = layoutFactory;
+        this.nullRNActivityWorkaround = new NullRNActivityWorkaround(reactContext);
+
         reactContext.addLifecycleEventListener(new LifecycleEventListenerAdapter() {
             @Override
             public void onHostPause() {
@@ -87,12 +90,8 @@ public class NavigationModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void getLaunchArgs(String commandId, Promise promise) {
-        // This is work-around for the RN problem described here:
-        // https://github.com/facebook/react-native/issues/37518
-        if (activity() == null) {
-            NullRNActivityWorkaround.waitForActivity(getReactApplicationContext());
-        }
-        promise.resolve(LaunchArgsParser.parse(activity()));
+        Activity activity = nullRNActivityWorkaround.getActivity();
+        promise.resolve(LaunchArgsParser.parse(activity));
     }
 
     private WritableMap createNavigationConstantsMap() {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NullRNActivityWorkaround.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NullRNActivityWorkaround.kt
@@ -1,22 +1,55 @@
 package com.reactnativenavigation.react
 
+import android.app.Activity
+import android.util.Log
+import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.ReactApplicationContext
-import com.reactnativenavigation.utils.sleep
+import com.reactnativenavigation.utils.sleepSafe
+import java.lang.ref.WeakReference
 
 private const val ACTIVITY_WAIT_INTERVAL = 100L
 private const val ACTIVITY_WAIT_TRIES = 150
 
-object NullRNActivityWorkaround {
-    @JvmStatic
-    fun waitForActivity(reactAppContext: ReactApplicationContext) {
-        var tries = 0
-        while (tries < ACTIVITY_WAIT_TRIES && !isActivityReady(reactAppContext)) {
-            sleep(ACTIVITY_WAIT_INTERVAL)
-            tries++
-        }
+private const val LOG_TAG = "RNN.NullActivity"
+
+/**
+ * This is a helper class to work-around this RN problem: https://github.com/facebook/react-native/issues/37518
+ *
+ * It is, hopefully, temporary.
+ */
+class NullRNActivityWorkaround(reactAppContext: ReactApplicationContext) {
+    private val reactAppContext: WeakReference<ReactApplicationContext>
+    @Volatile
+    private var hasHost = true
+
+    init {
+        this.reactAppContext = WeakReference(reactAppContext)
+        reactAppContext.addLifecycleEventListener(object: LifecycleEventListener {
+            override fun onHostDestroy() {
+                Log.d(LOG_TAG, "HOST_DESTROY")
+                hasHost = false
+            }
+            override fun onHostResume() {
+                Log.d(LOG_TAG, "HOST_RESUME")
+                hasHost = true
+            }
+            override fun onHostPause() {}
+        })
     }
 
-    private fun isActivityReady(reactAppContext: ReactApplicationContext): Boolean {
-        return reactAppContext.hasCurrentActivity()
+    fun getActivity(): Activity? {
+        waitForActivity()
+        return reactAppContext.get()?.currentActivity
+    }
+
+    private fun waitForActivity() {
+        val activityReady = { (reactAppContext.get()?.hasCurrentActivity() ?: false) }
+
+        var tries = 0
+        while (tries < ACTIVITY_WAIT_TRIES && hasHost && !activityReady()) {
+            Log.d(LOG_TAG, "Busy-waiting for activity! Try: #$tries...")
+            sleepSafe(ACTIVITY_WAIT_INTERVAL)
+            tries++
+        }
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NullRNActivityWorkaround.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NullRNActivityWorkaround.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.util.Log
 import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.ReactApplicationContext
-import com.reactnativenavigation.utils.sleepSafe
+import com.reactnativenavigation.utils.busyRetry
 import java.lang.ref.WeakReference
 
 private const val ACTIVITY_WAIT_INTERVAL = 100L
@@ -43,13 +43,13 @@ class NullRNActivityWorkaround(reactAppContext: ReactApplicationContext) {
     }
 
     private fun waitForActivity() {
-        val activityReady = { (reactAppContext.get()?.hasCurrentActivity() ?: false) }
+        val isActivityReady = { (reactAppContext.get()?.hasCurrentActivity() ?: false) }
 
-        var tries = 0
-        while (tries < ACTIVITY_WAIT_TRIES && hasHost && !activityReady()) {
-            Log.d(LOG_TAG, "Busy-waiting for activity! Try: #$tries...")
-            sleepSafe(ACTIVITY_WAIT_INTERVAL)
-            tries++
+        busyRetry(ACTIVITY_WAIT_TRIES, ACTIVITY_WAIT_INTERVAL) { tries ->
+            if (!isActivityReady() && hasHost) {
+                Log.d(LOG_TAG, "Busy-waiting for activity! Try: #$tries...")
+                true
+            } else false
         }
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NullRNActivityWorkaround.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NullRNActivityWorkaround.kt
@@ -1,0 +1,22 @@
+package com.reactnativenavigation.react
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.reactnativenavigation.utils.sleep
+
+private const val ACTIVITY_WAIT_INTERVAL = 100L
+private const val ACTIVITY_WAIT_TRIES = 150
+
+object NullRNActivityWorkaround {
+    @JvmStatic
+    fun waitForActivity(reactAppContext: ReactApplicationContext) {
+        var tries = 0
+        while (tries < ACTIVITY_WAIT_TRIES && !isActivityReady(reactAppContext)) {
+            sleep(ACTIVITY_WAIT_INTERVAL)
+            tries++
+        }
+    }
+
+    private fun isActivityReady(reactAppContext: ReactApplicationContext): Boolean {
+        return reactAppContext.hasCurrentActivity()
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/Retry.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/Retry.kt
@@ -1,0 +1,9 @@
+package com.reactnativenavigation.utils
+
+fun busyRetry(times: Int, interval: Long, callback: (tries: Int) -> Boolean) {
+    var tries = 0
+    while (tries < times && !callback(tries)) {
+        sleepSafe(interval)
+        tries++
+    }
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/Sleep.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/Sleep.kt
@@ -1,6 +1,6 @@
 package com.reactnativenavigation.utils
 
-fun sleep(ms: Long) {
+fun sleepSafe(ms: Long) {
     try {
         Thread.sleep(ms)
     } catch (e: InterruptedException) {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/Sleep.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/Sleep.kt
@@ -1,0 +1,9 @@
+package com.reactnativenavigation.utils
+
+fun sleep(ms: Long) {
+    try {
+        Thread.sleep(ms)
+    } catch (e: InterruptedException) {
+        e.printStackTrace()
+    }
+}

--- a/lib/android/app/src/test/java/com/reactnativenavigation/react/NavigationModuleTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/react/NavigationModuleTest.java
@@ -69,13 +69,13 @@ public class NavigationModuleTest extends BaseTest {
         NavigationModule spy = spy(uut);
         when(spy.activity()).thenReturn(mock(NavigationActivity.class));
         Runnable runnable = mock(Runnable.class);
-        spy.handle(runnable);
+        spy.runOnUIThread(runnable);
         ShadowLooper.idleMainLooper();
         verify(runnable).run();
 
         when(spy.activity()).thenReturn(null);
         Runnable dontRun = mock(Runnable.class);
-        spy.handle(dontRun);
+        spy.runOnUIThread(dontRun);
         ShadowLooper.idleMainLooper();
         verify(dontRun, times(0)).run();
     }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/react/NavigationModuleTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/react/NavigationModuleTest.java
@@ -69,13 +69,13 @@ public class NavigationModuleTest extends BaseTest {
         NavigationModule spy = spy(uut);
         when(spy.activity()).thenReturn(mock(NavigationActivity.class));
         Runnable runnable = mock(Runnable.class);
-        spy.runOnUIThread(runnable);
+        spy.handle(runnable);
         ShadowLooper.idleMainLooper();
         verify(runnable).run();
 
         when(spy.activity()).thenReturn(null);
         Runnable dontRun = mock(Runnable.class);
-        spy.runOnUIThread(dontRun);
+        spy.handle(dontRun);
         ShadowLooper.idleMainLooper();
         verify(dontRun, times(0)).run();
     }


### PR DESCRIPTION
Following the Android changes in Detox [20.14.0](https://github.com/wix/Detox/releases/tag/20.14.0) -- we've seen some instabilities related to getting launch arguments, as explained.

This should introduce a fix similar to what's been done for `react-native-launch-arguments`.

TODO:
- [x] Implement
- [ ] Add e2e test that proves the fix works

UPDATE:
- There's reason to believe this could be an issue with just RN .71, specifically.