### PR TITLE
fix(ios): center RNNReactButtonView inside navigation bar platter

### DIFF
--- a/ios/RNNReactButtonView.mm
+++ b/ios/RNNReactButtonView.mm
@@ -1,6 +1,10 @@
 #import "RNNReactButtonView.h"
+#import <React/RCTSurface.h>
 
-@implementation RNNReactButtonView
+@implementation RNNReactButtonView {
+    NSLayoutConstraint *_widthConstraint;
+    NSLayoutConstraint *_heightConstraint;
+}
 
 - (instancetype)initWithHost:(RCTHost *)host
                   moduleName:(NSString *)moduleName
@@ -10,15 +14,50 @@
          reactViewReadyBlock:(RNNReactViewReadyCompletionBlock)reactViewReadyBlock {
     self = [super initWithHost:host moduleName:moduleName initialProperties:initialProperties eventEmitter:eventEmitter sizeMeasureMode:convertToSurfaceSizeMeasureMode(RCTRootViewSizeFlexibilityWidthAndHeight) reactViewReadyBlock:reactViewReadyBlock];
     [host.surfacePresenter addObserver:self];
-    self.backgroundColor = UIColor.clearColor;
+    self.backgroundColor = [UIColor clearColor];
+
+    if (@available(iOS 26.0, *)) {
+        if (![self designRequiresCompatibility]) {
+            self.translatesAutoresizingMaskIntoConstraints = NO;
+            _widthConstraint = [self.widthAnchor constraintEqualToConstant:0];
+            _heightConstraint = [self.heightAnchor constraintEqualToConstant:0];
+            _widthConstraint.priority = UILayoutPriorityDefaultHigh;
+            _heightConstraint.priority = UILayoutPriorityDefaultHigh;
+            _widthConstraint.active = YES;
+            _heightConstraint.active = YES;
+        }
+    }
 
     return self;
+}
+
+- (BOOL)designRequiresCompatibility {
+    static BOOL checked = NO;
+    static BOOL result = NO;
+    if (!checked) {
+        checked = YES;
+        result = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIDesignRequiresCompatibility"] boolValue];
+    }
+    return result;
 }
 
 - (void)didMountComponentsWithRootTag:(NSInteger)rootTag {
     if (self.surface.rootTag == rootTag) {
         [super didMountComponentsWithRootTag:rootTag];
         [self sizeToFit];
+        if (@available(iOS 26.0, *)) {
+            if (![self designRequiresCompatibility]) {
+                [self updateConstraintsToFitSize];
+            }
+        }
+    }
+}
+
+- (void)updateConstraintsToFitSize {
+    CGSize size = self.frame.size;
+    if (size.width > 0 && size.height > 0) {
+        _widthConstraint.constant = size.width;
+        _heightConstraint.constant = size.height;
     }
 }
 

--- a/ios/RNNReactButtonView.mm
+++ b/ios/RNNReactButtonView.mm
@@ -4,6 +4,7 @@
 @implementation RNNReactButtonView {
     NSLayoutConstraint *_widthConstraint;
     NSLayoutConstraint *_heightConstraint;
+    BOOL _didCenter;
 }
 
 - (instancetype)initWithHost:(RCTHost *)host
@@ -25,6 +26,7 @@
             _heightConstraint.priority = UILayoutPriorityDefaultHigh;
             _widthConstraint.active = YES;
             _heightConstraint.active = YES;
+            _didCenter = NO;
         }
     }
 
@@ -58,6 +60,22 @@
     if (size.width > 0 && size.height > 0) {
         _widthConstraint.constant = size.width;
         _heightConstraint.constant = size.height;
+    }
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    if (@available(iOS 26.0, *)) {
+        if ([self designRequiresCompatibility]) return;
+        if (!_didCenter && self.superview && self.frame.size.width > 0) {
+            CGFloat wrapperWidth = self.superview.bounds.size.width;
+            CGFloat selfWidth = self.frame.size.width;
+            if (wrapperWidth > selfWidth) {
+                _didCenter = YES;
+                CGFloat tx = (wrapperWidth - selfWidth) / 2.0;
+                self.layer.affineTransform = CGAffineTransformMakeTranslation(tx, 0);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

On iOS 26, the internal `_UITAMICAdaptorView` wrapper view (~36pt) is wider than the React button content (~24.7pt), and UIKit pins the custom view to the leading edge. This makes the button icon/text appear visually off-center within the circular Liquid Glass platter.

## Solution

Apply a one-time horizontal `CGAffineTransform` in `layoutSubviews` to shift the `RNNReactButtonView` to the center of its wrapper view.

The centering is computed once (guarded by `_didCenter`) to avoid repeated recalculations.

**Depends on:** #8299

## Test plan

- Verify the custom React top bar button icon/text is visually centered within the circular Liquid Glass platter on iOS 26
- Test on multiple screens with different button sizes (icon-only, text, etc.)
- Verify centering is correct in both LTR and RTL layouts

Made with [Cursor](https://cursor.com)