### PR TITLE
tabbar text fix

### DIFF
--- a/ios/RNNBottomTabsController.mm
+++ b/ios/RNNBottomTabsController.mm
@@ -7,6 +7,8 @@
 @property(nonatomic, strong) RNNDotIndicatorPresenter *dotIndicatorPresenter;
 @property(nonatomic, strong) UILongPressGestureRecognizer *longPressRecognizer;
 
+- (void)rnn_cycleAllTabsThenRestoreInitialSelection;
+
 @end
 
 @implementation RNNBottomTabsController {
@@ -16,6 +18,8 @@
     BOOL _tabBarNeedsRestore;
     RNNNavigationOptions *_options;
     BOOL _didFinishSetup;
+    BOOL _rnnDidApplyInitialTabBarSelectionFix;
+    BOOL _rnnSuppressTabSelectionEvents;
 }
 
 - (instancetype)initWithLayoutInfo:(RNNLayoutInfo *)layoutInfo
@@ -49,12 +53,7 @@
                       eventEmitter:eventEmitter
               childViewControllers:childViewControllers];
 
-    if (@available(iOS 26.0, *)) {
-        UITabBarAppearance *appearance = [UITabBarAppearance new];
-        [appearance configureWithDefaultBackground];
-        self.tabBar.standardAppearance = appearance;
-        self.tabBar.scrollEdgeAppearance = [appearance copy];
-    } else if (@available(iOS 13.0, *)) {
+    if (@available(iOS 13.0, *)) {
         UITabBarAppearance *appearance = [UITabBarAppearance new];
         [appearance configureWithOpaqueBackground];
         appearance.backgroundEffect = nil;
@@ -90,8 +89,40 @@
     }
 }
 
-- (void)viewDidLoad {
-    [super viewDidLoad];
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    // iOS 26: first layout can misplace tab item titles; cycling selection (then restoring) forces a
+    // correct layout without user interaction. Defer so all tab children are in the hierarchy.
+    if (@available(iOS 26.0, *)) {
+        if (!_rnnDidApplyInitialTabBarSelectionFix) {
+            _rnnDidApplyInitialTabBarSelectionFix = YES;
+            __weak RNNBottomTabsController *weakSelf = self;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [weakSelf rnn_cycleAllTabsThenRestoreInitialSelection];
+            });
+        }
+    }
+}
+
+- (void)rnn_cycleAllTabsThenRestoreInitialSelection {
+    NSUInteger count = self.childViewControllers.count;
+    if (count <= 1) {
+        return;
+    }
+
+    NSUInteger initial = _currentTabIndex;
+    if (initial >= count) {
+        initial = 0;
+    }
+
+    _rnnSuppressTabSelectionEvents = YES;
+    [UIView performWithoutAnimation:^{
+        for (NSUInteger i = 0; i < count; i++) {
+            [self setSelectedIndex:i];
+        }
+        [self setSelectedIndex:initial];
+    }];
+    _rnnSuppressTabSelectionEvents = NO;
 }
 
 - (void)createTabBarItems:(NSArray<UIViewController *> *)childViewControllers {
@@ -200,6 +231,9 @@
 
 - (void)tabBarController:(UITabBarController *)tabBarController
     didSelectViewController:(UIViewController *)viewController {
+    if (_rnnSuppressTabSelectionEvents) {
+        return;
+    }
     [self.eventEmitter sendBottomTabSelected:@(tabBarController.selectedIndex)
                                   unselected:@(_previousTabIndex)];
 }
@@ -215,6 +249,10 @@
     shouldSelectViewController:(UIViewController *)viewController {
     NSUInteger _index = [tabBarController.viewControllers indexOfObject:viewController];
     BOOL isMoreTab = ![tabBarController.viewControllers containsObject:viewController];
+
+    if (_rnnSuppressTabSelectionEvents) {
+        return YES;
+    }
 
     [self.eventEmitter sendBottomTabPressed:@(_index)];
 


### PR DESCRIPTION
<h2>Fix iOS 26 bottom tab item title layout on first paint</h2>

<blockquote>
<p><b>Context:</b> On <b>iOS 26</b>, <code>UITabBar</code> item <b>titles</b> can be laid out wrong on the first pass (e.g. too low or clipped). <b>Changing the selected tab</b> corrects the layout. Using <code>tabsAttachMode: 'together'</code> alone does <b>not</b> fix it, so this is not only an <code>afterInitialTab</code> attach-order issue.</p>
</blockquote>

<h3>What changed</h3>
<ul>
  <li><b>One-time tab selection pass</b> in <code>RNNBottomTabsController</code>: after the bar appears, programmatically set <code>selectedIndex</code> to <b>each</b> tab, then <b>restore</b> the initial index, inside <code>UIView</code> <code>performWithoutAnimation</code>.</li>
  <li>Runs on <b>iOS 26+</b> only, <b>once</b> per controller (<code>_rnnDidApplyInitialTabBarSelectionFix</code>).</li>
  <li><b>Deferred</b> with <code>dispatch_async</code> to the <b>main</b> queue so tab children are attached first.</li>
  <li><code>_rnnSuppressTabSelectionEvents</code>: while cycling, skip <code>BottomTabPressed</code> / <code>BottomTabSelected</code> and return <b>YES</b> from <code>shouldSelectViewController:</code> so the cycle is not blocked by per-tab options (e.g. <code>selectTabOnPress</code>).</li>
  <li>No <code>tabBar</code> <code>layoutIfNeeded</code> in the loop; <b>selection changes</b> are enough.</li>
  <li><code>__weak RNNBottomTabsController *weakSelf</code> for the async block (explicit type in <code>.mm</code>).</li>
</ul>

<h3>Tab bar appearance in <code>init</code></h3>
<ul>
  <li>Single <b>iOS 13+</b> path: <code>configureWithOpaqueBackground</code>, <code>backgroundEffect = nil</code>, <code>systemBackgroundColor</code>, <code>scrollEdgeAppearance</code> on iOS 15+, <b>non-translucent</b> (no separate iOS 26 <code>configureWithDefaultBackground</code> in this controller).</li>
</ul>

<h3>Files</h3>
<ul>
  <li><code>ios/RNNBottomTabsController.mm</code></li>
</ul>

<h3>How to verify</h3>
<ul>
  <li>Run the <b>playground</b> on an <b>iOS 26.1</b> simulator with a <b>bottom tabs</b> root; tab <b>titles</b> should look correct <b>before</b> any manual tab change.</li>
  <li>Confirm there are <b>no</b> extra <code>BottomTabSelected</code> / <code>BottomTabPressed</code> events for the internal cycle; real user taps still emit as usual.</li>
</ul>