### PR TITLE
fix(ios): avoid setting selected-index before setup has finished.

### DIFF
--- a/lib/ios/RNNBottomTabsController.m
+++ b/lib/ios/RNNBottomTabsController.m
@@ -13,6 +13,8 @@
     NSUInteger _previousTabIndex;
     BottomTabsBaseAttacher *_bottomTabsAttacher;
     BOOL _tabBarNeedsRestore;
+    RNNNavigationOptions *_options;
+    BOOL _didFinishSetup;
 }
 
 - (instancetype)initWithLayoutInfo:(RNNLayoutInfo *)layoutInfo
@@ -28,6 +30,15 @@
     _bottomTabsAttacher = bottomTabsAttacher;
     _bottomTabPresenter = bottomTabPresenter;
     _dotIndicatorPresenter = dotIndicatorPresenter;
+    _options = options;
+    _didFinishSetup = NO;
+
+    IntNumber *currentTabIndex = options.bottomTabs.currentTabIndex;
+    if ([currentTabIndex hasValue]) {
+      NSUInteger currentTabIndexValue = [currentTabIndex get];
+      _previousTabIndex = currentTabIndexValue;
+      _currentTabIndex = currentTabIndexValue;
+    }
 
     self = [super initWithLayoutInfo:layoutInfo
                            creator:creator
@@ -36,13 +47,6 @@
                          presenter:presenter
                       eventEmitter:eventEmitter
               childViewControllers:childViewControllers];
-
-    IntNumber *currentTabIndex = options.bottomTabs.currentTabIndex;
-    if ([currentTabIndex hasValue]) {
-      NSUInteger currentTabIndexValue = [currentTabIndex get];
-      _previousTabIndex = currentTabIndexValue;
-      _currentTabIndex = currentTabIndexValue;
-    }
 
     if (@available(iOS 13.0, *)) {
         self.tabBar.standardAppearance = [UITabBarAppearance new];
@@ -60,6 +64,7 @@
                                                       action:@selector(handleLongPressGesture:)];
     [self.tabBar addGestureRecognizer:self.longPressRecognizer];
 
+    _didFinishSetup = YES;
     return self;
 }
 
@@ -132,8 +137,15 @@
 }
 
 - (void)setSelectedIndex:(NSUInteger)selectedIndex {
-    _currentTabIndex = selectedIndex;
-    [super setSelectedIndex:selectedIndex];
+    IntNumber *currentTabIndex = _options.bottomTabs.currentTabIndex;
+    if ([currentTabIndex hasValue] && !_didFinishSetup) {
+        NSUInteger currentTabIndexValue = [currentTabIndex get];
+        _currentTabIndex = currentTabIndexValue;
+    } else {
+        _currentTabIndex = selectedIndex;
+    }
+
+    [super setSelectedIndex:_currentTabIndex];
 }
 
 - (UIViewController *)selectedViewController {

--- a/playground/ios/NavigationTests/RNNCommandsHandlerTest.m
+++ b/playground/ios/NavigationTests/RNNCommandsHandlerTest.m
@@ -554,8 +554,7 @@
            completion:^(NSString *componentId){
            }];
 
-	// TODO: for some reason the controller always loads the default controller (index 0), regardless the initial value.
-	XCTAssertTrue(_vc1.isViewLoaded);
+	XCTAssertFalse(_vc1.isViewLoaded);
 	XCTAssertTrue(_vc2.isViewLoaded);
 	XCTAssertFalse(_vc3.isViewLoaded);
 


### PR DESCRIPTION
This fixes the issue mentioned on #7921, #7922 and #7924.

This prevents the bug of loading of the tab from index `0` immediately after calling the `super` init regardless of the custom initial rendered tab. More specifically, the original issue was the method `setSelectedIndex` was called immediately when calling to the `super` initializer with a `0` value regardless of the initial `currentTabIndex` value.

After this fix, changing the `selectedIndex` with the non-initial value from `options` will not have any effect before the setup has finished.