### PR TITLE
[iOS] Fabric renderer fix

### DIFF
--- a/lib/ios/RNNReactView.mm
+++ b/lib/ios/RNNReactView.mm
@@ -17,6 +17,7 @@
            reactViewReadyBlock:(RNNReactViewReadyCompletionBlock)reactViewReadyBlock {
   RCTFabricSurface *surface = [[RCTFabricSurface alloc] initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties];
   self = [super initWithSurface:surface sizeMeasureMode:sizeMeasureMode];
+  [surface start];
 #else
 - (instancetype)initWithBridge:(RCTBridge *)bridge
                     moduleName:(NSString *)moduleName


### PR DESCRIPTION
After migration to RN73,`RNNReactView` now extends from `RCTSurfaceHostingProxyRootView` and uses new `initWithBridge:` implementation (with Fabric) with `RCTFabricSurface` instance. In `initWithBridge:` method, we call `[super initWithSurface:surface sizeMeasureMode:sizeMeasureMode]`, but this method located in `RCTSurfaceHostingView` (parent for `RCTSurfaceHostingProxyRootView`)  and does not call `[surface start]` (unlike `RCTSurfaceHostingProxyRootView` `[super initWithSurface:surface]` that calls it, but it does not allow us to specify `RCTSurfaceSizeMeasureMode`), so all we need to do is to call `[surface start]` after `RNNReactView` init.

Also I created Expo plugin for this wonderful library, it supports SDK 49 and SDK 50 (RN 72 & 73): [RNN Expo Plugin](https://github.com/TheLonelyAstronaut/rnn-expo-plugin)