### PR TITLE
fix: Android top bar buttons disappeared when lock screen then unlock screen

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/navigator/Navigator.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/navigator/Navigator.java
@@ -284,6 +284,9 @@ public class Navigator extends ParentController<ViewGroup> {
 
     public void onHostResume() {
         overlayManager.onHostResume();
+        if (root != null && root.getView() != null) {
+            root.getView().requestLayout();
+        }
         if (!modalStack.isEmpty()) {
             modalStack.onHostResume();
             if(modalStack.peekDisplayedOverCurrentContext()){


### PR DESCRIPTION
### What happened?
Android top bar buttons disappear After Locking the screen then unlock the screen.

### What was the expected behavior?
The top bar buttons should keep showing.

### Was it tested on the latest react-native-navigation?
I have tested this issue on the latest react-native-navigation release and it still reproduces.

###  Root Cause
The `onGlobalLayout` is not triggered when the lock screen then unlocks the screen.

### In what environment did this happen?
React Native Navigation version: -
Has Fabric (React Native's new rendering system) enabled: no
Device model: Pixel 6
Android version: 14

### Reproduce the Issue:

1. On Android, open the Playground app, select Options Tab
2. Click the `Buttons Screen` button
3. Click the `Push` button
4. Lock the screen then wake up the phone and unlock the screen
5. Back to the `Buttons Screen` page.
6. The title `Buttons` and the button `Two` disappeared

### Screenshot
Before:

https://github.com/user-attachments/assets/6ab1c91f-77b5-4f6a-b9ae-a2d684f32959


After:

https://github.com/user-attachments/assets/fb276a48-2132-4f05-8994-1eb1f6d8e0a8



