### PR TITLE
iOS - Add title customization to scroll edge appearance (#8207)

### DIFF
--- a/ios/RNNScrollEdgeAppearanceOptions.h
+++ b/ios/RNNScrollEdgeAppearanceOptions.h
@@ -1,9 +1,11 @@
 #import "RNNComponentOptions.h"
 #import "RNNOptions.h"
 #import "RNNScrollEdgeAppearanceBackgroundOptions.h"
+#import "RNNTitleOptions.h"
 
 @interface RNNScrollEdgeAppearanceOptions : RNNOptions
 
+@property(nonatomic, strong) RNNTitleOptions *title;
 @property(nonatomic, strong) RNNScrollEdgeAppearanceBackgroundOptions *background;
 @property(nonatomic, strong) Bool *active;
 @property(nonatomic, strong) Bool *noBorder;

--- a/ios/RNNScrollEdgeAppearanceOptions.mm
+++ b/ios/RNNScrollEdgeAppearanceOptions.mm
@@ -9,12 +9,14 @@
     self.active = [BoolParser parse:dict key:@"active"];
     self.noBorder = [BoolParser parse:dict key:@"noBorder"];
     self.borderColor = [ColorParser parse:dict key:@"borderColor"];
+    self.title = [[RNNTitleOptions alloc] initWithDict:dict[@"title"]];
 
     return self;
 }
 
 - (void)mergeOptions:(RNNScrollEdgeAppearanceOptions *)options {
     [self.background mergeOptions:options.background];
+    [self.title mergeOptions:options.title];
 
     if (options.active.hasValue)
         self.active = options.active;

--- a/ios/TopBarAppearancePresenter.mm
+++ b/ios/TopBarAppearancePresenter.mm
@@ -19,8 +19,13 @@
     [self setBackgroundColor:[options.background.color withDefault:nil]];
     [self setScrollEdgeAppearanceColor:[options.scrollEdgeAppearance.background.color
                                            withDefault:nil]];
+    
     [self setTitleAttributes:options.title];
     [self setLargeTitleAttributes:options.largeTitle];
+    if (options.scrollEdgeAppearance.title && [options.scrollEdgeAppearance.title hasValue]) {
+        [self setScrollEdgeTitleAttributes:options.scrollEdgeAppearance.title];
+    }
+    
     [self setBorderColor:[options.borderColor withDefault:nil]];
     [self showBorder:![options.noBorder withDefault:NO]];
     [self setBackButtonOptions:options.backButton];
@@ -155,6 +160,29 @@
     }
     
     self.getAppearance.titleTextAttributes = titleTextAttributes;
+    self.getScrollEdgeAppearance.titleTextAttributes = titleTextAttributes;
+}
+
+- (void)setScrollEdgeTitleAttributes:(RNNTitleOptions *)titleOptions {
+    NSString *fontFamily = [titleOptions.fontFamily withDefault:nil];
+    NSString *fontWeight = [titleOptions.fontWeight withDefault:nil];
+    NSNumber *fontSize = [titleOptions.fontSize withDefault:nil];
+    UIColor *fontColor = [titleOptions.color withDefault:nil];
+
+    NSDictionary *titleTextAttributes =
+        [RNNFontAttributesCreator createFromDictionary:self.getScrollEdgeAppearance.titleTextAttributes
+                                            fontFamily:fontFamily
+                                              fontSize:fontSize
+                                            fontWeight:fontWeight
+                                                 color:fontColor
+                                              centered:YES];
+
+    id attrib = titleTextAttributes[NSParagraphStyleAttributeName];
+    if ([attrib isKindOfClass:[NSMutableParagraphStyle class]]) {
+        ((NSMutableParagraphStyle *)titleTextAttributes[NSParagraphStyleAttributeName]).lineBreakMode =
+            NSLineBreakByTruncatingTail;
+    }
+
     self.getScrollEdgeAppearance.titleTextAttributes = titleTextAttributes;
 }
 

--- a/src/interfaces/Options.ts
+++ b/src/interfaces/Options.ts
@@ -457,7 +457,37 @@ export interface OptionsTopBarScrollEdgeAppearanceBackground {
   translucent?: boolean;
 }
 
+export interface OptionsTopBarScrollEdgeAppearanceTitle {
+  /**
+   * Font size
+   */
+  fontSize?: number;
+  /**
+   * Text color
+   */
+  color?: Color;
+  /**
+   * Set the font family for the title
+   */
+  fontFamily?: FontFamily;
+  /**
+   * Set the font style for the title
+   */
+  fontStyle?: FontStyle;
+  /**
+   * Specifies font weight. The values 'normal' and 'bold' are supported
+   * for most fonts. Not all fonts have a variant for each of the numeric
+   * values, in that case the closest one is chosen.
+   */
+  fontWeight?: FontWeight;
+}
+
 export interface OptionsTopBarScrollEdgeAppearance {
+  /**
+   * Title configuration applied when the scroll view reaches the edge
+   * ### (iOS specific)
+   */
+  title?: OptionsTopBarScrollEdgeAppearanceTitle;
   background?: OptionsTopBarScrollEdgeAppearanceBackground;
   active: boolean;
   /**


### PR DESCRIPTION
## Add scrollEdgeAppearance title styling support (iOS)

### What
This PR adds support for configuring top bar **title styling specifically for
`scrollEdgeAppearance` on iOS**.

UIKit treats `scrollEdgeAppearance` as a full `UINavigationBarAppearance`,
including `titleTextAttributes`. Previously, React Native Navigation always
applied the same title attributes to both the standard and scroll-edge
appearances, making it impossible to customize the title when the scroll edge
state is active.

This change exposes scroll-edge title configuration.

---

### API
```js
topBar: {
  title: {
    text: 'Artists',
    color: 'white',
    fontSize: 18
  },
  scrollEdgeAppearance: {
    active: true,
    title: {
      color: 'white',
      fontSize: 26,
      fontWeight: 'bold',
    },
  },
}
```

### Demo

<img src="https://github.com/user-attachments/assets/d249e5fb-88f7-40a2-b68f-6a1a850afa3d" width="260" />


### Tests
This change affects UIKit `UINavigationBarAppearance` behavior and depends on
scroll-edge state, which is not easily assertable via unit or e2e tests.
The behavior was verified manually using a scrollable screen and is demonstrated
in the attached GIF.


### Notes
- iOS only
- Backwards compatible
- No impact on Android