### PR TITLE
android: restore vertical centering for content-hugging custom top-bar buttons

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
+++ b/android/src/main/java/com/reactnativenavigation/views/stack/topbar/titlebar/TitleBarReactButtonView.java
@@ -50,10 +50,12 @@ public class TitleBarReactButtonView extends ReactView {
         // before the content has laid out that width is collapsed (~1px), Fabric lays the content into
         // it and the button never recovers (#8320/#8326 did this and regressed under the New Arch).
         //
-        // Height: EXACTLY the available bar height. Giving the surface a filled height (rather than a
-        // content-hugging AT_MOST height) lets content that centers itself (e.g. a flex container with
-        // justifyContent: 'center') sit vertically centered in the bar, matching the legacy layout.
-        // It does not cause the width collapse — only a forced width does.
+        // Height: bounded (AT_MOST) so the surface sizes to its content height. The view is then
+        // centered vertically by the toolbar's action-view layout and the CENTER_VERTICAL gravity set
+        // in onViewAdded(). Forcing EXACTLY the full bar height (as #8328 did) made the surface fill
+        // the bar, so content-hugging buttons that don't self-center (plain text like "Publish", a
+        // fixed-size avatar image) were pinned to the top. AT_MOST height does NOT cause the width
+        // collapse — only a forced EXACTLY *width* does.
         int widthSpec = component.width.hasValue()
                 ? createExactSpec(component.width)
                 : makeMeasureSpec(resolveAvailableWidth(widthMeasureSpec), AT_MOST);
@@ -66,7 +68,7 @@ public class TitleBarReactButtonView extends ReactView {
             return createExactSpec(dimension);
         }
         int availableSize = MeasureSpec.getSize(measureSpec);
-        return makeMeasureSpec(availableSize > 0 ? availableSize : Math.max(resolveActionBarSize(), 1), EXACTLY);
+        return makeMeasureSpec(availableSize > 0 ? availableSize : Math.max(resolveActionBarSize(), 1), AT_MOST);
     }
 
     private int resolveAvailableWidth(int measureSpec) {

--- a/android/src/test/java/com/reactnativenavigation/views/TitleBarReactButtonViewTest.java
+++ b/android/src/test/java/com/reactnativenavigation/views/TitleBarReactButtonViewTest.java
@@ -34,12 +34,14 @@ public class TitleBarReactButtonViewTest extends BaseTest {
 
     // Without explicit dimensions the button measures the hosted React surface ONCE:
     //  - width  AT_MOST  → the surface sizes itself to its content (max-of-children under Fabric).
-    //  - height EXACTLY the available bar height → the surface gets a filled box so content that
-    //    centers itself (flex justifyContent: 'center') stays vertically centered in the bar.
+    //  - height AT_MOST  → the surface sizes to its content height; the view is then centered
+    //    vertically in the bar by the toolbar's action-view layout + the CENTER_VERTICAL gravity from
+    //    onViewAdded(). A forced EXACTLY full-bar height would pin content-hugging buttons (plain
+    //    text, a fixed-size avatar) to the top.
     // It deliberately does not push a forced EXACTLY *width*; under the New Architecture that re-pushes
     // a (initially collapsed) width to the async Fabric layout and the button never recovers.
     @Test
-    public void missingDimensionsSizeWidthToContentAndFillHeight() {
+    public void missingDimensionsSizeToContent() {
         Activity activity = newActivity();
         TitleBarReactButtonView uut = createView(activity, new ComponentOptions());
         RecordingContentView child = new RecordingContentView(activity);
@@ -48,11 +50,11 @@ public class TitleBarReactButtonViewTest extends BaseTest {
         uut.measure(makeMeasureSpec(PARENT_WIDTH, AT_MOST), makeMeasureSpec(PARENT_HEIGHT, AT_MOST));
 
         assertThat(uut.getMeasuredWidth()).isEqualTo(CHILD_WIDTH);
-        assertThat(uut.getMeasuredHeight()).isEqualTo(PARENT_HEIGHT);
+        assertThat(uut.getMeasuredHeight()).isEqualTo(CHILD_HEIGHT);
         assertThat(child.widthMeasureSpecs.size()).isEqualTo(1);
         assertThat(getMode(child.widthMeasureSpecs.get(0))).isEqualTo(AT_MOST);
         assertThat(getSize(child.widthMeasureSpecs.get(0))).isEqualTo(PARENT_WIDTH);
-        assertThat(getMode(child.heightMeasureSpecs.get(0))).isEqualTo(EXACTLY);
+        assertThat(getMode(child.heightMeasureSpecs.get(0))).isEqualTo(AT_MOST);
         assertThat(getSize(child.heightMeasureSpecs.get(0))).isEqualTo(PARENT_HEIGHT);
     }
 
@@ -78,7 +80,7 @@ public class TitleBarReactButtonViewTest extends BaseTest {
     }
 
     @Test
-    public void zeroParentSpecsFallBackToScreenWidthAndActionBarHeight() {
+    public void zeroParentSpecsFallBackToScreenWidthAndBoundedActionBarHeight() {
         Activity activity = newActivity();
         TitleBarReactButtonView uut = createView(activity, new ComponentOptions());
         RecordingContentView child = new RecordingContentView(activity);
@@ -90,12 +92,12 @@ public class TitleBarReactButtonViewTest extends BaseTest {
         assertThat(getMode(child.widthMeasureSpecs.get(0))).isEqualTo(AT_MOST);
         assertThat(getSize(child.widthMeasureSpecs.get(0)))
                 .isEqualTo(Math.max(activity.getResources().getDisplayMetrics().widthPixels, 1));
-        assertThat(getMode(child.heightMeasureSpecs.get(0))).isEqualTo(EXACTLY);
+        assertThat(getMode(child.heightMeasureSpecs.get(0))).isEqualTo(AT_MOST);
         assertThat(getSize(child.heightMeasureSpecs.get(0))).isEqualTo(Math.max(resolveActionBarSize(activity), 1));
     }
 
     @Test
-    public void rtlMissingDimensionsUseBoundedWidthAndFilledHeight() {
+    public void rtlMissingDimensionsUseBoundedWidthAndHeight() {
         Activity activity = newActivity();
         TitleBarReactButtonView uut = createView(activity, new ComponentOptions());
         RecordingContentView child = new RecordingContentView(activity);
@@ -107,7 +109,7 @@ public class TitleBarReactButtonViewTest extends BaseTest {
         assertThat(child.widthMeasureSpecs.size()).isEqualTo(1);
         assertThat(getMode(child.widthMeasureSpecs.get(0))).isEqualTo(AT_MOST);
         assertThat(getSize(child.widthMeasureSpecs.get(0))).isEqualTo(PARENT_WIDTH);
-        assertThat(getMode(child.heightMeasureSpecs.get(0))).isEqualTo(EXACTLY);
+        assertThat(getMode(child.heightMeasureSpecs.get(0))).isEqualTo(AT_MOST);
         assertThat(getSize(child.heightMeasureSpecs.get(0))).isEqualTo(PARENT_HEIGHT);
     }
 


### PR DESCRIPTION
## Summary
Custom React top-bar buttons (`topBar.leftButtons` / `rightButtons` with `{ component }`) that have **no explicit `height`** render **pinned to the top of the bar** instead of vertically centered on Android. It affects **any content-hugging button — both text (e.g. an Owner-app "Publish" button) and fixed-size images (the profile-picture / avatar left button)** — not just text.

This is the vertical-alignment regression that came back with #8328 (RNN 8.8.9). #8328 correctly fixed the New-Architecture width collapse, but as part of it changed the no-explicit-dimension **height** spec from `AT_MOST` (what #8326 used) to `EXACTLY` the full bar height.

## Root cause
With `EXACTLY` full-bar height, the hosted `ReactSurfaceView` is forced to fill the whole bar. Centering then relies entirely on the **content centering itself** (a flex container with `justifyContent: 'center'`). #8328 was validated only against such a self-centering flex button, so it missed the common case: a content-hugging button (`<View><Text>…</Text></View>`, or a fixed-size avatar image) is laid out at the **top** of the filled box → top-aligned.

The `CENTER_VERTICAL` gravity applied in `onViewAdded()` (added in #8326) is still present but is **moot under a filled height** — the child fills the parent, so there is nothing left to center.

## Fix
Make the no-explicit-dimension **height** bounded (`AT_MOST`) again, keeping #8328's content-hugging **width** (`AT_MOST`) untouched. The surface then sizes to its content height and is centered by the toolbar's action-view layout + the existing `onViewAdded` `CENTER_VERTICAL` gravity — for **all** content-hugging buttons (text and image), without requiring each component to self-center.

This recombines:
- #8328's **width `AT_MOST`** → no Fabric width collapse (~1px), and
- #8326's **height `AT_MOST` + gravity** → correct vertical centering.

Per #8328's own analysis, only a forced **`EXACTLY` width** triggers the Fabric collapse; the height mode is independent, so this does not reintroduce the collapse. Buttons that pass an explicit `width`/`height` are unchanged (still measured `EXACTLY`).

```diff
// TitleBarReactButtonView.createHeightSpec(...)
         int availableSize = MeasureSpec.getSize(measureSpec);
-        return makeMeasureSpec(availableSize > 0 ? availableSize : Math.max(resolveActionBarSize(), 1), EXACTLY);
+        return makeMeasureSpec(availableSize > 0 ? availableSize : Math.max(resolveActionBarSize(), 1), AT_MOST);
```

## Changes
- `TitleBarReactButtonView.createHeightSpec(...)`: no-dimension branch `EXACTLY` → `AT_MOST` (+ updated the `onMeasure` comment that documented the filled-height rationale).
- `TitleBarReactButtonViewTest`: reverted the height assertions #8328 flipped — child height-spec mode back to `AT_MOST` and measured height back to content height (`CHILD_HEIGHT`) in the missing-dimension / zero-parent / RTL cases. Explicit-dimension button unchanged. `contentCenteringReplacesExistingVerticalGravityOnly` is now meaningful again (the child is shorter than the bar, so gravity actually centers it).

## Validation
- Unit: `TitleBarReactButtonViewTest` updated/green.
- On-device (Detox, release): `Buttons` suite — esp. the `buttons_navbar` snapshot (`should render top/navigation-bar buttons in the right order`): the round flex component button must stay **vertically centered** (no snapshot regen expected, since `AT_MOST` height ≈ legacy content-sizing); `Stack` suite green.
- Manual (engine RC): Owner-app "Publish" text button vertically centered & not clipped; profile/avatar left button vertically centered; Spaces RTL notification + bell still present (no collapse).

## Context & links
- Follow-up to #8328 (RNN 8.8.9), #8326, #8320, #8306 — the chain of Android custom top-bar button measurement changes.
- Re-bumps after the engine bump that shipped #8328: https://github.com/wix-private/mobile-apps-engine/pull/3470
- RNN history:
  - #8328 — https://github.com/wix/react-native-navigation/pull/8328 (Fabric collapse fix that introduced this alignment regression)
  - #8326 — https://github.com/wix/react-native-navigation/pull/8326
  - #8320 — https://github.com/wix/react-native-navigation/pull/8320
  - #8306 — https://github.com/wix/react-native-navigation/pull/8306
- Jira:
  - WOAINFRA-3363 — https://wix.atlassian.net/browse/WOAINFRA-3363 ("Publish" button missing/misaligned, Owner app)
  - WOAINFRA-3362 — https://wix.atlassian.net/browse/WOAINFRA-3362 (related: Android RTL header icons, Fit/Spaces)
