### PR TITLE
fix:  adding a component inside a LayoutsProcessor is broken

### DIFF
--- a/lib/src/commands/Commands.test.ts
+++ b/lib/src/commands/Commands.test.ts
@@ -140,7 +140,14 @@ describe('Commands', () => {
         root: { component: { name: 'com.example.MyScreen' } },
       });
       expect(layoutProcessor.process).toBeCalledWith(
-        { component: { name: 'com.example.MyScreen', options: {}, id: 'Component+UNIQUE_ID' } },
+        {
+          component: {
+            name: 'com.example.MyScreen',
+            options: {},
+            id: 'Component+UNIQUE_ID',
+            processedByNavigation: true,
+          },
+        },
         CommandName.SetRoot
       );
     });
@@ -168,6 +175,7 @@ describe('Commands', () => {
             id: 'Component+UNIQUE_ID',
             name: 'com.example.MyScreen',
             options: { topBar: { visible: false } },
+            processedByNavigation: true,
           },
         },
         CommandName.SetRoot
@@ -326,7 +334,14 @@ describe('Commands', () => {
     it('process layout with layoutProcessor', () => {
       uut.showModal({ component: { name: 'com.example.MyScreen' } });
       expect(layoutProcessor.process).toBeCalledWith(
-        { component: { id: 'Component+UNIQUE_ID', name: 'com.example.MyScreen', options: {} } },
+        {
+          component: {
+            id: 'Component+UNIQUE_ID',
+            name: 'com.example.MyScreen',
+            options: {},
+            processedByNavigation: true,
+          },
+        },
         CommandName.ShowModal
       );
     });
@@ -437,7 +452,14 @@ describe('Commands', () => {
     it('process layout with layoutProcessor', () => {
       uut.push('theComponentId', { component: { name: 'com.example.MyScreen' } });
       expect(layoutProcessor.process).toBeCalledWith(
-        { component: { id: 'Component+UNIQUE_ID', name: 'com.example.MyScreen', options: {} } },
+        {
+          component: {
+            id: 'Component+UNIQUE_ID',
+            name: 'com.example.MyScreen',
+            options: {},
+            processedByNavigation: true,
+          },
+        },
         CommandName.Push
       );
     });
@@ -573,7 +595,14 @@ describe('Commands', () => {
     it('process layout with layoutProcessor', () => {
       uut.setStackRoot('theComponentId', [{ component: { name: 'com.example.MyScreen' } }]);
       expect(layoutProcessor.process).toBeCalledWith(
-        { component: { id: 'Component+UNIQUE_ID', name: 'com.example.MyScreen', options: {} } },
+        {
+          component: {
+            id: 'Component+UNIQUE_ID',
+            name: 'com.example.MyScreen',
+            options: {},
+            processedByNavigation: true,
+          },
+        },
         CommandName.SetStackRoot
       );
     });
@@ -619,7 +648,14 @@ describe('Commands', () => {
     it('process layout with layoutProcessor', () => {
       uut.showOverlay({ component: { name: 'com.example.MyScreen' } });
       expect(layoutProcessor.process).toBeCalledWith(
-        { component: { id: 'Component+UNIQUE_ID', name: 'com.example.MyScreen', options: {} } },
+        {
+          component: {
+            id: 'Component+UNIQUE_ID',
+            name: 'com.example.MyScreen',
+            options: {},
+            processedByNavigation: true,
+          },
+        },
         CommandName.ShowOverlay
       );
     });

--- a/lib/src/commands/Commands.ts
+++ b/lib/src/commands/Commands.ts
@@ -31,6 +31,7 @@ export class Commands {
     const input = cloneLayout(simpleApi);
     this.optionsCrawler.crawl(input.root);
     const processedRoot = this.layoutProcessor.process(input.root, CommandName.SetRoot);
+    this.optionsCrawler.crawl(processedRoot);
     const root = this.layoutTreeParser.parse(processedRoot);
 
     const modals = map(input.modals, (modal) => {

--- a/lib/src/commands/OptionsCrawler.ts
+++ b/lib/src/commands/OptionsCrawler.ts
@@ -4,6 +4,7 @@ import isFunction from 'lodash/isFunction';
 import { Store } from '../components/Store';
 import { Options } from '../interfaces/Options';
 import {
+  InnerLayoutComponent,
   Layout,
   LayoutBottomTabs,
   LayoutComponent,
@@ -75,9 +76,11 @@ export class OptionsCrawler {
     return (component as ComponentWithOptions).options !== undefined;
   }
 
-  private applyStaticOptions(layout: LayoutComponent) {
+  private applyStaticOptions(layout: InnerLayoutComponent) {
+    if (layout.processedByNavigation) return;
     const staticOptions = this.staticOptionsIfPossible(layout);
     layout.options = merge({}, staticOptions, layout.options);
+    layout.processedByNavigation = true;
   }
 
   private staticOptionsIfPossible(layout: LayoutComponent) {
@@ -85,7 +88,7 @@ export class OptionsCrawler {
     const reactComponent = foundReactGenerator ? foundReactGenerator() : undefined;
     if (reactComponent && this.isComponentWithOptions(reactComponent)) {
       return isFunction(reactComponent.options)
-        ? reactComponent.options({ componentId: layout.id, ...layout.passProps } || {})
+        ? reactComponent.options({ componentId: layout.id, ...layout.passProps })
         : reactComponent.options;
     }
     return {};

--- a/lib/src/interfaces/Layout.ts
+++ b/lib/src/interfaces/Layout.ts
@@ -1,5 +1,9 @@
 import { Options } from './Options';
 
+export interface InnerLayoutComponent<P = {}> extends LayoutComponent<P> {
+  processedByNavigation?: boolean;
+}
+
 export interface LayoutComponent<P = {}> {
   /**
    * Component reference id, Auto generated if empty


### PR DESCRIPTION
after layout process, we need another options crawl - in case one of the layout processors added a new component.
using a flag to prevent option merge on the old components