### PR TITLE
Fix crash coming from top-bar color animation (#8098)

### DIFF
--- a/lib/android/app/src/androidTest/java/com/reactnativenavigation/TestUtils.java
+++ b/lib/android/app/src/androidTest/java/com/reactnativenavigation/TestUtils.java
@@ -43,10 +43,13 @@ public class TestUtils {
                 .setId("stack" + CompatUtils.generateViewId())
                 .setChildRegistry(new ChildControllersRegistry())
                 .setTopBarController(topBarController)
-                .setStackPresenter(new StackPresenter(activity, new TitleBarReactViewCreatorMock(),
-                        new TopBarBackgroundViewCreatorMock(), new TitleBarButtonCreatorMock(),
+                .setStackPresenter(new StackPresenter(activity,
+                        new TitleBarReactViewCreatorMock(),
+                        new TitleBarButtonCreatorMock(),
+                        topBarController,
                         new IconResolver(activity, new ImageLoader()), new TypefaceLoaderMock(), new RenderChecker(),
-                        new Options()))
+                        new Options(),
+                        new TopBarBackgroundViewCreatorMock()))
                 .setInitialOptions(new Options());
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/options/LayoutFactory.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/options/LayoutFactory.java
@@ -186,21 +186,22 @@ public class LayoutFactory {
 	}
 
 	private ViewController<?> createStack(LayoutNode node) {
+		final TopBarController topBarController = new TopBarController();
 		return new StackControllerBuilder(activity, eventEmitter)
 				.setChildren(createChildren(node.children))
 				.setChildRegistry(childRegistry)
-				.setTopBarController(new TopBarController())
+				.setTopBarController(topBarController)
 				.setId(node.id)
 				.setInitialOptions(parseOptions(node.getOptions()))
 				.setStackPresenter(new StackPresenter(activity,
 						new TitleBarReactViewCreator(),
-						new TopBarBackgroundViewCreator(),
 						new TitleBarButtonCreator(),
+						topBarController,
 						new IconResolver(activity, new ImageLoader()),
 						new TypefaceLoader(activity),
 						new RenderChecker(),
-						defaultOptions
-				))
+						defaultOptions,
+						new TopBarBackgroundViewCreator()))
 				.setPresenter(new Presenter(activity, defaultOptions))
 				.build();
 	}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackController.java
@@ -439,7 +439,7 @@ public class StackController extends ParentController<StackLayout> {
     @Override
     public StackLayout createView() {
         StackLayout stackLayout = new StackLayout(getActivity(), topBarController, getId());
-        presenter.bindView(topBarController, getBottomTabsController());
+        presenter.bindView(getBottomTabsController());
         addInitialChild(stackLayout);
         return stackLayout;
     }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenter.java
@@ -89,15 +89,17 @@ public class StackPresenter {
     private final TypefaceLoader typefaceLoader;
 
     public StackPresenter(Activity activity,
-            TitleBarReactViewCreator titleViewCreator,
-            TopBarBackgroundViewCreator topBarBackgroundViewCreator,
-            TitleBarButtonCreator buttonCreator,
-            IconResolver iconResolver,
-            TypefaceLoader typefaceLoader,
-            RenderChecker renderChecker,
-            Options defaultOptions) {
+                          TitleBarReactViewCreator titleViewCreator,
+                          TitleBarButtonCreator buttonCreator,
+                          TopBarController topBarController,
+                          IconResolver iconResolver,
+                          TypefaceLoader typefaceLoader,
+                          RenderChecker renderChecker,
+                          Options defaultOptions,
+                          TopBarBackgroundViewCreator topBarBackgroundViewCreator) {
         this.activity = activity;
         this.titleViewCreator = titleViewCreator;
+        this.topBarController = topBarController;
         this.topBarBackgroundViewCreator = topBarBackgroundViewCreator;
         this.buttonCreator = buttonCreator;
         this.iconResolver = iconResolver;
@@ -118,8 +120,7 @@ public class StackPresenter {
         return defaultOptions;
     }
 
-    public void bindView(TopBarController topBarController, @Nullable BottomTabsController bottomTabsController) {
-        this.topBarController = topBarController;
+    public void bindView(@Nullable BottomTabsController bottomTabsController) {
         this.bottomTabsController = bottomTabsController;
         topBar = topBarController.getView();
     }

--- a/lib/android/app/src/test/java/com/reactnativenavigation/TestUtils.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/TestUtils.java
@@ -31,19 +31,37 @@ import org.mockito.Mockito;
 
 public class TestUtils {
     public static StackControllerBuilder newStackController(Activity activity) {
-        TopBarController topBarController = new TopBarController() {
-            @Override
-            protected TopBar createTopBar(@NonNull Context context, @NonNull StackLayout stackLayout) {
-                TopBar topBar = super.createTopBar(context, stackLayout);
-                topBar.layout(0, 0, 1000, UiUtils.getTopBarHeight(context));
-                return topBar;
-            }
-        };
+        return newStackController(activity, null);
+    }
+
+    public static StackControllerBuilder newStackController(Activity activity, TopBarController topBarController) {
+        if (topBarController == null) {
+            topBarController = new TopBarController() {
+                @Override
+                protected TopBar createTopBar(@NonNull Context context, @NonNull StackLayout stackLayout) {
+                    TopBar topBar = super.createTopBar(context, stackLayout);
+                    topBar.layout(0, 0, 1000, UiUtils.getTopBarHeight(context));
+                    return topBar;
+                }
+            };
+        }
+
+        StackPresenter stackPresenter = new StackPresenter(activity,
+                new TitleBarReactViewCreatorMock(),
+                new TitleBarButtonCreatorMock(),
+                topBarController,
+                new IconResolver(activity,
+                new ImageLoader()),
+                new TypefaceLoaderMock(),
+                new RenderChecker(),
+                new Options(),
+                new TopBarBackgroundViewCreatorMock());
+
         return new StackControllerBuilder(activity, Mockito.mock(EventEmitter.class))
                 .setId("stack" + CompatUtils.generateViewId())
                 .setChildRegistry(new ChildControllersRegistry())
                 .setTopBarController(topBarController)
-                .setStackPresenter(new StackPresenter(activity, new TitleBarReactViewCreatorMock(), new TopBarBackgroundViewCreatorMock(), new TitleBarButtonCreatorMock(), new IconResolver(activity, new ImageLoader()), new TypefaceLoaderMock(), new RenderChecker(), new Options()))
+                .setStackPresenter(stackPresenter)
                 .setInitialOptions(new Options());
     }
 

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/OptionsApplyingTest.java
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/OptionsApplyingTest.java
@@ -72,8 +72,7 @@ public class OptionsApplyingTest extends BaseTest {
                 return topBar;
             }
         };
-        stack = TestUtils.newStackController(activity)
-                .setTopBarController(topBarController)
+        stack = TestUtils.newStackController(activity, topBarController)
                 .build();
         stack.ensureViewIsCreated();
         stack.getView().layout(0, 0, 1000, 1000);

--- a/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenterTest.kt
+++ b/lib/android/app/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenterTest.kt
@@ -24,6 +24,7 @@ import com.reactnativenavigation.viewcontrollers.stack.topbar.button.ButtonContr
 import com.reactnativenavigation.viewcontrollers.stack.topbar.button.ButtonPresenter
 import com.reactnativenavigation.viewcontrollers.stack.topbar.button.IconResolver
 import com.reactnativenavigation.viewcontrollers.stack.topbar.title.TitleBarReactViewController
+import com.reactnativenavigation.viewcontrollers.statusbar.StatusBarPresenter
 import com.reactnativenavigation.viewcontrollers.viewcontroller.ViewController
 import com.reactnativenavigation.views.stack.StackLayout
 import com.reactnativenavigation.views.stack.topbar.TopBar
@@ -66,6 +67,7 @@ class StackPresenterTest : BaseTest() {
     override fun beforeEach() {
         super.beforeEach()
         activity = spy(newActivity())
+        StatusBarPresenter.init(activity)
         val titleViewCreator: TitleBarReactViewCreatorMock = object : TitleBarReactViewCreatorMock() {
             override fun create(context: Context, componentId: String, componentName: String): TitleBarReactView {
                 reactTitleView = spy(super.create(context, componentId, componentName))
@@ -76,18 +78,19 @@ class StackPresenterTest : BaseTest() {
         typefaceLoader = createTypeFaceLoader()
         iconResolver = IconResolverFake(activity)
         buttonCreator = TitleBarButtonCreatorMock()
+        topBarController = createTopBarController()
         ogUut = StackPresenter(
-                activity,
-                titleViewCreator,
-                TopBarBackgroundViewCreatorMock(),
-                buttonCreator,
-                iconResolver,
-                typefaceLoader,
-                renderChecker,
-                Options()
+            activity,
+            titleViewCreator,
+            buttonCreator,
+            topBarController,
+            iconResolver,
+            typefaceLoader,
+            renderChecker,
+            Options(),
+            TopBarBackgroundViewCreatorMock()
         )
         uut = spy(ogUut)
-        createTopBarController()
         parent = TestUtils.newStackController(activity)
                 .setTopBarController(topBarController)
                 .setStackPresenter(uut)
@@ -1043,8 +1046,8 @@ class StackPresenterTest : BaseTest() {
         verify(topBarController, times(t)).hide()
     }
 
-    private fun createTopBarController() {
-        topBarController = spy(object : TopBarController() {
+    private fun createTopBarController(): TopBarController {
+        return spy(object : TopBarController() {
             override fun createTopBar(context: Context, stackLayout: StackLayout): TopBar {
                 topBar = spy(super.createTopBar(context, stackLayout))
                 topBar.layout(0, 0, 1000, UiUtils.getTopBarHeight(activity))


### PR DESCRIPTION
This is a replay of #8098 over the 8.x.x version