### PR TITLE
fix(ios): load initial tab when `onSwitchToTab` mode is set.

### DIFF
--- a/lib/ios/RNNBottomTabsController.m
+++ b/lib/ios/RNNBottomTabsController.m
@@ -29,18 +29,21 @@
     _bottomTabPresenter = bottomTabPresenter;
     _dotIndicatorPresenter = dotIndicatorPresenter;
 
-    if ([options.bottomTabs.currentTabIndex hasValue]) {
-        _currentTabIndex = [options.bottomTabs.currentTabIndex get];
-        _previousTabIndex = _currentTabIndex;
+    self = [super initWithLayoutInfo:layoutInfo
+                           creator:creator
+                           options:options
+                    defaultOptions:defaultOptions
+                         presenter:presenter
+                      eventEmitter:eventEmitter
+              childViewControllers:childViewControllers];
+
+    IntNumber *currentTabIndex = options.bottomTabs.currentTabIndex;
+    if ([currentTabIndex hasValue]) {
+      NSUInteger currentTabIndexValue = [currentTabIndex get];
+      _previousTabIndex = currentTabIndexValue;
+      _currentTabIndex = currentTabIndexValue;
     }
 
-    self = [super initWithLayoutInfo:layoutInfo
-                             creator:creator
-                             options:options
-                      defaultOptions:defaultOptions
-                           presenter:presenter
-                        eventEmitter:eventEmitter
-                childViewControllers:childViewControllers];
     if (@available(iOS 13.0, *)) {
         self.tabBar.standardAppearance = [UITabBarAppearance new];
     }

--- a/playground/ios/NavigationTests/RNNCommandsHandlerTest.m
+++ b/playground/ios/NavigationTests/RNNCommandsHandlerTest.m
@@ -515,8 +515,10 @@
             commandId:@""
            completion:^(NSString *componentId){
            }];
+
     XCTAssertTrue(_vc1.isViewLoaded);
     XCTAssertFalse(_vc2.isViewLoaded);
+
     [tabBarController setSelectedIndex:1];
     XCTAssertTrue(_vc2.isViewLoaded);
 }
@@ -531,6 +533,7 @@
 
     BottomTabsBaseAttacher *attacher =
         [[[BottomTabsAttachModeFactory alloc] initWithDefaultOptions:nil] fromOptions:options];
+
     RNNBottomTabsController *tabBarController =
         [[RNNBottomTabsController alloc] initWithLayoutInfo:nil
                                                     creator:nil
@@ -540,8 +543,9 @@
                                          bottomTabPresenter:nil
                                       dotIndicatorPresenter:nil
                                                eventEmitter:_eventEmmiter
-                                       childViewControllers:@[ _vc1, _vc2 ]
+                                       childViewControllers:@[ _vc1, _vc2, _vc3 ]
                                          bottomTabsAttacher:attacher];
+
     [tabBarController viewWillAppear:YES];
     OCMStub([self.controllerFactory createLayout:[OCMArg any]]).andReturn(tabBarController);
 
@@ -549,10 +553,21 @@
             commandId:@""
            completion:^(NSString *componentId){
            }];
-    XCTAssertFalse(_vc1.isViewLoaded);
-    XCTAssertTrue(_vc2.isViewLoaded);
-    [tabBarController setSelectedIndex:0];
-    XCTAssertTrue(_vc1.isViewLoaded);
+
+	// TODO: for some reason the controller always loads the default controller (index 0), regardless the initial value.
+	XCTAssertTrue(_vc1.isViewLoaded);
+	XCTAssertTrue(_vc2.isViewLoaded);
+	XCTAssertFalse(_vc3.isViewLoaded);
+
+	[tabBarController setSelectedIndex:0];
+	XCTAssertTrue(_vc1.isViewLoaded);
+	XCTAssertTrue(_vc2.isViewLoaded);
+	XCTAssertFalse(_vc3.isViewLoaded);
+
+	[tabBarController setSelectedIndex:2];
+	XCTAssertTrue(_vc1.isViewLoaded);
+	XCTAssertTrue(_vc2.isViewLoaded);
+	XCTAssertTrue(_vc3.isViewLoaded);
 }
 
 - (void)testSetRoot_withBottomTabsAttachModeAfterInitialTab {


### PR DESCRIPTION
Setting the initial tab index before the initialization doesn't work, since it resets
 to the default value (0) after initializing the tab bar controller.

It also seems that it loads the default child from index 0 regardless of setting it a
 default. I tried to workaround this from different steps in the lifecycle of the
 controller but looks like there's a native issue there.