### PR TITLE
White stripes as statusbar and navigation bar on android

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/NavigationActivity.java
+++ b/android/src/main/java/com/reactnativenavigation/NavigationActivity.java
@@ -70,6 +70,16 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
         ViewGroup contentLayout = findViewById(android.R.id.content);
         navigator.setContentLayout(contentLayout);
         SystemUiUtils.setupSystemBarBackgrounds(this, contentLayout);
+        applyThemeStatusBarColor();
+    }
+
+    private void applyThemeStatusBarColor() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM
+                && SystemUiUtils.needsManualStatusBarBackground()) {
+            //noinspection deprecation
+            getWindow().setStatusBarColor(android.graphics.Color.TRANSPARENT);
+            SystemUiUtils.setStatusBarColor(getWindow(), android.graphics.Color.TRANSPARENT);
+        }
     }
 
     @Override

--- a/android/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
+++ b/android/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
@@ -25,6 +25,7 @@ object SystemUiUtils {
     private const val THREE_BUTTON_NAV_BAR_OPACITY = 0.8f
 
     private var statusBarBackgroundView: View? = null
+    private var statusBarBackgroundActivity: java.lang.ref.WeakReference<Activity>? = null
     private var navBarBackgroundView: View? = null
     @JvmStatic
     var isEdgeToEdgeActive = false
@@ -88,27 +89,33 @@ object SystemUiUtils {
             sbView.setBackgroundColor(Color.BLACK)
             statusBarBackgroundView = sbView
         } else {
-            val contentLayout = activity.findViewById<ViewGroup>(android.R.id.content)
-            val view = View(activity).apply {
-                setBackgroundColor(Color.BLACK)
-            }
-            val params = FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT, 0, Gravity.TOP
-            )
-            contentLayout.addView(view, params)
-            statusBarBackgroundView = view
-
-            ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
-                val sbHeight = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top
-                val lp = v.layoutParams
-                if (lp.height != sbHeight) {
-                    lp.height = sbHeight
-                    v.layoutParams = lp
-                }
-                insets
-            }
-            view.requestApplyInsets()
+            statusBarBackgroundActivity = java.lang.ref.WeakReference(activity)
         }
+    }
+
+    private fun ensureStatusBarBackgroundView(): View? {
+        statusBarBackgroundView?.let { return it }
+        val activity = statusBarBackgroundActivity?.get() ?: return null
+        val contentLayout = activity.findViewById<ViewGroup>(android.R.id.content) ?: return null
+        val view = View(activity)
+        val params = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT, 0, Gravity.TOP
+        )
+        contentLayout.addView(view, params)
+        statusBarBackgroundView = view
+        statusBarBackgroundActivity = null
+
+        ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+            val sbHeight = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top
+            val lp = v.layoutParams
+            if (lp.height != sbHeight) {
+                lp.height = sbHeight
+                v.layoutParams = lp
+            }
+            insets
+        }
+        view.requestApplyInsets()
+        return view
     }
 
     private fun setupNavigationBarBackground(contentLayout: ViewGroup) {
@@ -169,6 +176,7 @@ object SystemUiUtils {
     @JvmStatic
     fun tearDown() {
         statusBarBackgroundView = null
+        statusBarBackgroundActivity = null
         navBarBackgroundView = null
         isEdgeToEdgeActive = false
         isThreeButtonNav = false
@@ -217,15 +225,25 @@ object SystemUiUtils {
             Color.green(color),
             Color.blue(color)
         )
-        setStatusBarColor(window, opaqueColor)
+        applyStatusBarColor(window, opaqueColor)
     }
 
     /**
-     * Sets the status bar background color.
-     * Uses the view-based background when available (edge-to-edge),
-     * falls back to the deprecated window API on older configurations.
+     * Sets the status bar background color, lazily creating a manual view on API 35+
+     * if the system view wasn't available at setup time. Use this for explicit app-level
+     * color requests (e.g. from MainActivity).
      */
     fun setStatusBarColor(window: Window?, color: Int) {
+        val view = ensureStatusBarBackgroundView()
+        if (view != null) {
+            view.setBackgroundColor(color)
+        } else {
+            @Suppress("DEPRECATION")
+            window?.statusBarColor = color
+        }
+    }
+
+    private fun applyStatusBarColor(window: Window?, color: Int) {
         statusBarBackgroundView?.setBackgroundColor(color) ?: run {
             @Suppress("DEPRECATION")
             window?.statusBarColor = color

--- a/android/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
+++ b/android/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
@@ -69,11 +69,11 @@ object SystemUiUtils {
      * Initializes view-based system bar backgrounds for edge-to-edge.
      * Call from Activity.onPostCreate after the navigator content layout is set.
      *
-     * Status bar: reuses the system's android:id/statusBarBackground DecorView child.
+     * Status bar: reuses the system's android:id/statusBarBackground DecorView child
+     * when available. On API 35+ with EdgeToEdge, this view may not exist, so a
+     * manual view is created in the content layout, sized by status bar insets.
      * Navigation bar: creates a view in [contentLayout] sized by WindowInsets,
      * since the system's navigationBarBackground is not available with EdgeToEdge.
-     *
-     * Both fall back to deprecated window APIs when the views are unavailable.
      */
     @JvmStatic
     fun setupSystemBarBackgrounds(activity: Activity, contentLayout: ViewGroup) {
@@ -87,6 +87,27 @@ object SystemUiUtils {
         if (sbView != null) {
             sbView.setBackgroundColor(Color.BLACK)
             statusBarBackgroundView = sbView
+        } else {
+            val contentLayout = activity.findViewById<ViewGroup>(android.R.id.content)
+            val view = View(activity).apply {
+                setBackgroundColor(Color.BLACK)
+            }
+            val params = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT, 0, Gravity.TOP
+            )
+            contentLayout.addView(view, params)
+            statusBarBackgroundView = view
+
+            ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+                val sbHeight = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top
+                val lp = v.layoutParams
+                if (lp.height != sbHeight) {
+                    lp.height = sbHeight
+                    v.layoutParams = lp
+                }
+                insets
+            }
+            view.requestApplyInsets()
         }
     }
 

--- a/android/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
+++ b/android/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
@@ -86,7 +86,6 @@ object SystemUiUtils {
         if (statusBarBackgroundView != null) return
         val sbView = activity.window.decorView.findViewById<View>(android.R.id.statusBarBackground)
         if (sbView != null) {
-            sbView.setBackgroundColor(Color.BLACK)
             statusBarBackgroundView = sbView
         } else {
             statusBarBackgroundActivity = java.lang.ref.WeakReference(activity)
@@ -160,6 +159,14 @@ object SystemUiUtils {
     }
 
     /**
+     * Returns true when the system statusBarBackground view was not found during setup,
+     * meaning a manual view will be lazily created on the first setStatusBarColor call.
+     * Use this to decide whether to apply a theme-based initial status bar color.
+     */
+    @JvmStatic
+    fun needsManualStatusBarBackground(): Boolean = statusBarBackgroundActivity != null
+
+    /**
      * Marks edge-to-edge as active. Call after EdgeToEdge.enable() in the activity.
      * This flag controls whether navigation bar insets are forwarded to SafeAreaView
      * and whether the view-based nav bar background is used for color changes.
@@ -231,8 +238,9 @@ object SystemUiUtils {
     /**
      * Sets the status bar background color, lazily creating a manual view on API 35+
      * if the system view wasn't available at setup time. Use this for explicit app-level
-     * color requests (e.g. from MainActivity).
+     * color requests (e.g. from MainActivity or NavigationActivity).
      */
+    @JvmStatic
     fun setStatusBarColor(window: Window?, color: Int) {
         val view = ensureStatusBarBackgroundView()
         if (view != null) {


### PR DESCRIPTION
## Fix: status bar background missing on API 35+ with edge-to-edge
On API 35+, `EdgeToEdge.enable()` no longer creates the `android.R.id.statusBarBackground` view in the DecorView. `setupStatusBarBackground` relied on finding this view to apply status bar colors — when it was `null`, `setStatusBarColor` fell back to the deprecated `window.statusBarColor` API, which is silently ignored on API 35+. This caused the status bar area to appear white/transparent regardless of the color set by the app.
The fix adds a fallback in `setupStatusBarBackground`: when the system view is not found, a manual view is created in `android.R.id.content`, positioned at `Gravity.TOP` and sized dynamically via `WindowInsetsCompat.Type.statusBars()` insets. This mirrors the existing approach used by `setupNavigationBarBackground`, which already creates its own view unconditionally.

### Reproduction
Any app using `activateEdgeToEdge()` on an API 35+ device in dark mode — the status bar stays white instead of adopting the app's color. Visible as white stripes at the top of the screen.

https://wix.atlassian.net/browse/WOAINFRA-3301