### PR TITLE
fix(ios): add Auto Layout constraints to RNNReactButtonView

### DIFF
--- a/ios/RNNReactButtonView.mm
+++ b/ios/RNNReactButtonView.mm
@@ -1,6 +1,10 @@
 #import "RNNReactButtonView.h"
+#import <React/RCTSurface.h>
 
-@implementation RNNReactButtonView
+@implementation RNNReactButtonView {
+    NSLayoutConstraint *_widthConstraint;
+    NSLayoutConstraint *_heightConstraint;
+}
 
 - (instancetype)initWithHost:(RCTHost *)host
                   moduleName:(NSString *)moduleName
@@ -10,15 +14,50 @@
          reactViewReadyBlock:(RNNReactViewReadyCompletionBlock)reactViewReadyBlock {
     self = [super initWithHost:host moduleName:moduleName initialProperties:initialProperties eventEmitter:eventEmitter sizeMeasureMode:convertToSurfaceSizeMeasureMode(RCTRootViewSizeFlexibilityWidthAndHeight) reactViewReadyBlock:reactViewReadyBlock];
     [host.surfacePresenter addObserver:self];
-    self.backgroundColor = UIColor.clearColor;
+    self.backgroundColor = [UIColor clearColor];
+
+    if (@available(iOS 26.0, *)) {
+        if (![self designRequiresCompatibility]) {
+            self.translatesAutoresizingMaskIntoConstraints = NO;
+            _widthConstraint = [self.widthAnchor constraintEqualToConstant:0];
+            _heightConstraint = [self.heightAnchor constraintEqualToConstant:0];
+            _widthConstraint.priority = UILayoutPriorityDefaultHigh;
+            _heightConstraint.priority = UILayoutPriorityDefaultHigh;
+            _widthConstraint.active = YES;
+            _heightConstraint.active = YES;
+        }
+    }
 
     return self;
+}
+
+- (BOOL)designRequiresCompatibility {
+    static BOOL checked = NO;
+    static BOOL result = NO;
+    if (!checked) {
+        checked = YES;
+        result = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIDesignRequiresCompatibility"] boolValue];
+    }
+    return result;
 }
 
 - (void)didMountComponentsWithRootTag:(NSInteger)rootTag {
     if (self.surface.rootTag == rootTag) {
         [super didMountComponentsWithRootTag:rootTag];
         [self sizeToFit];
+        if (@available(iOS 26.0, *)) {
+            if (![self designRequiresCompatibility]) {
+                [self updateConstraintsToFitSize];
+            }
+        }
+    }
+}
+
+- (void)updateConstraintsToFitSize {
+    CGSize size = self.frame.size;
+    if (size.width > 0 && size.height > 0) {
+        _widthConstraint.constant = size.width;
+        _heightConstraint.constant = size.height;
     }
 }
 


### PR DESCRIPTION
## Problem

On iOS 26, the Liquid Glass navigation bar wraps `UIBarButtonItem.customView` in several internal layout containers (`_UITAMICAdaptorView`, `_TtCC5UIKit19NavigationButtonBar15ItemWrapperView`, etc.). Without explicit size constraints, these wrappers can collapse to zero height after a pop → tab-switch → tab-switch → push cycle, making the React-rendered button disappear.

## Solution

- Set `translatesAutoresizingMaskIntoConstraints = NO` on `RNNReactButtonView`
- Add explicit `widthAnchor` / `heightAnchor` constraints at `UILayoutPriorityDefaultHigh` (750) to avoid conflicts with UIKit's internal constraints
- Update constraints in `didMountComponentsWithRootTag:` after `sizeToFit` to reflect the measured React surface size
- Import `<React/RCTSurface.h>` for surface access

## Test plan

- Navigate to a screen with a custom React top bar button (component-based `UIBarButtonItem`)
- Pop, switch to another tab, switch to a third tab, then push back to the original screen
- Verify the button remains visible throughout the cycle
- Verify no white background bleeds through on the Liquid Glass navigation bar

Made with [Cursor](https://cursor.com)