### PR TITLE
Mocked side-menus - support

### DIFF
--- a/e2e/SideMenu.test.js
+++ b/e2e/SideMenu.test.js
@@ -3,7 +3,7 @@ import TestIDs from '../playground/src/testIDs';
 
 const { elementByLabel, elementById } = Utils;
 
-describe.e2e('SideMenu', () => {
+describe('SideMenu', () => {
   beforeEach(async () => {
     await device.launchApp({ newInstance: true });
     await elementById(TestIDs.SIDE_MENU_BTN).tap();
@@ -38,13 +38,13 @@ describe.e2e('SideMenu', () => {
     await expect(elementById(TestIDs.CLOSE_RIGHT_SIDE_MENU_BTN)).toBeNotVisible();
   });
 
-  it('should rotate', async () => {
+  it.e2e('should rotate', async () => {
     await elementById(TestIDs.OPEN_LEFT_SIDE_MENU_BTN).tap();
     await device.setOrientation('landscape');
     await expect(elementById(TestIDs.LEFT_SIDE_MENU_PUSH_BTN)).toBeVisible();
   });
 
-  it(':ios: rotation should update drawer height', async () => {
+  it.e2e(':ios: rotation should update drawer height', async () => {
     await elementById(TestIDs.OPEN_LEFT_SIDE_MENU_BTN).tap();
     await expect(elementByLabel('left drawer height: 869')).toBeVisible();
     await device.setOrientation('landscape');
@@ -53,23 +53,24 @@ describe.e2e('SideMenu', () => {
     await expect(elementByLabel('left drawer height: 869')).toBeVisible();
   });
 
-  it('should set left drawer width', async () => {
+  it.e2e('should set left drawer width', async () => {
     await elementById(TestIDs.OPEN_LEFT_SIDE_MENU_BTN).tap();
+    await expect(elementById(TestIDs.SIDE_MENU_LEFT_DRAWER_HEIGHT_TEXT)).toBeVisible();
     await expect(elementByLabel('left drawer width: 250')).toBeVisible();
   });
 
-  it('should change left drawer width', async () => {
+  it.e2e('should change left drawer width', async () => {
     await elementById(TestIDs.CHANGE_LEFT_SIDE_MENU_WIDTH_BTN).tap();
     await elementById(TestIDs.OPEN_LEFT_SIDE_MENU_BTN).tap();
     await expect(elementByLabel('left drawer width: 50')).toBeVisible();
   });
 
-  it('should set right drawer width', async () => {
+  it.e2e('should set right drawer width', async () => {
     await elementById(TestIDs.OPEN_RIGHT_SIDE_MENU_BTN).tap();
     await expect(elementByLabel('right drawer width: 250')).toBeVisible();
   });
 
-  it('should change right drawer width', async () => {
+  it.e2e('should change right drawer width', async () => {
     await elementById(TestIDs.CHANGE_RIGHT_SIDE_MENU_WIDTH_BTN).tap();
     await elementById(TestIDs.OPEN_RIGHT_SIDE_MENU_BTN).tap();
     await expect(elementByLabel('right drawer width: 50')).toBeVisible();

--- a/lib/Mock/Components/ComponentScreen.tsx
+++ b/lib/Mock/Components/ComponentScreen.tsx
@@ -25,7 +25,8 @@ export const ComponentScreen = connect(
     }
 
     isVisible(): boolean {
-      return LayoutStore.isVisibleLayout(this.props.layoutNode);
+      const isVisible = LayoutStore.isVisibleLayout(this.props.layoutNode);
+      return isVisible;
     }
 
     renderTabBar() {

--- a/lib/Mock/Components/LayoutComponent.tsx
+++ b/lib/Mock/Components/LayoutComponent.tsx
@@ -4,6 +4,7 @@ import { BottomTabs } from './BottomTabs';
 import { ComponentProps } from '../ComponentProps';
 import { ComponentScreen } from './ComponentScreen';
 import { Stack } from './Stack';
+import { SideMenuRoot, SideMenuCenter, SideMenuLeft, SideMenuRight } from './SideMenu';
 
 export const LayoutComponent = class extends Component<ComponentProps> {
   render() {
@@ -14,6 +15,14 @@ export const LayoutComponent = class extends Component<ComponentProps> {
         return <Stack layoutNode={this.props.layoutNode} />;
       case 'Component':
         return <ComponentScreen layoutNode={this.props.layoutNode} />;
+      case 'SideMenuRoot':
+        return <SideMenuRoot layoutNode={this.props.layoutNode} />;
+      case 'SideMenuLeft':
+        return <SideMenuLeft layoutNode={this.props.layoutNode} />;
+      case 'SideMenuCenter':
+        return <SideMenuCenter layoutNode={this.props.layoutNode} />;
+      case 'SideMenuRight':
+        return <SideMenuRight layoutNode={this.props.layoutNode} />;
     }
 
     return <View />;

--- a/lib/Mock/Components/SideMenu.tsx
+++ b/lib/Mock/Components/SideMenu.tsx
@@ -1,0 +1,27 @@
+import React, { Component } from 'react';
+import { connect } from '../connect';
+import { ComponentProps } from '../ComponentProps';
+import { LayoutComponent } from './LayoutComponent';
+import ParentNode from '../Layouts/ParentNode';
+
+export const SideMenuRoot = connect(
+  class extends Component<ComponentProps> {
+    render() {
+      const children = this.props.layoutNode.children;
+      return children.map((child: ParentNode) => {
+        return <LayoutComponent key={child.nodeId} layoutNode={child} />;
+      });
+    }
+  }
+);
+
+class SideMenuComponent extends Component<ComponentProps> {
+  render() {
+    const children = this.props.layoutNode.children;
+    const component = children[0];
+    return <LayoutComponent key={component.nodeId} layoutNode={component} />;
+  }
+}
+export const SideMenuLeft = connect(SideMenuComponent);
+export const SideMenuCenter = connect(SideMenuComponent);
+export const SideMenuRight = connect(SideMenuComponent);

--- a/lib/Mock/Layouts/BottomTabsNode.ts
+++ b/lib/Mock/Layouts/BottomTabsNode.ts
@@ -10,8 +10,10 @@ export default class BottomTabsNode extends ParentNode {
     this.selectedIndex = layout.data?.options?.bottomTabs?.currentTabIndex || 0;
   }
 
-  mergeOptions(options: Options) {
-    super.mergeOptions(options);
+  mergeOptions(_options: Options) {
+    super.mergeOptions(_options);
+
+    const { options } = this.data;
     if (options.bottomTabs?.currentTabIndex) {
       this.selectedIndex = options.bottomTabs?.currentTabIndex;
       switchTabByIndex(this, this.selectedIndex);

--- a/lib/Mock/Layouts/LayoutNodeFactory.ts
+++ b/lib/Mock/Layouts/LayoutNodeFactory.ts
@@ -2,6 +2,11 @@ import BottomTabs from './BottomTabsNode';
 import ComponentNode from './ComponentNode';
 import Stack from './StackNode';
 import ParentNode from './ParentNode';
+import SideMenuRootNode, {
+  SideMenuLeftNode,
+  SideMenuRightNode,
+  SideMenuCenterNode,
+} from './SideMenu';
 
 export default class LayoutNodeFactory {
   static create(layout: any, parentNode?: ParentNode) {
@@ -10,7 +15,15 @@ export default class LayoutNodeFactory {
         return new ComponentNode(layout, parentNode);
       case 'Stack':
         return new Stack(layout, parentNode);
-      default:
+      case 'SideMenuRoot':
+        return new SideMenuRootNode(layout, parentNode);
+      case 'SideMenuLeft':
+        return new SideMenuLeftNode(layout, parentNode);
+      case 'SideMenuCenter':
+        return new SideMenuCenterNode(layout, parentNode);
+      case 'SideMenuRight':
+        return new SideMenuRightNode(layout, parentNode);
+      default: // TODO Undo
       case 'BottomTabs':
         return new BottomTabs(layout, parentNode);
     }

--- a/lib/Mock/Layouts/ParentNode.ts
+++ b/lib/Mock/Layouts/ParentNode.ts
@@ -35,6 +35,10 @@ export default class ParentNode extends Node {
     return this;
   }
 
+  applyOptions(_options: Options) {
+    this.parentNode?.applyOptions(_options);
+  }
+
   mergeOptions(options: Options) {
     this.data.options = _.mergeWith(this.data.options, options, (objValue, srcValue, key) => {
       if (_.isArray(objValue)) {

--- a/lib/Mock/Layouts/SideMenu.ts
+++ b/lib/Mock/Layouts/SideMenu.ts
@@ -1,0 +1,79 @@
+import ParentNode from './ParentNode';
+import ComponentNode from './ComponentNode';
+import { Options } from '../../src/index';
+import * as layoutActions from '../actions/layoutActions';
+import { NodeType } from './Node';
+
+const isCenterChild = (child: ParentNode) => child.type === 'SideMenuCenter';
+const isLeftChild = (child: ParentNode) => child.type === 'SideMenuLeft';
+const isRightChild = (child: ParentNode) => child.type === 'SideMenuRight';
+
+export default class SideMenuRootNode extends ParentNode {
+  visibleChild: ParentNode;
+
+  constructor(layout: any, parentNode?: ParentNode) {
+    super(layout, 'SideMenuRoot', parentNode);
+
+    this.visibleChild = this._getCenterChild();
+    if (!this.visibleChild) {
+      throw new Error('SideMenuRootNode must have a SideMenuCenter child');
+    }
+  }
+
+  mergeOptions(options: Options) {
+    super.mergeOptions(options);
+
+    this._updateVisibility(options);
+  }
+
+  /**
+   * @override
+   */
+  getVisibleLayout(): ComponentNode {
+    return this.visibleChild.getVisibleLayout();
+  }
+
+  _updateVisibility(options: Options) {
+    if (options.sideMenu?.left?.visible) {
+      this.visibleChild = this._getLeftChild();
+      layoutActions.openSideMenu(this.visibleChild);
+    } else if (options.sideMenu?.right?.visible) {
+      this.visibleChild = this._getRightChild();
+      layoutActions.openSideMenu(this.visibleChild);
+    } else {
+      this.visibleChild = this._getCenterChild();
+      layoutActions.closeSideMenu(this.visibleChild);
+    }
+  }
+
+  _getCenterChild = () => this.children.find(isCenterChild) as ParentNode;
+  _getLeftChild = () => this.children.find(isLeftChild) as ParentNode;
+  _getRightChild = () => this.children.find(isRightChild) as ParentNode;
+}
+
+export class SideMenuNode extends ParentNode {
+  constructor(layout: any, type: NodeType, parentNode?: ParentNode) {
+    super(layout, type, parentNode);
+  }
+
+  getVisibleLayout() {
+    return this.children[0].getVisibleLayout();
+  }
+}
+
+export class SideMenuLeftNode extends SideMenuNode {
+  constructor(layout: any, parentNode?: ParentNode) {
+    super(layout, 'SideMenuLeft', parentNode);
+  }
+}
+export class SideMenuRightNode extends SideMenuNode {
+  constructor(layout: any, parentNode?: ParentNode) {
+    super(layout, 'SideMenuRight', parentNode);
+  }
+}
+
+export class SideMenuCenterNode extends SideMenuNode {
+  constructor(layout: any, parentNode?: ParentNode) {
+    super(layout, 'SideMenuCenter', parentNode);
+  }
+}

--- a/lib/Mock/Layouts/SideMenu.ts
+++ b/lib/Mock/Layouts/SideMenu.ts
@@ -20,6 +20,12 @@ export default class SideMenuRootNode extends ParentNode {
     }
   }
 
+  applyOptions(_options: Options) {
+    super.applyOptions(_options);
+
+    this._updateVisibility(_options);
+  }
+
   mergeOptions(options: Options) {
     super.mergeOptions(options);
 
@@ -34,15 +40,17 @@ export default class SideMenuRootNode extends ParentNode {
   }
 
   _updateVisibility(options: Options) {
-    if (options.sideMenu?.left?.visible) {
-      this.visibleChild = this._getLeftChild();
-      layoutActions.openSideMenu(this.visibleChild);
-    } else if (options.sideMenu?.right?.visible) {
-      this.visibleChild = this._getRightChild();
-      layoutActions.openSideMenu(this.visibleChild);
-    } else {
-      this.visibleChild = this._getCenterChild();
-      layoutActions.closeSideMenu(this.visibleChild);
+    if (options.sideMenu) {
+      if (options.sideMenu.left?.visible) {
+        this.visibleChild = this._getLeftChild();
+        layoutActions.openSideMenu(this.visibleChild);
+      } else if (options.sideMenu.right?.visible) {
+        this.visibleChild = this._getRightChild();
+        layoutActions.openSideMenu(this.visibleChild);
+      } else {
+        this.visibleChild = this._getCenterChild();
+        layoutActions.closeSideMenu(this.visibleChild);
+      }
     }
   }
 

--- a/lib/Mock/Stores/LayoutStore.ts
+++ b/lib/Mock/Stores/LayoutStore.ts
@@ -83,6 +83,11 @@ const setters = remx.setters({
   closeSideMenu(_layout: SideMenuNode) {
     state.sideMenu = undefined;
   },
+  applyOptions(componentId: string, options: Options) {
+    const layout = getters.getLayoutById(componentId);
+    if (layout) layout.applyOptions(options);
+    else console.warn(`[RNN error] Merge options failure: cannot find layout for: ${componentId}`);
+  },
   mergeOptions(componentId: string, options: Options) {
     const layout = getters.getLayoutById(componentId);
     if (layout) layout.mergeOptions(options);

--- a/lib/Mock/Stores/LayoutStore.ts
+++ b/lib/Mock/Stores/LayoutStore.ts
@@ -78,6 +78,12 @@ const setters = remx.setters({
     getters.getLayoutById(layout.nodeId).selectedIndex = index;
   },
   openSideMenu(layout: SideMenuNode) {
+    if (state.sideMenu) {
+      throw new Error(
+        'A side-menu is already open; Mocked-testing of multiple side-menu scenarios is not supported yet.' +
+          ' You can submit a request in https://github.com/wix/react-native-navigation/issues/new/choose.'
+      );
+    }
     state.sideMenu = layout;
   },
   closeSideMenu(_layout: SideMenuNode) {
@@ -107,10 +113,9 @@ const getters = remx.getters({
       layout = state.root;
     }
 
-    // TODO revisit this logic; working or not - state.sideMenu has
-    //   to be touched here in order to force reevaluation of the visible layout
-    //   while side menu open/close handling (i.e. to move away-from / back-to the
-    //   side-menu center child).
+    // Note: While this logic should be fair for all use cases (i.e. even multiple side-menus across tabs),
+    // there is no current test case that justifies it. Nevertheless, it's required to pass the tests,
+    // because otherwise getVisibleLayout() would not be revisited whenever side-menus are opened/closed.
     if (layout && state.sideMenu && findNode(state.sideMenu.nodeId, layout!)) {
       layout = state.sideMenu.parentNode;
     }

--- a/lib/Mock/actions/layoutActions.ts
+++ b/lib/Mock/actions/layoutActions.ts
@@ -1,4 +1,5 @@
 import ParentNode from '../Layouts/ParentNode';
+import { SideMenuNode } from '../Layouts/SideMenu';
 import { LayoutStore } from '../Stores/LayoutStore';
 
 export const switchTabByIndex = (bottomTabs: ParentNode | undefined, index: number) => {
@@ -7,4 +8,14 @@ export const switchTabByIndex = (bottomTabs: ParentNode | undefined, index: numb
     LayoutStore.selectTabIndex(bottomTabs, index);
     LayoutStore.getVisibleLayout().componentDidAppear();
   }
+};
+
+export const openSideMenu = (sideMenu: SideMenuNode) => {
+  LayoutStore.openSideMenu(sideMenu);
+  LayoutStore.getVisibleLayout().componentDidAppear();
+};
+
+export const closeSideMenu = (layout: SideMenuNode) => {
+  LayoutStore.getVisibleLayout().componentDidDisappear();
+  LayoutStore.closeSideMenu(layout);
 };

--- a/lib/Mock/mocks/NativeCommandsSender.tsx
+++ b/lib/Mock/mocks/NativeCommandsSender.tsx
@@ -39,6 +39,7 @@ export class NativeCommandsSender {
       const layoutNode = LayoutNodeFactory.create(layout, stack);
       stack.getVisibleLayout().componentDidDisappear();
       LayoutStore.push(layoutNode, stack);
+      LayoutStore.applyOptions(layoutNode.nodeId, layoutNode.data.options);
       stack.getVisibleLayout().componentDidAppear();
       resolve(stack.getVisibleLayout().nodeId);
       this.reportCommandCompletion(CommandName.Push, commandId);


### PR DESCRIPTION
Fixes #7981 -- introduces fundamental support for side-menus in mocked tests

Caveats:
- Multiple side-menus (i.e. across several tabs) are not supported yet

--
@yedidyak fyi