### PR TITLE
chore: upgrade react-native-blur version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@react-native/metro-config": "^0.73.2",
     "@react-native/babel-preset": "^0.73.18",
     "@react-native/typescript-config": "^0.73.1",
-    "@react-native-community/blur": "^3.6.0",
+    "@react-native-community/blur": "^4.4.1",
     "@react-native-community/datetimepicker": "^3.4.7",
     "@react-native-community/eslint-config": "2.0.0",
     "@react-native-community/netinfo": "^5.9.4",


### PR DESCRIPTION
Should solve this Gradle issue during the build:

```

* What went wrong:
--
  | Execution failed for task ':react-native-community_blur:extractReleaseAnnotations'.
  | > Error while evaluating property 'hasAndroidAnnotations' of task ':react-native-community_blur:extractReleaseAnnotations'.
  | > Could not resolve all artifacts for configuration ':react-native-community_blur:releaseCompileClasspath'.
  | > Failed to transform blurview-1.6.3.aar (com.eightbitlab:blurview:1.6.3) to match attributes {artifactType=android-classes-jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}.
  | > Could not find blurview-1.6.3.jar (com.eightbitlab:blurview:1.6.3).
  | Searched in the following locations:
  | https://jcenter.bintray.com/com/eightbitlab/blurview/1.6.3/blurview-1.6.3.aar
  | https://jcenter.bintray.com/com/eightbitlab/blurview/1.6.3/blurview-1.6.3.jar

```