### PR TITLE
RNNav 8.1 issue in engine

### DIFF
--- a/lib/ios/RNNBottomTabsController.h
+++ b/lib/ios/RNNBottomTabsController.h
@@ -1,10 +1,10 @@
+#import <UIKit/UIKit.h>
 #import "BottomTabPresenter.h"
 #import "BottomTabsBaseAttacher.h"
 #import "RNNBottomTabsPresenter.h"
 #import "RNNDotIndicatorPresenter.h"
 #import "RNNEventEmitter.h"
 #import "UIViewController+LayoutProtocol.h"
-#import <UIKit/UIKit.h>
 
 @interface RNNBottomTabsController
     : UITabBarController <RNNLayoutProtocol, UITabBarControllerDelegate>

--- a/lib/ios/RNNBridgeEventEmitter.h
+++ b/lib/ios/RNNBridgeEventEmitter.h
@@ -1,4 +1,6 @@
 #import "RNNEventEmitter.h"
+#import <React/RCTBridgeModule.h>
 
-@interface RNNBridgeEventEmitter : RNNEventEmitter
+@interface RNNBridgeEventEmitter : RNNEventEmitter <RCTBridgeModule>
 @end
+

--- a/lib/ios/RNNBridgeEventEmitter.mm
+++ b/lib/ios/RNNBridgeEventEmitter.mm
@@ -1,5 +1,7 @@
 #import "RNNBridgeEventEmitter.h"
+#import <React/RCTBridgeModule.h>
 
 @implementation RNNBridgeEventEmitter {}
 
+RCT_EXPORT_MODULE()
 @end

--- a/lib/ios/RNNBridgeEventEmitter.mm
+++ b/lib/ios/RNNBridgeEventEmitter.mm
@@ -1,7 +1,6 @@
 #import "RNNBridgeEventEmitter.h"
-#import <React/RCTBridgeModule.h>
 
-@implementation RNNBridgeEventEmitter {}
+@implementation RNNBridgeEventEmitter
 
 RCT_EXPORT_MODULE()
 @end

--- a/lib/ios/RNNEmitterConstants.h
+++ b/lib/ios/RNNEmitterConstants.h
@@ -1,0 +1,16 @@
+typedef NSString * EmitterEvents NS_STRING_ENUM;
+extern EmitterEvents const AppLaunched;
+extern EmitterEvents const CommandCompleted;
+extern EmitterEvents const BottomTabSelected;
+extern EmitterEvents const BottomTabLongPressed;
+extern EmitterEvents const ComponentWillAppear;
+extern EmitterEvents const ComponentDidAppear;
+extern EmitterEvents const ComponentDidDisappear;
+extern EmitterEvents const NavigationButtonPressed;
+extern EmitterEvents const ModalDismissed;
+extern EmitterEvents const ModalAttemptedToDismiss;
+extern EmitterEvents const SearchBarUpdated;
+extern EmitterEvents const SearchBarCancelPressed;
+extern EmitterEvents const PreviewCompleted;
+extern EmitterEvents const ScreenPopped;
+extern EmitterEvents const BottomTabPressed;

--- a/lib/ios/RNNEmitterConstants.mm
+++ b/lib/ios/RNNEmitterConstants.mm
@@ -1,0 +1,18 @@
+#import "RNNEmitterConstants.h"
+
+EmitterEvents const AppLaunched = @"RNN.AppLaunched";
+EmitterEvents const CommandCompleted = @"RNN.CommandCompleted";
+EmitterEvents const BottomTabSelected = @"RNN.BottomTabSelected";
+EmitterEvents const BottomTabLongPressed = @"RNN.BottomTabLongPressed";
+EmitterEvents const ComponentWillAppear = @"RNN.ComponentWillAppear";
+EmitterEvents const ComponentDidAppear = @"RNN.ComponentDidAppear";
+EmitterEvents const ComponentDidDisappear = @"RNN.ComponentDidDisappear";
+EmitterEvents const NavigationButtonPressed = @"RNN.NavigationButtonPressed";
+EmitterEvents const ModalDismissed = @"RNN.ModalDismissed";
+EmitterEvents const ModalAttemptedToDismiss = @"RNN.ModalAttemptedToDismiss";
+EmitterEvents const SearchBarUpdated = @"RNN.SearchBarUpdated";
+EmitterEvents const SearchBarCancelPressed = @"RNN.SearchBarCancelPressed";
+EmitterEvents const PreviewCompleted = @"RNN.PreviewCompleted";
+EmitterEvents const ScreenPopped = @"RNN.ScreenPopped";
+EmitterEvents const BottomTabPressed = @"RNN.BottomTabPressed";
+

--- a/lib/ios/RNNEventEmitter.h
+++ b/lib/ios/RNNEventEmitter.h
@@ -1,13 +1,19 @@
 #import <Foundation/Foundation.h>
+#ifndef RCT_NEW_ARCH_ENABLED
 #import <React/RCTEventEmitter.h>
+#endif
 
+#ifdef RCT_NEW_ARCH_ENABLED
 @class RCTHost;
-@class RCTBridge;
-
 @interface RNNEventEmitter : NSObject
+#else
+@interface RNNEventEmitter : RCTEventEmitter
+#endif
 
+#ifdef RCT_NEW_ARCH_ENABLED
 - (void)setHost:(RCTHost *)host;
 @property(nonatomic, strong, readonly) RCTHost *host;
+#endif
 
 - (void)sendOnAppLaunched;
 

--- a/lib/ios/RNNModalManagerEventHandler.h
+++ b/lib/ios/RNNModalManagerEventHandler.h
@@ -1,5 +1,6 @@
-#import "RNNEventEmitter.h"
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import "RNNEventEmitter.h"
 
 @interface RNNModalManagerEventHandler : NSObject
 

--- a/lib/ios/RNNReactRootViewCreator.h
+++ b/lib/ios/RNNReactRootViewCreator.h
@@ -1,6 +1,6 @@
+#import <Foundation/Foundation.h>
 #import "RNNComponentViewCreator.h"
 #import "RNNEventEmitter.h"
-#import <Foundation/Foundation.h>
 #import <React/RCTBridge.h>
 
 @interface RNNReactRootViewCreator : NSObject <RNNComponentViewCreator>

--- a/lib/ios/RNNViewControllerFactory.h
+++ b/lib/ios/RNNViewControllerFactory.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 #import "BottomTabsAttachModeFactory.h"
 #import "RNNComponentViewCreator.h"
@@ -5,8 +7,6 @@
 #import "RNNExternalComponentStore.h"
 #import "RNNNavigationOptions.h"
 #import "RNNReactComponentRegistry.h"
-#import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 
 @interface RNNViewControllerFactory : NSObject
 

--- a/lib/ios/StackControllerDelegate.h
+++ b/lib/ios/StackControllerDelegate.h
@@ -1,10 +1,11 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
 #ifdef RCT_NEW_ARCH_ENABLED
 #import "RNNEventEmitter.h"
 #else
 #import "RNNEventEmitter.h"
 #endif
-#import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 
 @class RCTHost;
 

--- a/lib/ios/TurboModules/RNNTurboEventEmitter.h
+++ b/lib/ios/TurboModules/RNNTurboEventEmitter.h
@@ -1,24 +1,6 @@
 #ifdef RCT_NEW_ARCH_ENABLED
-#import "RNNEventEmitter.h"
+#import <React/RCTEventEmitter.h>
 #import <rnnavigation/rnnavigation.h>
-
-typedef NSString * EmitterEvents NS_STRING_ENUM;
-
-extern EmitterEvents const AppLaunched;
-extern EmitterEvents const CommandCompleted;
-extern EmitterEvents const BottomTabSelected;
-extern EmitterEvents const BottomTabLongPressed;
-extern EmitterEvents const ComponentWillAppear;
-extern EmitterEvents const ComponentDidAppear;
-extern EmitterEvents const ComponentDidDisappear;
-extern EmitterEvents const NavigationButtonPressed;
-extern EmitterEvents const ModalDismissed;
-extern EmitterEvents const ModalAttemptedToDismiss;
-extern EmitterEvents const SearchBarUpdated;
-extern EmitterEvents const SearchBarCancelPressed;
-extern EmitterEvents const PreviewCompleted;
-extern EmitterEvents const ScreenPopped;
-extern EmitterEvents const BottomTabPressed;
 
 @interface RNNTurboEventEmitter : RCTEventEmitter <NativeRNNTurboEventEmitterSpec>
 - (void)send:(NSString *)eventName body:(id)body;

--- a/lib/ios/TurboModules/RNNTurboEventEmitter.mm
+++ b/lib/ios/TurboModules/RNNTurboEventEmitter.mm
@@ -1,23 +1,7 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 #import "RNNTurboEventEmitter.h"
-
+#import "RNNEmitterConstants.h"
 #import "RNNUtils.h"
-
-EmitterEvents const AppLaunched = @"RNN.AppLaunched";
-EmitterEvents const CommandCompleted = @"RNN.CommandCompleted";
-EmitterEvents const BottomTabSelected = @"RNN.BottomTabSelected";
-EmitterEvents const BottomTabLongPressed = @"RNN.BottomTabLongPressed";
-EmitterEvents const ComponentWillAppear = @"RNN.ComponentWillAppear";
-EmitterEvents const ComponentDidAppear = @"RNN.ComponentDidAppear";
-EmitterEvents const ComponentDidDisappear = @"RNN.ComponentDidDisappear";
-EmitterEvents const NavigationButtonPressed = @"RNN.NavigationButtonPressed";
-EmitterEvents const ModalDismissed = @"RNN.ModalDismissed";
-EmitterEvents const ModalAttemptedToDismiss = @"RNN.ModalAttemptedToDismiss";
-EmitterEvents const SearchBarUpdated = @"RNN.SearchBarUpdated";
-EmitterEvents const SearchBarCancelPressed = @"RNN.SearchBarCancelPressed";
-EmitterEvents const PreviewCompleted = @"RNN.PreviewCompleted";
-EmitterEvents const ScreenPopped = @"RNN.ScreenPopped";
-EmitterEvents const BottomTabPressed = @"RNN.BottomTabPressed";
 
 @implementation RNNTurboEventEmitter {
   NSInteger _appLaunchedListenerCount;

--- a/lib/ios/UIViewController+LayoutProtocol.h
+++ b/lib/ios/UIViewController+LayoutProtocol.h
@@ -1,6 +1,6 @@
+#import <UIKit/UIKit.h>
 #import "RNNEventEmitter.h"
 #import "RNNLayoutProtocol.h"
-#import <UIKit/UIKit.h>
 
 typedef void (^RNNReactViewReadyCompletionBlock)(void);
 


### PR DESCRIPTION
Fixed an issue when library is being used by old arch components where the RNNBridgeEventEmitter is not used as an actual emitter.