### PR TITLE
Fix component listeners for prototype-named IDs

### DIFF
--- a/src/events/ComponentEventsObserver.test.tsx
+++ b/src/events/ComponentEventsObserver.test.tsx
@@ -355,6 +355,28 @@ describe('ComponentEventsObserver', () => {
     expect(didAppearFn).not.toHaveBeenCalled();
   });
 
+  it.each(['component.with.dots', 'toString', '__proto__'])(
+    'removes all listeners for the %s component id',
+    (componentId) => {
+      const listener = jest.fn();
+      const registered = uut.registerComponentListener(
+        { componentDidDisappear: listener },
+        componentId
+      );
+
+      uut.unmounted(componentId);
+      uut.notifyComponentDidDisappear({
+        componentId,
+        componentName: 'doesnt matter',
+        componentType: 'Component',
+      });
+      const callCount = listener.mock.calls.length;
+      registered.remove();
+
+      expect(callCount).toBe(0);
+    }
+  );
+
   it(`supports multiple listeners with same componentId`, () => {
     const screen1 = render(<SimpleScreen componentId={'myCompId'} />);
     const screen2 = render(<SimpleScreen componentId={'myCompId'} />);

--- a/src/events/ComponentEventsObserver.ts
+++ b/src/events/ComponentEventsObserver.ts
@@ -2,7 +2,6 @@ import type { Component } from 'react';
 import isString from 'lodash/isString';
 import isNil from 'lodash/isNil';
 import uniqueId from 'lodash/uniqueId';
-import unset from 'lodash/unset';
 import forEach from 'lodash/forEach';
 import { EventSubscription } from '../interfaces/EventSubscription';
 import { NavigationComponentListener } from '../interfaces/NavigationComponentListener';
@@ -23,7 +22,9 @@ import { Store } from '../components/Store';
 type ReactComponentWithIndexing = NavigationComponentListener & Record<string, any>;
 
 export class ComponentEventsObserver {
-  private listeners: Record<string, Record<string, ReactComponentWithIndexing>> = {};
+  private listeners: Record<string, Record<string, ReactComponentWithIndexing>> = Object.create(
+    null
+  );
   private alreadyRegistered = false;
 
   constructor(
@@ -92,11 +93,11 @@ export class ComponentEventsObserver {
     const key = uniqueId();
     this.listeners[componentId][key] = listener;
 
-    return { remove: () => unset(this.listeners[componentId], key) };
+    return { remove: () => delete this.listeners[componentId]?.[key] };
   }
 
   public unmounted(componentId: string) {
-    unset(this.listeners, componentId);
+    delete this.listeners[componentId];
   }
 
   notifyComponentWillAppear(event: ComponentWillAppearEvent) {


### PR DESCRIPTION
## Problem

`ComponentEventsObserver` stores public component IDs in a normal object and removes them through Lodash path semantics. IDs such as `toString` and `__proto__` therefore collide with inherited properties, while IDs containing dots are interpreted as nested paths. Their listeners can attach incorrectly and remain active after `unmounted()`.

## Fix

- use a prototype-free registry for component IDs
- delete component and subscription keys directly, preserving every ID literally
- remove the no-longer-needed `lodash/unset` import

## Breaking changes

None. Ordinary component IDs retain the same behavior; previously broken valid string IDs now register and clean up correctly.

## Test plan

- Added parameterized regressions for dotted, `toString`, and `__proto__` component IDs.
- Exact baseline fails the prototype-name cases; the fixed focused suite passes 16/16 tests.
- Full `yarn test-js` passes: 38 suites/398 tests; 11 suites/59 tests remain intentionally skipped.
- Focused ESLint, Bob module/type builds, and `git diff --check` pass.

