### PR TITLE
Fix swift delegate detection

### DIFF
--- a/ReactNativeNavigation.podspec
+++ b/ReactNativeNavigation.podspec
@@ -15,6 +15,8 @@ Find.find(start_dir) do |path|
   end
 end
 
+swift_project = File.exist?(swift_delegate_path)
+
 # Debug output
 if swift_project
   puts "ReactNativeNavigation: Swift AppDelegate detected - enabling Swift-compatible configuration"

--- a/ReactNativeNavigation.podspec
+++ b/ReactNativeNavigation.podspec
@@ -1,19 +1,24 @@
 require 'json'
+require 'find'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 # Detect if this is a Swift project by looking for user AppDelegate.swift files
-dependency_paths = ['/node_modules/', '/Pods/', '/build/', '/Build/', '/DerivedData/']
-swift_project = Dir.glob('**/AppDelegate.swift')
-                   .reject { |file| dependency_paths.any? { |path| file.include?(path) } }
-                   .any?
+start_dir = File.expand_path('../..', __FILE__)
+swift_delegate_path = nil
+Find.find(start_dir) do |path|
+  if path =~ /AppDelegate\.swift$/
+    swift_delegate_path = path
+    break
+  end
+end
 
 # Debug output
 if swift_project
   puts "ReactNativeNavigation: Swift AppDelegate detected - enabling Swift-compatible configuration"
-else  
+else
   puts "ReactNativeNavigation: Objective-C AppDelegate detected - using standard configuration"
 end
 
@@ -43,19 +48,19 @@ Pod::Spec.new do |s|
   end
 
   folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -DFOLLY_CFG_NO_COROUTINES=1'
-  
+
   # Base xcconfig settings
   xcconfig_settings = {
       'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/boost" "$(PODS_ROOT)/boost-for-react-native"  "$(PODS_ROOT)/RCT-Folly" "$(PODS_ROOT)/Headers/Private/React-Core" "$(PODS_ROOT)/Headers/Private/Yoga"',
       "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
       "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
   }
-  
+
   # Only add DEFINES_MODULE for Swift projects
   if swift_project
     xcconfig_settings["DEFINES_MODULE"] = "YES"
   end
-  
+
   s.pod_target_xcconfig = xcconfig_settings
 
   if fabric_enabled

--- a/ReactNativeNavigation.podspec
+++ b/ReactNativeNavigation.podspec
@@ -6,7 +6,7 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 # Detect if this is a Swift project by looking for user AppDelegate.swift files
-start_dir = File.expand_path('../..', __FILE__)
+start_dir = File.expand_path('../../', __dir__)
 swift_delegate_path = nil
 Find.find(start_dir) do |path|
   if path =~ /AppDelegate\.swift$/


### PR DESCRIPTION
During `pod install` react-native-navigation does not correctly detect if a project has an obj-c or swift AppDelegate. Resulting in the a crash saying `ReactNativeNavigationModule not found`
https://github.com/wix/react-native-navigation/issues/8049

This should handle both normal and monorepo projects