### PR TITLE
fix(android): #8061 new arch overlay problem

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/touch/OverlayTouchDelegate.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/touch/OverlayTouchDelegate.kt
@@ -19,7 +19,7 @@ open class OverlayTouchDelegate(private val component: ComponentLayout, private 
     }
 
     @VisibleForTesting
-    open fun handleDown(event: MotionEvent) = when (event.coordinatesInsideView(reactView.getChildAt(0))) {
+    open fun handleDown(event: MotionEvent) = when (event.coordinatesInsideView(reactView.getChildAt(1))) {
         true -> component.superOnInterceptTouchEvent(event)
         false -> interceptTouchOutside.isFalse
     }


### PR DESCRIPTION
Hello,
I’ve been investigating the overlay issue for a while. While debugging, I noticed that the touch events were falling into child 0 instead of 1 in this view. With this change, touch interactions started working correctly.

I also tested the overlay with different configurations, and it worked as expected.

This fixes the issue described here: https://github.com/wix/react-native-navigation/issues/8061