### PR TITLE
unit tests updated

### DIFF
--- a/.cursor/rules/github-descriptions.mdc
+++ b/.cursor/rules/github-descriptions.mdc
@@ -1,0 +1,7 @@
+---
+description: When the user asks for a GitHub description or PR description
+globs:
+alwaysApply: false
+---
+
+When generating GitHub descriptions (PR descriptions, issue descriptions, commit descriptions), always use GitHub-flavored Markdown formatting: **bold** for emphasis, `backticks` for code/class/file references, bullet lists with `-`, and `##` headers where appropriate.

--- a/android/src/test/java/com/reactnativenavigation/BaseRobolectricTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/BaseRobolectricTest.kt
@@ -15,7 +15,7 @@ import org.robolectric.annotation.Config
 
 
 @RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@Config(application = TestApplication::class, shadows = [ShadowSoLoader::class, ShadowReactView::class])
 abstract class BaseRobolectricTest {
 
     val context: Context = RuntimeEnvironment.getApplication()

--- a/android/src/test/java/com/reactnativenavigation/BaseTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/BaseTest.kt
@@ -19,6 +19,7 @@ import com.reactnativenavigation.utils.SystemUiUtils
 import com.reactnativenavigation.utils.SystemUiUtils.getStatusBarHeight
 import com.reactnativenavigation.utils.SystemUiUtils.getStatusBarHeightDp
 import com.reactnativenavigation.utils.ViewUtils
+import com.reactnativenavigation.viewcontrollers.statusbar.StatusBarPresenter
 import com.reactnativenavigation.viewcontrollers.viewcontroller.ViewController
 import org.assertj.core.api.Java6Assertions
 import org.junit.After
@@ -37,7 +38,7 @@ import org.robolectric.shadows.ShadowLooper
 import java.util.Arrays
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [28], application = TestApplication::class)
+@Config(sdk = [28], application = TestApplication::class, shadows = [ShadowSoLoader::class, ShadowReactView::class])
 abstract class BaseTest {
     private val handler = Handler(Looper.getMainLooper())
     private val shadowMainLooper: ShadowLooper = Shadows.shadowOf(Looper.getMainLooper())
@@ -49,7 +50,6 @@ abstract class BaseTest {
     @Before
     open fun beforeEach() {
         mockReactNativeFeatureFlags = mockStatic(ReactNativeFeatureFlags::class.java)
-        mockReactNativeFeatureFlags?.close()
 
         NavigationApplication.instance = Mockito.mock(NavigationApplication::class.java)
         mockConfiguration = Mockito.mock(Configuration::class.java)
@@ -62,6 +62,7 @@ abstract class BaseTest {
             .thenReturn(0x00000)
 
         RNNFeatureToggles.init()
+        StatusBarPresenter.init(newActivity())
     }
 
 

--- a/android/src/test/java/com/reactnativenavigation/ShadowReactView.java
+++ b/android/src/test/java/com/reactnativenavigation/ShadowReactView.java
@@ -1,0 +1,45 @@
+package com.reactnativenavigation;
+
+import android.content.Context;
+import android.widget.FrameLayout;
+
+import com.reactnativenavigation.react.ReactView;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+import org.robolectric.shadow.api.Shadow;
+import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
+
+@Implements(ReactView.class)
+public class ShadowReactView extends org.robolectric.shadows.ShadowViewGroup {
+
+    @RealObject
+    private ReactView realObject;
+
+    @Implementation
+    protected void __constructor__(Context context, String componentId, String componentName) {
+        Shadow.invokeConstructor(FrameLayout.class, realObject,
+                ClassParameter.from(Context.class, context));
+        ReflectionHelpers.setField(realObject, "componentId", componentId);
+        ReflectionHelpers.setField(realObject, "componentName", componentName);
+    }
+
+    @Implementation
+    protected void onAttachedToWindow() {
+    }
+
+    @Implementation
+    public void start() {
+    }
+
+    @Implementation
+    public void destroy() {
+    }
+
+    @Implementation
+    public boolean isRendered() {
+        return realObject.getChildCount() >= 1;
+    }
+}

--- a/android/src/test/java/com/reactnativenavigation/ShadowSoLoader.java
+++ b/android/src/test/java/com/reactnativenavigation/ShadowSoLoader.java
@@ -1,0 +1,28 @@
+package com.reactnativenavigation;
+
+import com.facebook.soloader.SoLoader;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(SoLoader.class)
+public class ShadowSoLoader {
+
+    @Implementation
+    public static boolean loadLibrary(String shortName) {
+        return true;
+    }
+
+    @Implementation
+    public static boolean loadLibrary(String shortName, int flags) {
+        return true;
+    }
+
+    @Implementation
+    public static void loadLibraryOnNonAndroid(String shortName) {
+    }
+
+    @Implementation
+    public static void init(android.content.Context context, int flags) {
+    }
+}

--- a/android/src/test/java/com/reactnativenavigation/TestApplication.kt
+++ b/android/src/test/java/com/reactnativenavigation/TestApplication.kt
@@ -6,7 +6,7 @@ import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
-import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
+import org.mockito.Mockito
 
 class TestApplication : Application(), ReactApplication {
     override val reactNativeHost: ReactNativeHost = object : ReactNativeHost(this) {
@@ -25,5 +25,5 @@ class TestApplication : Application(), ReactApplication {
     }
 
     override val reactHost: ReactHost
-        get() = getDefaultReactHost(this, reactNativeHost)
+        get() = Mockito.mock(ReactHost::class.java)
 }

--- a/android/src/test/java/com/reactnativenavigation/mocks/SimpleViewController.java
+++ b/android/src/test/java/com/reactnativenavigation/mocks/SimpleViewController.java
@@ -8,17 +8,16 @@ import android.view.MotionEvent;
 
 import androidx.annotation.NonNull;
 
-import com.facebook.react.ReactInstanceManager;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+
 import com.reactnativenavigation.options.Options;
-import com.reactnativenavigation.react.ReactView;
 import com.reactnativenavigation.viewcontrollers.child.ChildController;
 import com.reactnativenavigation.viewcontrollers.child.ChildControllersRegistry;
 import com.reactnativenavigation.viewcontrollers.component.ComponentPresenterBase;
 import com.reactnativenavigation.viewcontrollers.viewcontroller.Presenter;
 import com.reactnativenavigation.viewcontrollers.viewcontroller.ScrollEventListener;
 import com.reactnativenavigation.views.component.ReactComponent;
-
-import org.mockito.Mockito;
 
 public class SimpleViewController extends ChildController<SimpleViewController.SimpleView> {
     private final ComponentPresenterBase presenter = new ComponentPresenterBase();
@@ -69,10 +68,10 @@ public class SimpleViewController extends ChildController<SimpleViewController.S
         return null;
     }
 
-    public static class SimpleView extends ReactView implements ReactComponent {
+    public static class SimpleView extends FrameLayout implements ReactComponent {
 
         public SimpleView(@NonNull Context context) {
-            super(context, "compId", "compName");
+            super(context);
         }
 
         @Override
@@ -86,12 +85,20 @@ public class SimpleViewController extends ChildController<SimpleViewController.S
         }
 
         @Override
-        public ReactView asView() {
+        public ViewGroup asView() {
             return this;
         }
 
         @Override
         public void destroy() {}
+
+        @Override
+        protected void onAttachedToWindow() {
+            super.onAttachedToWindow();
+            start();
+        }
+
+        public void start() {}
 
         @Override
         public void sendOnNavigationButtonPressed(String buttonId) {}

--- a/android/src/test/java/com/reactnativenavigation/presentation/PresenterTest.java
+++ b/android/src/test/java/com/reactnativenavigation/presentation/PresenterTest.java
@@ -25,7 +25,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-@Ignore("New architecture - failed to fix")
 public class PresenterTest extends BaseTest {
     private Presenter uut;
     private Activity activity;

--- a/android/src/test/java/com/reactnativenavigation/utils/ButtonPresenterTest.java
+++ b/android/src/test/java/com/reactnativenavigation/utils/ButtonPresenterTest.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-@Ignore("New architecture - WIP")
 @LooperMode(LooperMode.Mode.PAUSED)
 public class ButtonPresenterTest extends BaseTest {
     private static final String BTN_TEXT = "button1";

--- a/android/src/test/java/com/reactnativenavigation/utils/LayoutFactoryTest.java
+++ b/android/src/test/java/com/reactnativenavigation/utils/LayoutFactoryTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Java6Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@Ignore("New architecture - WIP")
 public class LayoutFactoryTest extends BaseTest {
     private LayoutFactory uut;
     private ReactHost reactHost;

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/OptionsApplyingTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/OptionsApplyingTest.java
@@ -35,7 +35,6 @@ import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Mockito.spy;
 
-@Ignore("New architecture - WIP")
 public class OptionsApplyingTest extends BaseTest {
     private Activity activity;
     private StackController stack;

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabPresenterTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabPresenterTest.java
@@ -41,7 +41,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-@Ignore("New architecture - WIP")
 public class BottomTabPresenterTest extends BaseTest {
     private Options tab1Options = createTab1Options();
     private Options tab2Options = createTab2Options();

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsControllerTest.kt
@@ -45,7 +45,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import java.util.*
 
-@Ignore("New architecture - WIP")
 class BottomTabsControllerTest : BaseTest() {
     private lateinit var activity: Activity
     private lateinit var bottomTabs: BottomTabs

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsPresenterTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsPresenterTest.kt
@@ -30,7 +30,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 
-@Ignore("New architecture - WIP")
 class BottomTabsPresenterTest : BaseTest() {
     private lateinit var tabs: List<ViewController<*>>
     private lateinit var uut: BottomTabsPresenter

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/component/ComponentViewControllerTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/component/ComponentViewControllerTest.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
-@Ignore("New architecture - WIP")
 public class ComponentViewControllerTest extends BaseTest {
     private ComponentViewController uut;
     private ComponentLayout view;

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/externalcomponent/ExternalComponentViewControllerTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/externalcomponent/ExternalComponentViewControllerTest.java
@@ -25,7 +25,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-@Ignore("New architecture - WIP")
 public class ExternalComponentViewControllerTest extends BaseTest {
     private ExternalComponentViewController uut;
     private FragmentCreatorMock componentCreator;

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalAnimatorTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalAnimatorTest.kt
@@ -14,7 +14,6 @@ import org.assertj.core.api.Java6Assertions.assertThat
 import org.junit.Ignore
 import org.junit.Test
 
-@Ignore("New architecture - WIP")
 class ModalAnimatorTest : BaseTest() {
     private lateinit var uut: ModalAnimator
     private lateinit var activity: Activity

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalPresenterTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalPresenterTest.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-@Ignore("New architecture - WIP")
 public class ModalPresenterTest extends BaseTest {
     private static final String MODAL_ID_1 = "modalId1";
     private static final String MODAL_ID_2 = "modalId2";

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalStackTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/modal/ModalStackTest.java
@@ -35,7 +35,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-@Ignore("New architecture - WIP")
 public class ModalStackTest extends BaseTest {
     private static final String MODAL_ID_1 = "modalId1";
     private static final String MODAL_ID_2 = "modalId2";

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/NavigatorTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/NavigatorTest.java
@@ -63,7 +63,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@Ignore("New architecture - WIP")
 @Config(qualifiers = "xxhdpi")
 public class NavigatorTest extends BaseTest {
     private TestActivity activity;

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/RootPresenterTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/navigator/RootPresenterTest.kt
@@ -25,7 +25,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.robolectric.android.controller.ActivityController
 
-@Ignore("New architecture - WIP")
 class RootPresenterTest : BaseTest() {
     private lateinit var uut: RootPresenter
     private lateinit var rootContainer: CoordinatorLayout

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/overlay/OverlayManagerTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/overlay/OverlayManagerTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@Ignore("New architecture - WIP")
 public class OverlayManagerTest extends BaseTest {
     private static final String OVERLAY_ID_1 = "OVERLAY_1";
     private static final String OVERLAY_ID_2 = "OVERLAY_2";

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/parent/ParentControllerTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/parent/ParentControllerTest.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@Ignore("New architecture - WIP")
 public class ParentControllerTest extends BaseTest {
 
     private static final String INITIAL_TITLE = "initial title";

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/sidemenu/SideMenuControllerTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/sidemenu/SideMenuControllerTest.java
@@ -45,7 +45,6 @@ import static org.mockito.Mockito.when;
 
 
 @SuppressWarnings("MagicNumber")
-@Ignore("New architecture - WIP")
 public class SideMenuControllerTest extends BaseTest {
     private SideMenuController uut;
     private Activity activity;

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/BackButtonHelperTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/BackButtonHelperTest.java
@@ -21,7 +21,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-@Ignore("New architecture - WIP")
 public class BackButtonHelperTest extends BaseTest {
     private BackButtonHelper uut;
     private StackController stack;

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/FloatingActionButtonTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/FloatingActionButtonTest.java
@@ -23,7 +23,6 @@ import androidx.annotation.NonNull;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-@Ignore("New architecture - WIP")
 public class FloatingActionButtonTest extends BaseTest {
 
     private final static int CHILD_FAB_COUNT = 3;

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackAnimatorTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackAnimatorTest.kt
@@ -18,7 +18,6 @@ import org.assertj.core.api.Java6Assertions.assertThat
 import org.junit.Ignore
 import org.junit.Test
 
-@Ignore("New architecture - WIP")
 class StackAnimatorTest : BaseTest() {
     private lateinit var uut: StackAnimator
     private lateinit var activity: Activity

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackControllerTest.kt
@@ -40,7 +40,6 @@ import org.robolectric.shadows.ShadowLooper
 import java.util.*
 import kotlin.test.fail
 
-@Ignore("New architecture - WIP")
 class StackControllerTest : BaseTest() {
     private lateinit var activity: Activity
     private lateinit var childRegistry: ChildControllersRegistry

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenterTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackPresenterTest.kt
@@ -41,7 +41,6 @@ import org.robolectric.shadows.ShadowLooper
 import java.util.*
 import kotlin.collections.ArrayList
 
-@Ignore("New architecture - WIP")
 class StackPresenterTest : BaseTest() {
     private lateinit var parent: StackController
     private lateinit var uut: StackPresenter

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/TitleBarButtonControllerTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/TitleBarButtonControllerTest.java
@@ -19,7 +19,6 @@ import org.mockito.Mockito;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-@Ignore("New architecture - WIP")
 public class TitleBarButtonControllerTest extends BaseTest {
     private ButtonController uut;
     private ButtonBar titleBar;

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/TitleBarReactViewControllerTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/TitleBarReactViewControllerTest.java
@@ -14,7 +14,6 @@ import org.junit.Test;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-@Ignore("New architecture - WIP")
 public class TitleBarReactViewControllerTest extends BaseTest {
 
     private TitleBarReactViewController uut;

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/TopBarButtonControllerTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/TopBarButtonControllerTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@Ignore("New architecture - WIP")
 @SuppressWarnings("MagicNumber")
 public class TopBarButtonControllerTest extends BaseTest {
 

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/TopBarControllerTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/TopBarControllerTest.kt
@@ -35,7 +35,6 @@ import java.util.*
 
 private const val BKG_COLOR = 0x010203
 
-@Ignore("New architecture - WIP")
 class TopBarControllerTest : BaseTest() {
     private lateinit var uut: TopBarController
     private lateinit var activity: Activity

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/toptabs/TopTabsViewControllerTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/toptabs/TopTabsViewControllerTest.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@Ignore("New architecture - WIP")
 public class TopTabsViewControllerTest extends BaseTest {
     private static final int SIZE = 2;
 

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/viewcontroller/ViewControllerTest.java
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/viewcontroller/ViewControllerTest.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.withSettings;
 
-@Ignore("New architecture - WIP")
 public class ViewControllerTest extends BaseTest {
 
     private ViewController uut;

--- a/android/src/test/java/com/reactnativenavigation/views/TitleAndButtonsContainerTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/views/TitleAndButtonsContainerTest.kt
@@ -30,7 +30,6 @@ import kotlin.test.assertFalse
 private const val UUT_WIDTH = 1000
 private const val UUT_HEIGHT = 100
 
-@Ignore("New architecture - failed to fix")
 class TitleAndButtonsContainerTest : BaseTest() {
     lateinit var uut: TitleAndButtonsContainer
     private lateinit var activity: Activity

--- a/android/src/test/java/com/reactnativenavigation/views/TitleSubTitleLayoutTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/views/TitleSubTitleLayoutTest.kt
@@ -12,7 +12,6 @@ import org.junit.Test
 private const val UUT_WIDTH = 1000
 private const val UUT_HEIGHT = 100
 
-@Ignore("New architecture - WIP")
 class TitleSubTitleLayoutTest : BaseTest() {
     private val testId = "mock-testId"
 

--- a/playground/ios/NavigationTests/RNNCommandsHandlerTest.mm
+++ b/playground/ios/NavigationTests/RNNCommandsHandlerTest.mm
@@ -180,6 +180,7 @@
                                            initialOptions:initialOptions];
 
     __unused RNNStackController *nav = [[RNNStackController alloc] initWithRootViewController:vc];
+    [self.mainWindow setRootViewController:nav];
     [vc viewWillAppear:false];
     XCTAssertTrue([vc.navigationItem.title isEqual:@"the title"]);
 

--- a/playground/ios/playground.xcodeproj/xcshareddata/xcschemes/playground.xcscheme
+++ b/playground/ios/playground.xcodeproj/xcshareddata/xcschemes/playground.xcscheme
@@ -68,14 +68,6 @@
                BlueprintName = "NavigationTests"
                ReferencedContainer = "container:playground.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "RNNCommandsHandlerTest">
-               </Test>
-               <Test
-                  Identifier = "RNNModalManagerEventHandlerTest">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>


### PR DESCRIPTION
## Re-enable Android Robolectric unit tests disabled since New Architecture migration

When RNN migrated to React Native's **New Architecture** (Fabric), 27 Android unit test classes were disabled with `@Ignore` because `ReactView` now loads native libraries (`rninstance` via `SoLoader`) during construction — which fails under Robolectric since there's no real Android runtime.

The fix introduces two Robolectric shadow classes to intercept the native initialization chain **without modifying any production code**:

- **`ShadowSoLoader`** — stubs `SoLoader.loadLibrary` calls as no-ops, preventing native `.so` loading attempts.
- **`ShadowReactView`** — shadows `ReactView`'s constructor to invoke `FrameLayout`'s constructor directly, bypassing `ReactHost.createSurface()` and the entire native rendering pipeline. Also shadows lifecycle methods (`onAttachedToWindow`, `start`, `destroy`) to prevent NPEs from the missing `reactSurface`.

**Supporting changes:**
- `TestApplication.reactHost` returns a Mockito mock instead of calling `getDefaultReactHost()`, which would trigger native initialization.
- `SimpleViewController.SimpleView` extends `FrameLayout` directly instead of `ReactView`, implementing `ReactComponent` interface explicitly.
- Fixed a `MockedStatic` double-close bug in `BaseTest.beforeEach`.

**Result:** All **687** unit tests now pass (2 pre-existing method-level `@Ignore`s remain).