### PR TITLE
Inbox Conversation Screen Lacks Back Navigation Control On iPad (iOS 26)

### DIFF
--- a/ios/TopBarPresenter.mm
+++ b/ios/TopBarPresenter.mm
@@ -160,8 +160,19 @@
     NSNumber *fontSize = [backButtonOptions.fontSize withDefault:nil];
 
     UIViewController *previousViewControllerInStack = self.previousViewControllerInStack;
-    UIBarButtonItem *backItem = [[RNNUIBarBackButtonItem alloc] initWithOptions:backButtonOptions];
     UINavigationItem *previousNavigationItem = previousViewControllerInStack.navigationItem;
+
+    BOOL hasCustomization = icon || color || title || fontFamily || fontSize ||
+                            backButtonOptions.displayMode.hasValue ||
+                            backButtonOptions.sfSymbol.hasValue ||
+                            backButtonOptions.iconBackground.hasValue ||
+                            ![backButtonOptions.showTitle withDefault:YES];
+
+    if (!hasCustomization) {
+        return;
+    }
+
+    UIBarButtonItem *backItem = [[RNNUIBarBackButtonItem alloc] initWithOptions:backButtonOptions];
 
     if (@available(iOS 13.0, *)) {
         UIImage *sfSymbol = [UIImage systemImageNamed:[backButtonOptions.sfSymbol withDefault:nil]];
@@ -195,7 +206,9 @@
                    cornerRadius:cornerRadius];
     }
 
-    [self setBackIndicatorImage:icon withColor:color];
+    if (icon) {
+        [self setBackIndicatorImage:icon withColor:color];
+    }
 
     title = title ? title : (previousNavigationItem.title ? previousNavigationItem.title : @"");
 

--- a/ios/TopBarPresenter.mm
+++ b/ios/TopBarPresenter.mm
@@ -166,6 +166,7 @@
                             backButtonOptions.displayMode.hasValue ||
                             backButtonOptions.sfSymbol.hasValue ||
                             backButtonOptions.iconBackground.hasValue ||
+                            backButtonOptions.enableMenu.hasValue ||
                             ![backButtonOptions.showTitle withDefault:YES];
 
     if (!hasCustomization) {

--- a/playground/ios/NavigationTests/RNNStackPresenterTest.mm
+++ b/playground/ios/NavigationTests/RNNStackPresenterTest.mm
@@ -73,9 +73,8 @@
 
 - (void)testApplyOptions_shouldSetBackButtonOnBoundViewController_withDefaultValues {
     [self.uut applyOptions:self.options];
-    XCTAssertTrue(
-        [self.boundViewController.viewControllers.firstObject.navigationItem.backBarButtonItem.title
-            isEqualToString:@""]);
+    XCTAssertNil(
+        self.boundViewController.viewControllers.firstObject.navigationItem.backBarButtonItem);
 }
 
 - (void)testSetBackButtonIcon_withColor_shouldSetColor {


### PR DESCRIPTION
## Fix: Back button not appearing on iPad with iOS 26

On iOS 26, the system back button in `UINavigationBar` can disappear on iPad when a custom `backBarButtonItem` is set on the previous view controller's `navigationItem` — even when no actual back button customization is configured.

### Root cause

`TopBarPresenter.setBackButtonOptions` was unconditionally creating an `RNNUIBarBackButtonItem` and assigning it to the previous view controller's `navigationItem.backBarButtonItem`, regardless of whether any back button options (icon, color, title, font, etc.) were actually specified. It also called `setBackIndicatorImage:` with a `nil` image, which could clear the system's default back chevron.

On iOS 26, Apple introduced **Liquid Glass** — a new compositing layer for navigation bars that renders differently on real device hardware (particularly iPad). A custom but empty `backBarButtonItem` does not participate correctly in this new rendering pipeline, causing the back button to become invisible on real iPad devices while still appearing on iPhone and in the Simulator.

### Fix

- Early-return from `setBackButtonOptions:` when no customization is present, preserving the system's native back button
- Guard `setBackIndicatorImage:` behind an `if (icon)` check to avoid clearing the default indicator when no custom icon is set

This ensures that the system back button is only replaced when the developer explicitly configures back button options via `topBar.backButton`.

**Affected:** iPad on iOS 26 (real device)
**Reported in:** INBOX-7622