### PR TITLE
fix: route screenPopped event to correct handler

### DIFF
--- a/src/events/ComponentEventsObserver.ts
+++ b/src/events/ComponentEventsObserver.ts
@@ -58,7 +58,7 @@ export class ComponentEventsObserver {
       this.notifySearchBarCancelPressed
     );
     this.nativeEventsReceiver.registerPreviewCompletedListener(this.notifyPreviewCompleted);
-    this.nativeEventsReceiver.registerScreenPoppedListener(this.notifyPreviewCompleted);
+    this.nativeEventsReceiver.registerScreenPoppedListener(this.notifyScreenPopped);
   }
 
   public bindComponent(


### PR DESCRIPTION
## Summary

- `registerScreenPoppedListener` in `ComponentEventsObserver.registerOnceForAllComponentEvents()` was wired to `this.notifyPreviewCompleted` instead of `this.notifyScreenPopped`
- This caused native `screenPopped` events (emitted after iOS swipe-back gesture pops a screen) to be dispatched as `previewCompleted` to component listeners, meaning no listener with a `screenPopped` handler would ever receive the event

## Context

Reported via [SCHED-45583](https://wix.atlassian.net/browse/SCHED-45583) and [Slack thread](https://wix.slack.com/archives/C3B1EMVF0/p1768913893581339).

After the fix in PR #8222 to emit `screenPopped` on swipe-back, the event still didn't reach component listeners because of this wiring bug.