### PR TITLE
android: fix custom top bar title Fill alignment

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleAndButtonsContainer.kt
+++ b/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleAndButtonsContainer.kt
@@ -106,6 +106,7 @@ class TitleAndButtonsContainer(context: Context) : ViewGroup(context) {
     override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
         val titleComponent = getTitleComponent()
         val isCenter = titleComponentAlignment == Alignment.Center
+        val isFill = titleComponentAlignment == Alignment.Fill
         val containerWidth = r - l
         val containerHeight = b - t
         val isRTL = isRTL()
@@ -114,7 +115,7 @@ class TitleAndButtonsContainer(context: Context) : ViewGroup(context) {
         val leftBarWidth = leftButtonBar.measuredWidth
         val rightBarWidth = rightButtonBar.measuredWidth
 
-        val (titleLeft, titleRight) = resolveHorizontalTitleBoundsLimit(containerWidth, titleWidth, leftBarWidth, rightBarWidth, isCenter, isRTL)
+        val (titleLeft, titleRight) = resolveHorizontalTitleBoundsLimit(containerWidth, titleWidth, leftBarWidth, rightBarWidth, isCenter, isRTL, isFill)
         val (titleTop, titleBottom) = resolveVerticalTitleBoundsLimit(containerHeight, titleHeight)
         val (leftButtonsLeft, leftButtonsRight) = resolveLeftButtonsBounds(containerWidth, leftBarWidth, isRTL)
         val (rightButtonsLeft, rightButtonsRight) = resolveRightButtonsBounds(containerWidth, rightButtonBar.measuredWidth, isRTL)

--- a/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleAndButtonsMeasurer.kt
+++ b/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleAndButtonsMeasurer.kt
@@ -43,7 +43,8 @@ fun resolveHorizontalTitleBoundsLimit(
         leftBarWidth: Int,
         rightBarWidth: Int,
         isCenter: Boolean,
-        isRTL: Boolean
+        isRTL: Boolean,
+        isFill: Boolean = false
 ): Pair<TitleLeft, TitleRight> {
     val resolvedLeftBarWidth = if (isRTL) rightBarWidth else leftBarWidth
     val resolvedRightBarWidth = if (isRTL) leftBarWidth else rightBarWidth
@@ -51,6 +52,13 @@ fun resolveHorizontalTitleBoundsLimit(
     var suggestedRight: TitleRight
 
     val rightLimit = parentWidth - resolvedRightBarWidth
+    if (isFill) {
+        // Fill alignment must span the entire space between the left and right
+        // button bars without the DEFAULT_LEFT_MARGIN_PX reservation used for
+        // left-aligned titles. Mirrors the measure spec produced by
+        // makeTitleAtMostWidthMeasureSpec when isFill = true.
+        return resolvedLeftBarWidth to rightLimit
+    }
     if (isCenter) {
         val availableSpace = parentWidth - resolvedLeftBarWidth - resolvedRightBarWidth
         if (titleWidth >= availableSpace) {

--- a/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleAndButtonsMeasurer.kt
+++ b/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleAndButtonsMeasurer.kt
@@ -19,12 +19,14 @@ fun makeTitleAtMostWidthMeasureSpec(containerWidth: Int, rightBarWidth: Int, lef
     return if (isCenter) {
         val availableWidth = containerWidth - rightBarWidth - leftBarWidth
         View.MeasureSpec.makeMeasureSpec(availableWidth, View.MeasureSpec.AT_MOST)
+    } else if (isFill) {
+        // Fill alignment must span the entire space between left and right button bars,
+        // so do not reserve the DEFAULT_LEFT_MARGIN_PX padding used for left-aligned titles.
+        val availableWidth = containerWidth - rightBarWidth - leftBarWidth
+        View.MeasureSpec.makeMeasureSpec(availableWidth, View.MeasureSpec.EXACTLY)
     } else {
         val availableWidth = containerWidth - rightBarWidth - leftBarWidth - 2 * DEFAULT_LEFT_MARGIN_PX
-        View.MeasureSpec.makeMeasureSpec(
-            availableWidth,
-            if (isFill) View.MeasureSpec.EXACTLY else View.MeasureSpec.AT_MOST
-        )
+        View.MeasureSpec.makeMeasureSpec(availableWidth, View.MeasureSpec.AT_MOST)
     }
 }
 

--- a/android/src/test/java/com/reactnativenavigation/utils/TitleAndButtonsMeasurer.kt
+++ b/android/src/test/java/com/reactnativenavigation/utils/TitleAndButtonsMeasurer.kt
@@ -1,7 +1,9 @@
 package com.reactnativenavigation.utils
 
+import android.view.View
 import com.reactnativenavigation.BaseRobolectricTest
 import com.reactnativenavigation.views.stack.topbar.titlebar.DEFAULT_LEFT_MARGIN_PX
+import com.reactnativenavigation.views.stack.topbar.titlebar.makeTitleAtMostWidthMeasureSpec
 import com.reactnativenavigation.views.stack.topbar.titlebar.resolveHorizontalTitleBoundsLimit
 import com.reactnativenavigation.views.stack.topbar.titlebar.resolveLeftButtonsBounds
 import com.reactnativenavigation.views.stack.topbar.titlebar.resolveRightButtonsBounds
@@ -354,5 +356,83 @@ class TitleAndButtonsMeasurer : BaseRobolectricTest() {
         val (left, right) = resolveHorizontalTitleBoundsLimit(parentWidth, barWidth, leftButtons, rightButtons, center, isRTL)
         assertEquals(parentWidth - leftButtons - DEFAULT_LEFT_MARGIN_PX - barWidth - DEFAULT_LEFT_MARGIN_PX, left)
         assertEquals(parentWidth - leftButtons - DEFAULT_LEFT_MARGIN_PX, right)
+    }
+
+    // ----- makeTitleAtMostWidthMeasureSpec -----
+
+    @Test
+    fun `makeTitleAtMostWidthMeasureSpec - Fill - no buttons - EXACTLY full container width`() {
+        val spec = makeTitleAtMostWidthMeasureSpec(parentWidth, 0, 0, isCenter = false, isFill = true)
+        assertEquals(View.MeasureSpec.EXACTLY, View.MeasureSpec.getMode(spec))
+        assertEquals(parentWidth, View.MeasureSpec.getSize(spec))
+    }
+
+    @Test
+    fun `makeTitleAtMostWidthMeasureSpec - Fill - with buttons - EXACTLY width minus bars`() {
+        val leftBar = 120
+        val rightBar = 80
+        val spec = makeTitleAtMostWidthMeasureSpec(parentWidth, rightBar, leftBar, isCenter = false, isFill = true)
+        assertEquals(View.MeasureSpec.EXACTLY, View.MeasureSpec.getMode(spec))
+        assertEquals(parentWidth - leftBar - rightBar, View.MeasureSpec.getSize(spec))
+    }
+
+    @Test
+    fun `makeTitleAtMostWidthMeasureSpec - Center - AT_MOST full container width minus bars`() {
+        val leftBar = 100
+        val rightBar = 100
+        val spec = makeTitleAtMostWidthMeasureSpec(parentWidth, rightBar, leftBar, isCenter = true)
+        assertEquals(View.MeasureSpec.AT_MOST, View.MeasureSpec.getMode(spec))
+        assertEquals(parentWidth - leftBar - rightBar, View.MeasureSpec.getSize(spec))
+    }
+
+    @Test
+    fun `makeTitleAtMostWidthMeasureSpec - default (left-aligned) - keeps 2 x DEFAULT_LEFT_MARGIN_PX reservation`() {
+        val leftBar = 100
+        val rightBar = 100
+        val spec = makeTitleAtMostWidthMeasureSpec(parentWidth, rightBar, leftBar, isCenter = false, isFill = false)
+        assertEquals(View.MeasureSpec.AT_MOST, View.MeasureSpec.getMode(spec))
+        assertEquals(parentWidth - leftBar - rightBar - 2 * DEFAULT_LEFT_MARGIN_PX, View.MeasureSpec.getSize(spec))
+    }
+
+    // ----- resolveHorizontalTitleBoundsLimit - Fill alignment -----
+
+    @Test
+    fun `Fill - no buttons - Title should span full container width`() {
+        val barWidth = 200 // measured width of the title component
+        val leftButtons = 0
+        val rightButtons = 0
+        val isRTL = false
+        val center = false
+        val isFill = true
+        val (left, right) = resolveHorizontalTitleBoundsLimit(parentWidth, barWidth, leftButtons, rightButtons, center, isRTL, isFill)
+        assertEquals(0, left)
+        assertEquals(parentWidth, right)
+    }
+
+    @Test
+    fun `Fill - with buttons - Title should span between buttons without DEFAULT_LEFT_MARGIN_PX`() {
+        val barWidth = 200
+        val leftButtons = 120
+        val rightButtons = 80
+        val isRTL = false
+        val center = false
+        val isFill = true
+        val (left, right) = resolveHorizontalTitleBoundsLimit(parentWidth, barWidth, leftButtons, rightButtons, center, isRTL, isFill)
+        assertEquals(leftButtons, left)
+        assertEquals(parentWidth - rightButtons, right)
+    }
+
+    @Test
+    fun `RTL - Fill - with buttons - Title should span between buttons after RTL flip`() {
+        val barWidth = 200
+        val leftButtons = 120
+        val rightButtons = 80
+        val isRTL = true
+        val center = false
+        val isFill = true
+        val (left, right) = resolveHorizontalTitleBoundsLimit(parentWidth, barWidth, leftButtons, rightButtons, center, isRTL, isFill)
+        // RTL flips logical left/right: leftButtons render on the right edge, rightButtons on the left.
+        assertEquals(rightButtons, left)
+        assertEquals(parentWidth - leftButtons, right)
     }
 }

--- a/android/src/test/java/com/reactnativenavigation/views/TitleAndButtonsContainerTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/views/TitleAndButtonsContainerTest.kt
@@ -352,8 +352,11 @@ class TitleAndButtonsContainerTest : BaseTest() {
         )
         component = uut.getTitleComponent()
         idleMainLooper()
-        assertThat(component.left).isEqualTo(DEFAULT_LEFT_MARGIN_PX)
-        assertThat(component.right).isEqualTo(titleBarWidth + 2 * DEFAULT_LEFT_MARGIN_PX)
+        // Fill alignment must span the full container width between left and right
+        // button bars (zero-width here). The previous assertion that allowed the
+        // DEFAULT_LEFT_MARGIN_PX reservation matched left-aligned behaviour, not Fill.
+        assertThat(component.left).isEqualTo(0)
+        assertThat(component.right).isEqualTo(UUT_WIDTH)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes a regression introduced in [PR #8182](https://github.com/wix/react-native-navigation/pull/8182): Fill-aligned custom title components on Android still render with a margin gap on both edges instead of spanning the entire space between the left and right button bars. Reproducible on upstream `master`.

Three layered fixes plus tests, in three reviewable commits:

### 1. `makeTitleAtMostWidthMeasureSpec` - drop the 32dp reservation for Fill

#8182 added the `isFill` parameter and switched the MeasureSpec mode from `AT_MOST` to `EXACTLY` for Fill, but the else branch still subtracts `2 * DEFAULT_LEFT_MARGIN_PX` (32dp). That reservation is the Material-style breathing room for left-aligned titles - wrong for Fill, whose intent is edge-to-edge.

### 2. `resolveHorizontalTitleBoundsLimit` + `TitleAndButtonsContainer.onLayout` - position Fill edge-to-edge

Even with #1, Fill titles were laid out via `resolveHorizontalTitleBoundsLimit`, which had no Fill awareness and applied the same 16dp reservation as left-aligned titles. Result: the React component is measured at the full available width but laid out in a slot 16dp narrower on each side. This commit adds `isFill: Boolean = false` to the helper (default keeps existing callers unchanged) and threads the flag from `onLayout`.

### 3. Tests - Robolectric coverage for the matrix that turned the regression on

`makeTitleAtMostWidthMeasureSpec` had zero direct unit tests, and the existing Fill assertion in `TitleAndButtonsContainerTest` codified the buggy left-aligned-with-margins position. This commit:

- Adds Robolectric tests for `makeTitleAtMostWidthMeasureSpec` covering Fill / Center / left-aligned with and without button bars, asserting on both `MeasureSpec.getMode()` and `MeasureSpec.getSize()`.
- Adds Robolectric tests for `resolveHorizontalTitleBoundsLimit(isFill = true)` covering no-buttons / with-buttons / RTL.
- Corrects the buggy Fill assertion in `TitleAndButtonsContainerTest.onLayout - should measure and layout children when alignment changes` to assert the actual Fill intent (`left = 0`, `right = UUT_WIDTH`).

## Related

- Closes the Fill manifestation reported in [#6456](https://github.com/wix/react-native-navigation/issues/6456) (Custom topbar title does not take the whole space).
- Follow-up to [#8182](https://github.com/wix/react-native-navigation/pull/8182), which added the `isFill` plumbing without the margin handling and without a Robolectric assertion on the measured width.

## Validation

Verified end-to-end on a physical Samsung Galaxy S21 (Android 15) by capturing matched before/after pairs against the same playground build. Repro builds: master `1afec76bae` vs this PR `462c6f53ca`. A custom `TopBarTitleTestScreen` mounts a 32×32 red marker as `leftButton.component` plus a long Fill-aligned title; the red square makes the leftover gap obvious.

**State 1 - Fill title with subtitle:**

| Before (master `1afec76bae`) | After (this PR) |
|---|---|
| <img width="1080" height="2400" alt="state-1-with-subtitle" src="https://github.com/user-attachments/assets/8f662300-8880-4248-9457-59893d13af86" /> | <img width="1080" height="2400" alt="state-1-with-subtitle" src="https://github.com/user-attachments/assets/8b021193-3916-4752-955b-89ec18bfb119" /> |

**State 2 - Fill title without subtitle (the original report from #6456):**

| Before (master `1afec76bae`) | After (this PR) |
|---|---|
| <img width="1080" height="2400" alt="state-2-without-subtitle-BUG" src="https://github.com/user-attachments/assets/ef7cf439-3169-47d3-ac55-f5d0d9d10740" /> | <img width="1080" height="2400" alt="state-2-without-subtitle-BUG" src="https://github.com/user-attachments/assets/1bbdd7f5-d5c6-4e74-a6a3-9b8d36a01e52" /> |

In the "after" shots the title sits flush against the red marker, the ~32dp leftover gap is gone, and a few more characters of the long title fit before truncation - matching the Fill-aligned edge-to-edge intent.

New Robolectric tests added in this PR exercise the matrix that turned the regression on. Local `yarn test-unit-android` run pending.

## What is not yet here / open questions

- A matching playground assertion (Detox `toHaveRect`) on the Fill-aligned title's right edge - happy to add this if you would prefer it land in this PR.
- iOS parity. #8182 also touched `RNNReactTitleView.mm` (`_expectedHeight`). My device repro is Android-only; iOS Fill appears correct in adjacent testing but a maintainer eye on it would be welcome.
