### PR TITLE
Fix status bar crash -- RuntimeException: Tried to create view after it has already been destroyed

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
@@ -12,14 +12,12 @@ import androidx.core.view.WindowInsetsControllerCompat
 import kotlin.math.abs
 import kotlin.math.ceil
 
-
 object SystemUiUtils {
     private const val STATUS_BAR_HEIGHT_M = 24
     internal const val STATUS_BAR_HEIGHT_TRANSLUCENCY = 0.65f
     private var statusBarHeight = -1
     var navigationBarDefaultColor = -1
         private set
-
 
     @JvmStatic
     fun getStatusBarHeight(activity: Activity?): Int {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/statusbar/StatusBarPresenter.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/statusbar/StatusBarPresenter.kt
@@ -120,7 +120,8 @@ class StatusBarPresenter private constructor(
 
     private fun setStatusBarVisible(viewController: ViewController<*>, visible: Bool) {
         val window = window.get() ?: return
-        val view = if (viewController.view != null) viewController.view else window.decorView
+        val view = viewController.peekView() ?: window.decorView
+
         if (visible.isFalse) {
             hideStatusBar(window, view)
         } else {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/ViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/ViewController.java
@@ -254,6 +254,11 @@ public abstract class ViewController<T extends ViewGroup> implements ViewTreeObs
         if (view.getParent() == null) parent.addView(view, index);
     }
 
+    @Nullable
+    public T peekView() {
+        return view;
+    }
+
     public String getId() {
         return id;
     }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/BaseTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/BaseTest.java
@@ -61,7 +61,6 @@ public abstract class BaseTest {
         RNNFeatureToggles.init();
     }
 
-
     public void mockSystemUiUtils(int statusBarHeight, int statusBarHeightDp, Functions.Func1<MockedStatic<SystemUiUtils>> mockedBlock) {
         try (MockedStatic<SystemUiUtils> theMock = Mockito.mockStatic(SystemUiUtils.class)) {
             theMock.when(() -> {


### PR DESCRIPTION
```
java.lang.RuntimeException: Unable to pause activity {<packageId>.MainActivity}: java.lang.RuntimeException: Tried to create view after it has already been destroyed
    at android.app.ActivityThread.performPauseActivityIfNeeded(ActivityThread.java:5023)
    at android.app.ActivityThread.performPauseActivity(ActivityThread.java:4974)
    at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:4925)
    at android.app.servertransaction.PauseActivityItem.execute(PauseActivityItem.java:46)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2203)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:268)
    at android.app.ActivityThread.main(ActivityThread.java:8019)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:627)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:997)
java.lang.RuntimeException: Tried to create view after it has already been destroyed
    at com.reactnativenavigation.viewcontrollers.viewcontroller.ViewController.getView(ViewController.java:238)
    at com.reactnativenavigation.viewcontrollers.child.ChildController.getView(ChildController.java:37)
    at com.reactnativenavigation.viewcontrollers.statusbar.StatusBarPresenter.setStatusBarVisible(StatusBarPresenter.kt:123)
    at com.reactnativenavigation.viewcontrollers.statusbar.StatusBarPresenter.applyOptions(StatusBarPresenter.kt:41)
    at com.reactnativenavigation.viewcontrollers.viewcontroller.Presenter.applyStatusBarOptions(Presenter.java:108)
    at com.reactnativenavigation.viewcontrollers.viewcontroller.Presenter.onViewBroughtToFront(Presenter.java:64)
    at com.reactnativenavigation.viewcontrollers.child.ChildController.onViewBroughtToFront(ChildController.java:63)
    at com.reactnativenavigation.viewcontrollers.child.ChildControllersRegistry.onViewDisappear(ChildControllersRegistry.java:17)
    at com.reactnativenavigation.viewcontrollers.child.ChildController.onViewDisappear(ChildController.java:59)
    at com.reactnativenavigation.viewcontrollers.component.ComponentViewController.onViewDisappear(ComponentViewController.java:111)
    at com.reactnativenavigation.viewcontrollers.parent.ParentController.onViewDisappear(ParentController.java:58)
    at com.reactnativenavigation.viewcontrollers.parent.ParentController.onViewDisappear(ParentController.java:58)
    at com.reactnativenavigation.viewcontrollers.parent.ParentController.onViewDisappear(ParentController.java:58)
    at com.reactnativenavigation.viewcontrollers.navigator.Navigator.onHostPause(Navigator.java:281)
    at com.reactnativenavigation.react.NavigationModule$1.lambda$onHostPause$0(NavigationModule.java:63)
    at com.reactnativenavigation.react.NavigationModule$1.$r8$lambda$1QEZL3bKjVa-AfAQKVEYY2MSdag(NavigationModule.java:0)
    at com.reactnativenavigation.react.NavigationModule$1$$ExternalSyntheticLambda1.run(NavigationModule:0)
    at com.reactnativenavigation.utils.UiUtils.runOnMainThread(UiUtils.java:85)
    at com.reactnativenavigation.react.NavigationModule$1.onHostPause(NavigationModule.java:62)
    at com.facebook.react.bridge.ReactContext.onHostPause(ReactContext.java:336)
    at com.facebook.react.ReactInstanceManager.moveToBeforeResumeLifecycleState(ReactInstanceManager.java:778)
    at com.facebook.react.ReactInstanceManager.onHostPause(ReactInstanceManager.java:567)
    at com.facebook.react.ReactInstanceManager.onHostPause(ReactInstanceManager.java:593)
    at com.reactnativenavigation.react.NavigationReactInitializer.onActivityPaused(NavigationReactInitializer.java:40)
    at com.reactnativenavigation.react.ReactGateway.onActivityPaused(ReactGateway.java:52)
    at com.reactnativenavigation.NavigationActivity.onPause(NavigationActivity.java:85)
    at android.app.Activity.performPause(Activity.java:8263)
    at android.app.Instrumentation.callActivityOnPause(Instrumentation.java:1516)
    at android.app.ActivityThread.performPauseActivityIfNeeded(ActivityThread.java:5013)
    at android.app.ActivityThread.performPauseActivity(ActivityThread.java:4974)
    at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:4925)
    at android.app.servertransaction.PauseActivityItem.execute(PauseActivityItem.java:46)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2203)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:268)
    at android.app.ActivityThread.main(ActivityThread.java:8019)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:627)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:997)
```