### PR TITLE
Support prototype-named component store keys

### DIFF
--- a/src/components/Store.test.ts
+++ b/src/components/Store.test.ts
@@ -48,6 +48,28 @@ describe('Store', () => {
     expect(uut.getComponentClassForName('example.mycomponent')).toEqual(MyWrappedComponent);
   });
 
+  it.each(['toString', '__proto__'])('treats %s as a regular store key', (key) => {
+    expect(uut.getPropsForId(key)).toEqual({});
+    expect(uut.getComponentClassForName(key)).toBeUndefined();
+    expect(uut.getComponentInstance(key)).toBeUndefined();
+    expect(uut.hasRegisteredWrappedComponent(key)).toBe(false);
+
+    const ComponentClass = () => class MyComponent extends React.Component {};
+    const componentInstance = {} as IWrappedComponent;
+    class WrappedComponent extends React.Component {}
+
+    uut.updateProps(key, { foo: 'bar' });
+    uut.setComponentClassForName(key, ComponentClass);
+    uut.setComponentInstance(key, componentInstance);
+    uut.setWrappedComponent(key, WrappedComponent);
+
+    expect(uut.getPropsForId(key)).toEqual({ foo: 'bar' });
+    expect(uut.getComponentClassForName(key)).toBe(ComponentClass);
+    expect(uut.getComponentInstance(key)).toBe(componentInstance);
+    expect(uut.hasRegisteredWrappedComponent(key)).toBe(true);
+    expect(uut.getWrappedComponent(key)).toBe(WrappedComponent);
+  });
+
   it('clear props by component id when clear component', () => {
     uut.updateProps('refUniqueId', { foo: 'bar' });
     uut.clearComponent('refUniqueId');

--- a/src/components/Store.ts
+++ b/src/components/Store.ts
@@ -3,11 +3,11 @@ import { ComponentProvider } from 'react-native';
 import { IWrappedComponent } from './ComponentWrapper';
 
 export class Store {
-  private componentsByName: Record<string, ComponentProvider> = {};
-  private propsById: Record<string, any> = {};
-  private pendingPropsById: Record<string, any> = {};
-  private componentsInstancesById: Record<string, IWrappedComponent> = {};
-  private wrappedComponents: Record<string, React.ComponentClass<any>> = {};
+  private componentsByName: Record<string, ComponentProvider> = Object.create(null);
+  private propsById: Record<string, any> = Object.create(null);
+  private pendingPropsById: Record<string, any> = Object.create(null);
+  private componentsInstancesById: Record<string, IWrappedComponent> = Object.create(null);
+  private wrappedComponents: Record<string, React.ComponentClass<any>> = Object.create(null);
   private lazyRegistratorFn: ((lazyComponentRequest: string | number) => void) | undefined;
 
   updateProps(componentId: string, props: any, callback?: () => void) {


### PR DESCRIPTION
## Problem

The component Store keeps five public component-name/ID registries in ordinary objects. Names such as `toString` and `__proto__` therefore resolve inherited values: lazy registration can be skipped, unregistered props/instances/wrapped components appear present, and normal store/retrieve operations return incorrect data.

## Fix

Initialize all five key registries without Object prototypes. This preserves the existing string-key API and constant-time lookups while making every public component name and ID an independent own key.

## Breaking changes

None. Previously broken names now behave like ordinary component names and IDs.

## Test plan

- Added parameterized `toString` and `__proto__` regressions covering initial absence and normal store/retrieve behavior for props, component providers, instances, and wrapped components.
- Exact baseline fails both parameterized cases; fixed focused suite passes 17/17.
- Full `yarn test-js` passes: 38 suites, 397 tests; 11 suites/59 tests remain intentionally skipped.
- Bob module/type builds and `git diff --check` pass.
- Focused ESLint has no errors; its one no-shadow warning is pre-existing in an unchanged callback test.