### PR TITLE
fix(iOS): avoid cutting-off text on bottom bar buttons on iPad.

### DIFF
--- a/lib/ios/RNNTabBarItemCreator.m
+++ b/lib/ios/RNNTabBarItemCreator.m
@@ -97,7 +97,7 @@
                     fontSize:fontSize
                   fontWeight:fontWeight
                        color:textColor
-                    centered:NO];
+                    centered:YES];
     [self setTitleAttributes:tabItem titleAttributes:normalAttributes];
 
     NSDictionary *selectedAttributes = [RNNFontAttributesCreator
@@ -106,7 +106,7 @@
                     fontSize:fontSize
                   fontWeight:fontWeight
                        color:selectedTextColor
-                    centered:NO];
+                    centered:YES];
     [self setSelectedTitleAttributes:tabItem selectedTitleAttributes:selectedAttributes];
 }
 


### PR DESCRIPTION
For some reason, this change resolves the issue in the attached snapshots.

When `centered=YES`, setting the text alignment to `NSTextAlignmentCenter` ([see here](https://github.com/wix/react-native-navigation/blob/4b48f75ae5e3b319d6243362bbf77f769d50990e/lib/ios/RNNFontAttributesCreator.m#L44)) may incidentally cause the text layout engine to more effectively manage the available space. Doesn't seem like it affects anything in iPhones.

Overall, it seems like a bug in UIKit..

**Before:**
![Screenshot 2024-03-20 at 17 16 15](https://github.com/wix/react-native-navigation/assets/55082339/490e3cb4-df65-4bd0-932c-c63da3c7a49d)

**After:**
![Screenshot 2024-03-20 at 18 10 10](https://github.com/wix/react-native-navigation/assets/55082339/da60598b-d204-4bf0-8706-498b1128f53c)
