### PR TITLE
feat: Add Kotlin autolinker for React Native 0.63.x+

### DIFF
--- a/autolink/fixtures/rn72/MainActivity.java.template
+++ b/autolink/fixtures/rn72/MainActivity.java.template
@@ -1,0 +1,32 @@
+package com.app;
+
+import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
+import com.facebook.react.defaults.DefaultReactActivityDelegate;
+
+public class MainActivity extends ReactActivity {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "App";
+  }
+
+  /**
+   * Returns the instance of the {@link ReactActivityDelegate}. Here we use a util class {@link
+   * DefaultReactActivityDelegate} which allows you to easily enable Fabric and Concurrent React
+   * (aka React 18) with two boolean flags.
+   */
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new DefaultReactActivityDelegate(
+        this,
+        getMainComponentName(),
+        // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+        DefaultNewArchitectureEntryPoint.getFabricEnabled());
+  }
+}

--- a/autolink/fixtures/rn72/MainApplication.java.template
+++ b/autolink/fixtures/rn72/MainApplication.java.template
@@ -1,0 +1,62 @@
+package com.app;
+
+import android.app.Application;
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
+import com.facebook.react.defaults.DefaultReactNativeHost;
+import com.facebook.soloader.SoLoader;
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost =
+      new DefaultReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+          return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // packages.add(new MyReactNativePackage());
+          return packages;
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+          return "index";
+        }
+
+        @Override
+        protected boolean isNewArchEnabled() {
+          return BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+        }
+
+        @Override
+        protected Boolean isHermesEnabled() {
+          return BuildConfig.IS_HERMES_ENABLED;
+        }
+      };
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    SoLoader.init(this, /* native exopackage */ false);
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      // If you opted-in for the New Architecture, we load the native entry point for this app.
+      DefaultNewArchitectureEntryPoint.load();
+    }
+    ReactNativeFlipper.initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+}

--- a/autolink/fixtures/rn73/MainActivity.kt.template
+++ b/autolink/fixtures/rn73/MainActivity.kt.template
@@ -1,0 +1,22 @@
+package com.app
+
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+import com.facebook.react.defaults.DefaultReactActivityDelegate
+
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun getMainComponentName(): String = "App"
+
+  /**
+   * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]
+   * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
+   */
+  override fun createReactActivityDelegate(): ReactActivityDelegate =
+      DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+}

--- a/autolink/fixtures/rn73/MainApplication.kt.template
+++ b/autolink/fixtures/rn73/MainApplication.kt.template
@@ -1,0 +1,45 @@
+package com.app
+
+import android.app.Application
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactHost
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
+import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
+import com.facebook.react.defaults.DefaultReactNativeHost
+import com.facebook.react.flipper.ReactNativeFlipper
+import com.facebook.soloader.SoLoader
+
+class MainApplication : Application(), ReactApplication {
+
+  override val reactNativeHost: ReactNativeHost =
+      object : DefaultReactNativeHost(this) {
+        override fun getPackages(): List<ReactPackage> =
+            PackageList(this).packages.apply {
+              // Packages that cannot be autolinked yet can be added manually here, for example:
+              // add(MyReactNativePackage())
+            }
+
+        override fun getJSMainModuleName(): String = "index"
+
+        override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
+
+        override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+        override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+      }
+
+  override val reactHost: ReactHost
+    get() = getDefaultReactHost(this.applicationContext, reactNativeHost)
+
+  override fun onCreate() {
+    super.onCreate()
+    SoLoader.init(this, false)
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      // If you opted-in for the New Architecture, we load the native entry point for this app.
+      load()
+    }
+    ReactNativeFlipper.initializeFlipper(this, reactNativeHost.reactInstanceManager)
+  }
+}

--- a/autolink/postlink/__snapshots__/activityLinker.test.js.snap
+++ b/autolink/postlink/__snapshots__/activityLinker.test.js.snap
@@ -67,7 +67,6 @@ public class MainActivity extends NavigationActivity {
 "
 `;
 
-
 exports[`activityLinker should work for RN 0.71 1`] = `
 "package com.app;
 
@@ -77,6 +76,40 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
 import com.facebook.react.defaults.DefaultReactActivityDelegate;
 
 public class MainActivity extends NavigationActivity {
+
+  
+
+  
+}
+"
+`;
+
+exports[`activityLinker should work for RN 0.72 1`] = `
+"package com.app;
+
+import com.reactnativenavigation.NavigationActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
+import com.facebook.react.defaults.DefaultReactActivityDelegate;
+
+public class MainActivity extends NavigationActivity {
+
+  
+
+  
+}
+"
+`;
+
+exports[`activityLinker should work for RN 0.73 1`] = `
+"package com.app
+
+import com.reactnativenavigation.NavigationActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+import com.facebook.react.defaults.DefaultReactActivityDelegate
+
+class MainActivity : NavigationActivity() {
 
   
 

--- a/autolink/postlink/__snapshots__/applicationLinker.test.js.snap
+++ b/autolink/postlink/__snapshots__/applicationLinker.test.js.snap
@@ -1,0 +1,118 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`applicationLinker should work for RN 0.72 1`] = `
+"package com.app;
+
+import android.app.Application;
+import com.facebook.react.PackageList;
+import com.reactnativenavigation.NavigationApplication;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
+import com.facebook.react.defaults.DefaultReactNativeHost;
+import com.reactnativenavigation.react.NavigationReactNativeHost;
+import com.facebook.soloader.SoLoader;
+import java.util.List;
+
+public class MainApplication extends NavigationApplication {
+
+  private final ReactNativeHost mReactNativeHost =
+      new NavigationReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+          return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings(\\"UnnecessaryLocalVariable\\")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // packages.add(new MyReactNativePackage());
+          return packages;
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+          return \\"index\\";
+        }
+
+        @Override
+        protected boolean isNewArchEnabled() {
+          return BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+        }
+
+        @Override
+        protected Boolean isHermesEnabled() {
+          return BuildConfig.IS_HERMES_ENABLED;
+        }
+      };
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      // If you opted-in for the New Architecture, we load the native entry point for this app.
+      DefaultNewArchitectureEntryPoint.load();
+    }
+    ReactNativeFlipper.initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+}
+"
+`;
+
+exports[`applicationLinker should work for RN 0.73 1`] = `
+"package com.app
+
+import android.app.Application
+import com.facebook.react.PackageList
+import com.reactnativenavigation.NavigationApplication
+import com.facebook.react.ReactHost
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
+import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
+import com.facebook.react.defaults.DefaultReactNativeHost
+import com.reactnativenavigation.react.NavigationReactNativeHost
+import com.facebook.react.flipper.ReactNativeFlipper
+import com.facebook.soloader.SoLoader
+
+class MainApplication : NavigationApplication() {
+
+  override val reactNativeHost: ReactNativeHost =
+      object : NavigationReactNativeHost(this) {
+        override fun getPackages(): List<ReactPackage> =
+            PackageList(this).packages.apply {
+              // Packages that cannot be autolinked yet can be added manually here, for example:
+              // add(MyReactNativePackage())
+            }
+
+        override fun getJSMainModuleName(): String = \\"index\\"
+
+        override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
+
+        override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+        override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+      }
+
+  override val reactHost: ReactHost
+    get() = getDefaultReactHost(this.applicationContext, reactNativeHost)
+
+  override fun onCreate() {
+    super.onCreate()
+    
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      // If you opted-in for the New Architecture, we load the native entry point for this app.
+      load()
+    }
+    ReactNativeFlipper.initializeFlipper(this, reactNativeHost.reactInstanceManager)
+  }
+}
+"
+`;

--- a/autolink/postlink/activityLinker.test.js
+++ b/autolink/postlink/activityLinker.test.js
@@ -100,4 +100,56 @@ describe('activityLinker', () => {
     const mainActivityContent = fs.readFileSync(linker.activityPath, 'utf8');
     expect(mainActivityContent).toMatchSnapshot();
   });
+
+  it('should work for RN 0.72', () => {
+    jest.mock('../postlink/path', () => {
+      const { copyFileSync } = require('fs');
+      const { tmpdir } = require('os');
+      const path = require('path');
+
+      const tmpMainActivityPath = path.resolve(tmpdir(), 'rnn-tests_MainActivity.java');
+
+      copyFileSync(
+        path.resolve('autolink/fixtures/rn72/MainActivity.java.template'),
+        tmpMainActivityPath
+      );
+
+      return {
+        mainActivityJava: tmpMainActivityPath,
+      };
+    });
+
+    const ActivityLinker = require('./activityLinker');
+    const linker = new ActivityLinker();
+
+    linker.link();
+    const mainActivityContent = fs.readFileSync(linker.activityPath, 'utf8');
+    expect(mainActivityContent).toMatchSnapshot();
+  });
+
+  it('should work for RN 0.73', () => {
+    jest.mock('../postlink/path', () => {
+      const { copyFileSync } = require('fs');
+      const { tmpdir } = require('os');
+      const path = require('path');
+
+      const tmpMainActivityPath = path.resolve(tmpdir(), 'rnn-tests_MainActivity.kt');
+
+      copyFileSync(
+        path.resolve('autolink/fixtures/rn73/MainActivity.kt.template'),
+        tmpMainActivityPath
+      );
+
+      return {
+        mainActivityJava: tmpMainActivityPath,
+      };
+    });
+
+    const ActivityLinker = require('./activityLinker');
+    const linker = new ActivityLinker();
+
+    linker.link();
+    const mainActivityContent = fs.readFileSync(linker.activityPath, 'utf8');
+    expect(mainActivityContent).toMatchSnapshot();
+  });
 });

--- a/autolink/postlink/applicationLinker.test.js
+++ b/autolink/postlink/applicationLinker.test.js
@@ -1,0 +1,75 @@
+import fs from 'fs';
+
+/**
+ * Mocks
+ */
+
+jest.mock('../postlink/log', () => ({
+  log: console.log,
+  logn: console.log,
+  warn: console.log,
+  warnn: console.log,
+  info: console.log,
+  infon: console.log,
+  debug: console.log,
+  debugn: console.log,
+  errorn: console.log,
+}));
+
+/**
+ * Tests
+ */
+
+describe('applicationLinker', () => {
+  it('should work for RN 0.72', () => {
+    jest.mock('../postlink/path', () => {
+      const { copyFileSync } = require('fs');
+      const { tmpdir } = require('os');
+      const path = require('path');
+
+      const tmpApplicationJavaPath = path.resolve(tmpdir(), 'rnn-tests_MainApplication.java');
+
+      copyFileSync(
+        path.resolve('autolink/fixtures/rn72/MainApplication.java.template'),
+        tmpApplicationJavaPath
+      );
+
+      return {
+        mainApplicationJava: tmpApplicationJavaPath,
+      };
+    });
+
+    const ApplicationLinker = require('./applicationLinker');
+    const linker = new ApplicationLinker();
+
+    linker.link();
+    const mainActivityContent = fs.readFileSync(linker.applicationPath, 'utf8');
+    expect(mainActivityContent).toMatchSnapshot();
+  });
+
+  it('should work for RN 0.73', () => {
+    jest.mock('../postlink/path', () => {
+      const { copyFileSync } = require('fs');
+      const { tmpdir } = require('os');
+      const path = require('path');
+
+      const tmpApplicationJavaPath = path.resolve(tmpdir(), 'rnn-tests_MainApplication.kt');
+
+      copyFileSync(
+        path.resolve('autolink/fixtures/rn73/MainApplication.kt.template'),
+        tmpApplicationJavaPath
+      );
+
+      return {
+        mainApplicationJava: tmpApplicationJavaPath,
+      };
+    });
+
+    const ApplicationLinker = require('./applicationLinker');
+    const linker = new ApplicationLinker();
+
+    linker.link();
+    const mainActivityContent = fs.readFileSync(linker.applicationPath, 'utf8');
+    expect(mainActivityContent).toMatchSnapshot();
+  });
+});

--- a/autolink/postlink/gradleLinker.js
+++ b/autolink/postlink/gradleLinker.js
@@ -173,7 +173,7 @@ class GradleLinker {
    * @param {string} contents
    */
   _isKotlinPluginDeclared(contents) {
-    return /org.jetbrains.kotlin:kotlin-gradle-plugin:/.test(contents);
+    return /org\.jetbrains\.kotlin:kotlin-gradle-plugin:?/.test(contents);
   }
 }
 

--- a/autolink/postlink/path.js
+++ b/autolink/postlink/path.js
@@ -3,11 +3,13 @@ var ignoreFolders = {
   ignore: ['node_modules/**', '**/build/**', '**/Build/**', '**/DerivedData/**', '**/*-tvOS*/**'],
 };
 
-exports.mainActivityJava = glob.sync('**/MainActivity.java', ignoreFolders)[0];
-exports.mainActivityKotlin = glob.sync('**/MainActivity.kt', ignoreFolders)[0];
-var mainApplicationJava = glob.sync('**/MainApplication.java', ignoreFolders)[0];
+exports.mainActivityJava = glob.sync('**/MainActivity.{java,kt}', ignoreFolders)[0];
+var mainApplicationJava = glob.sync('**/MainApplication.{java,kt}', ignoreFolders)[0];
 exports.mainApplicationJava = mainApplicationJava;
-exports.rootGradle = mainApplicationJava.replace(/android\/app\/.*\.java/, 'android/build.gradle');
+exports.rootGradle = mainApplicationJava.replace(
+  /android\/app\/.*\.(java|kt)/,
+  'android/build.gradle'
+);
 
 var reactNativeVersion = require('../../../react-native/package.json').version;
 exports.appDelegate = glob.sync(


### PR DESCRIPTION
Issue: https://github.com/wix/react-native-navigation/issues/7821, https://github.com/wix/react-native-navigation/issues/7943

Script was tested on: `0.72`, `0.73`, `0.74`, `0.75`, `0.76`


**To test:**

```tsx
npx @react-native-community/cli init Rn74 --version 0.74
cd Rn74
yarn add react-native-navigation@https://github.com/retyui/react-native-navigation.git#feat/retyui/add-kotlin-autolinker
npx rnn-link
```


<img width="569" alt="Screenshot 2024-12-03 at 13 41 49" src="https://github.com/user-attachments/assets/79753203-7e56-4992-8f23-9e59b8c15329">
