### PR TITLE
feat: add NativeScript navigation surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,12 @@
       "source": "./src/Mock/index.ts",
       "react-native": "./src/Mock/index.ts"
     },
+    "./nativescript": {
+      "types": "./lib/typescript/nativescript/index.d.ts",
+      "default": "./lib/module/nativescript/index.js",
+      "source": "./src/nativescript/index.ts",
+      "react-native": "./src/nativescript/index.ts"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -71,6 +77,7 @@
     "lint": "eslint --ext .js,.jsx,.ts,.tsx ./"
   },
   "peerDependencies": {
+    "@nativescript/react-native": "*",
     "react": "*",
     "react-native": "*",
     "remx": "*"

--- a/src/Navigation.ts
+++ b/src/Navigation.ts
@@ -1,5 +1,5 @@
 import isArray from 'lodash/isArray';
-import { NativeCommandsSender } from './adapters/NativeCommandsSender';
+import { NativeCommandsModule } from './adapters/NativeCommandsSender';
 import { NativeEventsReceiver } from './adapters/NativeEventsReceiver';
 import { UniqueIdProvider } from './adapters/UniqueIdProvider';
 import { Store } from './components/Store';
@@ -50,7 +50,7 @@ export class NavigationRoot {
   private readonly linkingHandler: LinkingHandler;
 
   constructor(
-    private readonly nativeCommandsSender: NativeCommandsSender,
+    private readonly nativeCommandsSender: NativeCommandsModule,
     private readonly nativeEventsReceiver: NativeEventsReceiver,
     private readonly appRegistryService: AppRegistryService
   ) {

--- a/src/NavigationDelegate.ts
+++ b/src/NavigationDelegate.ts
@@ -7,7 +7,7 @@ import { ProcessorSubscription } from './interfaces/ProcessorSubscription';
 import { CommandName } from './interfaces/CommandName';
 import { OptionsProcessor as OptionProcessor } from './interfaces/Processors';
 import { NavigationRoot } from './Navigation';
-import { NativeCommandsSender } from './adapters/NativeCommandsSender';
+import { NativeCommandsModule, NativeCommandsSender } from './adapters/NativeCommandsSender';
 import { NativeEventsReceiver } from './adapters/NativeEventsReceiver';
 import { AppRegistryService } from './adapters/AppRegistryService';
 import { LinkingConfig } from './linking/types';
@@ -23,7 +23,7 @@ export class NavigationDelegate {
   }
 
   private createConcreteNavigation(
-    nativeCommandsSender: NativeCommandsSender,
+    nativeCommandsSender: NativeCommandsModule,
     nativeEventsReceiver: NativeEventsReceiver,
     appRegistryService: AppRegistryService
   ) {
@@ -249,7 +249,7 @@ export class NavigationDelegate {
   }
 
   public mockNativeComponents(
-    mockedNativeCommandsSender: NativeCommandsSender,
+    mockedNativeCommandsSender: NativeCommandsModule,
     mockedNativeEventsReceiver: NativeEventsReceiver,
     mockedAppRegistryService: AppRegistryService
   ) {

--- a/src/adapters/Constants.ts
+++ b/src/adapters/Constants.ts
@@ -1,4 +1,4 @@
-import { NativeCommandsSender } from './NativeCommandsSender';
+import { NativeCommandsModule } from './NativeCommandsSender';
 
 export interface NavigationConstants {
   statusBarHeight: number;
@@ -8,12 +8,12 @@ export interface NavigationConstants {
 }
 
 export class Constants {
-  static async get(nativeCommandSender: NativeCommandsSender): Promise<NavigationConstants> {
+  static async get(nativeCommandSender: NativeCommandsModule): Promise<NavigationConstants> {
     const constants: NavigationConstants = await nativeCommandSender.getNavigationConstants();
     return new Constants(constants);
   }
 
-  static getSync(nativeCommandSender: NativeCommandsSender): NavigationConstants {
+  static getSync(nativeCommandSender: NativeCommandsModule): NavigationConstants {
     const constants: NavigationConstants = nativeCommandSender.getNavigationConstantsSync();
     return new Constants(constants);
   }

--- a/src/adapters/NativeCommandsSender.ts
+++ b/src/adapters/NativeCommandsSender.ts
@@ -1,7 +1,7 @@
 import { NavigationConstants } from './Constants';
 import RNNCommandsModule, { Spec } from './NativeRNNTurboModule';
 
-interface NativeCommandsModule {
+export interface NativeCommandsModule {
   setRoot(commandId: string, layout: { root: any; modals: any[]; overlays: any[] }): Promise<any>;
   setDefaultOptions(options: object): void;
   mergeOptions(componentId: string, options: object): void;

--- a/src/commands/Commands.ts
+++ b/src/commands/Commands.ts
@@ -2,7 +2,7 @@ import cloneDeepWith from 'lodash/cloneDeepWith';
 import cloneDeep from 'lodash/cloneDeep';
 import map from 'lodash/map';
 import { CommandsObserver } from '../events/CommandsObserver';
-import { NativeCommandsSender } from '../adapters/NativeCommandsSender';
+import { NativeCommandsModule } from '../adapters/NativeCommandsSender';
 import { UniqueIdProvider } from '../adapters/UniqueIdProvider';
 import { Options } from '../interfaces/Options';
 import { Layout, LayoutRoot } from '../interfaces/Layout';
@@ -20,7 +20,7 @@ export class Commands {
 
   constructor(
     private readonly store: Store,
-    private readonly nativeCommandsSender: NativeCommandsSender,
+    private readonly nativeCommandsSender: NativeCommandsModule,
     private readonly layoutTreeParser: LayoutTreeParser,
     private readonly layoutTreeCrawler: LayoutTreeCrawler,
     private readonly commandsObserver: CommandsObserver,

--- a/src/nativescript/NativeScriptCommandsSender.ts
+++ b/src/nativescript/NativeScriptCommandsSender.ts
@@ -1,0 +1,103 @@
+import { NavigationConstants } from '../adapters/Constants';
+import {
+  getNativeScriptNavigationStore,
+  normalizeNativeScriptLayout,
+} from './NativeScriptNavigationSurface';
+import { NativeCommandsModule } from '../adapters/NativeCommandsSender';
+
+type LayoutRootPayload = {
+  root: any;
+  modals?: any[];
+  overlays?: any[];
+};
+
+export class NativeScriptCommandsSender implements NativeCommandsModule {
+  private readonly store = getNativeScriptNavigationStore();
+
+  setRoot(_commandId: string, layout: LayoutRootPayload): Promise<string> {
+    const root = normalizeNativeScriptLayout(layout.root);
+    const modals = (layout.modals ?? []).map(normalizeNativeScriptLayout);
+    const overlays = (layout.overlays ?? []).map(normalizeNativeScriptLayout);
+    this.store.setRoot(root, modals, overlays);
+    return Promise.resolve(root.id ?? '');
+  }
+
+  setDefaultOptions(options: object): void {
+    this.store.setDefaultOptions(options as any);
+  }
+
+  mergeOptions(componentId: string, options: object): void {
+    this.store.mergeOptions(componentId, options as any);
+  }
+
+  push(_commandId: string, componentId: string, layout: object): Promise<string> {
+    const node = normalizeNativeScriptLayout(layout);
+    this.store.push(componentId, node);
+    return Promise.resolve(node.id ?? '');
+  }
+
+  pop(_commandId: string, componentId: string, _options?: object): Promise<string> {
+    return Promise.resolve(this.store.pop(componentId) ?? componentId);
+  }
+
+  popTo(_commandId: string, componentId: string, _options?: object): Promise<string> {
+    return Promise.resolve(this.store.popTo(componentId) ?? componentId);
+  }
+
+  popToRoot(_commandId: string, componentId: string, _options?: object): Promise<string> {
+    return Promise.resolve(this.store.popToRoot(componentId) ?? componentId);
+  }
+
+  setStackRoot(_commandId: string, componentId: string, layout: object[]): Promise<string> {
+    const children = layout.map(normalizeNativeScriptLayout);
+    this.store.setStackRoot(componentId, children);
+    return Promise.resolve(componentId);
+  }
+
+  showModal(_commandId: string, layout: object): Promise<string> {
+    const node = normalizeNativeScriptLayout(layout);
+    this.store.showModal(node);
+    return Promise.resolve(node.id ?? '');
+  }
+
+  dismissModal(_commandId: string, componentId: string, _options?: object): Promise<string> {
+    return Promise.resolve(this.store.dismissModal(componentId) ?? componentId);
+  }
+
+  dismissAllModals(_commandId: string, _options?: object): Promise<string> {
+    this.store.dismissAllModals();
+    return Promise.resolve('');
+  }
+
+  showOverlay(_commandId: string, layout: object): Promise<string> {
+    const node = normalizeNativeScriptLayout(layout);
+    this.store.showOverlay(node);
+    return Promise.resolve(node.id ?? '');
+  }
+
+  dismissOverlay(_commandId: string, componentId: string): Promise<string> {
+    return Promise.resolve(this.store.dismissOverlay(componentId) ?? componentId);
+  }
+
+  dismissAllOverlays(_commandId: string): Promise<string> {
+    this.store.dismissAllOverlays();
+    return Promise.resolve('');
+  }
+
+  getLaunchArgs(_commandId: string): Promise<string[]> {
+    return Promise.resolve([]);
+  }
+
+  getNavigationConstants(): Promise<NavigationConstants> {
+    return Promise.resolve(this.getNavigationConstantsSync());
+  }
+
+  getNavigationConstantsSync(): NavigationConstants {
+    return {
+      topBarHeight: 44,
+      statusBarHeight: 0,
+      bottomTabsHeight: 49,
+      backButtonId: 'RNN.back',
+    };
+  }
+}

--- a/src/nativescript/NativeScriptCommandsSender.ts
+++ b/src/nativescript/NativeScriptCommandsSender.ts
@@ -11,10 +11,49 @@ type LayoutRootPayload = {
   overlays?: any[];
 };
 
+const STACK_TRANSITION_LOCK_MS = 360;
+
 export class NativeScriptCommandsSender implements NativeCommandsModule {
   private readonly store = getNativeScriptNavigationStore();
+  private readonly pendingStackCommands = new Map<string, Promise<string>>();
+
+  private resolveAfterStackTransition(stackId: string, result: string): Promise<string> {
+    const pending = new Promise<string>((resolve) => {
+      setTimeout(() => {
+        if (this.pendingStackCommands.get(stackId) === pending) {
+          this.pendingStackCommands.delete(stackId);
+        }
+        resolve(result);
+      }, STACK_TRANSITION_LOCK_MS);
+    });
+    this.pendingStackCommands.set(stackId, pending);
+    return pending;
+  }
+
+  private runStackCommand(
+    componentId: string,
+    fallbackResult: string,
+    command: () => {didMutate: boolean; result: string; stackId?: string}
+  ): Promise<string> {
+    const candidateStackId = this.store.getStackIdForComponent(componentId) ?? componentId;
+    const pending = this.pendingStackCommands.get(candidateStackId);
+    if (pending) {
+      return pending;
+    }
+
+    const mutation = command();
+    if (!mutation.didMutate) {
+      return Promise.resolve(fallbackResult);
+    }
+
+    return this.resolveAfterStackTransition(
+      mutation.stackId ?? candidateStackId,
+      mutation.result
+    );
+  }
 
   setRoot(_commandId: string, layout: LayoutRootPayload): Promise<string> {
+    this.pendingStackCommands.clear();
     const root = normalizeNativeScriptLayout(layout.root);
     const modals = (layout.modals ?? []).map(normalizeNativeScriptLayout);
     const overlays = (layout.overlays ?? []).map(normalizeNativeScriptLayout);
@@ -32,20 +71,51 @@ export class NativeScriptCommandsSender implements NativeCommandsModule {
 
   push(_commandId: string, componentId: string, layout: object): Promise<string> {
     const node = normalizeNativeScriptLayout(layout);
-    this.store.push(componentId, node);
-    return Promise.resolve(node.id ?? '');
+    const pushedId = node.id ?? '';
+    return this.runStackCommand(componentId, pushedId, () => {
+      const mutation = this.store.push(componentId, node);
+      return {
+        didMutate: mutation.didPush,
+        result: mutation.pushedId ?? pushedId,
+        stackId: mutation.stackId,
+      };
+    });
   }
 
   pop(_commandId: string, componentId: string, _options?: object): Promise<string> {
-    return Promise.resolve(this.store.pop(componentId) ?? componentId);
+    return this.runStackCommand(componentId, componentId, () => {
+      const stackId = this.store.getStackIdForComponent(componentId);
+      const removed = this.store.pop(componentId);
+      return {
+        didMutate: removed != null,
+        result: removed ?? componentId,
+        stackId,
+      };
+    });
   }
 
   popTo(_commandId: string, componentId: string, _options?: object): Promise<string> {
-    return Promise.resolve(this.store.popTo(componentId) ?? componentId);
+    return this.runStackCommand(componentId, componentId, () => {
+      const stackId = this.store.getStackIdForComponent(componentId);
+      const removed = this.store.popTo(componentId);
+      return {
+        didMutate: removed != null,
+        result: removed ?? componentId,
+        stackId,
+      };
+    });
   }
 
   popToRoot(_commandId: string, componentId: string, _options?: object): Promise<string> {
-    return Promise.resolve(this.store.popToRoot(componentId) ?? componentId);
+    return this.runStackCommand(componentId, componentId, () => {
+      const stackId = this.store.getStackIdForComponent(componentId);
+      const removed = this.store.popToRoot(componentId);
+      return {
+        didMutate: removed != null,
+        result: removed ?? componentId,
+        stackId,
+      };
+    });
   }
 
   setStackRoot(_commandId: string, componentId: string, layout: object[]): Promise<string> {

--- a/src/nativescript/NativeScriptCommandsSender.ts
+++ b/src/nativescript/NativeScriptCommandsSender.ts
@@ -15,45 +15,55 @@ const STACK_TRANSITION_LOCK_MS = 360;
 
 export class NativeScriptCommandsSender implements NativeCommandsModule {
   private readonly store = getNativeScriptNavigationStore();
-  private readonly pendingStackCommands = new Map<string, Promise<string>>();
+  private readonly pendingCommandKeys = new Map<string, Promise<string>>();
+  private readonly stackCommandTails = new Map<string, Promise<unknown>>();
 
-  private resolveAfterStackTransition(stackId: string, result: string): Promise<string> {
-    const pending = new Promise<string>((resolve) => {
+  private resolveAfterStackTransition(result: string): Promise<string> {
+    return new Promise<string>((resolve) => {
       setTimeout(() => {
-        if (this.pendingStackCommands.get(stackId) === pending) {
-          this.pendingStackCommands.delete(stackId);
-        }
         resolve(result);
       }, STACK_TRANSITION_LOCK_MS);
     });
-    this.pendingStackCommands.set(stackId, pending);
-    return pending;
   }
 
   private runStackCommand(
+    kind: string,
     componentId: string,
     fallbackResult: string,
     command: () => {didMutate: boolean; result: string; stackId?: string}
   ): Promise<string> {
     const candidateStackId = this.store.getStackIdForComponent(componentId) ?? componentId;
-    const pending = this.pendingStackCommands.get(candidateStackId);
+    const commandKey = `${kind}:${candidateStackId}:${componentId}`;
+    const pending = this.pendingCommandKeys.get(commandKey);
     if (pending) {
       return pending;
     }
 
-    const mutation = command();
-    if (!mutation.didMutate) {
-      return Promise.resolve(fallbackResult);
-    }
-
-    return this.resolveAfterStackTransition(
-      mutation.stackId ?? candidateStackId,
-      mutation.result
-    );
+    const previousTail = this.stackCommandTails.get(candidateStackId);
+    const run = () => {
+      const mutation = command();
+      if (!mutation.didMutate) {
+        return fallbackResult;
+      }
+      return this.resolveAfterStackTransition(mutation.result);
+    };
+    const queued = previousTail ? previousTail.then(run, run) : Promise.resolve(run());
+    this.pendingCommandKeys.set(commandKey, queued);
+    const nextTail = queued.finally(() => {
+      if (this.pendingCommandKeys.get(commandKey) === queued) {
+        this.pendingCommandKeys.delete(commandKey);
+      }
+      if (this.stackCommandTails.get(candidateStackId) === nextTail) {
+        this.stackCommandTails.delete(candidateStackId);
+      }
+    });
+    this.stackCommandTails.set(candidateStackId, nextTail);
+    return queued;
   }
 
   setRoot(_commandId: string, layout: LayoutRootPayload): Promise<string> {
-    this.pendingStackCommands.clear();
+    this.pendingCommandKeys.clear();
+    this.stackCommandTails.clear();
     const root = normalizeNativeScriptLayout(layout.root);
     const modals = (layout.modals ?? []).map(normalizeNativeScriptLayout);
     const overlays = (layout.overlays ?? []).map(normalizeNativeScriptLayout);
@@ -72,7 +82,7 @@ export class NativeScriptCommandsSender implements NativeCommandsModule {
   push(_commandId: string, componentId: string, layout: object): Promise<string> {
     const node = normalizeNativeScriptLayout(layout);
     const pushedId = node.id ?? '';
-    return this.runStackCommand(componentId, pushedId, () => {
+    return this.runStackCommand('push', componentId, pushedId, () => {
       const mutation = this.store.push(componentId, node);
       return {
         didMutate: mutation.didPush,
@@ -83,7 +93,7 @@ export class NativeScriptCommandsSender implements NativeCommandsModule {
   }
 
   pop(_commandId: string, componentId: string, _options?: object): Promise<string> {
-    return this.runStackCommand(componentId, componentId, () => {
+    return this.runStackCommand('pop', componentId, componentId, () => {
       const stackId = this.store.getStackIdForComponent(componentId);
       const removed = this.store.pop(componentId);
       return {
@@ -95,7 +105,7 @@ export class NativeScriptCommandsSender implements NativeCommandsModule {
   }
 
   popTo(_commandId: string, componentId: string, _options?: object): Promise<string> {
-    return this.runStackCommand(componentId, componentId, () => {
+    return this.runStackCommand('popTo', componentId, componentId, () => {
       const stackId = this.store.getStackIdForComponent(componentId);
       const removed = this.store.popTo(componentId);
       return {
@@ -107,7 +117,7 @@ export class NativeScriptCommandsSender implements NativeCommandsModule {
   }
 
   popToRoot(_commandId: string, componentId: string, _options?: object): Promise<string> {
-    return this.runStackCommand(componentId, componentId, () => {
+    return this.runStackCommand('popToRoot', componentId, componentId, () => {
       const stackId = this.store.getStackIdForComponent(componentId);
       const removed = this.store.popToRoot(componentId);
       return {

--- a/src/nativescript/NativeScriptNavigation.test.tsx
+++ b/src/nativescript/NativeScriptNavigation.test.tsx
@@ -132,6 +132,54 @@ describe('createNativeScriptNavigation', () => {
     expect(finalChildren.map((child) => child.id)).toEqual(['rootComponent', 'detailOne']);
   });
 
+  it('queues opposite stack commands while a transition is pending', async () => {
+    const { Navigation } = createNativeScriptNavigation();
+
+    Navigation.registerComponent('com.example.Root', () => () => null);
+    Navigation.registerComponent('com.example.Detail', () => () => null);
+    await Navigation.setRoot({
+      root: {
+        stack: {
+          id: 'stack',
+          children: [
+            {
+              component: {
+                id: 'rootComponent',
+                name: 'com.example.Root',
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    jest.useFakeTimers();
+    const push = Navigation.push('rootComponent', {
+      component: {
+        id: 'detailComponent',
+        name: 'com.example.Detail',
+      },
+    });
+    const pop = Navigation.pop('detailComponent');
+
+    expect(
+      getNativeScriptNavigationStore().getState().snapshot.root?.children?.map((child) => child.id)
+    ).toEqual(['rootComponent', 'detailComponent']);
+
+    jest.advanceTimersByTime(360);
+    await expect(push).resolves.toBe('detailComponent');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(
+      getNativeScriptNavigationStore().getState().snapshot.root?.children?.map((child) => child.id)
+    ).toEqual(['rootComponent']);
+
+    jest.advanceTimersByTime(360);
+    await expect(pop).resolves.toBe('detailComponent');
+    jest.useRealTimers();
+  });
+
   it('syncs native back changes into the JS stack snapshot', async () => {
     const { Navigation } = createNativeScriptNavigation();
 

--- a/src/nativescript/NativeScriptNavigation.test.tsx
+++ b/src/nativescript/NativeScriptNavigation.test.tsx
@@ -1,0 +1,81 @@
+jest.mock(
+  '@nativescript/react-native',
+  () => ({
+    defineUIViewController: jest.fn(() => function NativeScriptViewController({children}: any) {
+      return children ?? null;
+    }),
+  }),
+  {virtual: true}
+);
+
+import { createNativeScriptNavigation } from './index';
+import { getNativeScriptNavigationStore } from './NativeScriptNavigationSurface';
+
+describe('createNativeScriptNavigation', () => {
+  it('creates a Navigation surface backed by the NativeScript command sender', async () => {
+    const { Navigation, NativeScriptNavigationRoot } = createNativeScriptNavigation();
+
+    Navigation.registerComponent('com.example.Root', () => () => null);
+    const result = await Navigation.setRoot({
+      root: { component: { name: 'com.example.Root', id: 'rootComponent' } },
+    });
+
+    expect(result).toBe('rootComponent');
+    expect(typeof NativeScriptNavigationRoot).toBe('function');
+    expect(getNativeScriptNavigationStore().getState().snapshot.root).toEqual({
+      type: 'Component',
+      id: 'rootComponent',
+      children: [],
+      data: { name: 'com.example.Root', options: {}, passProps: undefined },
+    });
+  });
+
+  it('pushes onto the parent stack when called with a child component id', async () => {
+    const { Navigation } = createNativeScriptNavigation();
+
+    Navigation.registerComponent('com.example.Root', () => () => null);
+    Navigation.registerComponent('com.example.Detail', () => () => null);
+    await Navigation.setRoot({
+      root: {
+        stack: {
+          id: 'stack',
+          children: [
+            {
+              component: {
+                id: 'rootComponent',
+                name: 'com.example.Root',
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    await Navigation.push('rootComponent', {
+      component: {
+        id: 'detailComponent',
+        name: 'com.example.Detail',
+      },
+    });
+
+    expect(getNativeScriptNavigationStore().getState().snapshot.root).toEqual({
+      type: 'Stack',
+      id: 'stack',
+      children: [
+        {
+          type: 'Component',
+          id: 'rootComponent',
+          children: [],
+          data: { name: 'com.example.Root', options: {}, passProps: undefined },
+        },
+        {
+          type: 'Component',
+          id: 'detailComponent',
+          children: [],
+          data: { name: 'com.example.Detail', options: {}, passProps: undefined },
+        },
+      ],
+      data: { options: undefined },
+    });
+  });
+});

--- a/src/nativescript/NativeScriptNavigation.test.tsx
+++ b/src/nativescript/NativeScriptNavigation.test.tsx
@@ -51,12 +51,16 @@ describe('createNativeScriptNavigation', () => {
       },
     });
 
-    await Navigation.push('rootComponent', {
+    jest.useFakeTimers();
+    const push = Navigation.push('rootComponent', {
       component: {
         id: 'detailComponent',
         name: 'com.example.Detail',
       },
     });
+    jest.advanceTimersByTime(360);
+    await push;
+    jest.useRealTimers();
 
     expect(getNativeScriptNavigationStore().getState().snapshot.root).toEqual({
       type: 'Stack',
@@ -77,5 +81,91 @@ describe('createNativeScriptNavigation', () => {
       ],
       data: { options: undefined },
     });
+  });
+
+  it('dedupes rapid pushes while a stack transition is pending', async () => {
+    const { Navigation } = createNativeScriptNavigation();
+
+    Navigation.registerComponent('com.example.Root', () => () => null);
+    Navigation.registerComponent('com.example.Detail', () => () => null);
+    await Navigation.setRoot({
+      root: {
+        stack: {
+          id: 'stack',
+          children: [
+            {
+              component: {
+                id: 'rootComponent',
+                name: 'com.example.Root',
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    jest.useFakeTimers();
+    const firstPush = Navigation.push('rootComponent', {
+      component: {
+        id: 'detailOne',
+        name: 'com.example.Detail',
+      },
+    });
+    const secondPush = Navigation.push('rootComponent', {
+      component: {
+        id: 'detailTwo',
+        name: 'com.example.Detail',
+      },
+    });
+
+    const children =
+      getNativeScriptNavigationStore().getState().snapshot.root?.children ?? [];
+    expect(children.map((child) => child.id)).toEqual(['rootComponent', 'detailOne']);
+
+    jest.advanceTimersByTime(360);
+    await expect(firstPush).resolves.toBe('detailOne');
+    await expect(secondPush).resolves.toBe('detailOne');
+    jest.useRealTimers();
+
+    const finalChildren =
+      getNativeScriptNavigationStore().getState().snapshot.root?.children ?? [];
+    expect(finalChildren.map((child) => child.id)).toEqual(['rootComponent', 'detailOne']);
+  });
+
+  it('syncs native back changes into the JS stack snapshot', async () => {
+    const { Navigation } = createNativeScriptNavigation();
+
+    Navigation.registerComponent('com.example.Root', () => () => null);
+    Navigation.registerComponent('com.example.Detail', () => () => null);
+    await Navigation.setRoot({
+      root: {
+        stack: {
+          id: 'stack',
+          children: [
+            {
+              component: {
+                id: 'rootComponent',
+                name: 'com.example.Root',
+              },
+            },
+            {
+              component: {
+                id: 'detailComponent',
+                name: 'com.example.Detail',
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    const removed = getNativeScriptNavigationStore().syncStackChildren('stack', [
+      'rootComponent',
+    ]);
+
+    expect(removed).toEqual(['detailComponent']);
+    expect(
+      getNativeScriptNavigationStore().getState().snapshot.root?.children?.map((child) => child.id)
+    ).toEqual(['rootComponent']);
   });
 });

--- a/src/nativescript/NativeScriptNavigation.tsx
+++ b/src/nativescript/NativeScriptNavigation.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { NavigationRoot } from '../Navigation';
+import { NativeEventsReceiver } from '../adapters/NativeEventsReceiver';
+import { AppRegistryService } from '../adapters/AppRegistryService';
+import { NativeScriptCommandsSender } from './NativeScriptCommandsSender';
+import { NativeScriptNavigationSurface } from './NativeScriptNavigationSurface';
+
+type NativeScriptNavigationApi = Record<string, any> & {
+  registerComponent(...args: any[]): any;
+  setRoot(layout: any): Promise<string>;
+  setDefaultOptions(options: any): void;
+  mergeOptions(componentId: string, options: any): void;
+};
+
+export type NativeScriptNavigationInstance = {
+  Navigation: NativeScriptNavigationApi;
+  NativeScriptNavigationRoot: React.ComponentType<{attachController?: boolean}>;
+};
+
+export function createNativeScriptNavigation(
+  appRegistryService = new AppRegistryService()
+): NativeScriptNavigationInstance {
+  const Navigation = new NavigationRoot(
+    new NativeScriptCommandsSender(),
+    new NativeEventsReceiver(),
+    appRegistryService
+  );
+
+  const NativeScriptNavigationRoot = function NativeScriptNavigationRoot({
+    attachController = true,
+  }: {
+    attachController?: boolean;
+  }) {
+    return (
+      <NativeScriptNavigationSurface
+        attachController={attachController}
+        store={Navigation.store}
+      />
+    );
+  };
+
+  return { Navigation, NativeScriptNavigationRoot };
+}
+
+export function registerNativeScriptNavigationRoot(appKey = 'ReactNativeNavigation') {
+  const appRegistryService = new AppRegistryService();
+  const navigation = createNativeScriptNavigation(appRegistryService);
+  appRegistryService.registerComponent(appKey, () => navigation.NativeScriptNavigationRoot);
+  return navigation;
+}

--- a/src/nativescript/NativeScriptNavigationSurface.tsx
+++ b/src/nativescript/NativeScriptNavigationSurface.tsx
@@ -58,6 +58,7 @@ const NativeScript = require('@nativescript/react-native') as
 const NativeScriptRuntime = ((NativeScript as {default?: NativeScriptModule}).default ??
   NativeScript) as NativeScriptModule;
 const initialWindowHeight = Dimensions.get('window').height;
+const NATIVE_STACK_TRANSITION_MS = 360;
 
 function makeNativeScriptNavigationStore(): NativeScriptNavigationStore {
   let state: NavigationSurfaceState = {
@@ -933,6 +934,9 @@ function getNavigationRegistry(globalObject: Record<string, any>): any {
   registry.parentChildren = registry.parentChildren ?? {};
   registry.containerChildKeys = registry.containerChildKeys ?? {};
   registry.containerChildCounts = registry.containerChildCounts ?? {};
+  registry.containerTransitioning = registry.containerTransitioning ?? {};
+  registry.containerTransitionTokens = registry.containerTransitionTokens ?? {};
+  registry.pendingNativeBackPresses = registry.pendingNativeBackPresses ?? {};
   globalObject[key] = registry;
   return registry;
 }
@@ -1101,8 +1105,41 @@ function configureNativeBackButton(controller: any, props: any, registry: any, c
   if (typeof button.sizeToFit === 'function') {
     button.sizeToFit();
   }
+  const currentWidth = button.frame?.size?.width ?? 0;
+  const CGRectMake = api?.CGRectMake ?? globalObject.CGRectMake;
+  if (typeof CGRectMake === 'function') {
+    button.frame = CGRectMake(0, 0, Math.max(96, currentWidth + 20), 44);
+  }
+  button.accessibilityIdentifier = `RNNBackButton.${props.componentId}`;
+  button.accessibilityLabel = backTitle;
+  button.exclusiveTouch = true;
   ctx.targetAction(button, UIControlEvents?.TouchUpInside ?? 64, () => {
     'worklet';
+    if (registry.containerTransitioning[props.parentId]) {
+      if (registry.pendingNativeBackPresses[props.parentId]) {
+        return;
+      }
+      registry.pendingNativeBackPresses[props.parentId] = true;
+      if (typeof setTimeout === 'function') {
+        setTimeout(() => {
+          'worklet';
+          registry.pendingNativeBackPresses[props.parentId] = false;
+          ctx.emit('onNativeBackPress', {
+            nativeEvent: {
+              componentId: props.componentId,
+            },
+          });
+        }, NATIVE_STACK_TRANSITION_MS);
+      } else {
+        registry.pendingNativeBackPresses[props.parentId] = false;
+        ctx.emit('onNativeBackPress', {
+          nativeEvent: {
+            componentId: props.componentId,
+          },
+        });
+      }
+      return;
+    }
     ctx.emit('onNativeBackPress', {
       nativeEvent: {
         componentId: props.componentId,
@@ -1136,6 +1173,30 @@ function emitNativeStackChange(ctx: any, navigationController: any) {
       childIds,
     },
   });
+}
+
+function applyNavigationChildren(
+  parent: any,
+  parentId: string,
+  registry: any,
+  globalObject: Record<string, any>,
+  animated: boolean,
+) {
+  'worklet';
+  const children = registry.parentChildren[parentId] ?? [];
+  const collected = collectChildControllers(parent, children, registry);
+  const childControllers = collected.controllers;
+  if (childControllers.length === 0) {
+    return;
+  }
+  const nativeChildControllers = nativeControllerArray(globalObject, childControllers);
+  if (typeof parent.setViewControllersAnimated === 'function') {
+    parent.setViewControllersAnimated(nativeChildControllers, animated);
+  } else {
+    parent.viewControllers = nativeChildControllers;
+  }
+  layoutVisibleController(parent);
+  scheduleAncestorTabBarFront(parent);
 }
 
 function reconcileNavigationChildren(
@@ -1173,6 +1234,28 @@ function reconcileNavigationChildren(
       previousKey != null &&
       previousCount > 0 &&
       Math.abs(nextCount - previousCount) === 1;
+    if (!didChangeChildren && registry.containerTransitioning[parentId]) {
+      layoutVisibleController(parent);
+      scheduleAncestorTabBarFront(parent);
+      return;
+    }
+    if (animated) {
+      const transitionToken = (registry.containerTransitionTokens[parentId] ?? 0) + 1;
+      registry.containerTransitionTokens[parentId] = transitionToken;
+      registry.containerTransitioning[parentId] = true;
+      if (typeof setTimeout === 'function') {
+        setTimeout(() => {
+          'worklet';
+          if (registry.containerTransitionTokens[parentId] !== transitionToken) {
+            return;
+          }
+          registry.containerTransitioning[parentId] = false;
+          applyNavigationChildren(parent, parentId, registry, globalObject, false);
+        }, NATIVE_STACK_TRANSITION_MS);
+      } else {
+        registry.containerTransitioning[parentId] = false;
+      }
+    }
     if (typeof parent.setViewControllersAnimated === 'function') {
       parent.setViewControllersAnimated(nativeChildControllers, animated);
     } else {

--- a/src/nativescript/NativeScriptNavigationSurface.tsx
+++ b/src/nativescript/NativeScriptNavigationSurface.tsx
@@ -1,0 +1,1691 @@
+import * as React from 'react';
+import { Dimensions, StyleSheet, View } from 'react-native';
+import { Store } from '../components/Store';
+import { Layout } from '../interfaces/Layout';
+import { Options } from '../interfaces/Options';
+
+type NativeScriptModule = typeof import('@nativescript/react-native');
+
+type ParsedLayoutNode = {
+  id?: string;
+  type?: string;
+  data?: {
+    name?: string | number;
+    passProps?: object;
+    options?: Options;
+  };
+  children?: ParsedLayoutNode[];
+};
+
+type NativeScriptNavigationSnapshot = {
+  root?: ParsedLayoutNode;
+  modals: ParsedLayoutNode[];
+  overlays: ParsedLayoutNode[];
+};
+
+type NavigationSurfaceState = {
+  snapshot: NativeScriptNavigationSnapshot;
+  defaultOptions: Options;
+  mergedOptions: Record<string, Options>;
+};
+
+type NavigationStoreListener = () => void;
+
+type NativeScriptNavigationStore = {
+  getState(): NavigationSurfaceState;
+  subscribe(listener: NavigationStoreListener): () => void;
+  setRoot(root: ParsedLayoutNode, modals?: ParsedLayoutNode[], overlays?: ParsedLayoutNode[]): void;
+  setDefaultOptions(options: Options): void;
+  mergeOptions(componentId: string, options: Options): void;
+  push(componentId: string, layout: ParsedLayoutNode): void;
+  pop(componentId: string): string | undefined;
+  popTo(componentId: string): string | undefined;
+  popToRoot(componentId: string): string | undefined;
+  setStackRoot(componentId: string, children: ParsedLayoutNode[]): void;
+  showModal(layout: ParsedLayoutNode): void;
+  dismissModal(componentId: string): string | undefined;
+  dismissAllModals(): void;
+  showOverlay(layout: ParsedLayoutNode): void;
+  dismissOverlay(componentId: string): string | undefined;
+  dismissAllOverlays(): void;
+};
+
+const NativeScript = require('@nativescript/react-native') as
+  | NativeScriptModule
+  | (NativeScriptModule & {default?: NativeScriptModule});
+const NativeScriptRuntime = ((NativeScript as {default?: NativeScriptModule}).default ??
+  NativeScript) as NativeScriptModule;
+const initialWindowHeight = Dimensions.get('window').height;
+
+function makeNativeScriptNavigationStore(): NativeScriptNavigationStore {
+  let state: NavigationSurfaceState = {
+    snapshot: {modals: [], overlays: []},
+    defaultOptions: {},
+    mergedOptions: {},
+  };
+  const listeners = new Set<NavigationStoreListener>();
+
+  const emit = () => {
+    for (const listener of Array.from(listeners)) {
+      listener();
+    }
+  };
+
+  const replaceState = (next: NavigationSurfaceState) => {
+    state = next;
+    emit();
+  };
+
+  const mutateTree = (
+    root: ParsedLayoutNode | undefined,
+    componentId: string,
+    mutator: (node: ParsedLayoutNode, parent?: ParsedLayoutNode) => void,
+    parent?: ParsedLayoutNode,
+  ): boolean => {
+    if (!root) {
+      return false;
+    }
+    if (root.id === componentId) {
+      mutator(root, parent);
+      return true;
+    }
+    for (const child of root.children ?? []) {
+      if (mutateTree(child, componentId, mutator, root)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const removeFromTree = (
+    root: ParsedLayoutNode | undefined,
+    componentId: string,
+  ): string | undefined => {
+    if (!root?.children) {
+      return undefined;
+    }
+    const index = root.children.findIndex((child) => child.id === componentId);
+    if (index >= 0) {
+      return root.children.splice(index, 1)[0]?.id;
+    }
+    for (const child of root.children) {
+      const removed = removeFromTree(child, componentId);
+      if (removed) {
+        return removed;
+      }
+    }
+    return undefined;
+  };
+
+  return {
+    getState: () => state,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    setRoot(root, modals = [], overlays = []) {
+      replaceState({
+        ...state,
+        snapshot: {root, modals, overlays},
+      });
+    },
+    setDefaultOptions(options) {
+      replaceState({...state, defaultOptions: options});
+    },
+    mergeOptions(componentId, options) {
+      replaceState({
+        ...state,
+        mergedOptions: {
+          ...state.mergedOptions,
+          [componentId]: {
+            ...(state.mergedOptions[componentId] ?? {}),
+            ...options,
+          },
+        },
+      });
+    },
+    push(componentId, layout) {
+      const snapshot = cloneSnapshot(state.snapshot);
+      let didPush = false;
+      mutateTree(snapshot.root, componentId, (node, parent) => {
+        const stackNode = node.type === 'Stack' ? node : parent?.type === 'Stack' ? parent : undefined;
+        if (stackNode) {
+          stackNode.children = [...(stackNode.children ?? []), layout];
+          didPush = true;
+        }
+      });
+      if (didPush) {
+        replaceState({...state, snapshot});
+      }
+    },
+    pop(componentId) {
+      const snapshot = cloneSnapshot(state.snapshot);
+      let removed: string | undefined;
+      mutateTree(snapshot.root, componentId, (_node, parent) => {
+        if (parent?.type === 'Stack' && parent.children && parent.children.length > 1) {
+          removed = parent.children.pop()?.id;
+        }
+      });
+      if (removed) {
+        replaceState({...state, snapshot});
+      }
+      return removed;
+    },
+    popTo(componentId) {
+      const snapshot = cloneSnapshot(state.snapshot);
+      let removed: string | undefined;
+      const trim = (node: ParsedLayoutNode): boolean => {
+        if (node.type === 'Stack' && node.children?.some((child) => child.id === componentId)) {
+          const index = node.children.findIndex((child) => child.id === componentId);
+          removed = node.children[node.children.length - 1]?.id;
+          node.children = node.children.slice(0, index + 1);
+          return true;
+        }
+        return (node.children ?? []).some(trim);
+      };
+      if (snapshot.root && trim(snapshot.root)) {
+        replaceState({...state, snapshot});
+      }
+      return removed;
+    },
+    popToRoot(componentId) {
+      const snapshot = cloneSnapshot(state.snapshot);
+      let removed: string | undefined;
+      mutateTree(snapshot.root, componentId, (_node, parent) => {
+        if (parent?.type === 'Stack' && parent.children && parent.children.length > 1) {
+          removed = parent.children[parent.children.length - 1]?.id;
+          parent.children = parent.children.slice(0, 1);
+        }
+      });
+      if (removed) {
+        replaceState({...state, snapshot});
+      }
+      return removed;
+    },
+    setStackRoot(componentId, children) {
+      const snapshot = cloneSnapshot(state.snapshot);
+      mutateTree(snapshot.root, componentId, (node) => {
+        if (node.type === 'Stack') {
+          node.children = children;
+        }
+      });
+      replaceState({...state, snapshot});
+    },
+    showModal(layout) {
+      replaceState({
+        ...state,
+        snapshot: {
+          ...state.snapshot,
+          modals: [...state.snapshot.modals, layout],
+        },
+      });
+    },
+    dismissModal(componentId) {
+      const snapshot = cloneSnapshot(state.snapshot);
+      const index = snapshot.modals.findIndex((modal) => includesLayoutId(modal, componentId));
+      if (index < 0) {
+        return undefined;
+      }
+      const removed = snapshot.modals.splice(index, 1)[0]?.id ?? componentId;
+      replaceState({...state, snapshot});
+      return removed;
+    },
+    dismissAllModals() {
+      replaceState({
+        ...state,
+        snapshot: {...state.snapshot, modals: []},
+      });
+    },
+    showOverlay(layout) {
+      replaceState({
+        ...state,
+        snapshot: {
+          ...state.snapshot,
+          overlays: [...state.snapshot.overlays, layout],
+        },
+      });
+    },
+    dismissOverlay(componentId) {
+      const snapshot = cloneSnapshot(state.snapshot);
+      let removed: string | undefined;
+      const direct = snapshot.overlays.findIndex((overlay) => overlay.id === componentId);
+      if (direct >= 0) {
+        removed = snapshot.overlays.splice(direct, 1)[0]?.id;
+      } else {
+        for (const overlay of snapshot.overlays) {
+          removed = removeFromTree(overlay, componentId);
+          if (removed) {
+            break;
+          }
+        }
+      }
+      if (removed) {
+        replaceState({...state, snapshot});
+      }
+      return removed;
+    },
+    dismissAllOverlays() {
+      replaceState({
+        ...state,
+        snapshot: {...state.snapshot, overlays: []},
+      });
+    },
+  };
+}
+
+const navigationStore = makeNativeScriptNavigationStore();
+
+export function getNativeScriptNavigationStore(): NativeScriptNavigationStore {
+  return navigationStore;
+}
+
+export function normalizeNativeScriptLayout(layout: Layout | ParsedLayoutNode): ParsedLayoutNode {
+  if ((layout as ParsedLayoutNode).type) {
+    return cloneNode(layout as ParsedLayoutNode);
+  }
+
+  const source = layout as Layout;
+  if (source.component) {
+    return {
+      id: source.component.id,
+      type: 'Component',
+      data: {
+        name: source.component.name,
+        passProps: source.component.passProps,
+        options: source.component.options,
+      },
+    };
+  }
+  if (source.externalComponent) {
+    return {
+      id: source.externalComponent.id,
+      type: 'ExternalComponent',
+      data: {
+        name: source.externalComponent.name,
+        passProps: source.externalComponent.passProps,
+        options: source.externalComponent.options,
+      },
+    };
+  }
+  if (source.stack) {
+    return {
+      id: source.stack.id,
+      type: 'Stack',
+      data: {options: source.stack.options},
+      children: (source.stack.children ?? []).map((child) =>
+        normalizeNativeScriptLayout(child as Layout),
+      ),
+    };
+  }
+  if (source.bottomTabs) {
+    return {
+      id: source.bottomTabs.id,
+      type: 'BottomTabs',
+      data: {options: source.bottomTabs.options},
+      children: (source.bottomTabs.children ?? []).map((child) =>
+        normalizeNativeScriptLayout(child as Layout),
+      ),
+    };
+  }
+  if (source.topTabs) {
+    return {
+      id: source.topTabs.id,
+      type: 'TopTabs',
+      data: {options: source.topTabs.options},
+      children: (source.topTabs.children ?? []).map((child) =>
+        normalizeNativeScriptLayout(child as Layout),
+      ),
+    };
+  }
+  if (source.sideMenu) {
+    return normalizeNativeScriptLayout(source.sideMenu.center as Layout);
+  }
+  if (source.splitView) {
+    return normalizeNativeScriptLayout((source.splitView.detail ?? source.splitView.master) as Layout);
+  }
+  return {type: 'Component', data: {name: 'Unknown'}};
+}
+
+export function NativeScriptNavigationSurface({
+  attachController = true,
+  store,
+}: {
+  attachController?: boolean;
+  store: Store;
+}) {
+  return (
+    <NativeScriptNavigationSurfaceContent
+      attachController={attachController}
+      store={store}
+    />
+  );
+}
+
+export function NativeScriptNavigationSurfaceContent({
+  attachController,
+  store,
+}: {
+  attachController: boolean;
+  store: Store;
+}) {
+  const state = React.useSyncExternalStore(
+    navigationStore.subscribe,
+    navigationStore.getState,
+    navigationStore.getState,
+  );
+
+  return (
+    <View collapsable={false} style={styles.rootFill}>
+      {state.snapshot.root ? (
+        <NativeScriptLayoutNode
+          node={state.snapshot.root}
+          attachRootController={attachController}
+          store={store}
+          mergedOptions={state.mergedOptions}
+        />
+      ) : null}
+      {state.snapshot.modals.map((modal) => (
+        <NativeScriptModalNode
+          key={modal.id}
+          node={modal}
+          attachRootController
+          store={store}
+          mergedOptions={state.mergedOptions}
+        />
+      ))}
+      {state.snapshot.overlays.map((overlay) => (
+        <NativeScriptOverlayNode
+          key={overlay.id}
+          node={overlay}
+          attachRootController
+          store={store}
+          mergedOptions={state.mergedOptions}
+        />
+      ))}
+    </View>
+  );
+}
+
+function NativeScriptLayoutNode({
+  attachRootController,
+  node,
+  parentId,
+  store,
+  mergedOptions,
+}: {
+  attachRootController: boolean;
+  node: ParsedLayoutNode;
+  parentId?: string;
+  store: Store;
+  mergedOptions: Record<string, Options>;
+}) {
+  const componentId = node.id ?? `${node.type ?? 'node'}-${Math.random().toString(36).slice(2)}`;
+  const options = mergeOptions(node.data?.options, mergedOptions[componentId]);
+  const attachToReactView = parentId == null;
+
+  if (node.type === 'Stack') {
+    return (
+      <NativeScriptStackController
+        attachController={parentId == null ? attachRootController : false}
+        attachNativeView={attachToReactView}
+        componentId={componentId}
+        options={options}
+        parentId={parentId}
+        style={styles.rootFill}>
+        {(node.children ?? []).map((child) => (
+          <NativeScriptLayoutNode
+            key={child.id}
+            attachRootController={attachRootController}
+            node={child}
+            parentId={componentId}
+            store={store}
+            mergedOptions={mergedOptions}
+          />
+        ))}
+      </NativeScriptStackController>
+    );
+  }
+
+  if (node.type === 'BottomTabs' || node.type === 'TopTabs') {
+    return (
+      <NativeScriptTabsController
+        attachController={parentId == null ? attachRootController : false}
+        attachNativeView={attachToReactView}
+        componentId={componentId}
+        options={options}
+        parentId={parentId}
+        style={styles.rootFill}>
+        {(node.children ?? []).map((child) => (
+          <NativeScriptLayoutNode
+            key={child.id}
+            attachRootController={attachRootController}
+            node={child}
+            parentId={componentId}
+            store={store}
+            mergedOptions={mergedOptions}
+          />
+        ))}
+      </NativeScriptTabsController>
+    );
+  }
+
+  return (
+    <NativeScriptComponentController
+      attachController={parentId == null ? attachRootController : false}
+      attachNativeView={attachToReactView}
+      componentId={componentId}
+      componentName={node.data?.name}
+      options={options}
+      parentId={parentId}
+      style={styles.rootFill}>
+      <RegisteredComponent
+        componentId={componentId}
+        componentName={node.data?.name}
+        passProps={node.data?.passProps}
+        store={store}
+      />
+    </NativeScriptComponentController>
+  );
+}
+
+function NativeScriptModalNode({
+  attachRootController,
+  node,
+  store,
+  mergedOptions,
+}: {
+  attachRootController: boolean;
+  node: ParsedLayoutNode;
+  store: Store;
+  mergedOptions: Record<string, Options>;
+}) {
+  return (
+    <NativeScriptPresentedController componentId={node.id} presentation="modal" style={styles.fill}>
+      <NativeScriptLayoutNode
+        attachRootController={attachRootController}
+        node={node}
+        store={store}
+        mergedOptions={mergedOptions}
+      />
+    </NativeScriptPresentedController>
+  );
+}
+
+function NativeScriptOverlayNode({
+  attachRootController,
+  node,
+  store,
+  mergedOptions,
+}: {
+  attachRootController: boolean;
+  node: ParsedLayoutNode;
+  store: Store;
+  mergedOptions: Record<string, Options>;
+}) {
+  return (
+    <NativeScriptPresentedController componentId={node.id} presentation="overlay" style={styles.fill}>
+      <NativeScriptLayoutNode
+        attachRootController={attachRootController}
+        node={node}
+        store={store}
+        mergedOptions={mergedOptions}
+      />
+    </NativeScriptPresentedController>
+  );
+}
+
+function RegisteredComponent({
+  componentId,
+  componentName,
+  passProps,
+  store,
+}: {
+  componentId: string;
+  componentName?: string | number;
+  passProps?: object;
+  store: Store;
+}) {
+  if (componentName == null) {
+    return null;
+  }
+  const componentProvider = store.getComponentClassForName(componentName);
+  if (!componentProvider) {
+    return null;
+  }
+  const Component = componentProvider() as React.ComponentType<any>;
+  return (
+    <View collapsable={false} style={styles.rootFill}>
+      <Component {...passProps} componentId={componentId} />
+    </View>
+  );
+}
+
+function viewContainsDescendant(view: any, descendant: any): boolean {
+  'worklet';
+  if (!view || !descendant || typeof descendant.isDescendantOfView !== 'function') {
+    return false;
+  }
+  try {
+    return descendant.isDescendantOfView(view) === true;
+  } catch {
+    return false;
+  }
+}
+
+function isNativeKind(view: any, nativeClass: any): boolean {
+  'worklet';
+  if (!view || !nativeClass || typeof view.isKindOfClass !== 'function') {
+    return false;
+  }
+  try {
+    return view.isKindOfClass(nativeClass) === true;
+  } catch {
+    return false;
+  }
+}
+
+function firstDescendantOfKind(view: any, nativeClass: any, depth: number): any {
+  'worklet';
+  if (!view || depth > 6) {
+    return null;
+  }
+  if (isNativeKind(view, nativeClass)) {
+    return view;
+  }
+  const subviews = view.subviews;
+  const count = !subviews ? 0 : typeof subviews.count === 'number' ? subviews.count : (subviews.length ?? 0);
+  for (let index = 0; index < count; index++) {
+    const subview =
+      subviews && typeof subviews.objectAtIndex === 'function'
+        ? subviews.objectAtIndex(index)
+        : subviews?.[index];
+    const found = firstDescendantOfKind(subview, nativeClass, depth + 1);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+}
+
+function keepAncestorTabBarFront(controller: any) {
+  'worklet';
+  const startView = controller?.view;
+  const globalObject = globalThis as Record<string, any>;
+  const api = globalObject.__nativeScriptNativeApi;
+  const UITabBar = api?.UITabBar ?? globalObject.UITabBar;
+  if (!startView || !UITabBar) {
+    return;
+  }
+  let currentView = startView;
+  for (let depth = 0; currentView && depth < 12; depth++) {
+    const parent = currentView.superview;
+    if (!parent) {
+      return;
+    }
+    const subviews = parent.subviews;
+    const count = !subviews ? 0 : typeof subviews.count === 'number' ? subviews.count : (subviews.length ?? 0);
+    for (let index = 0; index < count; index++) {
+      const candidate =
+        subviews && typeof subviews.objectAtIndex === 'function'
+          ? subviews.objectAtIndex(index)
+          : subviews?.[index];
+      if (!candidate || candidate === currentView || viewContainsDescendant(candidate, startView)) {
+        continue;
+      }
+      const tabBar = firstDescendantOfKind(candidate, UITabBar, 0);
+      if (!tabBar) {
+        continue;
+      }
+      tabBar.hidden = false;
+      tabBar.alpha = 1;
+      tabBar.userInteractionEnabled = true;
+      if (tabBar.layer) {
+        tabBar.layer.zPosition = 1000;
+      }
+      if (candidate.layer) {
+        candidate.layer.zPosition = 1000;
+      }
+      if (typeof parent.bringSubviewToFront === 'function') {
+        parent.bringSubviewToFront(candidate);
+      }
+      return;
+    }
+    currentView = parent;
+  }
+}
+
+function scheduleAncestorTabBarFront(controller: any) {
+  'worklet';
+  keepAncestorTabBarFront(controller);
+  if (typeof setTimeout !== 'function') {
+    return;
+  }
+  const restore = () => {
+    'worklet';
+    keepAncestorTabBarFront(controller);
+  };
+  setTimeout(restore, 0);
+  setTimeout(restore, 32);
+  setTimeout(restore, 120);
+}
+
+function nativeValue(name: string): any {
+  'worklet';
+  const globalObject = globalThis as Record<string, any>;
+  const api = globalObject.__nativeScriptNativeApi;
+  return api?.[name] ?? globalObject[name];
+}
+
+function nativeColor(value: unknown, fallback: string): any {
+  'worklet';
+  const UIColor = nativeValue('UIColor');
+  if (!UIColor) {
+    return null;
+  }
+  if (typeof value === 'string' && value[0] === '#' && value.length === 7) {
+    const red = parseInt(value.slice(1, 3), 16) / 255;
+    const green = parseInt(value.slice(3, 5), 16) / 255;
+    const blue = parseInt(value.slice(5, 7), 16) / 255;
+    if (
+      Number.isFinite(red) &&
+      Number.isFinite(green) &&
+      Number.isFinite(blue) &&
+      typeof UIColor.colorWithRedGreenBlueAlpha === 'function'
+    ) {
+      return UIColor.colorWithRedGreenBlueAlpha(red, green, blue, 1);
+    }
+  }
+  if (value && typeof value === 'object') {
+    return value;
+  }
+  return UIColor[fallback] ?? null;
+}
+
+function arrayItem(array: any, index: number): any {
+  'worklet';
+  if (!array) {
+    return null;
+  }
+  if (typeof array.objectAtIndex === 'function') {
+    return array.objectAtIndex(index);
+  }
+  return array[index];
+}
+
+function arrayCount(array: any): number {
+  'worklet';
+  if (!array) {
+    return 0;
+  }
+  return typeof array.count === 'number' ? array.count : (array.length ?? 0);
+}
+
+function flexibleSizeMask(): number {
+  'worklet';
+  const autoresizing = nativeValue('UIViewAutoresizing');
+  return (autoresizing?.FlexibleWidth ?? 2) + (autoresizing?.FlexibleHeight ?? 16);
+}
+
+function isNativeScrollView(view: any): boolean {
+  'worklet';
+  const UIScrollView = nativeValue('UIScrollView');
+  if (!view || !UIScrollView || typeof view.isKindOfClass !== 'function') {
+    return false;
+  }
+  try {
+    return view.isKindOfClass(UIScrollView) === true;
+  } catch {
+    return false;
+  }
+}
+
+function shouldFillHostedSubview(rootView: any, subview: any): boolean {
+  'worklet';
+  const parentBounds = rootView?.bounds ?? rootView?.frame;
+  const frame = subview?.frame;
+  const parentWidth = parentBounds?.size?.width ?? 0;
+  const childWidth = frame?.size?.width ?? 0;
+  const originX = frame?.origin?.x ?? 0;
+  const originY = frame?.origin?.y ?? 0;
+  if (parentWidth <= 0) {
+    return false;
+  }
+  return (
+    Math.abs(originX) < 1 &&
+    Math.abs(originY) < 1 &&
+    (childWidth <= 0 || Math.abs(childWidth - parentWidth) < 2)
+  );
+}
+
+function layoutSingleHostedSubviewChain(rootView: any, depth: number) {
+  'worklet';
+  if (!rootView || depth > 8 || isNativeScrollView(rootView)) {
+    return;
+  }
+  const subviews = rootView.subviews;
+  const count = arrayCount(subviews);
+  for (let index = 0; index < count; index++) {
+    const subview = arrayItem(subviews, index);
+    if (!subview || !shouldFillHostedSubview(rootView, subview)) {
+      continue;
+    }
+    subview.frame = rootView.bounds;
+    subview.autoresizingMask = flexibleSizeMask();
+    if (typeof subview.setNeedsLayout === 'function') {
+      subview.setNeedsLayout();
+    }
+    if (typeof subview.layoutIfNeeded === 'function') {
+      subview.layoutIfNeeded();
+    }
+    layoutSingleHostedSubviewChain(subview, depth + 1);
+  }
+}
+
+function layoutHostedReactSubviews(controller: any) {
+  'worklet';
+  const rootView = controller?.view;
+  if (!rootView) {
+    return;
+  }
+  if (typeof rootView.setNeedsLayout === 'function') {
+    rootView.setNeedsLayout();
+  }
+  if (typeof rootView.layoutIfNeeded === 'function') {
+    rootView.layoutIfNeeded();
+  }
+  const mask = flexibleSizeMask();
+  const subviews = rootView.subviews;
+  const count = arrayCount(subviews);
+  for (let index = 0; index < count; index++) {
+    const subview = arrayItem(subviews, index);
+    if (subview) {
+      subview.frame = rootView.bounds;
+      subview.autoresizingMask = mask;
+      layoutSingleHostedSubviewChain(subview, 0);
+    }
+  }
+}
+
+function layoutVisibleController(controller: any) {
+  'worklet';
+  if (!controller?.view) {
+    return;
+  }
+  if (typeof controller.view.setNeedsLayout === 'function') {
+    controller.view.setNeedsLayout();
+  }
+  if (typeof controller.view.layoutIfNeeded === 'function') {
+    controller.view.layoutIfNeeded();
+  }
+  const visibleController =
+    controller.visibleViewController ?? controller.selectedViewController ?? controller.topViewController;
+  if (visibleController && visibleController !== controller) {
+    layoutVisibleController(visibleController);
+    return;
+  }
+  layoutHostedReactSubviews(controller);
+}
+
+function rectEdgeAll(): number {
+  'worklet';
+  const edge = nativeValue('UIRectEdge');
+  return edge?.All ?? edge?.all ?? 15;
+}
+
+function configureExtendedLayout(controller: any) {
+  'worklet';
+  if (!controller) {
+    return;
+  }
+  controller.edgesForExtendedLayout = rectEdgeAll();
+  controller.extendedLayoutIncludesOpaqueBars = true;
+}
+
+function configureNavigationBar(controller: any) {
+  'worklet';
+  const navigationBar = controller?.navigationBar;
+  if (!navigationBar) {
+    return;
+  }
+  configureExtendedLayout(controller);
+  navigationBar.translucent = true;
+  navigationBar.prefersLargeTitles = false;
+  const UIColor = nativeValue('UIColor');
+  const clearColor = UIColor?.clearColor ?? null;
+  if (clearColor) {
+    navigationBar.backgroundColor = clearColor;
+  }
+  const UINavigationBarAppearance = nativeValue('UINavigationBarAppearance');
+  if (UINavigationBarAppearance && typeof UINavigationBarAppearance.alloc === 'function') {
+    const allocated = UINavigationBarAppearance.alloc();
+    const appearance =
+      allocated && typeof allocated.init === 'function' ? allocated.init() : allocated;
+    if (typeof appearance.configureWithTransparentBackground === 'function') {
+      appearance.configureWithTransparentBackground();
+    } else if (typeof appearance.configureWithDefaultBackground === 'function') {
+      appearance.configureWithDefaultBackground();
+    }
+    if (clearColor) {
+      appearance.backgroundColor = clearColor;
+      appearance.shadowColor = clearColor;
+    }
+    navigationBar.standardAppearance = appearance;
+    navigationBar.scrollEdgeAppearance = appearance;
+    navigationBar.compactAppearance = appearance;
+  }
+}
+
+const NativeScriptComponentController = NativeScriptRuntime.defineUIViewController<{
+  componentId: string;
+  componentName?: string | number;
+  options?: Options;
+  parentId?: string;
+  style?: unknown;
+}, any>({
+  debugName: 'RNNComponentViewController',
+  layout: {sizing: 'fill'},
+  createController({componentId, componentName, options}) {
+    'worklet';
+    const api = (globalThis as Record<string, any>).__nativeScriptNativeApi;
+    const globals = globalThis as Record<string, any>;
+    const UIViewController = api?.UIViewController ?? globals.UIViewController;
+    if (!UIViewController || typeof UIViewController.alloc !== 'function') {
+      throw new Error(`UIViewController is not allocatable in the UI runtime: ${typeof UIViewController}`);
+    }
+    const allocated = UIViewController.alloc();
+    const controller = allocated && typeof allocated.init === 'function' ? allocated.init() : allocated;
+    configureExtendedLayout(controller);
+    const UIColor = api?.UIColor ?? globals.UIColor;
+    controller.view.backgroundColor =
+      nativeColor('#f6f7fb', 'systemBackgroundColor') ?? UIColor.systemBackgroundColor;
+    const topBarTitle = (options as any)?.topBar?.title?.text;
+    const bottomTabTitle = (options as any)?.bottomTab?.text;
+    controller.title = topBarTitle ?? bottomTabTitle ?? (componentName != null ? '' + componentName : componentId);
+    const UITabBarItem = api?.UITabBarItem ?? globals.UITabBarItem;
+    if (UITabBarItem && typeof UITabBarItem.alloc === 'function') {
+      const itemAllocated = UITabBarItem.alloc();
+      const tabBarItem = itemAllocated && typeof itemAllocated.init === 'function' ? itemAllocated.init() : itemAllocated;
+      tabBarItem.title = bottomTabTitle ?? controller.title;
+      const badge = (options as any)?.bottomTab?.badge;
+      if (badge != null) {
+        tabBarItem.badgeValue = '' + badge;
+      }
+      const testID = (options as any)?.bottomTab?.testID;
+      if (testID != null) {
+        tabBarItem.accessibilityIdentifier = '' + testID;
+      }
+      controller.tabBarItem = tabBarItem;
+    }
+    return controller;
+  },
+  childrenView(controller) {
+    'worklet';
+    return controller.view;
+  },
+  update(controller, props) {
+    'worklet';
+    const topBarTitle = (props.options as any)?.topBar?.title?.text;
+    const bottomTabTitle = (props.options as any)?.bottomTab?.text;
+    controller.title =
+      topBarTitle ?? bottomTabTitle ?? (props.componentName != null ? '' + props.componentName : props.componentId);
+    const api = (globalThis as Record<string, any>).__nativeScriptNativeApi;
+    const globals = globalThis as Record<string, any>;
+    const UITabBarItem = api?.UITabBarItem ?? globals.UITabBarItem;
+    if (UITabBarItem && typeof UITabBarItem.alloc === 'function') {
+      const itemAllocated = UITabBarItem.alloc();
+      const tabBarItem = itemAllocated && typeof itemAllocated.init === 'function' ? itemAllocated.init() : itemAllocated;
+      tabBarItem.title = bottomTabTitle ?? controller.title;
+      const badge = (props.options as any)?.bottomTab?.badge;
+      if (badge != null) {
+        tabBarItem.badgeValue = '' + badge;
+      }
+      const testID = (props.options as any)?.bottomTab?.testID;
+      if (testID != null) {
+        tabBarItem.accessibilityIdentifier = '' + testID;
+      }
+      controller.tabBarItem = tabBarItem;
+    }
+    const key = '__rnnNativeScriptNavigationRegistry';
+    const globalObject = globalThis as Record<string, any>;
+    const registry = globalObject[key] ?? {controllers: {}, kinds: {}, parentChildren: {}};
+    globalObject[key] = registry;
+    registry.controllers[props.componentId] = controller;
+    registry.kinds[props.componentId] = 'component';
+    if (props.parentId) {
+      const children = registry.parentChildren[props.parentId] ?? [];
+      let exists = false;
+      for (let index = 0; index < children.length; index++) {
+        if (children[index] === props.componentId) {
+          exists = true;
+          break;
+        }
+      }
+      if (!exists) {
+        children[children.length] = props.componentId;
+        registry.parentChildren[props.parentId] = children;
+      }
+      const parent = registry.controllers[props.parentId];
+      if (parent) {
+        const childControllers: any[] = [];
+        for (let index = 0; index < children.length; index++) {
+          const child = registry.controllers[children[index]];
+          if (child) {
+            const childParent = child.parentViewController;
+            if (childParent && childParent !== parent) {
+              child.willMoveToParentViewController(null);
+              child.removeFromParentViewController();
+            }
+            if (child.view?.superview) {
+              child.view.removeFromSuperview();
+            }
+            childControllers[childControllers.length] = child;
+          }
+        }
+        const kind = registry.kinds[props.parentId];
+        const NSArray = api?.NSArray ?? globals.NSArray;
+        const nativeChildControllers =
+          NSArray && typeof NSArray.arrayWithArray === 'function'
+            ? NSArray.arrayWithArray(childControllers)
+            : childControllers;
+        if (kind === 'stack' && childControllers.length > 0) {
+          parent.setViewControllersAnimated(nativeChildControllers, false);
+        } else if (kind === 'tabs') {
+          if (typeof parent.setViewControllersAnimated === 'function') {
+            parent.setViewControllersAnimated(nativeChildControllers, false);
+          } else {
+            parent.viewControllers = nativeChildControllers;
+          }
+          if (parent.selectedIndex >= childControllers.length) {
+            parent.selectedIndex = 0;
+          }
+        }
+        layoutVisibleController(parent);
+      }
+    }
+    layoutVisibleController(controller);
+    scheduleAncestorTabBarFront(controller);
+  },
+  mounted(controller, props) {
+    'worklet';
+    const key = '__rnnNativeScriptNavigationRegistry';
+    const globalObject = globalThis as Record<string, any>;
+    const registry = globalObject[key] ?? {controllers: {}, kinds: {}, parentChildren: {}};
+    globalObject[key] = registry;
+    registry.controllers[props.componentId] = controller;
+    registry.kinds[props.componentId] = 'component';
+    if (props.parentId) {
+      const children = registry.parentChildren[props.parentId] ?? [];
+      let exists = false;
+      for (let index = 0; index < children.length; index++) {
+        if (children[index] === props.componentId) {
+          exists = true;
+          break;
+        }
+      }
+      if (!exists) {
+        children[children.length] = props.componentId;
+        registry.parentChildren[props.parentId] = children;
+      }
+      const parent = registry.controllers[props.parentId];
+      if (parent) {
+        const childControllers: any[] = [];
+        for (let index = 0; index < children.length; index++) {
+          const child = registry.controllers[children[index]];
+          if (child) {
+            const childParent = child.parentViewController;
+            if (childParent && childParent !== parent) {
+              child.willMoveToParentViewController(null);
+              child.removeFromParentViewController();
+            }
+            if (child.view?.superview) {
+              child.view.removeFromSuperview();
+            }
+            childControllers[childControllers.length] = child;
+          }
+        }
+        const kind = registry.kinds[props.parentId];
+        const api = globalObject.__nativeScriptNativeApi;
+        const NSArray = api?.NSArray ?? globalObject.NSArray;
+        const nativeChildControllers =
+          NSArray && typeof NSArray.arrayWithArray === 'function'
+            ? NSArray.arrayWithArray(childControllers)
+            : childControllers;
+        if (kind === 'stack' && childControllers.length > 0) {
+          parent.setViewControllersAnimated(nativeChildControllers, false);
+        } else if (kind === 'tabs') {
+          if (typeof parent.setViewControllersAnimated === 'function') {
+            parent.setViewControllersAnimated(nativeChildControllers, false);
+          } else {
+            parent.viewControllers = nativeChildControllers;
+          }
+          if (parent.selectedIndex >= childControllers.length) {
+            parent.selectedIndex = 0;
+          }
+        }
+        layoutVisibleController(parent);
+      }
+    }
+    layoutVisibleController(controller);
+    scheduleAncestorTabBarFront(controller);
+  },
+  dispose(_controller, props) {
+    'worklet';
+    const key = '__rnnNativeScriptNavigationRegistry';
+    const globalObject = globalThis as Record<string, any>;
+    const registry = globalObject[key];
+    if (!registry) {
+      return;
+    }
+    registry.controllers[props.componentId] = undefined;
+    registry.kinds[props.componentId] = undefined;
+    registry.parentChildren[props.componentId] = undefined;
+    if (props.parentId) {
+      const children = registry.parentChildren[props.parentId] ?? [];
+      for (let index = children.length - 1; index >= 0; index--) {
+        if (children[index] === props.componentId) {
+          for (let moveIndex = index; moveIndex < children.length - 1; moveIndex++) {
+            children[moveIndex] = children[moveIndex + 1];
+          }
+          children.length = children.length - 1;
+        }
+      }
+      registry.parentChildren[props.parentId] = children;
+    }
+  },
+});
+
+const NativeScriptStackController = NativeScriptRuntime.defineUIViewController<{
+  componentId: string;
+  options?: Options;
+  parentId?: string;
+  style?: unknown;
+  }, any>({
+  debugName: 'RNNStackController',
+  layout: {sizing: 'fill'},
+  createController() {
+    'worklet';
+    const api = (globalThis as Record<string, any>).__nativeScriptNativeApi;
+    const globals = globalThis as Record<string, any>;
+    const UIViewController = api?.UIViewController ?? globals.UIViewController;
+    const UINavigationController = api?.UINavigationController ?? globals.UINavigationController;
+    if (!UIViewController || typeof UIViewController.alloc !== 'function') {
+      throw new Error(`UIViewController is not allocatable in the UI runtime: ${typeof UIViewController}`);
+    }
+    if (!UINavigationController || typeof UINavigationController.alloc !== 'function') {
+      throw new Error(`UINavigationController is not allocatable in the UI runtime: ${typeof UINavigationController}`);
+    }
+    const placeholderAllocated = UIViewController.alloc();
+    const placeholder =
+      placeholderAllocated && typeof placeholderAllocated.init === 'function'
+        ? placeholderAllocated.init()
+        : placeholderAllocated;
+    const UIColor = api?.UIColor ?? globals.UIColor;
+    placeholder.view.backgroundColor =
+      nativeColor('#f6f7fb', 'systemBackgroundColor') ?? UIColor.systemBackgroundColor;
+    const allocated = UINavigationController.alloc();
+    const controller = allocated && typeof allocated.init === 'function' ? allocated.init() : allocated;
+    configureExtendedLayout(controller);
+    configureNavigationBar(controller);
+    const UIView = api?.UIView ?? globals.UIView;
+    if (UIView && typeof UIView.alloc === 'function') {
+      const mountViewAllocated = UIView.alloc();
+      const mountView =
+        mountViewAllocated && typeof mountViewAllocated.init === 'function'
+          ? mountViewAllocated.init()
+          : mountViewAllocated;
+      mountView.tag = 83922041;
+      mountView.hidden = true;
+      mountView.userInteractionEnabled = false;
+      controller.view.addSubview(mountView);
+    }
+    const NSArray = api?.NSArray ?? globals.NSArray;
+    const placeholderControllers = [placeholder];
+    controller.viewControllers =
+      NSArray && typeof NSArray.arrayWithArray === 'function'
+        ? NSArray.arrayWithArray(placeholderControllers)
+        : placeholderControllers;
+    return controller;
+  },
+  childrenView(controller) {
+    'worklet';
+    const existingMountView =
+      controller.view && typeof controller.view.viewWithTag === 'function'
+        ? controller.view.viewWithTag(83922041)
+        : null;
+    if (existingMountView) {
+      return existingMountView;
+    }
+    const api = (globalThis as Record<string, any>).__nativeScriptNativeApi;
+    const globals = globalThis as Record<string, any>;
+    const UIView = api?.UIView ?? globals.UIView;
+    if (UIView && typeof UIView.alloc === 'function') {
+      const mountViewAllocated = UIView.alloc();
+      const mountView =
+        mountViewAllocated && typeof mountViewAllocated.init === 'function'
+          ? mountViewAllocated.init()
+          : mountViewAllocated;
+      mountView.tag = 83922041;
+      mountView.hidden = true;
+      mountView.userInteractionEnabled = false;
+      controller.view.addSubview(mountView);
+      return mountView;
+    }
+    return controller.view;
+  },
+  update(controller, props) {
+    'worklet';
+    const topBar = (props.options as any)?.topBar;
+    if (topBar?.visible === false) {
+      controller.setNavigationBarHiddenAnimated(true, false);
+    } else if (topBar?.visible === true) {
+      controller.setNavigationBarHiddenAnimated(false, false);
+    }
+    configureNavigationBar(controller);
+    const key = '__rnnNativeScriptNavigationRegistry';
+    const globalObject = globalThis as Record<string, any>;
+    const registry = globalObject[key] ?? {controllers: {}, kinds: {}, parentChildren: {}};
+    globalObject[key] = registry;
+    registry.controllers[props.componentId] = controller;
+    registry.kinds[props.componentId] = 'stack';
+    if (props.parentId) {
+      const children = registry.parentChildren[props.parentId] ?? [];
+      let exists = false;
+      for (let index = 0; index < children.length; index++) {
+        if (children[index] === props.componentId) {
+          exists = true;
+          break;
+        }
+      }
+      if (!exists) {
+        children[children.length] = props.componentId;
+        registry.parentChildren[props.parentId] = children;
+      }
+    }
+    const ownChildren = registry.parentChildren[props.componentId] ?? [];
+    const childControllers: any[] = [];
+    for (let index = 0; index < ownChildren.length; index++) {
+      const child = registry.controllers[ownChildren[index]];
+      if (child) {
+        const childParent = child.parentViewController;
+        if (childParent && childParent !== controller) {
+          child.willMoveToParentViewController(null);
+          child.removeFromParentViewController();
+        }
+        if (child.view?.superview) {
+          child.view.removeFromSuperview();
+        }
+        childControllers[childControllers.length] = child;
+      }
+    }
+    if (childControllers.length > 0) {
+      const api = globalObject.__nativeScriptNativeApi;
+      const NSArray = api?.NSArray ?? globalObject.NSArray;
+      controller.setViewControllersAnimated(
+        NSArray && typeof NSArray.arrayWithArray === 'function'
+          ? NSArray.arrayWithArray(childControllers)
+          : childControllers,
+        false,
+      );
+    }
+    layoutVisibleController(controller);
+    scheduleAncestorTabBarFront(controller);
+  },
+  mounted(controller, props) {
+    'worklet';
+    const key = '__rnnNativeScriptNavigationRegistry';
+    const globalObject = globalThis as Record<string, any>;
+    const registry = globalObject[key] ?? {controllers: {}, kinds: {}, parentChildren: {}};
+    globalObject[key] = registry;
+    registry.controllers[props.componentId] = controller;
+    registry.kinds[props.componentId] = 'stack';
+    if (props.parentId) {
+      const children = registry.parentChildren[props.parentId] ?? [];
+      let exists = false;
+      for (let index = 0; index < children.length; index++) {
+        if (children[index] === props.componentId) {
+          exists = true;
+          break;
+        }
+      }
+      if (!exists) {
+        children[children.length] = props.componentId;
+        registry.parentChildren[props.parentId] = children;
+      }
+    }
+    const ownChildren = registry.parentChildren[props.componentId] ?? [];
+    const childControllers: any[] = [];
+    for (let index = 0; index < ownChildren.length; index++) {
+      const child = registry.controllers[ownChildren[index]];
+      if (child) {
+        const childParent = child.parentViewController;
+        if (childParent && childParent !== controller) {
+          child.willMoveToParentViewController(null);
+          child.removeFromParentViewController();
+        }
+        if (child.view?.superview) {
+          child.view.removeFromSuperview();
+        }
+        childControllers[childControllers.length] = child;
+      }
+    }
+    if (childControllers.length > 0) {
+      const api = globalObject.__nativeScriptNativeApi;
+      const NSArray = api?.NSArray ?? globalObject.NSArray;
+      controller.setViewControllersAnimated(
+        NSArray && typeof NSArray.arrayWithArray === 'function'
+          ? NSArray.arrayWithArray(childControllers)
+          : childControllers,
+        false,
+      );
+    }
+    layoutVisibleController(controller);
+    scheduleAncestorTabBarFront(controller);
+  },
+  dispose(_controller, props) {
+    'worklet';
+    const key = '__rnnNativeScriptNavigationRegistry';
+    const globalObject = globalThis as Record<string, any>;
+    const registry = globalObject[key];
+    if (!registry) {
+      return;
+    }
+    registry.controllers[props.componentId] = undefined;
+    registry.kinds[props.componentId] = undefined;
+    registry.parentChildren[props.componentId] = undefined;
+    if (props.parentId) {
+      const children = registry.parentChildren[props.parentId] ?? [];
+      for (let index = children.length - 1; index >= 0; index--) {
+        if (children[index] === props.componentId) {
+          for (let moveIndex = index; moveIndex < children.length - 1; moveIndex++) {
+            children[moveIndex] = children[moveIndex + 1];
+          }
+          children.length = children.length - 1;
+        }
+      }
+      registry.parentChildren[props.parentId] = children;
+    }
+  },
+});
+
+const NativeScriptTabsController = NativeScriptRuntime.defineUIViewController<{
+  componentId: string;
+  options?: Options;
+  parentId?: string;
+  style?: unknown;
+}, any>({
+  debugName: 'RNNBottomTabsController',
+  layout: {sizing: 'fill'},
+  createController({options}) {
+    'worklet';
+    const api = (globalThis as Record<string, any>).__nativeScriptNativeApi;
+    const globals = globalThis as Record<string, any>;
+    const UITabBarController = api?.UITabBarController ?? globals.UITabBarController;
+    if (!UITabBarController || typeof UITabBarController.alloc !== 'function') {
+      throw new Error(`UITabBarController is not allocatable in the UI runtime: ${typeof UITabBarController}`);
+    }
+    const allocated = UITabBarController.alloc();
+    const controller = allocated && typeof allocated.init === 'function' ? allocated.init() : allocated;
+    configureExtendedLayout(controller);
+    controller.tabBar.translucent = true;
+    const UIView = api?.UIView ?? globals.UIView;
+    if (UIView && typeof UIView.alloc === 'function') {
+      const mountViewAllocated = UIView.alloc();
+      const mountView =
+        mountViewAllocated && typeof mountViewAllocated.init === 'function'
+          ? mountViewAllocated.init()
+          : mountViewAllocated;
+      mountView.tag = 83922041;
+      mountView.hidden = true;
+      mountView.userInteractionEnabled = false;
+      controller.view.addSubview(mountView);
+    }
+    const bottomTabs = (options as any)?.bottomTabs;
+    if (typeof bottomTabs?.currentTabIndex === 'number') {
+      controller.selectedIndex = bottomTabs.currentTabIndex;
+    }
+    if (bottomTabs?.visible === false) {
+      controller.tabBar.hidden = true;
+    } else if (bottomTabs?.visible === true) {
+      controller.tabBar.hidden = false;
+    }
+    return controller;
+  },
+  childrenView(controller) {
+    'worklet';
+    const existingMountView =
+      controller.view && typeof controller.view.viewWithTag === 'function'
+        ? controller.view.viewWithTag(83922041)
+        : null;
+    if (existingMountView) {
+      return existingMountView;
+    }
+    const api = (globalThis as Record<string, any>).__nativeScriptNativeApi;
+    const globals = globalThis as Record<string, any>;
+    const UIView = api?.UIView ?? globals.UIView;
+    if (UIView && typeof UIView.alloc === 'function') {
+      const mountViewAllocated = UIView.alloc();
+      const mountView =
+        mountViewAllocated && typeof mountViewAllocated.init === 'function'
+          ? mountViewAllocated.init()
+          : mountViewAllocated;
+      mountView.tag = 83922041;
+      mountView.hidden = true;
+      mountView.userInteractionEnabled = false;
+      controller.view.addSubview(mountView);
+      return mountView;
+    }
+    return controller.view;
+  },
+  update(controller, props) {
+    'worklet';
+    const bottomTabs = (props.options as any)?.bottomTabs;
+    if (typeof bottomTabs?.currentTabIndex === 'number') {
+      controller.selectedIndex = bottomTabs.currentTabIndex;
+    }
+    if (bottomTabs?.visible === false) {
+      controller.tabBar.hidden = true;
+    } else if (bottomTabs?.visible === true) {
+      controller.tabBar.hidden = false;
+    }
+    const key = '__rnnNativeScriptNavigationRegistry';
+    const globalObject = globalThis as Record<string, any>;
+    const registry = globalObject[key] ?? {controllers: {}, kinds: {}, parentChildren: {}};
+    globalObject[key] = registry;
+    registry.controllers[props.componentId] = controller;
+    registry.kinds[props.componentId] = 'tabs';
+    if (props.parentId) {
+      const children = registry.parentChildren[props.parentId] ?? [];
+      let exists = false;
+      for (let index = 0; index < children.length; index++) {
+        if (children[index] === props.componentId) {
+          exists = true;
+          break;
+        }
+      }
+      if (!exists) {
+        children[children.length] = props.componentId;
+        registry.parentChildren[props.parentId] = children;
+      }
+      const parent = registry.controllers[props.parentId];
+      if (parent) {
+        const childControllers: any[] = [];
+        for (let index = 0; index < children.length; index++) {
+          const child = registry.controllers[children[index]];
+          if (child) {
+            const childParent = child.parentViewController;
+            if (childParent && childParent !== parent) {
+              child.willMoveToParentViewController(null);
+              child.removeFromParentViewController();
+            }
+            if (child.view?.superview) {
+              child.view.removeFromSuperview();
+            }
+            childControllers[childControllers.length] = child;
+          }
+        }
+        const parentKind = registry.kinds[props.parentId];
+        const api = globalObject.__nativeScriptNativeApi;
+        const NSArray = api?.NSArray ?? globalObject.NSArray;
+        const nativeChildControllers =
+          NSArray && typeof NSArray.arrayWithArray === 'function'
+            ? NSArray.arrayWithArray(childControllers)
+            : childControllers;
+        if (parentKind === 'stack' && childControllers.length > 0) {
+          parent.setViewControllersAnimated(nativeChildControllers, false);
+        } else if (parentKind === 'tabs') {
+          if (typeof parent.setViewControllersAnimated === 'function') {
+            parent.setViewControllersAnimated(nativeChildControllers, false);
+          } else {
+            parent.viewControllers = nativeChildControllers;
+          }
+          if (parent.selectedIndex >= childControllers.length) {
+            parent.selectedIndex = 0;
+          }
+        }
+        layoutVisibleController(parent);
+      }
+    }
+    const ownChildren = registry.parentChildren[props.componentId] ?? [];
+    const childControllers: any[] = [];
+    for (let index = 0; index < ownChildren.length; index++) {
+      const child = registry.controllers[ownChildren[index]];
+      if (child) {
+        const childParent = child.parentViewController;
+        if (childParent && childParent !== controller) {
+          child.willMoveToParentViewController(null);
+          child.removeFromParentViewController();
+        }
+        if (child.view?.superview) {
+          child.view.removeFromSuperview();
+        }
+        childControllers[childControllers.length] = child;
+      }
+    }
+    const api = globalObject.__nativeScriptNativeApi;
+    const NSArray = api?.NSArray ?? globalObject.NSArray;
+    const nativeChildControllers =
+      NSArray && typeof NSArray.arrayWithArray === 'function'
+        ? NSArray.arrayWithArray(childControllers)
+        : childControllers;
+    if (typeof controller.setViewControllersAnimated === 'function') {
+      controller.setViewControllersAnimated(nativeChildControllers, false);
+    } else {
+      controller.viewControllers = nativeChildControllers;
+    }
+    if (controller.selectedIndex >= childControllers.length) {
+      controller.selectedIndex = 0;
+    }
+    layoutVisibleController(controller);
+  },
+  mounted(controller, props) {
+    'worklet';
+    const key = '__rnnNativeScriptNavigationRegistry';
+    const globalObject = globalThis as Record<string, any>;
+    const registry = globalObject[key] ?? {controllers: {}, kinds: {}, parentChildren: {}};
+    globalObject[key] = registry;
+    registry.controllers[props.componentId] = controller;
+    registry.kinds[props.componentId] = 'tabs';
+    if (props.parentId) {
+      const children = registry.parentChildren[props.parentId] ?? [];
+      let exists = false;
+      for (let index = 0; index < children.length; index++) {
+        if (children[index] === props.componentId) {
+          exists = true;
+          break;
+        }
+      }
+      if (!exists) {
+        children[children.length] = props.componentId;
+        registry.parentChildren[props.parentId] = children;
+      }
+      const parent = registry.controllers[props.parentId];
+      if (parent) {
+        const childControllers: any[] = [];
+        for (let index = 0; index < children.length; index++) {
+          const child = registry.controllers[children[index]];
+          if (child) {
+            const childParent = child.parentViewController;
+            if (childParent && childParent !== parent) {
+              child.willMoveToParentViewController(null);
+              child.removeFromParentViewController();
+            }
+            if (child.view?.superview) {
+              child.view.removeFromSuperview();
+            }
+            childControllers[childControllers.length] = child;
+          }
+        }
+        const parentKind = registry.kinds[props.parentId];
+        const api = globalObject.__nativeScriptNativeApi;
+        const NSArray = api?.NSArray ?? globalObject.NSArray;
+        const nativeChildControllers =
+          NSArray && typeof NSArray.arrayWithArray === 'function'
+            ? NSArray.arrayWithArray(childControllers)
+            : childControllers;
+        if (parentKind === 'stack' && childControllers.length > 0) {
+          parent.setViewControllersAnimated(nativeChildControllers, false);
+        } else if (parentKind === 'tabs') {
+          if (typeof parent.setViewControllersAnimated === 'function') {
+            parent.setViewControllersAnimated(nativeChildControllers, false);
+          } else {
+            parent.viewControllers = nativeChildControllers;
+          }
+          if (parent.selectedIndex >= childControllers.length) {
+            parent.selectedIndex = 0;
+          }
+        }
+        layoutVisibleController(parent);
+      }
+    }
+    const ownChildren = registry.parentChildren[props.componentId] ?? [];
+    const childControllers: any[] = [];
+    for (let index = 0; index < ownChildren.length; index++) {
+      const child = registry.controllers[ownChildren[index]];
+      if (child) {
+        const childParent = child.parentViewController;
+        if (childParent && childParent !== controller) {
+          child.willMoveToParentViewController(null);
+          child.removeFromParentViewController();
+        }
+        if (child.view?.superview) {
+          child.view.removeFromSuperview();
+        }
+        childControllers[childControllers.length] = child;
+      }
+    }
+    const api = globalObject.__nativeScriptNativeApi;
+    const NSArray = api?.NSArray ?? globalObject.NSArray;
+    const nativeChildControllers =
+      NSArray && typeof NSArray.arrayWithArray === 'function'
+        ? NSArray.arrayWithArray(childControllers)
+        : childControllers;
+    if (typeof controller.setViewControllersAnimated === 'function') {
+      controller.setViewControllersAnimated(nativeChildControllers, false);
+    } else {
+      controller.viewControllers = nativeChildControllers;
+    }
+    if (controller.selectedIndex >= childControllers.length) {
+      controller.selectedIndex = 0;
+    }
+    layoutVisibleController(controller);
+  },
+  dispose(_controller, props) {
+    'worklet';
+    const key = '__rnnNativeScriptNavigationRegistry';
+    const globalObject = globalThis as Record<string, any>;
+    const registry = globalObject[key];
+    if (!registry) {
+      return;
+    }
+    registry.controllers[props.componentId] = undefined;
+    registry.kinds[props.componentId] = undefined;
+    registry.parentChildren[props.componentId] = undefined;
+    if (props.parentId) {
+      const children = registry.parentChildren[props.parentId] ?? [];
+      for (let index = children.length - 1; index >= 0; index--) {
+        if (children[index] === props.componentId) {
+          for (let moveIndex = index; moveIndex < children.length - 1; moveIndex++) {
+            children[moveIndex] = children[moveIndex + 1];
+          }
+          children.length = children.length - 1;
+        }
+      }
+      registry.parentChildren[props.parentId] = children;
+    }
+  },
+});
+
+const NativeScriptPresentedController = NativeScriptRuntime.defineUIViewController<{
+  componentId?: string;
+  presentation: 'modal' | 'overlay';
+  style?: unknown;
+}, any>({
+  debugName: 'RNNPresentedController',
+  layout: {sizing: 'fill'},
+  createController() {
+    'worklet';
+    const api = (globalThis as Record<string, any>).__nativeScriptNativeApi;
+    const globals = globalThis as Record<string, any>;
+    const UIViewController = api?.UIViewController ?? globals.UIViewController;
+    if (!UIViewController || typeof UIViewController.alloc !== 'function') {
+      throw new Error(`UIViewController is not allocatable in the UI runtime: ${typeof UIViewController}`);
+    }
+    const allocated = UIViewController.alloc();
+    const controller = allocated && typeof allocated.init === 'function' ? allocated.init() : allocated;
+    const UIColor = api?.UIColor ?? globals.UIColor;
+    controller.view.backgroundColor = UIColor.clearColor;
+    return controller;
+  },
+  childrenView(controller) {
+    'worklet';
+    return controller.view;
+  },
+  mounted(controller, props) {
+    'worklet';
+    const api = (globalThis as Record<string, any>).__nativeScriptNativeApi;
+    const globals = globalThis as Record<string, any>;
+    const UIApplication = api?.UIApplication ?? globals.UIApplication;
+    const application = UIApplication?.sharedApplication;
+    const windows = application?.windows;
+    let root = null;
+    if (windows) {
+      for (let index = 0; index < windows.count; index++) {
+        const window = windows.objectAtIndex(index);
+        if (window.isKeyWindow) {
+          root = window.rootViewController;
+          break;
+        }
+      }
+    }
+    if (!root) {
+      root = application?.delegate?.window?.rootViewController ?? null;
+    }
+    if (!root || controller.presentingViewController) {
+      return;
+    }
+    if (props.presentation === 'overlay') {
+      controller.modalPresentationStyle = 5;
+    }
+    root.presentViewControllerAnimatedCompletion(controller, props.presentation === 'modal', null);
+  },
+  dispose(controller) {
+    'worklet';
+    if (controller.presentingViewController) {
+      controller.dismissViewControllerAnimatedCompletion(false, null);
+    }
+  },
+});
+
+function cloneNode(node: ParsedLayoutNode): ParsedLayoutNode {
+  return {
+    ...node,
+    data: node.data ? {...node.data} : undefined,
+    children: node.children?.map(cloneNode),
+  };
+}
+
+const styles = StyleSheet.create({
+  fill: {
+    flex: 1,
+  },
+  rootFill: {
+    flex: 1,
+    minHeight: initialWindowHeight,
+  },
+});
+
+function cloneSnapshot(snapshot: NativeScriptNavigationSnapshot): NativeScriptNavigationSnapshot {
+  return {
+    root: snapshot.root ? cloneNode(snapshot.root) : undefined,
+    modals: snapshot.modals.map(cloneNode),
+    overlays: snapshot.overlays.map(cloneNode),
+  };
+}
+
+function includesLayoutId(node: ParsedLayoutNode, componentId: string): boolean {
+  return node.id === componentId || (node.children ?? []).some((child) => includesLayoutId(child, componentId));
+}
+
+function mergeOptions(...options: Array<Options | undefined>): Options {
+  return Object.assign({}, ...options.filter(Boolean));
+}

--- a/src/nativescript/NativeScriptNavigationSurface.tsx
+++ b/src/nativescript/NativeScriptNavigationSurface.tsx
@@ -37,11 +37,13 @@ type NativeScriptNavigationStore = {
   setRoot(root: ParsedLayoutNode, modals?: ParsedLayoutNode[], overlays?: ParsedLayoutNode[]): void;
   setDefaultOptions(options: Options): void;
   mergeOptions(componentId: string, options: Options): void;
-  push(componentId: string, layout: ParsedLayoutNode): void;
+  getStackIdForComponent(componentId: string): string | undefined;
+  push(componentId: string, layout: ParsedLayoutNode): {didPush: boolean; pushedId?: string; stackId?: string};
   pop(componentId: string): string | undefined;
   popTo(componentId: string): string | undefined;
   popToRoot(componentId: string): string | undefined;
   setStackRoot(componentId: string, children: ParsedLayoutNode[]): void;
+  syncStackChildren(componentId: string, childIds: string[]): string[];
   showModal(layout: ParsedLayoutNode): void;
   dismissModal(componentId: string): string | undefined;
   dismissAllModals(): void;
@@ -117,6 +119,79 @@ function makeNativeScriptNavigationStore(): NativeScriptNavigationStore {
     return undefined;
   };
 
+  const findStackIdForComponent = (
+    root: ParsedLayoutNode | undefined,
+    componentId: string,
+    nearestStackId?: string,
+  ): string | undefined => {
+    if (!root) {
+      return undefined;
+    }
+    const currentStackId = root.type === 'Stack' ? root.id ?? nearestStackId : nearestStackId;
+    if (root.id === componentId) {
+      return currentStackId;
+    }
+    for (const child of root.children ?? []) {
+      const found = findStackIdForComponent(child, componentId, currentStackId);
+      if (found) {
+        return found;
+      }
+    }
+    return undefined;
+  };
+
+  const getStackIdForComponent = (componentId: string): string | undefined => {
+    const rootStackId = findStackIdForComponent(state.snapshot.root, componentId);
+    if (rootStackId) {
+      return rootStackId;
+    }
+    for (const modal of state.snapshot.modals) {
+      const modalStackId = findStackIdForComponent(modal, componentId);
+      if (modalStackId) {
+        return modalStackId;
+      }
+    }
+    for (const overlay of state.snapshot.overlays) {
+      const overlayStackId = findStackIdForComponent(overlay, componentId);
+      if (overlayStackId) {
+        return overlayStackId;
+      }
+    }
+    return undefined;
+  };
+
+  const syncStackChildren = (componentId: string, childIds: string[]): string[] => {
+    const snapshot = cloneSnapshot(state.snapshot);
+    let didSync = false;
+    let removedIds: string[] = [];
+    mutateTree(snapshot.root, componentId, (node) => {
+      if (node.type !== 'Stack' || !node.children) {
+        return;
+      }
+      const nextChildren: ParsedLayoutNode[] = [];
+      for (const childId of childIds) {
+        const child = node.children.find((candidate) => candidate.id === childId);
+        if (child) {
+          nextChildren.push(child);
+        }
+      }
+      const nextKey = nextChildren.map((child) => child.id).join('|');
+      const previousKey = node.children.map((child) => child.id).join('|');
+      if (nextKey === previousKey) {
+        return;
+      }
+      removedIds = node.children
+        .filter((child) => child.id != null && !childIds.includes(child.id))
+        .map((child) => child.id as string);
+      node.children = nextChildren;
+      didSync = true;
+    });
+    if (didSync) {
+      replaceState({...state, snapshot});
+    }
+    return removedIds;
+  };
+
   return {
     getState: () => state,
     subscribe(listener) {
@@ -144,19 +219,23 @@ function makeNativeScriptNavigationStore(): NativeScriptNavigationStore {
         },
       });
     },
+    getStackIdForComponent,
     push(componentId, layout) {
       const snapshot = cloneSnapshot(state.snapshot);
       let didPush = false;
+      let stackId: string | undefined;
       mutateTree(snapshot.root, componentId, (node, parent) => {
         const stackNode = node.type === 'Stack' ? node : parent?.type === 'Stack' ? parent : undefined;
         if (stackNode) {
           stackNode.children = [...(stackNode.children ?? []), layout];
+          stackId = stackNode.id ?? componentId;
           didPush = true;
         }
       });
       if (didPush) {
         replaceState({...state, snapshot});
       }
+      return {didPush, pushedId: layout.id, stackId};
     },
     pop(componentId) {
       const snapshot = cloneSnapshot(state.snapshot);
@@ -211,6 +290,7 @@ function makeNativeScriptNavigationStore(): NativeScriptNavigationStore {
       });
       replaceState({...state, snapshot});
     },
+    syncStackChildren,
     showModal(layout) {
       replaceState({
         ...state,
@@ -422,6 +502,22 @@ function NativeScriptLayoutNode({
   const componentId = node.id ?? `${node.type ?? 'node'}-${Math.random().toString(36).slice(2)}`;
   const options = mergeOptions(node.data?.options, mergedOptions[componentId]);
   const attachToReactView = parentId == null;
+  const handleNativeStackChange = React.useCallback((event: any) => {
+    const childIds = event?.nativeEvent?.childIds;
+    if (Array.isArray(childIds)) {
+      navigationStore.syncStackChildren(
+        componentId,
+        childIds.filter((childId): childId is string => typeof childId === 'string'),
+      );
+    }
+  }, [componentId]);
+  const handleNativeBackPress = React.useCallback((event: any) => {
+    const targetComponentId =
+      typeof event?.nativeEvent?.componentId === 'string'
+        ? event.nativeEvent.componentId
+        : componentId;
+    navigationStore.pop(targetComponentId);
+  }, [componentId]);
 
   if (node.type === 'Stack') {
     return (
@@ -429,6 +525,7 @@ function NativeScriptLayoutNode({
         attachController={parentId == null ? attachRootController : false}
         attachNativeView={attachToReactView}
         componentId={componentId}
+        onNativeStackChange={handleNativeStackChange}
         options={options}
         parentId={parentId}
         style={styles.rootFill}>
@@ -475,6 +572,7 @@ function NativeScriptLayoutNode({
       attachNativeView={attachToReactView}
       componentId={componentId}
       componentName={node.data?.name}
+      onNativeBackPress={handleNativeBackPress}
       options={options}
       parentId={parentId}
       style={styles.rootFill}>
@@ -826,6 +924,275 @@ function layoutVisibleController(controller: any) {
   layoutHostedReactSubviews(controller);
 }
 
+function getNavigationRegistry(globalObject: Record<string, any>): any {
+  'worklet';
+  const key = '__rnnNativeScriptNavigationRegistry';
+  const registry = globalObject[key] ?? {};
+  registry.controllers = registry.controllers ?? {};
+  registry.kinds = registry.kinds ?? {};
+  registry.parentChildren = registry.parentChildren ?? {};
+  registry.containerChildKeys = registry.containerChildKeys ?? {};
+  registry.containerChildCounts = registry.containerChildCounts ?? {};
+  globalObject[key] = registry;
+  return registry;
+}
+
+function addNavigationChild(registry: any, parentId: string, childId: string) {
+  'worklet';
+  const children = registry.parentChildren[parentId] ?? [];
+  let exists = false;
+  for (let index = 0; index < children.length; index++) {
+    if (children[index] === childId) {
+      exists = true;
+      break;
+    }
+  }
+  if (!exists) {
+    children[children.length] = childId;
+    registry.parentChildren[parentId] = children;
+  }
+}
+
+function removeNavigationChild(registry: any, parentId: string, childId: string) {
+  'worklet';
+  const children = registry.parentChildren[parentId] ?? [];
+  for (let index = children.length - 1; index >= 0; index--) {
+    if (children[index] === childId) {
+      for (let moveIndex = index; moveIndex < children.length - 1; moveIndex++) {
+        children[moveIndex] = children[moveIndex + 1];
+      }
+      children.length = children.length - 1;
+    }
+  }
+  registry.parentChildren[parentId] = children;
+}
+
+function navigationChildKey(childIds: any[]): string {
+  'worklet';
+  let key = '';
+  for (let index = 0; index < childIds.length; index++) {
+    key += '|' + childIds[index];
+  }
+  return key;
+}
+
+function nativeControllerArray(globalObject: Record<string, any>, childControllers: any[]): any {
+  'worklet';
+  const api = globalObject.__nativeScriptNativeApi;
+  const NSArray = api?.NSArray ?? globalObject.NSArray;
+  return NSArray && typeof NSArray.arrayWithArray === 'function'
+    ? NSArray.arrayWithArray(childControllers)
+    : childControllers;
+}
+
+function collectChildControllers(
+  parent: any,
+  children: any[],
+  registry: any,
+): {controllers: any[]; ids: any[]} {
+  'worklet';
+  const childControllers: any[] = [];
+  const activeChildIds: any[] = [];
+  for (let index = 0; index < children.length; index++) {
+    const childId = children[index];
+    const child = registry.controllers[childId];
+    if (!child) {
+      continue;
+    }
+    const childParent = child.parentViewController;
+    if (childParent && childParent !== parent) {
+      child.willMoveToParentViewController(null);
+      child.removeFromParentViewController();
+      if (child.view?.superview) {
+        child.view.removeFromSuperview();
+      }
+    }
+    childControllers[childControllers.length] = child;
+    activeChildIds[activeChildIds.length] = childId;
+  }
+  return {controllers: childControllers, ids: activeChildIds};
+}
+
+function componentIdForNativeController(registry: any, controller: any): string | null {
+  'worklet';
+  if (!controller) {
+    return null;
+  }
+  const controllers = registry.controllers ?? {};
+  for (const componentId in controllers) {
+    if (controllers[componentId] === controller) {
+      return componentId;
+    }
+  }
+  return null;
+}
+
+function navigationControllerChildIds(navigationController: any, registry: any): string[] {
+  'worklet';
+  const childIds: string[] = [];
+  const viewControllers = navigationController?.viewControllers;
+  const count = arrayCount(viewControllers);
+  for (let index = 0; index < count; index++) {
+    const childController = arrayItem(viewControllers, index);
+    const childId = componentIdForNativeController(registry, childController);
+    if (childId) {
+      childIds[childIds.length] = childId;
+    }
+  }
+  return childIds;
+}
+
+function navigationChildIndex(registry: any, parentId: string, childId: string): number {
+  'worklet';
+  const children = registry.parentChildren[parentId] ?? [];
+  for (let index = 0; index < children.length; index++) {
+    if (children[index] === childId) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function configureNativeBackButton(controller: any, props: any, registry: any, ctx: any) {
+  'worklet';
+  if (!ctx || !controller?.navigationItem || !props.parentId) {
+    return;
+  }
+  const parentKind = registry.kinds[props.parentId];
+  const childIndex = navigationChildIndex(registry, props.parentId, props.componentId);
+  if (parentKind !== 'stack' || childIndex <= 0) {
+    controller.navigationItem.leftBarButtonItem = null;
+    controller.navigationItem.hidesBackButton = false;
+    controller.__rnnNativeBackButtonId = null;
+    return;
+  }
+  if (controller.__rnnNativeBackButtonId === props.componentId) {
+    return;
+  }
+  const globalObject = globalThis as Record<string, any>;
+  const api = globalObject.__nativeScriptNativeApi;
+  const UIButton = api?.UIButton ?? globalObject.UIButton;
+  const UIBarButtonItem = api?.UIBarButtonItem ?? globalObject.UIBarButtonItem;
+  if (!UIButton || !UIBarButtonItem) {
+    return;
+  }
+  const UIButtonType = api?.UIButtonType ?? globalObject.UIButtonType;
+  const UIControlEvents = api?.UIControlEvents ?? globalObject.UIControlEvents;
+  const UIControlState = api?.UIControlState ?? globalObject.UIControlState;
+  const button =
+    typeof UIButton.buttonWithType === 'function'
+      ? UIButton.buttonWithType(UIButtonType?.System ?? 1)
+      : UIButton.alloc().init();
+  const normalState = UIControlState?.Normal ?? 0;
+  const previousChildId = (registry.parentChildren[props.parentId] ?? [])[childIndex - 1];
+  const previousController = registry.controllers[previousChildId];
+  const backTitle = previousController?.title ?? 'Back';
+  const UIImage = api?.UIImage ?? globalObject.UIImage;
+  const backImage =
+    UIImage && typeof UIImage.systemImageNamed === 'function'
+      ? UIImage.systemImageNamed('chevron.backward')
+      : null;
+  if (backImage && typeof button.setImageForState === 'function') {
+    button.setImageForState(backImage, normalState);
+  }
+  if (typeof button.setTitleForState === 'function') {
+    button.setTitleForState(backTitle, normalState);
+  }
+  if (typeof button.sizeToFit === 'function') {
+    button.sizeToFit();
+  }
+  ctx.targetAction(button, UIControlEvents?.TouchUpInside ?? 64, () => {
+    'worklet';
+    ctx.emit('onNativeBackPress', {
+      nativeEvent: {
+        componentId: props.componentId,
+      },
+    });
+  });
+  const allocatedItem = UIBarButtonItem.alloc();
+  controller.navigationItem.leftBarButtonItem =
+    allocatedItem && typeof allocatedItem.initWithCustomView === 'function'
+      ? allocatedItem.initWithCustomView(button)
+      : allocatedItem;
+  controller.navigationItem.hidesBackButton = true;
+  controller.__rnnNativeBackButtonId = props.componentId;
+}
+
+function emitNativeStackChange(ctx: any, navigationController: any) {
+  'worklet';
+  const globalObject = globalThis as Record<string, any>;
+  const registry = getNavigationRegistry(globalObject);
+  const childIds = navigationControllerChildIds(navigationController, registry);
+  const knownChildren = registry.parentChildren[ctx.componentId] ?? [];
+  if (childIds.length === 0 || childIds.length >= knownChildren.length) {
+    return;
+  }
+  registry.parentChildren[ctx.componentId] = childIds;
+  registry.containerChildKeys[ctx.componentId] = navigationChildKey(childIds);
+  registry.containerChildCounts[ctx.componentId] = childIds.length;
+  ctx.emit('onNativeStackChange', {
+    nativeEvent: {
+      componentId: ctx.componentId,
+      childIds,
+    },
+  });
+}
+
+function reconcileNavigationChildren(
+  parent: any,
+  parentId: string,
+  parentKind: string | undefined,
+  registry: any,
+  globalObject: Record<string, any>,
+) {
+  'worklet';
+  if (!parent || !parentKind) {
+    return;
+  }
+  const children = registry.parentChildren[parentId] ?? [];
+  const collected = collectChildControllers(parent, children, registry);
+  const childControllers = collected.controllers;
+  const activeChildIds = collected.ids;
+  const nextKey = navigationChildKey(activeChildIds);
+  const previousKey = registry.containerChildKeys[parentId];
+  const previousCount = registry.containerChildCounts[parentId] ?? 0;
+  const nextCount = childControllers.length;
+  const didChangeChildren = previousKey !== nextKey;
+  if (didChangeChildren) {
+    registry.containerChildKeys[parentId] = nextKey;
+    registry.containerChildCounts[parentId] = nextCount;
+  }
+
+  const nativeChildControllers = nativeControllerArray(globalObject, childControllers);
+  if (parentKind === 'stack') {
+    if (nextCount === 0) {
+      return;
+    }
+    const animated =
+      didChangeChildren &&
+      previousKey != null &&
+      previousCount > 0 &&
+      Math.abs(nextCount - previousCount) === 1;
+    if (typeof parent.setViewControllersAnimated === 'function') {
+      parent.setViewControllersAnimated(nativeChildControllers, animated);
+    } else {
+      parent.viewControllers = nativeChildControllers;
+    }
+  } else if (parentKind === 'tabs') {
+    if (typeof parent.setViewControllersAnimated === 'function') {
+      parent.setViewControllersAnimated(nativeChildControllers, false);
+    } else {
+      parent.viewControllers = nativeChildControllers;
+    }
+    if (parent.selectedIndex >= nextCount) {
+      parent.selectedIndex = 0;
+    }
+  }
+
+  layoutVisibleController(parent);
+  scheduleAncestorTabBarFront(parent);
+}
+
 function rectEdgeAll(): number {
   'worklet';
   const edge = nativeValue('UIRectEdge');
@@ -878,6 +1245,7 @@ function configureNavigationBar(controller: any) {
 const NativeScriptComponentController = NativeScriptRuntime.defineUIViewController<{
   componentId: string;
   componentName?: string | number;
+  onNativeBackPress?: (event: {nativeEvent: {componentId: string}}) => void;
   options?: Options;
   parentId?: string;
   style?: unknown;
@@ -922,7 +1290,7 @@ const NativeScriptComponentController = NativeScriptRuntime.defineUIViewControll
     'worklet';
     return controller.view;
   },
-  update(controller, props) {
+  update(controller, props, _previousProps, ctx) {
     'worklet';
     const topBarTitle = (props.options as any)?.topBar?.title?.text;
     const bottomTabTitle = (props.options as any)?.bottomTab?.text;
@@ -945,126 +1313,31 @@ const NativeScriptComponentController = NativeScriptRuntime.defineUIViewControll
       }
       controller.tabBarItem = tabBarItem;
     }
-    const key = '__rnnNativeScriptNavigationRegistry';
     const globalObject = globalThis as Record<string, any>;
-    const registry = globalObject[key] ?? {controllers: {}, kinds: {}, parentChildren: {}};
-    globalObject[key] = registry;
+    const registry = getNavigationRegistry(globalObject);
     registry.controllers[props.componentId] = controller;
     registry.kinds[props.componentId] = 'component';
     if (props.parentId) {
-      const children = registry.parentChildren[props.parentId] ?? [];
-      let exists = false;
-      for (let index = 0; index < children.length; index++) {
-        if (children[index] === props.componentId) {
-          exists = true;
-          break;
-        }
-      }
-      if (!exists) {
-        children[children.length] = props.componentId;
-        registry.parentChildren[props.parentId] = children;
-      }
+      addNavigationChild(registry, props.parentId, props.componentId);
       const parent = registry.controllers[props.parentId];
-      if (parent) {
-        const childControllers: any[] = [];
-        for (let index = 0; index < children.length; index++) {
-          const child = registry.controllers[children[index]];
-          if (child) {
-            const childParent = child.parentViewController;
-            if (childParent && childParent !== parent) {
-              child.willMoveToParentViewController(null);
-              child.removeFromParentViewController();
-            }
-            if (child.view?.superview) {
-              child.view.removeFromSuperview();
-            }
-            childControllers[childControllers.length] = child;
-          }
-        }
-        const kind = registry.kinds[props.parentId];
-        const NSArray = api?.NSArray ?? globals.NSArray;
-        const nativeChildControllers =
-          NSArray && typeof NSArray.arrayWithArray === 'function'
-            ? NSArray.arrayWithArray(childControllers)
-            : childControllers;
-        if (kind === 'stack' && childControllers.length > 0) {
-          parent.setViewControllersAnimated(nativeChildControllers, false);
-        } else if (kind === 'tabs') {
-          if (typeof parent.setViewControllersAnimated === 'function') {
-            parent.setViewControllersAnimated(nativeChildControllers, false);
-          } else {
-            parent.viewControllers = nativeChildControllers;
-          }
-          if (parent.selectedIndex >= childControllers.length) {
-            parent.selectedIndex = 0;
-          }
-        }
-        layoutVisibleController(parent);
-      }
+      reconcileNavigationChildren(parent, props.parentId, registry.kinds[props.parentId], registry, globalObject);
     }
+    configureNativeBackButton(controller, props, registry, ctx);
     layoutVisibleController(controller);
     scheduleAncestorTabBarFront(controller);
   },
-  mounted(controller, props) {
+  mounted(controller, props, ctx) {
     'worklet';
-    const key = '__rnnNativeScriptNavigationRegistry';
     const globalObject = globalThis as Record<string, any>;
-    const registry = globalObject[key] ?? {controllers: {}, kinds: {}, parentChildren: {}};
-    globalObject[key] = registry;
+    const registry = getNavigationRegistry(globalObject);
     registry.controllers[props.componentId] = controller;
     registry.kinds[props.componentId] = 'component';
     if (props.parentId) {
-      const children = registry.parentChildren[props.parentId] ?? [];
-      let exists = false;
-      for (let index = 0; index < children.length; index++) {
-        if (children[index] === props.componentId) {
-          exists = true;
-          break;
-        }
-      }
-      if (!exists) {
-        children[children.length] = props.componentId;
-        registry.parentChildren[props.parentId] = children;
-      }
+      addNavigationChild(registry, props.parentId, props.componentId);
       const parent = registry.controllers[props.parentId];
-      if (parent) {
-        const childControllers: any[] = [];
-        for (let index = 0; index < children.length; index++) {
-          const child = registry.controllers[children[index]];
-          if (child) {
-            const childParent = child.parentViewController;
-            if (childParent && childParent !== parent) {
-              child.willMoveToParentViewController(null);
-              child.removeFromParentViewController();
-            }
-            if (child.view?.superview) {
-              child.view.removeFromSuperview();
-            }
-            childControllers[childControllers.length] = child;
-          }
-        }
-        const kind = registry.kinds[props.parentId];
-        const api = globalObject.__nativeScriptNativeApi;
-        const NSArray = api?.NSArray ?? globalObject.NSArray;
-        const nativeChildControllers =
-          NSArray && typeof NSArray.arrayWithArray === 'function'
-            ? NSArray.arrayWithArray(childControllers)
-            : childControllers;
-        if (kind === 'stack' && childControllers.length > 0) {
-          parent.setViewControllersAnimated(nativeChildControllers, false);
-        } else if (kind === 'tabs') {
-          if (typeof parent.setViewControllersAnimated === 'function') {
-            parent.setViewControllersAnimated(nativeChildControllers, false);
-          } else {
-            parent.viewControllers = nativeChildControllers;
-          }
-          if (parent.selectedIndex >= childControllers.length) {
-            parent.selectedIndex = 0;
-          }
-        }
-        layoutVisibleController(parent);
-      }
+      reconcileNavigationChildren(parent, props.parentId, registry.kinds[props.parentId], registry, globalObject);
     }
+    configureNativeBackButton(controller, props, registry, ctx);
     layoutVisibleController(controller);
     scheduleAncestorTabBarFront(controller);
   },
@@ -1080,29 +1353,23 @@ const NativeScriptComponentController = NativeScriptRuntime.defineUIViewControll
     registry.kinds[props.componentId] = undefined;
     registry.parentChildren[props.componentId] = undefined;
     if (props.parentId) {
-      const children = registry.parentChildren[props.parentId] ?? [];
-      for (let index = children.length - 1; index >= 0; index--) {
-        if (children[index] === props.componentId) {
-          for (let moveIndex = index; moveIndex < children.length - 1; moveIndex++) {
-            children[moveIndex] = children[moveIndex + 1];
-          }
-          children.length = children.length - 1;
-        }
-      }
-      registry.parentChildren[props.parentId] = children;
+      removeNavigationChild(registry, props.parentId, props.componentId);
+      const parent = registry.controllers[props.parentId];
+      reconcileNavigationChildren(parent, props.parentId, registry.kinds[props.parentId], registry, globalObject);
     }
   },
 });
 
 const NativeScriptStackController = NativeScriptRuntime.defineUIViewController<{
   componentId: string;
+  onNativeStackChange?: (event: {nativeEvent: {componentId: string; childIds: string[]}}) => void;
   options?: Options;
   parentId?: string;
   style?: unknown;
   }, any>({
   debugName: 'RNNStackController',
   layout: {sizing: 'fill'},
-  createController() {
+  createController(ctx) {
     'worklet';
     const api = (globalThis as Record<string, any>).__nativeScriptNativeApi;
     const globals = globalThis as Record<string, any>;
@@ -1126,6 +1393,27 @@ const NativeScriptStackController = NativeScriptRuntime.defineUIViewController<{
     const controller = allocated && typeof allocated.init === 'function' ? allocated.init() : allocated;
     configureExtendedLayout(controller);
     configureNavigationBar(controller);
+    const delegateProtocol =
+      api?.getProtocol?.('UINavigationControllerDelegate') ??
+      api?.UINavigationControllerDelegate ??
+      globals.UINavigationControllerDelegate;
+    if (delegateProtocol) {
+      controller.delegate = ctx.delegate(controller, delegateProtocol, {
+        navigationControllerWillShowViewControllerAnimated(navigationController: any) {
+          'worklet';
+          if (typeof setTimeout === 'function') {
+            setTimeout(() => {
+              'worklet';
+              emitNativeStackChange(ctx, navigationController);
+            }, 0);
+          }
+        },
+        navigationControllerDidShowViewControllerAnimated(navigationController: any) {
+          'worklet';
+          emitNativeStackChange(ctx, navigationController);
+        },
+      });
+    }
     const UIView = api?.UIView ?? globals.UIView;
     if (UIView && typeof UIView.alloc === 'function') {
       const mountViewAllocated = UIView.alloc();
@@ -1181,105 +1469,29 @@ const NativeScriptStackController = NativeScriptRuntime.defineUIViewController<{
       controller.setNavigationBarHiddenAnimated(false, false);
     }
     configureNavigationBar(controller);
-    const key = '__rnnNativeScriptNavigationRegistry';
     const globalObject = globalThis as Record<string, any>;
-    const registry = globalObject[key] ?? {controllers: {}, kinds: {}, parentChildren: {}};
-    globalObject[key] = registry;
+    const registry = getNavigationRegistry(globalObject);
     registry.controllers[props.componentId] = controller;
     registry.kinds[props.componentId] = 'stack';
     if (props.parentId) {
-      const children = registry.parentChildren[props.parentId] ?? [];
-      let exists = false;
-      for (let index = 0; index < children.length; index++) {
-        if (children[index] === props.componentId) {
-          exists = true;
-          break;
-        }
-      }
-      if (!exists) {
-        children[children.length] = props.componentId;
-        registry.parentChildren[props.parentId] = children;
-      }
+      addNavigationChild(registry, props.parentId, props.componentId);
+      const parent = registry.controllers[props.parentId];
+      reconcileNavigationChildren(parent, props.parentId, registry.kinds[props.parentId], registry, globalObject);
     }
-    const ownChildren = registry.parentChildren[props.componentId] ?? [];
-    const childControllers: any[] = [];
-    for (let index = 0; index < ownChildren.length; index++) {
-      const child = registry.controllers[ownChildren[index]];
-      if (child) {
-        const childParent = child.parentViewController;
-        if (childParent && childParent !== controller) {
-          child.willMoveToParentViewController(null);
-          child.removeFromParentViewController();
-        }
-        if (child.view?.superview) {
-          child.view.removeFromSuperview();
-        }
-        childControllers[childControllers.length] = child;
-      }
-    }
-    if (childControllers.length > 0) {
-      const api = globalObject.__nativeScriptNativeApi;
-      const NSArray = api?.NSArray ?? globalObject.NSArray;
-      controller.setViewControllersAnimated(
-        NSArray && typeof NSArray.arrayWithArray === 'function'
-          ? NSArray.arrayWithArray(childControllers)
-          : childControllers,
-        false,
-      );
-    }
-    layoutVisibleController(controller);
-    scheduleAncestorTabBarFront(controller);
+    reconcileNavigationChildren(controller, props.componentId, 'stack', registry, globalObject);
   },
   mounted(controller, props) {
     'worklet';
-    const key = '__rnnNativeScriptNavigationRegistry';
     const globalObject = globalThis as Record<string, any>;
-    const registry = globalObject[key] ?? {controllers: {}, kinds: {}, parentChildren: {}};
-    globalObject[key] = registry;
+    const registry = getNavigationRegistry(globalObject);
     registry.controllers[props.componentId] = controller;
     registry.kinds[props.componentId] = 'stack';
     if (props.parentId) {
-      const children = registry.parentChildren[props.parentId] ?? [];
-      let exists = false;
-      for (let index = 0; index < children.length; index++) {
-        if (children[index] === props.componentId) {
-          exists = true;
-          break;
-        }
-      }
-      if (!exists) {
-        children[children.length] = props.componentId;
-        registry.parentChildren[props.parentId] = children;
-      }
+      addNavigationChild(registry, props.parentId, props.componentId);
+      const parent = registry.controllers[props.parentId];
+      reconcileNavigationChildren(parent, props.parentId, registry.kinds[props.parentId], registry, globalObject);
     }
-    const ownChildren = registry.parentChildren[props.componentId] ?? [];
-    const childControllers: any[] = [];
-    for (let index = 0; index < ownChildren.length; index++) {
-      const child = registry.controllers[ownChildren[index]];
-      if (child) {
-        const childParent = child.parentViewController;
-        if (childParent && childParent !== controller) {
-          child.willMoveToParentViewController(null);
-          child.removeFromParentViewController();
-        }
-        if (child.view?.superview) {
-          child.view.removeFromSuperview();
-        }
-        childControllers[childControllers.length] = child;
-      }
-    }
-    if (childControllers.length > 0) {
-      const api = globalObject.__nativeScriptNativeApi;
-      const NSArray = api?.NSArray ?? globalObject.NSArray;
-      controller.setViewControllersAnimated(
-        NSArray && typeof NSArray.arrayWithArray === 'function'
-          ? NSArray.arrayWithArray(childControllers)
-          : childControllers,
-        false,
-      );
-    }
-    layoutVisibleController(controller);
-    scheduleAncestorTabBarFront(controller);
+    reconcileNavigationChildren(controller, props.componentId, 'stack', registry, globalObject);
   },
   dispose(_controller, props) {
     'worklet';
@@ -1293,16 +1505,9 @@ const NativeScriptStackController = NativeScriptRuntime.defineUIViewController<{
     registry.kinds[props.componentId] = undefined;
     registry.parentChildren[props.componentId] = undefined;
     if (props.parentId) {
-      const children = registry.parentChildren[props.parentId] ?? [];
-      for (let index = children.length - 1; index >= 0; index--) {
-        if (children[index] === props.componentId) {
-          for (let moveIndex = index; moveIndex < children.length - 1; moveIndex++) {
-            children[moveIndex] = children[moveIndex + 1];
-          }
-          children.length = children.length - 1;
-        }
-      }
-      registry.parentChildren[props.parentId] = children;
+      removeNavigationChild(registry, props.parentId, props.componentId);
+      const parent = registry.controllers[props.parentId];
+      reconcileNavigationChildren(parent, props.parentId, registry.kinds[props.parentId], registry, globalObject);
     }
   },
 });
@@ -1387,187 +1592,29 @@ const NativeScriptTabsController = NativeScriptRuntime.defineUIViewController<{
     } else if (bottomTabs?.visible === true) {
       controller.tabBar.hidden = false;
     }
-    const key = '__rnnNativeScriptNavigationRegistry';
     const globalObject = globalThis as Record<string, any>;
-    const registry = globalObject[key] ?? {controllers: {}, kinds: {}, parentChildren: {}};
-    globalObject[key] = registry;
+    const registry = getNavigationRegistry(globalObject);
     registry.controllers[props.componentId] = controller;
     registry.kinds[props.componentId] = 'tabs';
     if (props.parentId) {
-      const children = registry.parentChildren[props.parentId] ?? [];
-      let exists = false;
-      for (let index = 0; index < children.length; index++) {
-        if (children[index] === props.componentId) {
-          exists = true;
-          break;
-        }
-      }
-      if (!exists) {
-        children[children.length] = props.componentId;
-        registry.parentChildren[props.parentId] = children;
-      }
+      addNavigationChild(registry, props.parentId, props.componentId);
       const parent = registry.controllers[props.parentId];
-      if (parent) {
-        const childControllers: any[] = [];
-        for (let index = 0; index < children.length; index++) {
-          const child = registry.controllers[children[index]];
-          if (child) {
-            const childParent = child.parentViewController;
-            if (childParent && childParent !== parent) {
-              child.willMoveToParentViewController(null);
-              child.removeFromParentViewController();
-            }
-            if (child.view?.superview) {
-              child.view.removeFromSuperview();
-            }
-            childControllers[childControllers.length] = child;
-          }
-        }
-        const parentKind = registry.kinds[props.parentId];
-        const api = globalObject.__nativeScriptNativeApi;
-        const NSArray = api?.NSArray ?? globalObject.NSArray;
-        const nativeChildControllers =
-          NSArray && typeof NSArray.arrayWithArray === 'function'
-            ? NSArray.arrayWithArray(childControllers)
-            : childControllers;
-        if (parentKind === 'stack' && childControllers.length > 0) {
-          parent.setViewControllersAnimated(nativeChildControllers, false);
-        } else if (parentKind === 'tabs') {
-          if (typeof parent.setViewControllersAnimated === 'function') {
-            parent.setViewControllersAnimated(nativeChildControllers, false);
-          } else {
-            parent.viewControllers = nativeChildControllers;
-          }
-          if (parent.selectedIndex >= childControllers.length) {
-            parent.selectedIndex = 0;
-          }
-        }
-        layoutVisibleController(parent);
-      }
+      reconcileNavigationChildren(parent, props.parentId, registry.kinds[props.parentId], registry, globalObject);
     }
-    const ownChildren = registry.parentChildren[props.componentId] ?? [];
-    const childControllers: any[] = [];
-    for (let index = 0; index < ownChildren.length; index++) {
-      const child = registry.controllers[ownChildren[index]];
-      if (child) {
-        const childParent = child.parentViewController;
-        if (childParent && childParent !== controller) {
-          child.willMoveToParentViewController(null);
-          child.removeFromParentViewController();
-        }
-        if (child.view?.superview) {
-          child.view.removeFromSuperview();
-        }
-        childControllers[childControllers.length] = child;
-      }
-    }
-    const api = globalObject.__nativeScriptNativeApi;
-    const NSArray = api?.NSArray ?? globalObject.NSArray;
-    const nativeChildControllers =
-      NSArray && typeof NSArray.arrayWithArray === 'function'
-        ? NSArray.arrayWithArray(childControllers)
-        : childControllers;
-    if (typeof controller.setViewControllersAnimated === 'function') {
-      controller.setViewControllersAnimated(nativeChildControllers, false);
-    } else {
-      controller.viewControllers = nativeChildControllers;
-    }
-    if (controller.selectedIndex >= childControllers.length) {
-      controller.selectedIndex = 0;
-    }
-    layoutVisibleController(controller);
+    reconcileNavigationChildren(controller, props.componentId, 'tabs', registry, globalObject);
   },
   mounted(controller, props) {
     'worklet';
-    const key = '__rnnNativeScriptNavigationRegistry';
     const globalObject = globalThis as Record<string, any>;
-    const registry = globalObject[key] ?? {controllers: {}, kinds: {}, parentChildren: {}};
-    globalObject[key] = registry;
+    const registry = getNavigationRegistry(globalObject);
     registry.controllers[props.componentId] = controller;
     registry.kinds[props.componentId] = 'tabs';
     if (props.parentId) {
-      const children = registry.parentChildren[props.parentId] ?? [];
-      let exists = false;
-      for (let index = 0; index < children.length; index++) {
-        if (children[index] === props.componentId) {
-          exists = true;
-          break;
-        }
-      }
-      if (!exists) {
-        children[children.length] = props.componentId;
-        registry.parentChildren[props.parentId] = children;
-      }
+      addNavigationChild(registry, props.parentId, props.componentId);
       const parent = registry.controllers[props.parentId];
-      if (parent) {
-        const childControllers: any[] = [];
-        for (let index = 0; index < children.length; index++) {
-          const child = registry.controllers[children[index]];
-          if (child) {
-            const childParent = child.parentViewController;
-            if (childParent && childParent !== parent) {
-              child.willMoveToParentViewController(null);
-              child.removeFromParentViewController();
-            }
-            if (child.view?.superview) {
-              child.view.removeFromSuperview();
-            }
-            childControllers[childControllers.length] = child;
-          }
-        }
-        const parentKind = registry.kinds[props.parentId];
-        const api = globalObject.__nativeScriptNativeApi;
-        const NSArray = api?.NSArray ?? globalObject.NSArray;
-        const nativeChildControllers =
-          NSArray && typeof NSArray.arrayWithArray === 'function'
-            ? NSArray.arrayWithArray(childControllers)
-            : childControllers;
-        if (parentKind === 'stack' && childControllers.length > 0) {
-          parent.setViewControllersAnimated(nativeChildControllers, false);
-        } else if (parentKind === 'tabs') {
-          if (typeof parent.setViewControllersAnimated === 'function') {
-            parent.setViewControllersAnimated(nativeChildControllers, false);
-          } else {
-            parent.viewControllers = nativeChildControllers;
-          }
-          if (parent.selectedIndex >= childControllers.length) {
-            parent.selectedIndex = 0;
-          }
-        }
-        layoutVisibleController(parent);
-      }
+      reconcileNavigationChildren(parent, props.parentId, registry.kinds[props.parentId], registry, globalObject);
     }
-    const ownChildren = registry.parentChildren[props.componentId] ?? [];
-    const childControllers: any[] = [];
-    for (let index = 0; index < ownChildren.length; index++) {
-      const child = registry.controllers[ownChildren[index]];
-      if (child) {
-        const childParent = child.parentViewController;
-        if (childParent && childParent !== controller) {
-          child.willMoveToParentViewController(null);
-          child.removeFromParentViewController();
-        }
-        if (child.view?.superview) {
-          child.view.removeFromSuperview();
-        }
-        childControllers[childControllers.length] = child;
-      }
-    }
-    const api = globalObject.__nativeScriptNativeApi;
-    const NSArray = api?.NSArray ?? globalObject.NSArray;
-    const nativeChildControllers =
-      NSArray && typeof NSArray.arrayWithArray === 'function'
-        ? NSArray.arrayWithArray(childControllers)
-        : childControllers;
-    if (typeof controller.setViewControllersAnimated === 'function') {
-      controller.setViewControllersAnimated(nativeChildControllers, false);
-    } else {
-      controller.viewControllers = nativeChildControllers;
-    }
-    if (controller.selectedIndex >= childControllers.length) {
-      controller.selectedIndex = 0;
-    }
-    layoutVisibleController(controller);
+    reconcileNavigationChildren(controller, props.componentId, 'tabs', registry, globalObject);
   },
   dispose(_controller, props) {
     'worklet';
@@ -1581,16 +1628,9 @@ const NativeScriptTabsController = NativeScriptRuntime.defineUIViewController<{
     registry.kinds[props.componentId] = undefined;
     registry.parentChildren[props.componentId] = undefined;
     if (props.parentId) {
-      const children = registry.parentChildren[props.parentId] ?? [];
-      for (let index = children.length - 1; index >= 0; index--) {
-        if (children[index] === props.componentId) {
-          for (let moveIndex = index; moveIndex < children.length - 1; moveIndex++) {
-            children[moveIndex] = children[moveIndex + 1];
-          }
-          children.length = children.length - 1;
-        }
-      }
-      registry.parentChildren[props.parentId] = children;
+      removeNavigationChild(registry, props.parentId, props.componentId);
+      const parent = registry.controllers[props.parentId];
+      reconcileNavigationChildren(parent, props.parentId, registry.kinds[props.parentId], registry, globalObject);
     }
   },
 });

--- a/src/nativescript/index.ts
+++ b/src/nativescript/index.ts
@@ -1,0 +1,5 @@
+export {
+  createNativeScriptNavigation,
+  registerNativeScriptNavigationRoot,
+} from './NativeScriptNavigation';
+export type { NativeScriptNavigationInstance } from './NativeScriptNavigation';

--- a/src/nativescript/native-script-react-native.d.ts
+++ b/src/nativescript/native-script-react-native.d.ts
@@ -4,6 +4,18 @@ declare module '@nativescript/react-native' {
 
   export type UIKitViewContext<Props extends object> = {
     props: Readonly<Props>;
+    emit<K extends keyof Props>(
+      eventName: K,
+      payload?: Props[K] extends ((arg: infer Payload) => unknown) | undefined
+        ? Payload
+        : unknown
+    ): void;
+    delegate<T extends object>(
+      object: unknown,
+      protocolRef: unknown,
+      implementation: Partial<T>
+    ): T;
+    targetAction(control: unknown, events: unknown, callback: () => void): void;
   };
 
   export type UIKitLayoutOptions = {

--- a/src/nativescript/native-script-react-native.d.ts
+++ b/src/nativescript/native-script-react-native.d.ts
@@ -1,0 +1,57 @@
+declare module '@nativescript/react-native' {
+  import * as React from 'react';
+  import { ViewProps } from 'react-native';
+
+  export type UIKitViewContext<Props extends object> = {
+    props: Readonly<Props>;
+  };
+
+  export type UIKitLayoutOptions = {
+    sizing?: 'fill' | 'intrinsic' | 'sizeThatFits' | 'autoLayout';
+    defaultSize?: {width?: number; height?: number};
+    minSize?: {width?: number; height?: number};
+    maxSize?: {width?: number; height?: number};
+  };
+
+  export type UIViewControllerDefinition<Props extends object, Controller = unknown> = {
+    debugName?: string;
+    layout?: UIKitLayoutOptions;
+    createController: (
+      ctx: UIKitViewContext<Props & ViewProps> & Readonly<Props & ViewProps>
+    ) => Controller;
+    childrenView?: (controller: Controller) => unknown;
+    update?: (
+      controller: Controller,
+      props: Readonly<Props & ViewProps>,
+      previousProps?: Readonly<Props & ViewProps>,
+      ctx?: UIKitViewContext<Props & ViewProps>
+    ) => void;
+    mounted?: (
+      controller: Controller,
+      props: Readonly<Props & ViewProps>,
+      ctx?: UIKitViewContext<Props & ViewProps>
+    ) => void;
+    dispose?: (
+      controller: Controller,
+      props: Readonly<Props & ViewProps>,
+      ctx?: UIKitViewContext<Props & ViewProps>
+    ) => void;
+  };
+
+  export function defineUIViewController<Props extends object, Controller = unknown>(
+    definition: UIViewControllerDefinition<Props, Controller>
+  ): React.ComponentType<
+    React.PropsWithChildren<
+      Props & ViewProps & {attachController?: boolean; attachNativeView?: boolean}
+    >
+  >;
+
+  export function getClass<T = unknown>(name: string): T | null;
+
+  const NativeScript: {
+    defineUIViewController: typeof defineUIViewController;
+    getClass: typeof getClass;
+  };
+
+  export default NativeScript;
+}


### PR DESCRIPTION
## Summary
- add a NativeScript-backed React Native Navigation surface for stack/component rendering
- serialize per-stack commands without dropping opposite push/pop taps
- preserve UIKit push/pop animations while reapplying hosted React content after transitions

## Verification
- npx eslint --ext .ts,.tsx src/nativescript/NativeScriptCommandsSender.ts src/nativescript/NativeScriptNavigationSurface.tsx src/nativescript/NativeScriptNavigation.test.tsx src/nativescript/native-script-react-native.d.ts
- npx jest src/nativescript/NativeScriptNavigation.test.tsx --runInBand
- node .yarn/releases/yarn-4.12.0.cjs bob build
- iPhone 17 iOS 26 simulator demo: push/pop animation, native back tap, rapid double-push dedupe, in-content pop