### PR TITLE
Fix side menu multiple connect warning

### DIFF
--- a/Mock/Components/SideMenu.tsx
+++ b/Mock/Components/SideMenu.tsx
@@ -15,13 +15,13 @@ export const SideMenuRoot = connect(
   }
 );
 
-class SideMenuComponent extends Component<ComponentProps> {
+const SideMenuComponent = connect(class extends Component<ComponentProps> {
   render() {
     const children = this.props.layoutNode.children;
     const component = children[0];
     return <LayoutComponent key={component.nodeId} layoutNode={component} />;
   }
-}
-export const SideMenuLeft = connect(SideMenuComponent);
-export const SideMenuCenter = connect(SideMenuComponent);
-export const SideMenuRight = connect(SideMenuComponent);
+});
+export const SideMenuLeft = SideMenuComponent;
+export const SideMenuCenter = SideMenuComponent;
+export const SideMenuRight = SideMenuComponent;


### PR DESCRIPTION
this change fix the following warning, by applying the connect function only once:
<img width="950" height="729" alt="image" src="https://github.com/user-attachments/assets/8f098469-9b8e-4157-810c-081f769acb9c" />
