### PR TITLE
fix: make sure we don't swallow errors inside the mock

### DIFF
--- a/lib/Mock/Components/LayoutComponent.tsx
+++ b/lib/Mock/Components/LayoutComponent.tsx
@@ -20,7 +20,8 @@ export const LayoutComponent = class extends Component<ComponentProps> {
   }
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     throw new Error(
-      `Error while trying to render layout ${this.props.layoutNode.nodeId} of type ${this.props.layoutNode.type}: ${error}\n${errorInfo?.componentStack}`
+      `Error while trying to render layout ${this.props.layoutNode.nodeId} of type ${this.props.layoutNode.type}: ${error}\n${errorInfo?.componentStack}`,
+      {cause: error}
     );
   }
 };

--- a/lib/Mock/Components/LayoutComponent.tsx
+++ b/lib/Mock/Components/LayoutComponent.tsx
@@ -19,9 +19,10 @@ export const LayoutComponent = class extends Component<ComponentProps> {
     return <View />;
   }
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    throw new Error(
+    const err =  new Error(
       `Error while trying to render layout ${this.props.layoutNode.nodeId} of type ${this.props.layoutNode.type}: ${error}\n${errorInfo?.componentStack}`,
-      {cause: error}
     );
+    (err as any).cause = error;
+    throw err;
   }
 };

--- a/lib/src/adapters/NativeEventsReceiver.mock.ts
+++ b/lib/src/adapters/NativeEventsReceiver.mock.ts
@@ -1,1 +1,3 @@
-export const { NativeEventsReceiver } = jest.genMockFromModule('./NativeEventsReceiver');
+export const { NativeEventsReceiver } = jest.genMockFromModule(
+  './NativeEventsReceiver'
+) as typeof import('./NativeEventsReceiver');

--- a/lib/src/events/EventsRegistry.test.tsx
+++ b/lib/src/events/EventsRegistry.test.tsx
@@ -19,7 +19,9 @@ describe('EventsRegistry', () => {
   it('exposes appLaunched event', () => {
     const subscription = {};
     const cb = jest.fn();
-    mockNativeEventsReceiver.registerAppLaunchedListener.mockReturnValueOnce(subscription);
+    (mockNativeEventsReceiver.registerAppLaunchedListener as jest.MockedFunction<
+      any
+    >).mockReturnValueOnce(subscription);
 
     const result = uut.registerAppLaunchedListener(cb);
 

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "shell-utils": "1.x.x",
     "ts-mockito": "^2.3.1",
     "typedoc": "0.x.x",
-    "typescript": "4.4.3"
+    "typescript": "5.5.4"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -50,9 +50,6 @@
     "release": "node ./scripts/release",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx ./"
   },
-  "overrides": {
-    "@babel/traverse": "7.22.6"
-  },
   "peerDependencies": {
     "react": "*",
     "react-native": "*",


### PR DESCRIPTION
adding {cause} should make it easier to understand where the error comes from.

