### PR TITLE
Disable action-menu clipChildren=false

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/ButtonBar.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/ButtonBar.kt
@@ -25,13 +25,6 @@ open class ButtonBar internal constructor(context: Context) : Toolbar(context) {
 
     override fun onViewAdded(child: View) {
         super.onViewAdded(child)
-        enableOverflowForReactButtonViews(child)
-    }
-
-    private fun enableOverflowForReactButtonViews(child: View) {
-        if (child is ActionMenuView) {
-            (child as ViewGroup).clipChildren = false
-        }
     }
 
     override fun setLayoutDirection(layoutDirection: Int) {


### PR DESCRIPTION
## Description

fixes #7832

After spending a fair amount of efforts trying to get a deep understanding the layout and view arrangement flow, i couldn't get to the very bottom of why the buttons menu transitively renders in a broken way, namely like this:

<img width="438" alt="image" src="https://github.com/wix/react-native-navigation/assets/9818880/3d536733-6b9e-4e01-af43-515279bd40ab">

instead of:

<img width="436" alt="image" src="https://github.com/wix/react-native-navigation/assets/9818880/34147535-c9c9-4263-b057-20e7f00aa4f9">

Nevertheless, `clipChildren=false` over the action menu's root (i.e. the `ActionMenuView` class) - introduced [here](https://github.com/wix/react-native-navigation/pull/6918/files) seems to be causing the flicker, while removing it doesn't seem to be introducing any regressions.

#### Further steps

While with `clipChildren=false` the layout is broken transitively, removing it doesn't make all-things-perfect. There is still a very noticeable flicker happening in each stack push/pop, which could probably be avoided. Read below for hints as to why that is.

_Update: Reported in #7862_

---
Some details for future reference:
- Pausing the app using a breakpoint over `ButtonBar#onLayout()` seems to be catching the app in with the visibility bug in-effect, meaning the menu layout phase is two-fold and that the button bar layout happening in between.
- Whether during a push _or_ a pop, the brokenly-rendered menu is laid out with the buttons of the **to-screen**. This hints that the problem comes from a process that contains a buttons-list clear and a repopulation that should be happening atomically but could be invalidating the menu view prematurely.
- The toolbar is a single instance per the generated stack (i.e. of the test app: tapping `Layouts` tab → `Stack` button)