### PR TITLE
Root component Appear not working in first time after launch

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/react/ReactView.java
+++ b/android/src/main/java/com/reactnativenavigation/react/ReactView.java
@@ -5,6 +5,7 @@ import static com.reactnativenavigation.utils.CoordinatorLayoutUtils.matchParent
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -27,11 +28,26 @@ import com.reactnativenavigation.views.component.Renderable;
 
 @SuppressLint("ViewConstructor")
 public class ReactView extends FrameLayout implements IReactView, Renderable {
+    private static final String TAG = "RNN.ReactView";
+    /**
+     * Upper bound on deferred lifecycle retries (~20s at ~60fps-style scheduling).
+     * After this we emit with React context even if {@link #isRendered()} is still false,
+     * matching legacy behavior for edge cases.
+     */
+    private static final int MAX_DEFERRED_LIFECYCLE_RETRIES = 1200;
+
     private final String componentId;
     private final String componentName;
     private boolean isAttachedToReactInstance = false;
 
     private final ReactSurface reactSurface;
+
+    private boolean pendingWillAppear;
+    private boolean pendingDidAppear;
+    private ComponentType pendingWillType;
+    private ComponentType pendingDidType;
+    private int deferredLifecycleRetryCount;
+    private boolean deferredLifecycleFlushPosted;
 
     public ReactView(final Context context, String componentId, String componentName) {
         super(context);
@@ -68,30 +84,114 @@ public class ReactView extends FrameLayout implements IReactView, Renderable {
 
     @Override
     public void destroy() {
+        clearDeferredLifecycleEvents();
         reactSurface.stop();
     }
 
     public void sendComponentWillStart(ComponentType type) {
-        this.post(() -> {
-            ReactContext currentReactContext = getReactContext();
-            if (currentReactContext != null)
-                new EventEmitter(currentReactContext).emitComponentWillAppear(componentId, componentName, type);
-        });
+        this.post(() -> handleSendComponentWillStart(type));
     }
 
     public void sendComponentStart(ComponentType type) {
-        this.post(() -> {
-            ReactContext currentReactContext = getReactContext();
-            if (currentReactContext != null) {
-                new EventEmitter(currentReactContext).emitComponentDidAppear(componentId, componentName, type);
-            }
-        });
+        this.post(() -> handleSendComponentStart(type));
     }
 
     public void sendComponentStop(ComponentType type) {
+        clearDeferredLifecycleEvents();
         ReactContext currentReactContext = getReactContext();
         if (currentReactContext != null) {
             new EventEmitter(currentReactContext).emitComponentDidDisappear(componentId, componentName, type);
+        }
+    }
+
+    private void handleSendComponentWillStart(ComponentType type) {
+        if (!shouldDeferLifecycleEmit()) {
+            emitComponentWillAppear(type);
+            return;
+        }
+        pendingWillAppear = true;
+        pendingWillType = type;
+        scheduleFlushDeferredLifecycleEvents();
+    }
+
+    private void handleSendComponentStart(ComponentType type) {
+        if (!shouldDeferLifecycleEmit()) {
+            emitComponentDidAppear(type);
+            return;
+        }
+        pendingDidAppear = true;
+        pendingDidType = type;
+        scheduleFlushDeferredLifecycleEvents();
+    }
+
+    /**
+     * Wait until the Fabric surface has mounted content so JS has typically committed the screen and
+     * {@code bindComponent} can receive appear events (parity with iOS {@code RNNReactView} pending appear).
+     */
+    private boolean shouldDeferLifecycleEmit() {
+        return getReactContext() == null || !isRendered();
+    }
+
+    private void scheduleFlushDeferredLifecycleEvents() {
+        if (deferredLifecycleFlushPosted) return;
+        deferredLifecycleFlushPosted = true;
+        post(() -> {
+            deferredLifecycleFlushPosted = false;
+            flushDeferredLifecycleEvents();
+        });
+    }
+
+    private void flushDeferredLifecycleEvents() {
+        if (!pendingWillAppear && !pendingDidAppear) {
+            deferredLifecycleRetryCount = 0;
+            return;
+        }
+
+        boolean strictReady = !shouldDeferLifecycleEmit();
+        if (!strictReady) {
+            if (++deferredLifecycleRetryCount <= MAX_DEFERRED_LIFECYCLE_RETRIES) {
+                scheduleFlushDeferredLifecycleEvents();
+                return;
+            }
+            deferredLifecycleRetryCount = 0;
+            if (getReactContext() == null) {
+                Log.w(TAG, "Deferred component lifecycle events dropped (React context not ready)");
+                clearDeferredLifecycleEvents();
+                return;
+            }
+            // Degraded: context exists but surface not reporting children yet — emit once (legacy timing).
+        } else {
+            deferredLifecycleRetryCount = 0;
+        }
+
+        if (pendingWillAppear) {
+            pendingWillAppear = false;
+            emitComponentWillAppear(pendingWillType);
+        }
+        if (pendingDidAppear) {
+            pendingDidAppear = false;
+            emitComponentDidAppear(pendingDidType);
+        }
+    }
+
+    private void clearDeferredLifecycleEvents() {
+        pendingWillAppear = false;
+        pendingDidAppear = false;
+        deferredLifecycleRetryCount = 0;
+        deferredLifecycleFlushPosted = false;
+    }
+
+    private void emitComponentWillAppear(ComponentType type) {
+        ReactContext currentReactContext = getReactContext();
+        if (currentReactContext != null) {
+            new EventEmitter(currentReactContext).emitComponentWillAppear(componentId, componentName, type);
+        }
+    }
+
+    private void emitComponentDidAppear(ComponentType type) {
+        ReactContext currentReactContext = getReactContext();
+        if (currentReactContext != null) {
+            new EventEmitter(currentReactContext).emitComponentDidAppear(componentId, componentName, type);
         }
     }
 


### PR DESCRIPTION
## Summary

**Android — `ReactView`:** defer **`RNN.ComponentWillAppear`** / **`RNN.ComponentDidAppear`** until **`ReactContext`** is available and the Fabric surface reports content (**`isRendered()`**), so JS can **`bindComponent`** before per-screen appear events. Aligns with iOS **`RNNReactView`** (pending appear until mount). Relates to **[#8265](https://github.com/wix/react-native-navigation/issues/8265)** (root **`componentDidAppear`** missed on first launch).

## Problem

- Instance **`componentDidAppear`** only works after **`Navigation.events().bindComponent(this)`** in mount. If native emits **`RNN.ComponentDidAppear`** before that, **`ComponentEventsObserver`** has no listeners for that **`componentId`** and the callback is dropped.
- On **Android**, appear could fire from **`ComponentViewController`** visibility before the surface had mounted content; **iOS** already defers in **`RNNReactView`**.

## What changed

- **`android/src/main/java/com/reactnativenavigation/react/ReactView.java`**
  - Defer when **`getReactContext() == null`** or **`!isRendered()`**
  - Pending will/did, coalesced flush, bounded retries, degraded fallback if context exists but the surface never reports children
  - Clear deferred state on **`sendComponentStop`** and **`destroy`**
