### PR TITLE
Fix processor registration and subscription removal

### DIFF
--- a/src/processors/LayoutProcessorsStore.test.ts
+++ b/src/processors/LayoutProcessorsStore.test.ts
@@ -27,4 +27,31 @@ describe('Layout processors Store', () => {
     remove();
     expect(uut.getProcessors()).toEqual([]);
   });
+
+  it('should unregister only the subscribed processor', () => {
+    const firstProcessor = (value: any, _commandName: string) => value;
+    const secondProcessor = (value: any, _commandName: string) => value;
+    const thirdProcessor = (value: any, _commandName: string) => value;
+    uut.addProcessor(firstProcessor);
+    const { remove } = uut.addProcessor(secondProcessor);
+    uut.addProcessor(thirdProcessor);
+
+    remove();
+
+    expect(uut.getProcessors()).toEqual([firstProcessor, thirdProcessor]);
+  });
+
+  it('should ignore repeated subscription removal', () => {
+    const processor = (value: any, _commandName: string) => value;
+    const firstSubscription = uut.addProcessor(processor);
+    const secondSubscription = uut.addProcessor(processor);
+
+    firstSubscription.remove();
+    firstSubscription.remove();
+
+    expect(uut.getProcessors()).toEqual([processor]);
+
+    secondSubscription.remove();
+    expect(uut.getProcessors()).toEqual([]);
+  });
 });

--- a/src/processors/LayoutProcessorsStore.ts
+++ b/src/processors/LayoutProcessorsStore.ts
@@ -6,8 +6,16 @@ export class LayoutProcessorsStore {
 
   public addProcessor(processor: LayoutProcessor): ProcessorSubscription {
     this.layoutProcessors.push(processor);
+    let removed = false;
 
-    return { remove: () => this.removeProcessor(processor) };
+    return {
+      remove: () => {
+        if (!removed) {
+          this.removeProcessor(processor);
+          removed = true;
+        }
+      },
+    };
   }
 
   public getProcessors(): LayoutProcessor[] {
@@ -15,6 +23,7 @@ export class LayoutProcessorsStore {
   }
 
   private removeProcessor(processor: LayoutProcessor) {
-    this.layoutProcessors.splice(this.layoutProcessors.indexOf(processor));
+    const index = this.layoutProcessors.indexOf(processor);
+    if (index !== -1) this.layoutProcessors.splice(index, 1);
   }
 }

--- a/src/processors/OptionProcessorsStore.test.ts
+++ b/src/processors/OptionProcessorsStore.test.ts
@@ -20,11 +20,47 @@ describe('Option processors Store', () => {
     expect(uut.getProcessors('topBar')).toEqual([processor, secondProcessor]);
   });
 
+  it.each(['toString', '__proto__'])(
+    'should register processors for the %s object path',
+    (optionPath) => {
+      const processor = (value: any, _commandName: string) => value;
+      uut.addProcessor(optionPath, processor);
+      expect(uut.getProcessors(optionPath)).toEqual([processor]);
+    }
+  );
+
   it('should unregister processor', () => {
     const processor = (value: any, _commandName: string) => value;
     const { remove } = uut.addProcessor('topBar', processor);
     expect(uut.getProcessors('topBar')).toEqual([processor]);
     remove();
+    expect(uut.getProcessors('topBar')).toEqual([]);
+  });
+
+  it('should unregister only the subscribed processor', () => {
+    const firstProcessor = (value: any, _commandName: string) => value;
+    const secondProcessor = (value: any, _commandName: string) => value;
+    const thirdProcessor = (value: any, _commandName: string) => value;
+    uut.addProcessor('topBar', firstProcessor);
+    const { remove } = uut.addProcessor('topBar', secondProcessor);
+    uut.addProcessor('topBar', thirdProcessor);
+
+    remove();
+
+    expect(uut.getProcessors('topBar')).toEqual([firstProcessor, thirdProcessor]);
+  });
+
+  it('should ignore repeated subscription removal', () => {
+    const processor = (value: any, _commandName: string) => value;
+    const firstSubscription = uut.addProcessor('topBar', processor);
+    const secondSubscription = uut.addProcessor('topBar', processor);
+
+    firstSubscription.remove();
+    firstSubscription.remove();
+
+    expect(uut.getProcessors('topBar')).toEqual([processor]);
+
+    secondSubscription.remove();
     expect(uut.getProcessors('topBar')).toEqual([]);
   });
 });

--- a/src/processors/OptionProcessorsStore.ts
+++ b/src/processors/OptionProcessorsStore.ts
@@ -2,7 +2,9 @@ import { ProcessorSubscription } from '../interfaces/ProcessorSubscription';
 import { OptionsProcessor } from '../interfaces/Processors';
 
 export class OptionProcessorsStore {
-  private optionsProcessorsByObjectPath: Record<string, OptionsProcessor<any>[]> = {};
+  private optionsProcessorsByObjectPath: Record<string, OptionsProcessor<any>[]> = Object.create(
+    null
+  );
 
   public addProcessor<T>(
     optionPath: string,
@@ -12,8 +14,16 @@ export class OptionProcessorsStore {
       this.optionsProcessorsByObjectPath[optionPath] = [];
 
     this.optionsProcessorsByObjectPath[optionPath].push(processor);
+    let removed = false;
 
-    return { remove: () => this.removeProcessor(optionPath, processor) };
+    return {
+      remove: () => {
+        if (!removed) {
+          this.removeProcessor(optionPath, processor);
+          removed = true;
+        }
+      },
+    };
   }
 
   public getProcessors(optionPath: string) {
@@ -21,8 +31,8 @@ export class OptionProcessorsStore {
   }
 
   private removeProcessor(optionPath: string, processor: OptionsProcessor<any>) {
-    this.optionsProcessorsByObjectPath[optionPath].splice(
-      this.optionsProcessorsByObjectPath[optionPath].indexOf(processor)
-    );
+    const processors = this.optionsProcessorsByObjectPath[optionPath];
+    const index = processors.indexOf(processor);
+    if (index !== -1) processors.splice(index, 1);
   }
 }


### PR DESCRIPTION
## Problem

Both processor stores remove subscriptions with `splice(index)` and no `deleteCount`. Removing one processor therefore removes it and every processor registered after it. Calling the same subscription twice can also pass `-1` and remove the last unrelated processor. Option processor paths additionally use a plain object registry, so valid public paths such as `toString` and `__proto__` collide with inherited properties and fail during registration.

## Fix

- remove exactly one matching processor
- make each returned subscription independently idempotent, including when the same function is registered twice
- store option-path arrays in a prototype-free registry
- retain O(n) lookup and existing processor ordering

## Breaking changes

None. The change restores the documented subscription boundary and accepts previously broken string paths.

## Test plan

- Added focused middle-removal regressions for both Layout and Option processor stores.
- Added duplicate-function regressions proving repeated removal of one subscription cannot remove the second subscription.
- Added parameterized `toString` and `__proto__` option-path coverage.
- Focused suites pass: 2 suites, 12 tests.
- Full `yarn test-js` passes: 38 suites, 401 tests; 11 suites/59 tests remain intentionally skipped.
- Focused ESLint, Bob module/type builds, and `git diff --check` pass.

Existing React act/deprecation warnings are unchanged.