### PR TITLE
fix(customrow): only attach BottomTabs custom row to NavigationActivity

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/customrow/BottomTabsCustomRowAttacher.kt
+++ b/android/src/main/java/com/reactnativenavigation/customrow/BottomTabsCustomRowAttacher.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.view.WindowInsets
 import android.widget.FrameLayout
+import com.reactnativenavigation.NavigationActivity
 import com.reactnativenavigation.views.bottomtabs.BottomTabs
 
 /**
@@ -77,6 +78,13 @@ internal object BottomTabsCustomRowAttacher : Application.ActivityLifecycleCallb
     }
 
     private fun ensureLayoutObserver(activity: Activity) {
+        // BottomTabs only ever live inside RNN's own NavigationActivity (an
+        // AppCompatActivity). Touching any other activity — e.g. a third-party
+        // relay such as AppAuth's RedirectUriReceiverActivity, whose theme is not
+        // a Theme.AppCompat descendant — forces AppCompat sub-decor inflation and
+        // crashes with "You need to use a Theme.AppCompat theme". Guard here so the
+        // global lifecycle observer never operates on foreign activities.
+        if (activity !is NavigationActivity) return
         val decor = activity.window?.decorView as? ViewGroup ?: return
         if (decor.getTag(TAG_OBSERVING) == true) return
         decor.setTag(TAG_OBSERVING, true)
@@ -90,6 +98,7 @@ internal object BottomTabsCustomRowAttacher : Application.ActivityLifecycleCallb
     }
 
     private fun tryAttach(activity: Activity) {
+        if (activity !is NavigationActivity) return
         val scanRoot = activity.window?.decorView as? ViewGroup
             ?: activity.findViewById<View>(android.R.id.content) as? ViewGroup
             ?: return


### PR DESCRIPTION
## Problem

Owner (Android) crashes during OAuth login. When AppAuth's `RedirectUriReceiverActivity` (the relay that receives the OAuth redirect) is created, the app dies with:

```
RuntimeException: Unable to start activity ... RedirectUriReceiverActivity:
IllegalStateException: You need to use a Theme.AppCompat theme (or descendant) with this activity.
  at BottomTabsCustomRowAttacher.tryAttach(BottomTabsCustomRowAttacher.kt:96)
  at BottomTabsCustomRowAttacher.onActivityCreated(BottomTabsCustomRowAttacher.kt:55)
```

**Sentry:** [WIX-ONE-APP-9GFHV](https://wix-o.sentry.io/issues/7535493012/) — ~5.9k events / 1.6k users, Android-only, still active.

## Root cause

`BottomTabsCustomRowAttacher` is a **global** `Application.ActivityLifecycleCallbacks` and runs `tryAttach()` → `findViewById(android.R.id.content)` on **every** activity in the process. For a foreign, non-AppCompat-themed activity (AppAuth's relay), that `findViewById` forces `AppCompatDelegate` sub-decor inflation, which requires a `Theme.AppCompat` and throws. Any third-party non-AppCompat activity (OAuth relays, SDK login flows, etc.) hits this, not just AppAuth.

## Fix

Guard the observer to RNN's own `NavigationActivity` — the only place `BottomTabs` (and thus the custom row) ever live. Foreign activities are skipped, so `findViewById` is never called on them.

```kotlin
private fun ensureLayoutObserver(activity: Activity) {
    if (activity !is NavigationActivity) return
    ...
}
private fun tryAttach(activity: Activity) {
    if (activity !is NavigationActivity) return
    ...
}
```

## Verification

Built the `playground` app with this change and reproduced the exact mechanism on a rooted emulator: launching a non-AppCompat-themed `AppCompatActivity` into the running process **no longer crashes** (unpatched: process dies with the stack above). The custom bottom-tabs feature still renders correctly on `NavigationActivity` — no regression.
