### PR TITLE
fix: [iPadOS 18] Disable the new UITabBarController view style in iPadOS 18

### DIFF
--- a/lib/ios/RNNBottomTabsController.m
+++ b/lib/ios/RNNBottomTabsController.m
@@ -81,6 +81,14 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+
+    if (@available(iOS 18, *))
+    {
+        if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)
+        {
+            self.traitOverrides.horizontalSizeClass = UIUserInterfaceSizeClassUnspecified;
+        }
+    }
 }
 
 - (void)createTabBarItems:(NSArray<UIViewController *> *)childViewControllers {


### PR DESCRIPTION
## Description

Since iPadOS 18, the Bottom Tab Bar on iPads is now positioned at the top of the screen, floating over the content, instead of at the bottom. This may be the feature by Apple in new version however creating poor user experience

### Fix
1. Check the ios18 and iPad variant 
2. If above condition statisfy, apply following 
    >.traitOverrides.horizontalSizeClass = UIUserInterfaceSizeClassUnspecified;

This will disable the new UITabBarController view style in iPadOS 18
 
### References
**Announcement:** https://developer.apple.com/design/human-interface-guidelines/tab-bars#iPadOS
