### PR TITLE
fix(Android): Kotlin build issues with RN 0.75.3

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/ReactTypefaceUtils.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/ReactTypefaceUtils.java
@@ -20,6 +20,7 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.views.text.ReactFontManager;
 import com.facebook.react.views.text.ReactTextShadowNode;
+import com.facebook.react.common.ReactConstants;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -96,12 +97,12 @@ public class ReactTypefaceUtils {
 
     int want = 0;
     if ((weight == Typeface.BOLD)
-        || ((oldStyle & Typeface.BOLD) != 0 && weight == ReactTextShadowNode.UNSET)) {
+        || ((oldStyle & Typeface.BOLD) != 0 && weight == ReactConstants.UNSET)) {
       want |= Typeface.BOLD;
     }
 
     if ((style == Typeface.ITALIC)
-        || ((oldStyle & Typeface.ITALIC) != 0 && style == ReactTextShadowNode.UNSET)) {
+        || ((oldStyle & Typeface.ITALIC) != 0 && style == ReactConstants.UNSET)) {
       want |= Typeface.ITALIC;
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/ReactViewGroup.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/ReactViewGroup.kt
@@ -4,4 +4,4 @@ import com.facebook.react.views.view.ReactViewBackgroundDrawable
 import com.facebook.react.views.view.ReactViewGroup
 
 val ReactViewGroup.borderRadius: Float
-    get() = (background as? ReactViewBackgroundDrawable)?.fullBorderRadius ?: 0f
+    get() = (background as? ReactViewBackgroundDrawable)?.fullBorderWidth ?: 0f

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/LayoutDirectionApplier.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/LayoutDirectionApplier.kt
@@ -6,10 +6,12 @@ import com.reactnativenavigation.options.Options
 
 class LayoutDirectionApplier {
     fun apply(root: ViewController<*>, options: Options, instanceManager: ReactInstanceManager) {
-        if (options.layout.direction.hasValue() && instanceManager.currentReactContext != null) {
-            root.activity.window.decorView.layoutDirection = options.layout.direction.get()
-            I18nUtil.getInstance().allowRTL(instanceManager.currentReactContext, options.layout.direction.isRtl)
-            I18nUtil.getInstance().forceRTL(instanceManager.currentReactContext, options.layout.direction.isRtl)
+        if (options.layout.direction.hasValue()) {
+            instanceManager.currentReactContext?.let { context ->
+                root.activity.window.decorView.layoutDirection = options.layout.direction.get()
+                I18nUtil.getInstance().allowRTL(context, options.layout.direction.isRtl)
+                I18nUtil.getInstance().forceRTL(context, options.layout.direction.isRtl)
+           }
         }
     }
 }

--- a/lib/android/app/src/reactNative71/java/com/reactnativenavigation/react/modal/ModalContentLayout.kt
+++ b/lib/android/app/src/reactNative71/java/com/reactnativenavigation/react/modal/ModalContentLayout.kt
@@ -49,17 +49,17 @@ class ModalContentLayout(context: Context?) : ReactViewGroup(context), RootView{
             updateFirstChildView()
         }
     }
-    override fun onChildStartedNativeGesture(child: View, androidEvent: MotionEvent?) {
+    override fun onChildStartedNativeGesture(child: View, androidEvent: MotionEvent) {
         mJSTouchDispatcher.onChildStartedNativeGesture(androidEvent, this.getEventDispatcher())
     }
-    override fun onChildStartedNativeGesture(androidEvent: MotionEvent?) {
+    override fun onChildStartedNativeGesture(androidEvent: MotionEvent) {
         mJSTouchDispatcher.onChildStartedNativeGesture(androidEvent, this.getEventDispatcher())
     }
-    override fun onChildEndedNativeGesture(child: View, androidEvent: MotionEvent?) {
+    override fun onChildEndedNativeGesture(child: View, androidEvent: MotionEvent) {
         mJSTouchDispatcher.onChildEndedNativeGesture(androidEvent, this.getEventDispatcher())
     }
     override fun requestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {}
-    private fun getEventDispatcher(): EventDispatcher? {
+    private fun getEventDispatcher(): EventDispatcher {
         val reactContext: ReactContext = this.getReactContext()
         return reactContext.getNativeModule(UIManagerModule::class.java)!!.eventDispatcher
     }
@@ -73,12 +73,12 @@ class ModalContentLayout(context: Context?) : ReactViewGroup(context), RootView{
         return this.context as ReactContext
     }
 
-    override fun onInterceptTouchEvent(event: MotionEvent?): Boolean {
+    override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
         mJSTouchDispatcher.handleTouchEvent(event, getEventDispatcher())
         return super.onInterceptTouchEvent(event)
     }
 
-    override fun onTouchEvent(event: MotionEvent?): Boolean {
+    override fun onTouchEvent(event: MotionEvent): Boolean {
         mJSTouchDispatcher.handleTouchEvent(event, getEventDispatcher())
         super.onTouchEvent(event)
         return true


### PR DESCRIPTION
## Summary

This PR fixes the following Kotlin build issues which were discovered after I upgraded `react-native` to `0.75.3` and `react-native-navigation` to `7.40.1`

```
> Task :react-native-navigation:compileReactNative71DebugKotlin FAILED
e: file:///private/tmp/nix-build-status-mobile-build-debug-android.drv-3/node_modules/
react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/
utils/ReactViewGroup.kt:7:59 Unresolved reference: fullBorderRadius

e: file:///private/tmp/nix-build-status-mobile-build-debug-android.drv-3/node_modules/
react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/
viewcontrollers/viewcontroller/LayoutDirectionApplier.kt:11:45 Smart cast to 'ReactContext' is impossible, 
because 'instanceManager.currentReactContext' is a property that has open or custom getter

e: file:///private/tmp/nix-build-status-mobile-build-debug-android.drv-3/node_modules/
react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/
viewcontrollers/viewcontroller/LayoutDirectionApplier.kt:12:45 Smart cast to 'ReactContext' is impossible, 
because 'instanceManager.currentReactContext' is a property that has open or custom getter

e: file:///private/tmp/nix-build-status-mobile-build-debug-android.drv-3/node_modules/
react-native-navigation/lib/android/app/src/reactNative71/java/com/reactnativenavigation/
react/modal/ModalContentLayout.kt:53:56 Type mismatch: inferred type is MotionEvent? 
but MotionEvent was expected

e: file:///private/tmp/nix-build-status-mobile-build-debug-android.drv-3/node_modules/
react-native-navigation/lib/android/app/src/reactNative71/java/com/reactnativenavigation/
react/modal/ModalContentLayout.kt:53:70 Type mismatch: inferred type is EventDispatcher? 
but EventDispatcher was expected

e: file:///private/tmp/nix-build-status-mobile-build-debug-android.drv-3/node_modules/
react-native-navigation/lib/android/app/src/reactNative71/java/com/reactnativenavigation/
react/modal/ModalContentLayout.kt:56:56 Type mismatch: inferred type is MotionEvent? 
but MotionEvent was expected

e: file:///private/tmp/nix-build-status-mobile-build-debug-android.drv-3/node_modules/
react-native-navigation/lib/android/app/src/reactNative71/java/com/reactnativenavigation/
react/modal/ModalContentLayout.kt:56:70 Type mismatch: inferred type is EventDispatcher? 
but EventDispatcher was expected

e: file:///private/tmp/nix-build-status-mobile-build-debug-android.drv-3/node_modules/
react-native-navigation/lib/android/app/src/reactNative71/java/com/reactnativenavigation/
react/modal/ModalContentLayout.kt:59:54 Type mismatch: inferred type is MotionEvent? 
but MotionEvent was expected

e: file:///private/tmp/nix-build-status-mobile-build-debug-android.drv-3/node_modules/
react-native-navigation/lib/android/app/src/reactNative71/java/com/reactnativenavigation/
react/modal/ModalContentLayout.kt:59:68 Type mismatch: inferred type is EventDispatcher? 
but EventDispatcher was expected

e: file:///private/tmp/nix-build-status-mobile-build-debug-android.drv-3/node_modules/
react-native-navigation/lib/android/app/src/reactNative71/java/com/reactnativenavigation/
react/modal/ModalContentLayout.kt:77:45 Type mismatch: inferred type is MotionEvent? 
but MotionEvent was expected

e: file:///private/tmp/nix-build-status-mobile-build-debug-android.drv-3/node_modules/
react-native-navigation/lib/android/app/src/reactNative71/java/com/reactnativenavigation/
react/modal/ModalContentLayout.kt:77:52 Type mismatch: inferred type is EventDispatcher? 
but EventDispatcher was expected

e: file:///private/tmp/nix-build-status-mobile-build-debug-android.drv-3/node_modules/
react-native-navigation/lib/android/app/src/reactNative71/java/com/reactnativenavigation/
react/modal/ModalContentLayout.kt:82:45 Type mismatch: inferred type is MotionEvent? 
but MotionEvent was expected

e: file:///private/tmp/nix-build-status-mobile-build-debug-android.drv-3/node_modules/
react-native-navigation/lib/android/app/src/reactNative71/java/com/reactnativenavigation/
react/modal/ModalContentLayout.kt:82:52 Type mismatch: inferred type is EventDispatcher? 
but EventDispatcher was expected
```

fixes: https://github.com/wix/react-native-navigation/issues/7905, https://github.com/wix/react-native-navigation/issues/7911