### PR TITLE
[BottomTabsCustomRow] Fix crash attaching custom row to non-AppCompat activities

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/customrow/BottomTabsCustomRowAttacher.kt
+++ b/android/src/main/java/com/reactnativenavigation/customrow/BottomTabsCustomRowAttacher.kt
@@ -90,10 +90,10 @@ internal object BottomTabsCustomRowAttacher : Application.ActivityLifecycleCallb
     }
 
     private fun tryAttach(activity: Activity) {
-        val scanRoot = activity.window?.decorView as? ViewGroup
-            ?: activity.findViewById<View>(android.R.id.content) as? ViewGroup
-            ?: return
-        val overlayHost = activity.findViewById<View>(android.R.id.content) as? ViewGroup
+        val scanRoot = activity.window?.decorView as? ViewGroup ?: return
+        // Resolve through the view tree: AppCompatActivity.findViewById() forces
+        // createSubDecor(), which throws unless the activity's theme is Theme.AppCompat.
+        val overlayHost = scanRoot.findViewById<View>(android.R.id.content) as? ViewGroup
             ?: scanRoot
 
         forEachBottomTabs(scanRoot) { bottomTabs ->


### PR DESCRIPTION
#### Problem

`BottomTabsCustomRowAttacher` is registered as process-wide `Application.ActivityLifecycleCallbacks`, so `tryAttach()` runs for **every** activity in the host app (from `onActivityCreated`, `onActivityStarted`, `onActivityResumed`, `registerOnce` and `rescan`).

`tryAttach()` resolved the overlay host with `Activity.findViewById(android.R.id.content)`. On an AppCompat activity that call routes through `AppCompatDelegateImpl.findViewById()`, which calls `ensureSubDecor()` -> `createSubDecor()`. `createSubDecor()` validates the theme and throws:

```
java.lang.IllegalStateException: You need to use a Theme.AppCompat theme (or descendant) with this activity.
  at androidx.appcompat.app.AppCompatDelegateImpl.createSubDecor(AppCompatDelegateImpl.java:902)
  at androidx.appcompat.app.AppCompatActivity.findViewById(AppCompatActivity.java:264)
  at com.reactnativenavigation.customrow.BottomTabsCustomRowAttacher.tryAttach(BottomTabsCustomRowAttacher.kt:96)
  at com.reactnativenavigation.customrow.BottomTabsCustomRowAttacher.onActivityCreated(BottomTabsCustomRowAttacher.kt:55)
  at android.app.Application.dispatchActivityCreated(Application.java:368)
```

The exception escapes `onActivityCreated`, so `performLaunchActivity()` raises a `RuntimeException` and Android force-finishes the activity. There is no `try/catch` on the path.

Any activity in the process that inherits a theme which is not a `Theme.AppCompat` descendant therefore crashes on creation, even though it has nothing to do with bottom tabs. This is easy to hit with activities that declare no `android:theme` of their own and so inherit an application theme such as `Theme.App.Starting` from `androidx.core:core-splashscreen`.

A concrete case: AppAuth's `net.openid.appauth.RedirectUriReceiverActivity` (an invisible activity that receives the OAuth redirect and declares no theme). It is force-finished before it can hand the intent to `AuthorizationManagementActivity`, so the authorization code is dropped and `authorize()` never resolves - breaking OAuth/OIDC sign-in entirely on Android.

#### Solution

- Resolve `android.R.id.content` from the decor view (`scanRoot.findViewById(...)`) instead of via the activity. `View.findViewById()` never engages `AppCompatDelegate`, so no sub-decor is created and no theme validation runs.
- Drop the now-redundant `activity.findViewById()` fallback used to derive `scanRoot`: it carried the same hazard, and if `decorView` is unavailable there is no hierarchy to scan or attach to.

Behaviour is unchanged for activities with a compatible theme - `Activity.findViewById()` already delegates to `getWindow().getDecorView().findViewById()`, so the resolved view is the same. On activities where `setContentView()` has not run yet, the lookup now returns `null` and falls back to `scanRoot` rather than eagerly building the AppCompat sub-decor as a side effect; those activities have no `BottomTabs` children yet, so `forEachBottomTabs` is a no-op and later `onActivityStarted` / `onActivityResumed` / layout-observer passes attach as before.

Worth considering as a follow-up (not included here, to keep this fix minimal): skipping non-RNN-hosted activities outright, since `BottomTabs` can only exist in an RNN activity, and `ensureLayoutObserver` currently installs a global layout listener on every activity in the process.

#### Extra information (Jira ticket, design doc, Slack thread, etc..)

- Jira: https://wix.atlassian.net/browse/WIXC-2909
- Jira: https://wix.atlassian.net/browse/WIXC-2910
- Regression traced to the `customrow` package being introduced between engine-native `33.39.63` (no `BottomTabsCustomRowAttacher`, redirect works) and `33.39.68` (attacher present, redirect crashes); reproduced on an Android emulator (API 35) with a Wix admin dev build.
