### PR TITLE
iOS: RN 77 no lifecycle events for Top Bar Title component

### DIFF
--- a/e2e/StaticLifecycleEvents.test.js
+++ b/e2e/StaticLifecycleEvents.test.js
@@ -72,7 +72,7 @@ describe('static lifecycle events', () => {
     ).toBeVisible();
   });
 
-  xit('top bar title willAppear didAppear didDisappear', async () => {
+  it('top bar title willAppear didAppear didDisappear', async () => {
     await elementById(TestIDs.PUSH_BTN).tap();
     await elementById(TestIDs.PUSH_OPTIONS_BUTTON).tap();
     await elementById(TestIDs.CLEAR_OVERLAY_EVENTS_BTN).tap();

--- a/lib/ios/TopBarTitlePresenter.mm
+++ b/lib/ios/TopBarTitlePresenter.mm
@@ -89,6 +89,8 @@
 
         viewController.navigationItem.titleView = nil;
         viewController.navigationItem.titleView = _customTitleView;
+        [_customTitleView componentWillAppear];
+        [_customTitleView componentDidAppear];
     } else {
         [_customTitleView removeFromSuperview];
         if (readyBlock) {


### PR DESCRIPTION
The problem was that when setting a titleView of a navigationItem the normal life cycle flow of a view will not be called so the RNNReactView componentWillAppear and DidAppear need to be implicitly called. 

This was somehow removed from the TopBarTitlePresenter.mm unit but is present on the current Master branch's file.

This PR restores those two lines and also actives the Unit test for that module.