### PR TITLE
android: stabilize custom top bar button layout

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
+++ b/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
@@ -32,25 +32,35 @@ public class TitleBarReactButtonView extends ReactView {
             this.setId(View.NO_ID);
         }
 
-        int finalHeightSpec = createHeightSpec(component.height);
-        if (component.width.hasValue()) {
-            super.onMeasure(createExactSpec(component.width), finalHeightSpec);
+        int initialWidthSpec = component.width.hasValue()
+                ? createExactSpec(component.width)
+                : makeMeasureSpec(resolveAvailableWidth(widthMeasureSpec), AT_MOST);
+        int initialHeightSpec = createHeightSpec(heightMeasureSpec, component.height);
+
+        // First discover the content size without forcing every custom button to actionBarSize.
+        super.onMeasure(initialWidthSpec, initialHeightSpec);
+
+        if (component.width.hasValue() && component.height.hasValue()) {
             return;
         }
 
-        // First discover the content width without forcing every custom button to actionBarSize.
-        super.onMeasure(makeMeasureSpec(resolveAvailableWidth(widthMeasureSpec), AT_MOST), finalHeightSpec);
-
         // Then give RN/Yoga a stable exact final box for compatibility with centered button layouts.
         // A small allowance avoids clipping implicit RN padding/subpixel layout while staying content-based.
-        super.onMeasure(makeMeasureSpec(resolveFinalWidth(getMeasuredWidth()), EXACTLY), finalHeightSpec);
+        int finalWidth = component.width.hasValue()
+                ? MeasureSpec.getSize(initialWidthSpec)
+                : resolveFinalWidth(getMeasuredWidth());
+        int finalHeight = component.height.hasValue()
+                ? MeasureSpec.getSize(initialHeightSpec)
+                : Math.max(getMeasuredHeight(), 1);
+        super.onMeasure(makeMeasureSpec(finalWidth, EXACTLY), makeMeasureSpec(finalHeight, EXACTLY));
     }
 
-    private int createHeightSpec(Number dimension) {
+    private int createHeightSpec(int measureSpec, Number dimension) {
         if (dimension.hasValue()) {
             return createExactSpec(dimension);
         }
-        return makeMeasureSpec(Math.max(resolveActionBarSize(), 1), EXACTLY);
+        int availableSize = MeasureSpec.getSize(measureSpec);
+        return makeMeasureSpec(availableSize > 0 ? availableSize : Math.max(resolveActionBarSize(), 1), AT_MOST);
     }
 
     private int resolveAvailableWidth(int measureSpec) {

--- a/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
+++ b/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
@@ -3,7 +3,9 @@ package com.reactnativenavigation.views.stack.topbar.titlebar;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.util.TypedValue;
+import android.view.Gravity;
 import android.view.View;
+import android.widget.FrameLayout;
 
 import com.reactnativenavigation.options.ComponentOptions;
 import com.reactnativenavigation.options.params.Number;
@@ -16,12 +18,23 @@ import static com.reactnativenavigation.utils.UiUtils.dpToPx;
 
 @SuppressLint("ViewConstructor")
 public class TitleBarReactButtonView extends ReactView {
-    private static final float FINAL_WIDTH_PADDING_DP = 2f;
+    private static final float FINAL_WIDTH_PADDING_DP = 1f;
     private final ComponentOptions component;
 
     public TitleBarReactButtonView(Context context, ComponentOptions component) {
         super(context, component.componentId.get(), component.name.get());
         this.component = component;
+    }
+
+    @Override
+    public void onViewAdded(View child) {
+        super.onViewAdded(child);
+        if (child.getLayoutParams() instanceof FrameLayout.LayoutParams) {
+            FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) child.getLayoutParams();
+            layoutParams.gravity = layoutParams.gravity == -1
+                    ? Gravity.CENTER_VERTICAL
+                    : (layoutParams.gravity & ~Gravity.VERTICAL_GRAVITY_MASK) | Gravity.CENTER_VERTICAL;
+        }
     }
 
     @Override

--- a/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
+++ b/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
@@ -31,32 +31,29 @@ public class TitleBarReactButtonView extends ReactView {
             this.setId(View.NO_ID);
         }
 
-        super.onMeasure(
-                createWidthSpec(widthMeasureSpec, component.width),
-                createHeightSpec(heightMeasureSpec, component.height)
-        );
+        int finalHeightSpec = createHeightSpec(component.height);
+        if (component.width.hasValue()) {
+            super.onMeasure(createExactSpec(component.width), finalHeightSpec);
+            return;
+        }
+
+        // First discover the content width without forcing every custom button to actionBarSize.
+        super.onMeasure(makeMeasureSpec(resolveAvailableWidth(widthMeasureSpec), AT_MOST), finalHeightSpec);
+
+        // Then give RN/Yoga a stable exact final box for compatibility with centered button layouts.
+        super.onMeasure(makeMeasureSpec(Math.max(getMeasuredWidth(), 1), EXACTLY), finalHeightSpec);
     }
 
-    private int createWidthSpec(int measureSpec, Number dimension) {
-        return createSpec(measureSpec, dimension, Math.max(getResources().getDisplayMetrics().widthPixels, 1));
-    }
-
-    private int createHeightSpec(int measureSpec, Number dimension) {
+    private int createHeightSpec(Number dimension) {
         if (dimension.hasValue()) {
             return createExactSpec(dimension);
         }
         return makeMeasureSpec(Math.max(resolveActionBarSize(), 1), EXACTLY);
     }
 
-    private int createSpec(int measureSpec, Number dimension, int fallbackSize) {
-        if (dimension.hasValue()) {
-            return createExactSpec(dimension);
-        } else {
-            // Use bounded wrap-content width to avoid RN/Yoga RTL padding issues caused by
-            // UNSPECIFIED, without forcing every custom button to actionBarSize width.
-            int availableSize = MeasureSpec.getSize(measureSpec);
-            return makeMeasureSpec(availableSize > 0 ? availableSize : fallbackSize, AT_MOST);
-        }
+    private int resolveAvailableWidth(int measureSpec) {
+        int availableSize = MeasureSpec.getSize(measureSpec);
+        return availableSize > 0 ? availableSize : Math.max(getResources().getDisplayMetrics().widthPixels, 1);
     }
 
     private int createExactSpec(Number dimension) {

--- a/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
+++ b/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
@@ -16,6 +16,7 @@ import static com.reactnativenavigation.utils.UiUtils.dpToPx;
 
 @SuppressLint("ViewConstructor")
 public class TitleBarReactButtonView extends ReactView {
+    private static final float FINAL_WIDTH_PADDING_DP = 2f;
     private final ComponentOptions component;
 
     public TitleBarReactButtonView(Context context, ComponentOptions component) {
@@ -41,7 +42,8 @@ public class TitleBarReactButtonView extends ReactView {
         super.onMeasure(makeMeasureSpec(resolveAvailableWidth(widthMeasureSpec), AT_MOST), finalHeightSpec);
 
         // Then give RN/Yoga a stable exact final box for compatibility with centered button layouts.
-        super.onMeasure(makeMeasureSpec(Math.max(getMeasuredWidth(), 1), EXACTLY), finalHeightSpec);
+        // A small allowance avoids clipping implicit RN padding/subpixel layout while staying content-based.
+        super.onMeasure(makeMeasureSpec(resolveFinalWidth(getMeasuredWidth()), EXACTLY), finalHeightSpec);
     }
 
     private int createHeightSpec(Number dimension) {
@@ -54,6 +56,10 @@ public class TitleBarReactButtonView extends ReactView {
     private int resolveAvailableWidth(int measureSpec) {
         int availableSize = MeasureSpec.getSize(measureSpec);
         return availableSize > 0 ? availableSize : Math.max(getResources().getDisplayMetrics().widthPixels, 1);
+    }
+
+    private int resolveFinalWidth(int measuredContentWidth) {
+        return Math.max(measuredContentWidth + (int) Math.ceil(dpToPx(getContext(), FINAL_WIDTH_PADDING_DP)), 1);
     }
 
     private int createExactSpec(Number dimension) {

--- a/android/src/test/java/com/reactnativenavigation/views/TitleBarReactButtonViewTest.java
+++ b/android/src/test/java/com/reactnativenavigation/views/TitleBarReactButtonViewTest.java
@@ -39,13 +39,13 @@ public class TitleBarReactButtonViewTest extends BaseTest {
 
         uut.measure(makeMeasureSpec(PARENT_WIDTH, AT_MOST), makeMeasureSpec(PARENT_HEIGHT, AT_MOST));
 
-        assertThat(uut.getMeasuredWidth()).isEqualTo(CHILD_WIDTH);
+        assertThat(uut.getMeasuredWidth()).isEqualTo(finalWidth(activity));
         assertThat(uut.getMeasuredHeight()).isEqualTo(resolveActionBarSize(activity));
         assertThat(child.widthMeasureSpecs.size()).isEqualTo(2);
         assertThat(getMode(child.widthMeasureSpecs.get(0))).isEqualTo(AT_MOST);
         assertThat(getSize(child.widthMeasureSpecs.get(0))).isEqualTo(PARENT_WIDTH);
         assertThat(getMode(child.widthMeasureSpecs.get(1))).isEqualTo(EXACTLY);
-        assertThat(getSize(child.widthMeasureSpecs.get(1))).isEqualTo(CHILD_WIDTH);
+        assertThat(getSize(child.widthMeasureSpecs.get(1))).isEqualTo(finalWidth(activity));
         assertThat(getMode(child.heightMeasureSpecs.get(1))).isEqualTo(EXACTLY);
         assertThat(getSize(child.heightMeasureSpecs.get(1))).isEqualTo(resolveActionBarSize(activity));
     }
@@ -85,7 +85,7 @@ public class TitleBarReactButtonViewTest extends BaseTest {
         assertThat(getSize(child.widthMeasureSpecs.get(0)))
                 .isEqualTo(Math.max(activity.getResources().getDisplayMetrics().widthPixels, 1));
         assertThat(getMode(child.widthMeasureSpecs.get(1))).isEqualTo(EXACTLY);
-        assertThat(getSize(child.widthMeasureSpecs.get(1))).isEqualTo(CHILD_WIDTH);
+        assertThat(getSize(child.widthMeasureSpecs.get(1))).isEqualTo(finalWidth(activity));
         assertThat(getMode(child.heightMeasureSpecs.get(0))).isEqualTo(EXACTLY);
         assertThat(getSize(child.heightMeasureSpecs.get(0))).isEqualTo(Math.max(resolveActionBarSize(activity), 1));
     }
@@ -104,7 +104,7 @@ public class TitleBarReactButtonViewTest extends BaseTest {
         assertThat(getMode(child.widthMeasureSpecs.get(0))).isEqualTo(AT_MOST);
         assertThat(getSize(child.widthMeasureSpecs.get(0))).isEqualTo(PARENT_WIDTH);
         assertThat(getMode(child.widthMeasureSpecs.get(1))).isEqualTo(EXACTLY);
-        assertThat(getSize(child.widthMeasureSpecs.get(1))).isEqualTo(CHILD_WIDTH);
+        assertThat(getSize(child.widthMeasureSpecs.get(1))).isEqualTo(finalWidth(activity));
         assertThat(getMode(child.heightMeasureSpecs.get(1))).isEqualTo(EXACTLY);
         assertThat(getSize(child.heightMeasureSpecs.get(1))).isEqualTo(resolveActionBarSize(activity));
     }
@@ -129,6 +129,10 @@ public class TitleBarReactButtonViewTest extends BaseTest {
             return TypedValue.complexToDimensionPixelSize(tv.data, activity.getResources().getDisplayMetrics());
         }
         return UiUtils.dpToPx(activity, 48);
+    }
+
+    private int finalWidth(Activity activity) {
+        return CHILD_WIDTH + (int) Math.ceil(UiUtils.dpToPx(activity, 2));
     }
 
     private static class RecordingContentView extends View {

--- a/android/src/test/java/com/reactnativenavigation/views/TitleBarReactButtonViewTest.java
+++ b/android/src/test/java/com/reactnativenavigation/views/TitleBarReactButtonViewTest.java
@@ -9,8 +9,10 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import android.app.Activity;
 import android.util.TypedValue;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 
 import com.reactnativenavigation.BaseTest;
 import com.reactnativenavigation.options.ComponentOptions;
@@ -113,6 +115,39 @@ public class TitleBarReactButtonViewTest extends BaseTest {
         assertThat(getSize(child.heightMeasureSpecs.get(1))).isEqualTo(CHILD_HEIGHT);
     }
 
+    @Test
+    public void contentRemainsCenteredWhenMenuCellLaysButtonOutTallerThanMeasuredHeight() {
+        Activity activity = newActivity();
+        TitleBarReactButtonView uut = createView(activity, new ComponentOptions());
+        RecordingContentView child = new RecordingContentView(activity);
+        setContentView(uut, child);
+
+        uut.measure(makeMeasureSpec(PARENT_WIDTH, AT_MOST), makeMeasureSpec(PARENT_HEIGHT, AT_MOST));
+        uut.layout(0, 0, uut.getMeasuredWidth(), PARENT_HEIGHT);
+
+        assertThat(uut.getMeasuredHeight()).isEqualTo(CHILD_HEIGHT);
+        assertThat(child.getTop()).isEqualTo((PARENT_HEIGHT - CHILD_HEIGHT) / 2);
+        assertThat(child.getBottom()).isEqualTo((PARENT_HEIGHT + CHILD_HEIGHT) / 2);
+    }
+
+    @Test
+    public void contentCenteringReplacesExistingVerticalGravityOnly() {
+        Activity activity = newActivity();
+        TitleBarReactButtonView uut = createView(activity, new ComponentOptions());
+        RecordingContentView child = new RecordingContentView(activity);
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+        );
+        params.gravity = Gravity.TOP | Gravity.RIGHT;
+
+        uut.addView(child, params);
+
+        FrameLayout.LayoutParams updatedParams = (FrameLayout.LayoutParams) child.getLayoutParams();
+        assertThat(updatedParams.gravity & Gravity.VERTICAL_GRAVITY_MASK).isEqualTo(Gravity.CENTER_VERTICAL);
+        assertThat(updatedParams.gravity & Gravity.HORIZONTAL_GRAVITY_MASK).isEqualTo(Gravity.RIGHT);
+    }
+
     private TitleBarReactButtonView createView(Activity activity, ComponentOptions component) {
         component.name = new Text("ButtonComponent");
         component.componentId = new Text("ButtonComponentId");
@@ -136,7 +171,7 @@ public class TitleBarReactButtonViewTest extends BaseTest {
     }
 
     private int finalWidth(Activity activity) {
-        return CHILD_WIDTH + (int) Math.ceil(UiUtils.dpToPx(activity, 2));
+        return CHILD_WIDTH + (int) Math.ceil(UiUtils.dpToPx(activity, 1f));
     }
 
     private static class RecordingContentView extends View {

--- a/android/src/test/java/com/reactnativenavigation/views/TitleBarReactButtonViewTest.java
+++ b/android/src/test/java/com/reactnativenavigation/views/TitleBarReactButtonViewTest.java
@@ -40,14 +40,16 @@ public class TitleBarReactButtonViewTest extends BaseTest {
         uut.measure(makeMeasureSpec(PARENT_WIDTH, AT_MOST), makeMeasureSpec(PARENT_HEIGHT, AT_MOST));
 
         assertThat(uut.getMeasuredWidth()).isEqualTo(finalWidth(activity));
-        assertThat(uut.getMeasuredHeight()).isEqualTo(resolveActionBarSize(activity));
+        assertThat(uut.getMeasuredHeight()).isEqualTo(CHILD_HEIGHT);
         assertThat(child.widthMeasureSpecs.size()).isEqualTo(2);
         assertThat(getMode(child.widthMeasureSpecs.get(0))).isEqualTo(AT_MOST);
         assertThat(getSize(child.widthMeasureSpecs.get(0))).isEqualTo(PARENT_WIDTH);
+        assertThat(getMode(child.heightMeasureSpecs.get(0))).isEqualTo(AT_MOST);
+        assertThat(getSize(child.heightMeasureSpecs.get(0))).isEqualTo(PARENT_HEIGHT);
         assertThat(getMode(child.widthMeasureSpecs.get(1))).isEqualTo(EXACTLY);
         assertThat(getSize(child.widthMeasureSpecs.get(1))).isEqualTo(finalWidth(activity));
         assertThat(getMode(child.heightMeasureSpecs.get(1))).isEqualTo(EXACTLY);
-        assertThat(getSize(child.heightMeasureSpecs.get(1))).isEqualTo(resolveActionBarSize(activity));
+        assertThat(getSize(child.heightMeasureSpecs.get(1))).isEqualTo(CHILD_HEIGHT);
     }
 
     @Test
@@ -72,7 +74,7 @@ public class TitleBarReactButtonViewTest extends BaseTest {
     }
 
     @Test
-    public void zeroParentWidthFallbacksToBoundedAtMostSpecAndHeightUsesActionBarSize() {
+    public void zeroParentSpecsFallbackToBoundedAtMostSpecs() {
         Activity activity = newActivity();
         TitleBarReactButtonView uut = createView(activity, new ComponentOptions());
         RecordingContentView child = new RecordingContentView(activity);
@@ -86,8 +88,10 @@ public class TitleBarReactButtonViewTest extends BaseTest {
                 .isEqualTo(Math.max(activity.getResources().getDisplayMetrics().widthPixels, 1));
         assertThat(getMode(child.widthMeasureSpecs.get(1))).isEqualTo(EXACTLY);
         assertThat(getSize(child.widthMeasureSpecs.get(1))).isEqualTo(finalWidth(activity));
-        assertThat(getMode(child.heightMeasureSpecs.get(0))).isEqualTo(EXACTLY);
+        assertThat(getMode(child.heightMeasureSpecs.get(0))).isEqualTo(AT_MOST);
         assertThat(getSize(child.heightMeasureSpecs.get(0))).isEqualTo(Math.max(resolveActionBarSize(activity), 1));
+        assertThat(getMode(child.heightMeasureSpecs.get(1))).isEqualTo(EXACTLY);
+        assertThat(getSize(child.heightMeasureSpecs.get(1))).isEqualTo(CHILD_HEIGHT);
     }
 
     @Test
@@ -106,7 +110,7 @@ public class TitleBarReactButtonViewTest extends BaseTest {
         assertThat(getMode(child.widthMeasureSpecs.get(1))).isEqualTo(EXACTLY);
         assertThat(getSize(child.widthMeasureSpecs.get(1))).isEqualTo(finalWidth(activity));
         assertThat(getMode(child.heightMeasureSpecs.get(1))).isEqualTo(EXACTLY);
-        assertThat(getSize(child.heightMeasureSpecs.get(1))).isEqualTo(resolveActionBarSize(activity));
+        assertThat(getSize(child.heightMeasureSpecs.get(1))).isEqualTo(CHILD_HEIGHT);
     }
 
     private TitleBarReactButtonView createView(Activity activity, ComponentOptions component) {

--- a/android/src/test/java/com/reactnativenavigation/views/TitleBarReactButtonViewTest.java
+++ b/android/src/test/java/com/reactnativenavigation/views/TitleBarReactButtonViewTest.java
@@ -21,6 +21,9 @@ import com.reactnativenavigation.views.stack.topbar.titlebar.TitleBarReactButton
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class TitleBarReactButtonViewTest extends BaseTest {
     private static final int PARENT_WIDTH = 200;
     private static final int PARENT_HEIGHT = 100;
@@ -28,15 +31,23 @@ public class TitleBarReactButtonViewTest extends BaseTest {
     private static final int CHILD_HEIGHT = 16;
 
     @Test
-    public void missingDimensionsMeasureToContentWithinParentBounds() {
+    public void missingDimensionsMeasureToContentThenRemeasureExactForStableAlignment() {
         Activity activity = newActivity();
         TitleBarReactButtonView uut = createView(activity, new ComponentOptions());
-        uut.addView(new FixedSizeView(activity), new ViewGroup.LayoutParams(CHILD_WIDTH, CHILD_HEIGHT));
+        RecordingContentView child = new RecordingContentView(activity);
+        setContentView(uut, child);
 
         uut.measure(makeMeasureSpec(PARENT_WIDTH, AT_MOST), makeMeasureSpec(PARENT_HEIGHT, AT_MOST));
 
         assertThat(uut.getMeasuredWidth()).isEqualTo(CHILD_WIDTH);
         assertThat(uut.getMeasuredHeight()).isEqualTo(resolveActionBarSize(activity));
+        assertThat(child.widthMeasureSpecs.size()).isEqualTo(2);
+        assertThat(getMode(child.widthMeasureSpecs.get(0))).isEqualTo(AT_MOST);
+        assertThat(getSize(child.widthMeasureSpecs.get(0))).isEqualTo(PARENT_WIDTH);
+        assertThat(getMode(child.widthMeasureSpecs.get(1))).isEqualTo(EXACTLY);
+        assertThat(getSize(child.widthMeasureSpecs.get(1))).isEqualTo(CHILD_WIDTH);
+        assertThat(getMode(child.heightMeasureSpecs.get(1))).isEqualTo(EXACTLY);
+        assertThat(getSize(child.heightMeasureSpecs.get(1))).isEqualTo(resolveActionBarSize(activity));
     }
 
     @Test
@@ -46,56 +57,70 @@ public class TitleBarReactButtonViewTest extends BaseTest {
         component.width = new Number(72);
         component.height = new Number(32);
         TitleBarReactButtonView uut = createView(activity, component);
-        uut.addView(new FixedSizeView(activity), new ViewGroup.LayoutParams(CHILD_WIDTH, CHILD_HEIGHT));
+        RecordingContentView child = new RecordingContentView(activity);
+        setContentView(uut, child);
 
         uut.measure(makeMeasureSpec(PARENT_WIDTH, AT_MOST), makeMeasureSpec(PARENT_HEIGHT, AT_MOST));
 
         assertThat(uut.getMeasuredWidth()).isEqualTo(UiUtils.dpToPx(activity, 72));
         assertThat(uut.getMeasuredHeight()).isEqualTo(UiUtils.dpToPx(activity, 32));
+        assertThat(child.widthMeasureSpecs.size()).isEqualTo(1);
+        assertThat(getMode(child.widthMeasureSpecs.get(0))).isEqualTo(EXACTLY);
+        assertThat(getSize(child.widthMeasureSpecs.get(0))).isEqualTo(UiUtils.dpToPx(activity, 72));
+        assertThat(getMode(child.heightMeasureSpecs.get(0))).isEqualTo(EXACTLY);
+        assertThat(getSize(child.heightMeasureSpecs.get(0))).isEqualTo(UiUtils.dpToPx(activity, 32));
     }
 
     @Test
     public void zeroParentWidthFallbacksToBoundedAtMostSpecAndHeightUsesActionBarSize() {
         Activity activity = newActivity();
         TitleBarReactButtonView uut = createView(activity, new ComponentOptions());
-        RecordingView child = new RecordingView(activity);
-        uut.addView(child, new ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-        ));
+        RecordingContentView child = new RecordingContentView(activity);
+        setContentView(uut, child);
 
         uut.measure(makeMeasureSpec(0, AT_MOST), makeMeasureSpec(0, AT_MOST));
 
-        assertThat(getMode(child.lastWidthMeasureSpec)).isEqualTo(AT_MOST);
-        assertThat(getSize(child.lastWidthMeasureSpec))
+        assertThat(child.widthMeasureSpecs.size()).isEqualTo(2);
+        assertThat(getMode(child.widthMeasureSpecs.get(0))).isEqualTo(AT_MOST);
+        assertThat(getSize(child.widthMeasureSpecs.get(0)))
                 .isEqualTo(Math.max(activity.getResources().getDisplayMetrics().widthPixels, 1));
-        assertThat(getMode(child.lastHeightMeasureSpec)).isEqualTo(EXACTLY);
-        assertThat(getSize(child.lastHeightMeasureSpec)).isEqualTo(Math.max(resolveActionBarSize(activity), 1));
+        assertThat(getMode(child.widthMeasureSpecs.get(1))).isEqualTo(EXACTLY);
+        assertThat(getSize(child.widthMeasureSpecs.get(1))).isEqualTo(CHILD_WIDTH);
+        assertThat(getMode(child.heightMeasureSpecs.get(0))).isEqualTo(EXACTLY);
+        assertThat(getSize(child.heightMeasureSpecs.get(0))).isEqualTo(Math.max(resolveActionBarSize(activity), 1));
     }
 
     @Test
     public void rtlMissingDimensionsUseBoundedSpecs() {
         Activity activity = newActivity();
         TitleBarReactButtonView uut = createView(activity, new ComponentOptions());
-        RecordingView child = new RecordingView(activity);
+        RecordingContentView child = new RecordingContentView(activity);
         uut.setLayoutDirection(View.LAYOUT_DIRECTION_RTL);
-        uut.addView(child, new ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-        ));
+        setContentView(uut, child);
 
         uut.measure(makeMeasureSpec(PARENT_WIDTH, AT_MOST), makeMeasureSpec(PARENT_HEIGHT, AT_MOST));
 
-        assertThat(getMode(child.lastWidthMeasureSpec)).isEqualTo(AT_MOST);
-        assertThat(getSize(child.lastWidthMeasureSpec)).isEqualTo(PARENT_WIDTH);
-        assertThat(getMode(child.lastHeightMeasureSpec)).isEqualTo(EXACTLY);
-        assertThat(getSize(child.lastHeightMeasureSpec)).isEqualTo(resolveActionBarSize(activity));
+        assertThat(child.widthMeasureSpecs.size()).isEqualTo(2);
+        assertThat(getMode(child.widthMeasureSpecs.get(0))).isEqualTo(AT_MOST);
+        assertThat(getSize(child.widthMeasureSpecs.get(0))).isEqualTo(PARENT_WIDTH);
+        assertThat(getMode(child.widthMeasureSpecs.get(1))).isEqualTo(EXACTLY);
+        assertThat(getSize(child.widthMeasureSpecs.get(1))).isEqualTo(CHILD_WIDTH);
+        assertThat(getMode(child.heightMeasureSpecs.get(1))).isEqualTo(EXACTLY);
+        assertThat(getSize(child.heightMeasureSpecs.get(1))).isEqualTo(resolveActionBarSize(activity));
     }
 
     private TitleBarReactButtonView createView(Activity activity, ComponentOptions component) {
         component.name = new Text("ButtonComponent");
         component.componentId = new Text("ButtonComponentId");
         return new TitleBarReactButtonView(activity, component);
+    }
+
+    private void setContentView(TitleBarReactButtonView uut, View child) {
+        uut.removeAllViews();
+        uut.addView(child, new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+        ));
     }
 
     private int resolveActionBarSize(Activity activity) {
@@ -106,30 +131,26 @@ public class TitleBarReactButtonViewTest extends BaseTest {
         return UiUtils.dpToPx(activity, 48);
     }
 
-    private static class FixedSizeView extends View {
-        FixedSizeView(Activity activity) {
+    private static class RecordingContentView extends View {
+        final List<Integer> widthMeasureSpecs = new ArrayList<>();
+        final List<Integer> heightMeasureSpecs = new ArrayList<>();
+
+        RecordingContentView(Activity activity) {
             super(activity);
         }
 
         @Override
         protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-            setMeasuredDimension(CHILD_WIDTH, CHILD_HEIGHT);
-        }
-    }
+            widthMeasureSpecs.add(widthMeasureSpec);
+            heightMeasureSpecs.add(heightMeasureSpec);
 
-    private static class RecordingView extends View {
-        int lastWidthMeasureSpec;
-        int lastHeightMeasureSpec;
-
-        RecordingView(Activity activity) {
-            super(activity);
-        }
-
-        @Override
-        protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-            lastWidthMeasureSpec = widthMeasureSpec;
-            lastHeightMeasureSpec = heightMeasureSpec;
-            setMeasuredDimension(getSize(widthMeasureSpec), getSize(heightMeasureSpec));
+            int measuredWidth = getMode(widthMeasureSpec) == EXACTLY
+                    ? getSize(widthMeasureSpec)
+                    : Math.min(CHILD_WIDTH, getSize(widthMeasureSpec));
+            int measuredHeight = getMode(heightMeasureSpec) == EXACTLY
+                    ? getSize(heightMeasureSpec)
+                    : Math.min(CHILD_HEIGHT, getSize(heightMeasureSpec));
+            setMeasuredDimension(measuredWidth, measuredHeight);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Stabilizes Android custom top-bar React button layout by keeping the bounded content-width discovery pass from #8320, then remeasuring the button with an exact final content width.
- Preserves title-width behavior from #8320 so custom buttons reserve their measured content width instead of a forced actionBarSize width.
- Updates regression coverage for missing dimensions, explicit dimensions, RTL, and zero-width parent fallback behavior.

## Validation
- `git diff --check`
- `./gradlew :react-native-navigation:testDebugUnitTest --tests com.reactnativenavigation.views.TitleBarReactButtonViewTest --tests com.reactnativenavigation.views.TitleAndButtonsContainerTest` — SUCCESS (37 successes, 0 failures, 0 skipped)

## Not Run
- Full Android unit/instrumentation suite; this change is scoped to the top-bar button measurement path and the focused affected tests passed.

## Risks
- Low to medium: scoped to Android custom React top-bar buttons without explicit width.
- The main behavior to watch is custom button width measurement for components whose content changes after initial layout.

## Review Context
- This is a follow-up to #8320. The first pass still uses bounded `AT_MOST` width to prevent title truncation.
- The second pass restores an exact final RN/Yoga layout box to address vertical alignment regressions in custom buttons.
- Pre-PR review found no cleanup items, blockers, or creator-intent questions.

## Suggested Reviewers
- Yedidya Kennard — latest relevant change owner for `TitleBarReactButtonView` and the new regression tests in #8320.
