### PR TITLE
[Android] Fix safe area miscalculation on HONOR phones

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -317,7 +317,7 @@ public class BottomTabsController extends ParentController<BottomTabsLayout> imp
     protected WindowInsetsCompat onApplyWindowInsets(View view, WindowInsetsCompat insets) {
         Insets sysInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars());
         view.setPaddingRelative(0, 0, 0, sysInsets.bottom);
-        return WindowInsetsCompat.CONSUMED;
+        return insets;
     }
 
 


### PR DESCRIPTION
Somehow bottomButtons layout breaks keyboard safe area on Honor (MagicOs) phone models.

### Description:
We have an app with bottomTabs layout.
When we push some modal that has TextInput and focus it, `adjustResize` doesn't work and important views that are placed on bottom became hidden behind the keyboard. But only on Honor phones 🤷‍♂️

**Initial screen:**
<img width="1080" height="2424" alt="Screenshot_1754628010" src="https://github.com/user-attachments/assets/1094ebb6-3d93-4931-8f67-27ee38b62990" />

**Before fix:**
<img width="1080" height="2424" alt="Screenshot_1754628261" src="https://github.com/user-attachments/assets/715bb0c0-f126-4ae8-b32f-3a0925ae973c" />

**After fix:**
<img width="1080" height="2424" alt="Screenshot_1754628018" src="https://github.com/user-attachments/assets/4e88bced-2a4d-4b5e-9ef0-47b056aab74e" />


## Additional info:
`react-native`: `0.77.3` (with some patches from [here](https://github.com/wix/react-native-navigation/issues/7945))
`react-native-navigation`: `7.50.0`
`softInputMode` is `adjustResize`


## Disclaimer
This is more of something to think about, rather that thorough merge request, as I'm not an advanced android developer and this works only for my case, but may break ton of others.
Screenshots are emulator representation of how it looks, not a real device screenshots.