### PR TITLE
fix: include postinstall.js in published artifact

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@ integration/
 playground/
 artifacts/
 scripts/
+!scripts/postinstall.js
 website/
 .travis.yml
 wallaby.js


### PR DESCRIPTION
Fixes bug introduced by https://github.com/wix/react-native-navigation/pull/7829/files that causes the package is failing upon install with: 

```
node_modules/react-native-navigation: Command failed.
Exit code: 1
Command: node scripts/postinstall.js
```

**UPDATE**: On a second thought, this postinstall script doesn't belong in this package at all. It's already fixed in [0.73.2](https://github.com/facebook/react-native/releases/tag/v0.73.2), and it's not proper for an npm package applying patches to other packages IMHO.