### PR TITLE
Navigation bar hierarchy fix

### DIFF
--- a/ios/UINavigationController+RNNOptions.mm
+++ b/ios/UINavigationController+RNNOptions.mm
@@ -72,11 +72,15 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
     if (!contentView)
         return nil;
 
-    UIView *barButton = [contentView findChildByClass:NSClassFromString(@"_UIButtonBarButton")];
-    if (!barButton) {
-        barButton = [contentView findDescendantByClass:NSClassFromString(@"_UIButtonBarButton")];
-    }
-    return barButton;
+    Class buttonClass = NSClassFromString(@"_UIButtonBarButton");
+
+    return [contentView findDescendantByClass:buttonClass
+                                 passingTest:^BOOL(UIView *view) {
+        if ([view respondsToSelector:NSSelectorFromString(@"isBackButton")]) {
+            return [[view valueForKey:@"backButton"] boolValue];
+        }
+        return YES;
+    }];
 }
 
 - (void)rnn_applyTestID:(NSString *)testID toBackButtonView:(UIView *)barButton {
@@ -87,19 +91,6 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 - (void)setBackButtonTestID:(NSString *)testID {
     if (!testID)
         return;
-
-    if (@available(iOS 26.0, *)) {
-        NSArray<UIViewController *> *vcs = self.viewControllers;
-        if (vcs.count >= 2) {
-            UIViewController *belowTop = vcs[vcs.count - 2];
-            if (!belowTop.navigationItem.backBarButtonItem) {
-                belowTop.navigationItem.backBarButtonItem =
-                    [[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-            }
-            belowTop.navigationItem.backBarButtonItem.accessibilityIdentifier = testID;
-            belowTop.navigationItem.backBarButtonItem.isAccessibilityElement = YES;
-        }
-    }
 
     UIView *barButton = [self rnn_findBackButtonView];
     if (barButton) {

--- a/ios/Utils/UIView+Utils.h
+++ b/ios/Utils/UIView+Utils.h
@@ -14,6 +14,8 @@ typedef NS_ENUM(NSInteger, ViewType) {
 
 - (UIView *)findDescendantByClass:clazz;
 
+- (UIView *)findDescendantByClass:(Class)clazz passingTest:(BOOL (^)(UIView *view))test;
+
 - (ViewType)viewType;
 
 - (void)stopMomentumScrollViews;

--- a/ios/Utils/UIView+Utils.mm
+++ b/ios/Utils/UIView+Utils.mm
@@ -29,6 +29,17 @@
     return nil;
 }
 
+- (UIView *)findDescendantByClass:(Class)clazz passingTest:(BOOL (^)(UIView *view))test {
+    for (UIView *child in [self subviews]) {
+        if ([child isKindOfClass:clazz] && test(child))
+            return child;
+        UIView *found = [child findDescendantByClass:clazz passingTest:test];
+        if (found)
+            return found;
+    }
+    return nil;
+}
+
 - (ViewType)viewType {
 #ifdef RCT_NEW_ARCH_ENABLED
 	if ([self isKindOfClass:[RCTImageComponentView class]]) {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "eslint-plugin-jest": "^28.11.0",
     "eslint-plugin-prettier": "3.1.4",
     "github-release-notes": "https://github.com/yogevbd/github-release-notes/tarball/e601b3dba72dcd6cba323c1286ea6dd0c0110b58",
-    "husky": "4.2.5",
+
     "identity-obj-proxy": "3.0.0",
     "jest": "^29.6.3",
     "lint-staged": "10.2.11",
@@ -152,11 +152,7 @@
     "playground"
   ],
   "packageManager": "yarn@4.12.0",
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
+
   "lint-staged": {
     "*.{js,ts,tsx}": "eslint --fix",
     "*.{h,m,mm}": "node ./scripts/check-clang-format",

--- a/playground/package.json
+++ b/playground/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-jest": "^28.11.0",
     "eslint-plugin-prettier": "3.1.4",
     "github-release-notes": "https://github.com/yogevbd/github-release-notes/tarball/e601b3dba72dcd6cba323c1286ea6dd0c0110b58",
-    "husky": "4.2.5",
+
     "identity-obj-proxy": "3.0.0",
     "jest": "^29.6.3",
     "lint-staged": "10.2.11",
@@ -85,11 +85,7 @@
     "typedoc": "0.x.x",
     "typescript": "^5.8.3"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
+
   "lint-staged": {
     "*.{js,ts,tsx}": "eslint --fix",
     "*.{h,m,mm}": "node ./scripts/check-clang-format"


### PR DESCRIPTION
In iOS 26.1 the hierarchy of the NavigationBar was changed so the back button could not be assigned the right ID for finding the object in tets.