### PR TITLE
fix(ios): ensure correct initial tab is rendered when onSwitchToTab is set

### DIFF
--- a/lib/ios/RNNBottomTabsController.m
+++ b/lib/ios/RNNBottomTabsController.m
@@ -29,6 +29,11 @@
     _bottomTabPresenter = bottomTabPresenter;
     _dotIndicatorPresenter = dotIndicatorPresenter;
 
+    if ([options.bottomTabs.currentTabIndex hasValue]) {
+        _currentTabIndex = [options.bottomTabs.currentTabIndex get];
+        _previousTabIndex = _currentTabIndex;
+    }
+
     self = [super initWithLayoutInfo:layoutInfo
                              creator:creator
                              options:options

--- a/playground/ios/NavigationTests/RNNCommandsHandlerTest.m
+++ b/playground/ios/NavigationTests/RNNCommandsHandlerTest.m
@@ -521,6 +521,40 @@
     XCTAssertTrue(_vc2.isViewLoaded);
 }
 
+- (void)testSetRoot_withBottomTabsAttachModeOnSwitchToTabWithCustomIndex {
+    [self.uut setReadyToReceiveCommands:true];
+    RNNNavigationOptions *options = [RNNNavigationOptions emptyOptions];
+    options.bottomTabs.tabsAttachMode =
+        [[BottomTabsAttachMode alloc] initWithValue:@"onSwitchToTab"];
+    options.animations.setRoot.waitForRender = [[Bool alloc] initWithBOOL:YES];
+    options.bottomTabs.currentTabIndex = [IntNumber withValue:@1];
+
+    BottomTabsBaseAttacher *attacher =
+        [[[BottomTabsAttachModeFactory alloc] initWithDefaultOptions:nil] fromOptions:options];
+    RNNBottomTabsController *tabBarController =
+        [[RNNBottomTabsController alloc] initWithLayoutInfo:nil
+                                                    creator:nil
+                                                    options:options
+                                             defaultOptions:[RNNNavigationOptions emptyOptions]
+                                                  presenter:[RNNBasePresenter new]
+                                         bottomTabPresenter:nil
+                                      dotIndicatorPresenter:nil
+                                               eventEmitter:_eventEmmiter
+                                       childViewControllers:@[ _vc1, _vc2 ]
+                                         bottomTabsAttacher:attacher];
+    [tabBarController viewWillAppear:YES];
+    OCMStub([self.controllerFactory createLayout:[OCMArg any]]).andReturn(tabBarController);
+
+    [self.uut setRoot:@{}
+            commandId:@""
+           completion:^(NSString *componentId){
+           }];
+    XCTAssertFalse(_vc1.isViewLoaded);
+    XCTAssertTrue(_vc2.isViewLoaded);
+    [tabBarController setSelectedIndex:0];
+    XCTAssertTrue(_vc1.isViewLoaded);
+}
+
 - (void)testSetRoot_withBottomTabsAttachModeAfterInitialTab {
     [self.uut setReadyToReceiveCommands:true];
     RNNNavigationOptions *options = [RNNNavigationOptions emptyOptions];


### PR DESCRIPTION
Fixes #7921 by setting _currentTabIndex in the RNNBottomTabsController before initialization happens.

>  _currentTabIndex needs to be set before the super() is called, since - [RNNBottomTabsController selectedViewController] will be called during initialization and which depends on _currentTabIndex. If not set, an initial render of the tab content with index 0 will occur when tabsAttachMode is set to "onSwitchToTab".
 
