### PR TITLE
fix for temporary black screen after launchscreen

### DIFF
--- a/lib/ios/TurboModules/RNNTurboManager.mm
+++ b/lib/ios/TurboModules/RNNTurboManager.mm
@@ -106,6 +106,7 @@
 
 - (void)onJavaScriptLoaded {
     RCTExecuteOnMainQueue(^{
+        // TODO: the isInitialRun is the right and final answer for this, this will stop a blackscreen appearing after the splashscreen on startup. OnReload this will still happen because of the rootViewController = nil; which is needed to clean up what is already appearing.
         if (!self->_isInitialRun) {
             UIApplication.sharedApplication.delegate.window.rootViewController = nil;
         }


### PR DESCRIPTION
We are only resetting the rootViewController in case of a reload, this way we prevent a temporary black screen after the launch screen which really doesn't look good at all.
Only on reload we need to reset the rootViewController.