### PR TITLE
Android e2e drawBehind configuration

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/NavigationActivity.java
+++ b/android/src/main/java/com/reactnativenavigation/NavigationActivity.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
+import android.graphics.Color;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -25,9 +26,11 @@ import com.reactnativenavigation.viewcontrollers.navigator.Navigator;
 
 import androidx.activity.EdgeToEdge;
 import androidx.activity.OnBackPressedCallback;
+import androidx.activity.SystemBarStyle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.WindowCompat;
 
 public class NavigationActivity extends AppCompatActivity implements DefaultHardwareBackBtnHandler, PermissionAwareActivity, JsDevReloadHandler.ReloadListener {
     @Nullable
@@ -189,8 +192,18 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
      * calling {@code EdgeToEdge.enable()} directly.
      */
     protected void activateEdgeToEdge() {
-        EdgeToEdge.enable(this);
+        EdgeToEdge.enable(
+                this,
+                SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT),
+                SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT)
+        );
         SystemUiUtils.activateEdgeToEdge();
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        SystemUiUtils.setNavigationBarContrastEnforced(getWindow(), false);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            getWindow().setStatusBarColor(Color.TRANSPARENT);
+            getWindow().setNavigationBarColor(Color.TRANSPARENT);
+        }
     }
 
     protected void addDefaultSplashLayout() {

--- a/android/src/main/java/com/reactnativenavigation/options/NavigationBarOptions.java
+++ b/android/src/main/java/com/reactnativenavigation/options/NavigationBarOptions.java
@@ -17,20 +17,38 @@ public class NavigationBarOptions {
 
         result.backgroundColor = ThemeColour.parse(context, json.optJSONObject("backgroundColor"));
         result.isVisible = BoolParser.parse(json, "visible");
+        result.drawBehind = BoolParser.parse(json, "drawBehind");
 
         return result;
     }
 
     public ThemeColour backgroundColor = new NullThemeColour();
     public Bool isVisible = new NullBool();
+    public Bool drawBehind = new NullBool();
 
     public void mergeWith(NavigationBarOptions other) {
         if (other.isVisible.hasValue()) isVisible = other.isVisible;
         if (other.backgroundColor.hasValue()) backgroundColor = other.backgroundColor;
+        if (other.drawBehind.hasValue()) drawBehind = other.drawBehind;
     }
 
     public void mergeWithDefault(NavigationBarOptions defaultOptions) {
         if (!isVisible.hasValue()) isVisible = defaultOptions.isVisible;
         if (!backgroundColor.hasValue()) backgroundColor = defaultOptions.backgroundColor;
+        if (!drawBehind.hasValue()) drawBehind = defaultOptions.drawBehind;
+    }
+
+    public boolean shouldDrawBehind() {
+        if (drawBehind.isFalse()) return false;
+        if (drawBehind.isTrue()) return true;
+        return backgroundColor.hasTransparency();
+    }
+
+    public boolean isDrawBehindAndVisible() {
+        return shouldDrawBehind() && isVisible.isTrueOrUndefined();
+    }
+
+    public boolean hasAnyValue() {
+        return isVisible.hasValue() || drawBehind.hasValue() || backgroundColor.hasValue();
     }
 }

--- a/android/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
+++ b/android/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.graphics.Color
 import android.graphics.Rect
 import android.graphics.drawable.ColorDrawable
+import android.os.Build
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -15,6 +16,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import kotlin.math.abs
 import kotlin.math.ceil
+import kotlin.math.max
 
 object SystemUiUtils {
     private const val STATUS_BAR_HEIGHT_M = 24
@@ -176,6 +178,29 @@ object SystemUiUtils {
         isEdgeToEdgeActive = true
     }
 
+    @JvmStatic
+    fun setNavigationBarContrastEnforced(window: Window?, enforced: Boolean) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window?.isNavigationBarContrastEnforced = enforced
+        }
+    }
+
+    @JvmStatic
+    fun getContentBottomSystemBarInset(insets: WindowInsetsCompat, drawBehindNavigationBar: Boolean): Int {
+        val imeBottom = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+        if (!isEdgeToEdgeActive) return imeBottom
+        if (drawBehindNavigationBar) return imeBottom
+        val navBarBottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
+        return max(imeBottom, navBarBottom)
+    }
+
+    @JvmStatic
+    fun getBottomTabsSystemBarPadding(insets: WindowInsetsCompat, drawBehindNavigationBar: Boolean): Int {
+        if (insets.getInsets(WindowInsetsCompat.Type.ime()).bottom > 0) return 0
+        if (isEdgeToEdgeActive && drawBehindNavigationBar) return 0
+        return insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom
+    }
+
     /**
      * Clears references to system bar background views.
      * Call from Activity.onDestroy to avoid leaking views across activity recreation.
@@ -316,17 +341,34 @@ object SystemUiUtils {
      * falls back to the deprecated window API on older configurations.
      */
     @JvmStatic
-    fun setNavigationBarBackgroundColor(window: Window?, color: Int, lightColor: Boolean) {
-        lastExplicitNavBarColor = color
+    fun setNavigationBarBackgroundColor(window: Window?, color: Int, lightColor: Boolean, hideOverlay: Boolean) {
         window?.let {
             WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightNavigationBars = lightColor
         }
+        if (hideOverlay) {
+            lastExplicitNavBarColor = null
+            navBarBackgroundView?.apply {
+                visibility = View.GONE
+                setBackgroundColor(Color.TRANSPARENT)
+            }
+            @Suppress("DEPRECATION")
+            window?.navigationBarColor = Color.TRANSPARENT
+            return
+        }
+
+        lastExplicitNavBarColor = color
+        navBarBackgroundView?.visibility = View.VISIBLE
         if (isEdgeToEdgeActive) {
             navBarBackgroundView?.setBackgroundColor(color)
         } else {
             @Suppress("DEPRECATION")
             window?.navigationBarColor = color
         }
+    }
+
+    @JvmStatic
+    fun setNavigationBarBackgroundColor(window: Window?, color: Int, lightColor: Boolean) {
+        setNavigationBarBackgroundColor(window, color, lightColor, Color.alpha(color) == 0)
     }
 
     // endregion

--- a/android/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
+++ b/android/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsController.java
@@ -13,7 +13,7 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
-import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
 import com.aurelhubert.ahbottomnavigation.AHBottomNavigation;
@@ -25,6 +25,7 @@ import com.reactnativenavigation.react.CommandListener;
 import com.reactnativenavigation.react.CommandListenerAdapter;
 import com.reactnativenavigation.react.events.EventEmitter;
 import com.reactnativenavigation.utils.ImageLoader;
+import com.reactnativenavigation.utils.SystemUiUtils;
 import com.reactnativenavigation.viewcontrollers.bottomtabs.attacher.BottomTabsAttacher;
 import com.reactnativenavigation.viewcontrollers.child.ChildControllersRegistry;
 import com.reactnativenavigation.viewcontrollers.parent.ParentController;
@@ -156,6 +157,7 @@ public class BottomTabsController extends ParentController<BottomTabsLayout> imp
     public void applyChildOptions(Options options, ViewController<?> child) {
         super.applyChildOptions(options, child);
         presenter.applyChildOptions(resolveCurrentOptions(), child);
+        onNavigationBarOptionsChanged(options);
         performOnParentController(parent -> parent.applyChildOptions(
                 this.options.copy()
                         .clearBottomTabsOptions()
@@ -170,6 +172,7 @@ public class BottomTabsController extends ParentController<BottomTabsLayout> imp
         super.mergeChildOptions(options, child);
         presenter.mergeChildOptions(options, child);
         tabPresenter.mergeChildOptions(options, child);
+        onNavigationBarOptionsChanged(options);
         performOnParentController(parent -> parent.mergeChildOptions(options.copy().clearBottomTabsOptions(), child));
     }
 
@@ -316,12 +319,21 @@ public class BottomTabsController extends ParentController<BottomTabsLayout> imp
 
     @Override
     protected WindowInsetsCompat onApplyWindowInsets(View view, WindowInsetsCompat insets) {
-        Insets sysInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars());
-        Insets imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime());
-
-        int bottomInset = (imeInsets.bottom > 0) ? 0 : sysInsets.bottom;
-        view.setPaddingRelative(0, 0, 0, bottomInset);
+        boolean drawBehindNavBar = resolveCurrentOptions().navigationBar.isDrawBehindAndVisible();
+        view.setPaddingRelative(0, 0, 0, SystemUiUtils.getBottomTabsSystemBarPadding(insets, drawBehindNavBar));
         return insets;
+    }
+
+    private void onNavigationBarOptionsChanged(Options options) {
+        if (!options.navigationBar.hasAnyValue()) return;
+        refreshNavigationBarInsets();
+    }
+
+    private void refreshNavigationBarInsets() {
+        if (getView() != null) {
+            applyBottomInset();
+            ViewCompat.requestApplyInsets(getView());
+        }
     }
 
     @RestrictTo(RestrictTo.Scope.TESTS)

--- a/android/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsPresenter.kt
+++ b/android/src/main/java/com/reactnativenavigation/viewcontrollers/bottomtabs/BottomTabsPresenter.kt
@@ -393,6 +393,7 @@ class BottomTabsPresenter(
     private fun syncNavigationBarColor(options: Options, tabsColor: Int) {
         val resolved = options.copy().withDefaultOptions(defaultOptions)
         if (resolved.navigationBar.backgroundColor.hasValue()) return
+        if (resolved.navigationBar.shouldDrawBehind()) return
         val window = (bottomTabsContainer.context as? Activity)?.window ?: return
         SystemUiUtils.setNavigationBarBackgroundColor(window, tabsColor, isColorLight(tabsColor))
     }

--- a/android/src/main/java/com/reactnativenavigation/viewcontrollers/component/ComponentViewController.java
+++ b/android/src/main/java/com/reactnativenavigation/viewcontrollers/component/ComponentViewController.java
@@ -173,11 +173,8 @@ public class ComponentViewController extends ChildController<ComponentLayout> {
                 insets.getInsets(WindowInsetsCompat.Type.navigationBars()).top -
                 systemBarsInsets.top;
 
-        int navBarBottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
-        int imeBottom = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
-        int systemWindowInsetBottom = SystemUiUtils.isEdgeToEdgeActive()
-                ? Math.max(imeBottom, navBarBottom)
-                : imeBottom;
+        boolean drawBehindNavBar = resolveCurrentOptions(presenter.defaultOptions).navigationBar.isDrawBehindAndVisible();
+        int systemWindowInsetBottom = SystemUiUtils.getContentBottomSystemBarInset(insets, drawBehindNavBar);
 
         WindowInsetsCompat finalInsets = new WindowInsetsCompat.Builder()
                 .setInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.ime(),

--- a/android/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/Presenter.java
+++ b/android/src/main/java/com/reactnativenavigation/viewcontrollers/viewcontroller/Presenter.java
@@ -11,6 +11,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewGroup.MarginLayoutParams;
 
+import androidx.core.view.ViewCompat;
+
 import com.reactnativenavigation.options.NavigationBarOptions;
 import com.reactnativenavigation.options.Options;
 import com.reactnativenavigation.options.OrientationOptions;
@@ -114,16 +116,16 @@ public class Presenter {
 
     private void applyNavigationBarOptions(NavigationBarOptions options) {
         applyNavigationBarVisibility(options);
-        setNavigationBarBackgroundColor(options);
+        applyNavigationBarBackground(options);
+        refreshNavigationBarInsets();
     }
 
     private void mergeNavigationBarOptions(NavigationBarOptions options) {
-        mergeNavigationBarVisibility(options);
-        setNavigationBarBackgroundColor(options);
-    }
-
-    private void mergeNavigationBarVisibility(NavigationBarOptions options) {
-        if (options.isVisible.hasValue()) applyNavigationBarOptions(options);
+        if (options.isVisible.hasValue()) {
+            applyNavigationBarVisibility(options);
+        }
+        applyNavigationBarBackground(options);
+        refreshNavigationBarInsets();
     }
 
     private void applyNavigationBarVisibility(NavigationBarOptions options) {
@@ -136,20 +138,38 @@ public class Presenter {
         }
     }
 
-    private void setNavigationBarBackgroundColor(NavigationBarOptions navigationBar) {
+    private void applyNavigationBarBackground(NavigationBarOptions navigationBar) {
         if (activity == null) return;
         int defaultColor = SystemUiUtils.getDefaultNavBarColor();
-        if (navigationBar.backgroundColor.canApplyValue()) {
-            int color = navigationBar.backgroundColor.get(defaultColor);
-            SystemUiUtils.setNavigationBarBackgroundColor(activity.getWindow(), color, isColorLight(color));
+        int color;
+        boolean hideOverlay;
+        if (navigationBar.isDrawBehindAndVisible()) {
+            if (navigationBar.backgroundColor.canApplyValue()) {
+                color = navigationBar.backgroundColor.get(defaultColor);
+                hideOverlay = Color.alpha(color) == 0;
+            } else {
+                color = Color.TRANSPARENT;
+                hideOverlay = true;
+            }
         } else {
-            SystemUiUtils.setNavigationBarBackgroundColor(activity.getWindow(), defaultColor, isColorLight(defaultColor));
+            hideOverlay = false;
+            color = navigationBar.backgroundColor.canApplyValue()
+                    ? navigationBar.backgroundColor.get(defaultColor)
+                    : defaultColor;
         }
+        SystemUiUtils.setNavigationBarBackgroundColor(
+                activity.getWindow(), color, isColorLight(color), hideOverlay);
+    }
+
+    private void refreshNavigationBarInsets() {
+        if (activity == null) return;
+        ViewCompat.requestApplyInsets(activity.getWindow().getDecorView());
     }
 
     public void onConfigurationChanged(ViewController controller, Options options) {
         Options withDefault = options.withDefaultOptions(defaultOptions);
-        setNavigationBarBackgroundColor(withDefault.navigationBar);
+        applyNavigationBarBackground(withDefault.navigationBar);
+        refreshNavigationBarInsets();
         StatusBarPresenter.instance.onConfigurationChanged(withDefault.statusBar);
         applyBackgroundColor(controller, withDefault);
     }

--- a/android/src/test/java/com/reactnativenavigation/presentation/PresenterTest.java
+++ b/android/src/test/java/com/reactnativenavigation/presentation/PresenterTest.java
@@ -96,4 +96,18 @@ public class PresenterTest extends BaseTest {
         verify(parentView).setPadding(2,1,4,3);
     }
 
+    @Test
+    public void applyNavigationBarDrawBehind_usesTransparentOverlay() {
+        mockSystemUiUtils(0, 0, (mockedStatic) -> {
+            ViewGroup spy = spy(new FrameLayout(activity));
+            Mockito.when(controller.getView()).thenReturn(spy);
+            Mockito.when(controller.resolveCurrentOptions()).thenReturn(Options.EMPTY);
+            Options options = new Options();
+            options.navigationBar.drawBehind = new Bool(true);
+            uut.applyOptions(controller, options);
+            mockedStatic.verify(() -> SystemUiUtils.setNavigationBarBackgroundColor(
+                    any(), eq(android.graphics.Color.TRANSPARENT), eq(false), eq(true)), times(1));
+        });
+    }
+
 }

--- a/src/interfaces/Options.ts
+++ b/src/interfaces/Options.ts
@@ -1574,6 +1574,11 @@ export interface AnimationOptions {
 export interface NavigationBarOptions {
   backgroundColor?: Color;
   visible?: boolean;
+  /**
+   * Draw screen content behind the system navigation bar while keeping it visible.
+   * On Android 15+ edge-to-edge, use with `backgroundColor: 'transparent'`.
+   */
+  drawBehind?: boolean;
 }
 
 /**

--- a/website/docs/api/options-navigationBar.mdx
+++ b/website/docs/api/options-navigationBar.mdx
@@ -40,3 +40,11 @@ Set the navigation bar color. When a light background color is used, the color o
 | Type                  | Required | Platform | Default |
 | --------------------- | -------- | -------- | ------- |
 | Color | No       | Android     | 'black' |
+
+### `drawBehind`
+
+Draw screen content behind the system navigation bar while keeping it visible (gesture pill / 3-button bar remain on screen). Use with edge-to-edge enabled in your activity. With `backgroundColor: 'transparent'`, content shows through the nav bar area; with an opaque color, RNN paints a scrim overlay without reserving bottom layout inset.
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | Android  |

--- a/website/docs/docs/style-edge-to-edge.mdx
+++ b/website/docs/docs/style-edge-to-edge.mdx
@@ -63,4 +63,28 @@ options: {
 }
 ```
 
+Use `navigationBar.drawBehind` with edge-to-edge to draw content behind the system navigation bar while keeping it visible (gesture pill or 3-button bar stay on screen). Layout insets skip the navigation bar height; RNN paints an optional scrim via `backgroundColor`:
+
+```js
+// Transparent nav bar — content shows through, pill visible
+options: {
+  navigationBar: {
+    visible: true,
+    drawBehind: true,
+    backgroundColor: 'transparent'
+  }
+}
+
+// Opaque scrim over content behind the nav bar
+options: {
+  navigationBar: {
+    visible: true,
+    drawBehind: true,
+    backgroundColor: '#20303C'
+  }
+}
+```
+
+Without `drawBehind`, an opaque `backgroundColor` reserves bottom inset so content sits above the navigation bar (traditional behavior). See [Navigation Bar options](../api/options-navigationBar) for `visible` and other fields.
+
 These options work in both edge-to-edge and non-edge-to-edge modes. In edge-to-edge mode, the colors are applied to the view-based overlays rather than the deprecated window APIs.


### PR DESCRIPTION
# Android edge-to-edge: `navigationBar.drawBehind`

## Summary

Adds `navigationBar.drawBehind` so apps on Android 15+ edge-to-edge can draw content behind the system navigation bar while keeping it visible (gesture pill or 3-button bar). Fixes incorrect bottom insets and bottom-tabs padding when the nav bar should be transparent or use a scrim overlay instead of reserving layout space.

## Problem

On API 35+ with edge-to-edge enabled, apps could not get the combination users expect:

| Desired behavior | What happened before |
| ---------------- | -------------------- |
| Transparent nav bar + gesture pill visible | System contrast scrim and/or RNN’s opaque `navBarBackgroundView` blocked transparency |
| Content extends to the bottom of the screen | Bottom layout inset was always applied for the navigation bar |
| Bottom tabs flush with screen bottom | Extra gray padding below the tab bar from `systemBars` insets |

Workarounds were limited:

- `navigationBar.visible: false` — hides the pill (not acceptable when gestures should stay visible)
- Opaque `backgroundColor` without draw-behind — content inset above a solid bar

## Solution

New option: **`navigationBar.drawBehind`** (Android only).

```js
// Transparent system nav area, pill visible, no bottom content inset
navigationBar: {
  visible: true,
  drawBehind: true,
  backgroundColor: 'transparent',
}

// Opaque scrim over content behind the nav bar, pill visible
navigationBar: {
  visible: true,
  drawBehind: true,
  backgroundColor: '#20303C',
}
```

`drawBehind: true` with `visible: true` (or omitted):

- Hides RNN’s nav-bar overlay view and sets the window navigation bar color to transparent
- Skips navigation-bar bottom inset for screen content and bottom tabs (IME inset still applies)
- Optionally paints a scrim via `backgroundColor` when not transparent

Traditional behavior is unchanged when `drawBehind` is false/omitted and `backgroundColor` is opaque: content is inset above the navigation bar.

`shouldDrawBehind()` also treats a transparent `backgroundColor` as draw-behind when `drawBehind` is not explicitly set to `false`.

## Implementation

| Area | Change |
| ---- | ------ |
| **`NavigationBarOptions`** | Parse/merge `drawBehind`; `shouldDrawBehind()`, `isDrawBehindAndVisible()` |
| **`NavigationActivity.activateEdgeToEdge()`** | `EdgeToEdge.enable()`, `setDecorFitsSystemWindows(false)`, disable nav-bar contrast enforcement, transparent window nav/status colors |
| **`SystemUiUtils`** | `setNavigationBarContrastEnforced()`; overlay hide via `hideOverlay` on `setNavigationBarBackgroundColor()`; shared `getContentBottomSystemBarInset()` / `getBottomTabsSystemBarPadding()` |
| **`Presenter`** | Apply transparent vs scrim vs traditional nav bar; refresh insets on merge |
| **`ComponentViewController`** | Skip nav-bar bottom inset when draw-behind + visible under E2E |
| **`BottomTabsController`** | Skip bottom `systemBars` padding when draw-behind + visible; refresh insets on child nav-bar option changes |
| **`BottomTabsPresenter`** | Skip syncing tab color to nav bar when `shouldDrawBehind()` |
| **Types / docs** | `Options.ts`, `options-navigationBar.mdx`, `style-edge-to-edge.mdx` |

## API

```ts
export interface NavigationBarOptions {
  backgroundColor?: Color;
  visible?: boolean;
  drawBehind?: boolean;
}
```

See [Navigation Bar options](https://github.com/wix/react-native-navigation/blob/master/website/docs/api/options-navigationBar.mdx) and [Edge-to-Edge guide](https://github.com/wix/react-native-navigation/blob/master/website/docs/docs/style-edge-to-edge.mdx).

## App setup (consumers)

Edge-to-edge must be enabled in the host app:

1. Theme: `android:windowOptOutEdgeToEdgeEnforcement` = `false` (API 35+)
2. Override `NavigationActivity.enableEdgeToEdge()` and call `activateEdgeToEdge()` when appropriate

Wix Engine apps still need a separate change: flip per-brand opt-out and remove legacy `window.statusBarColor` usage in `MainActivity` — not included in this PR.

## Limitations

- **Cannot hide only the gesture pill** while keeping the nav bar “visible” — Android does not expose that. Use `visible: false` to hide the entire system navigation bar (pill included).
- **`navigationBar` is Android-only** — no iOS equivalent (use `bottomTabs.drawBehind` / `bottomTabs.visible` on iOS).
- **Bottom tabs + draw-behind**: tab bar content does not extend behind the system nav bar; only the extra gray gap from incorrect insets is removed.

## Breaking changes

None. New option only; default behavior matches previous releases when `drawBehind` is not set.

Examples:
<img width="404" height="894" alt="Screenshot 2026-05-26 at 8 16 22" src="https://github.com/user-attachments/assets/49f0ed6f-f444-4012-855d-5baece57a8f0" />

<img width="407" height="894" alt="Screenshot 2026-05-25 at 16 40 38" src="https://github.com/user-attachments/assets/6c1304cf-0e0a-43b6-aedf-df9bc2cb55d6" />

<img width="407" height="894" alt="Screenshot 2026-05-25 at 16 40 55" src="https://github.com/user-attachments/assets/71774679-a221-4483-acf8-c54b2c7729f2" />

