### PR TITLE
build(playground): patch boost podspec on post-install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "main": "lib/dist/src/index.js",
   "typings": "lib/dist/src/index.d.ts",
   "scripts": {
+    "postinstall": "node scripts/postinstall.js",
     "build": "node ./scripts/build",
     "watch": "node ./scripts/watch",
     "xcode": "open playground/ios/playground.xcworkspace",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+
+const patchBoostPodspec = () => {
+  const log = message => console.log(`[POST-INSTALL] ${message}`);
+  const boostPodspecPath = `${process.cwd()}/node_modules/react-native/third-party-podspecs/boost.podspec`;
+  const originalUrl = 'https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2';
+  const patchedUrl = 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2';
+
+  if (!fs.existsSync(boostPodspecPath)) {
+    log('boost.podspec does not exist, skipping patch...');
+    return;
+  }
+
+  let boostPodspec = fs.readFileSync(boostPodspecPath, 'utf8');
+
+  if (!boostPodspec.includes(originalUrl)) {
+    log('boost.podspec is already patched or the URL is different, skipping patch...');
+    return;
+  }
+
+  log('Applying boost.podspec patch...');
+  boostPodspec = boostPodspec.replace(originalUrl, patchedUrl);
+  fs.writeFileSync(boostPodspecPath, boostPodspec, 'utf8');
+};
+
+function patchBoostPodspecIfNeeded() {
+  if (process.platform === 'darwin') {
+    console.log('[POST-INSTALL] Running boost.io podspec patch...');
+    patchBoostPodspec();
+  }
+}
+
+patchBoostPodspecIfNeeded();


### PR DESCRIPTION
add post-install patch to use boost.io's mirror due to installation errors from the original source
See https://github.com/boostorg/boost/issues/843