### PR TITLE
android: fix system navigation bar overlay color

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
+++ b/android/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
@@ -79,7 +79,7 @@ object SystemUiUtils {
     @JvmStatic
     fun setupSystemBarBackgrounds(activity: Activity, contentLayout: ViewGroup) {
         setupStatusBarBackground(activity)
-        setupNavigationBarBackground(contentLayout)
+        setupNavigationBarBackground(activity.window, contentLayout)
     }
 
     private fun setupStatusBarBackground(activity: Activity) {
@@ -117,10 +117,10 @@ object SystemUiUtils {
         return view
     }
 
-    private fun setupNavigationBarBackground(contentLayout: ViewGroup) {
+    private fun setupNavigationBarBackground(window: Window?, contentLayout: ViewGroup) {
         if (navBarBackgroundView != null) return
         val view = View(contentLayout.context).apply {
-            setBackgroundColor(Color.BLACK)
+            setBackgroundColor(getNavigationBarBackgroundColor(window))
         }
         val params = FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT, 0, Gravity.BOTTOM
@@ -134,7 +134,7 @@ object SystemUiUtils {
             val wasThreeButton = isThreeButtonNav
             isThreeButtonNav = tappableHeight > 0
             if (isThreeButtonNav != wasThreeButton) {
-                val color = lastExplicitNavBarColor ?: getDefaultNavBarColor()
+                val color = lastExplicitNavBarColor ?: getNavigationBarBackgroundColor(v)
                 v.setBackgroundColor(color)
             }
             val lp = v.layoutParams
@@ -145,6 +145,17 @@ object SystemUiUtils {
             insets
         }
         view.requestApplyInsets()
+    }
+
+    private fun getNavigationBarBackgroundColor(window: Window?): Int {
+        lastExplicitNavBarColor?.let { return it }
+        @Suppress("DEPRECATION")
+        return window?.navigationBarColor ?: getDefaultNavBarColor()
+    }
+
+    private fun getNavigationBarBackgroundColor(view: View): Int {
+        lastExplicitNavBarColor?.let { return it }
+        return (view.background as? ColorDrawable)?.color ?: getDefaultNavBarColor()
     }
 
     /**
@@ -321,9 +332,8 @@ object SystemUiUtils {
         window?.let {
             WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightNavigationBars = lightColor
         }
-        if (isEdgeToEdgeActive) {
-            navBarBackgroundView?.setBackgroundColor(color)
-        } else {
+        navBarBackgroundView?.setBackgroundColor(color)
+        if (!isEdgeToEdgeActive) {
             @Suppress("DEPRECATION")
             window?.navigationBarColor = color
         }

--- a/android/src/test/java/com/reactnativenavigation/utils/SystemUiUtilsTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/utils/SystemUiUtilsTest.kt
@@ -1,15 +1,27 @@
 package com.reactnativenavigation.utils
 
 import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.view.View
 import android.view.Window
+import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
 import com.reactnativenavigation.BaseRobolectricTest
 import com.reactnativenavigation.utils.SystemUiUtils.STATUS_BAR_HEIGHT_TRANSLUCENCY
+import org.assertj.core.api.Java6Assertions.assertThat
+import org.junit.After
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.verify
+import org.robolectric.Robolectric
 import kotlin.math.ceil
 
 class SystemUiUtilsTest : BaseRobolectricTest() {
+
+    @After
+    fun afterEach() {
+        SystemUiUtils.tearDown()
+    }
 
     @Test
     fun `setStatusBarColor - should change color considering alpha`() {
@@ -23,5 +35,56 @@ class SystemUiUtilsTest : BaseRobolectricTest() {
         SystemUiUtils.setStatusBarColor(window, color, true)
 
         verify(window).statusBarColor = Color.argb(ceil(STATUS_BAR_HEIGHT_TRANSLUCENCY*255).toInt(), 22, 255, 255)
+    }
+
+    @Test
+    fun `setupSystemBarBackgrounds - initializes navigation bar background from resolved color`() {
+        val activity = Robolectric.setupActivity(AppCompatActivity::class.java)
+        val contentLayout = FrameLayout(activity)
+        val initialColor = Color.RED
+        SystemUiUtils.setNavigationBarBackgroundColor(activity.window, initialColor, false)
+
+        SystemUiUtils.setupSystemBarBackgrounds(activity, contentLayout)
+
+        assertThat(getBackgroundColor(getNavigationBarBackground(contentLayout))).isEqualTo(initialColor)
+    }
+
+    @Test
+    fun `setNavigationBarBackgroundColor - updates view and window color when edge-to-edge is inactive`() {
+        val activity = Robolectric.setupActivity(AppCompatActivity::class.java)
+        val contentLayout = FrameLayout(activity)
+        @Suppress("DEPRECATION")
+        activity.window.navigationBarColor = Color.BLACK
+        SystemUiUtils.setupSystemBarBackgrounds(activity, contentLayout)
+
+        SystemUiUtils.setNavigationBarBackgroundColor(activity.window, Color.WHITE, true)
+
+        assertThat(getBackgroundColor(getNavigationBarBackground(contentLayout))).isEqualTo(Color.WHITE)
+        assertThat(activity.window.decorView.systemUiVisibility and View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR)
+            .isEqualTo(View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR)
+    }
+
+    @Test
+    fun `setNavigationBarBackgroundColor - updates view and icon appearance when edge-to-edge is active`() {
+        val activity = Robolectric.setupActivity(AppCompatActivity::class.java)
+        val contentLayout = FrameLayout(activity)
+        val initialColor = Color.RED
+        SystemUiUtils.setNavigationBarBackgroundColor(activity.window, initialColor, false)
+        SystemUiUtils.setupSystemBarBackgrounds(activity, contentLayout)
+        SystemUiUtils.activateEdgeToEdge()
+
+        SystemUiUtils.setNavigationBarBackgroundColor(activity.window, Color.WHITE, true)
+
+        assertThat(getBackgroundColor(getNavigationBarBackground(contentLayout))).isEqualTo(Color.WHITE)
+        assertThat(activity.window.decorView.systemUiVisibility and View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR)
+            .isEqualTo(View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR)
+    }
+
+    private fun getNavigationBarBackground(contentLayout: FrameLayout): View {
+        return contentLayout.getChildAt(contentLayout.childCount - 1)
+    }
+
+    private fun getBackgroundColor(view: View): Int {
+        return (view.background as ColorDrawable).color
     }
 }


### PR DESCRIPTION
## Summary
- Fix Android system navigation-bar overlay color initialization so the manual nav-bar background starts from the current window/resolved color instead of hardcoded black.
- Keep the manual nav-bar background in sync whenever `setNavigationBarBackgroundColor(...)` is called, including non-edge-to-edge mode.
- Add Robolectric coverage for initial overlay color, non-edge-to-edge window/view updates, and edge-to-edge view/icon updates.

## Validation
- `git diff --check` — PASS
- Pre-PR self-review — PASS; no safe autofixes applied, no sensitive files found

## Not Run
- `yarn install` — blocked in Yarn fetch step by repeated `RequestError EBADF`; `node_modules/@react-native/gradle-plugin` was not installed
- `cd playground/android && ./gradlew :react-native-navigation:testDebugUnitTest --tests com.reactnativenavigation.utils.SystemUiUtilsTest` — blocked because `node_modules/@react-native/gradle-plugin` is missing

## Risks
- Low-to-medium: scoped to Android system bar color handling, but affects both edge-to-edge and non-edge-to-edge navigation-bar coloring.
- Explicit `navigationBar.backgroundColor` should still win; bottom-tabs sync remains unchanged.

## Review Context
- WOAINFRA-3349 reports black OS navigation/gesture area under otherwise light app UI.
- The likely regression was the manual nav-bar background view being initialized to black and not repainted outside edge-to-edge mode.
- This fix does not change public JS APIs or app resource behavior.

## Suggested Reviewers
- @markdevocht — dominant/latest relevant editor for the Android system-bar code touched here.
