### PR TITLE
Ignore stale initial links after reconfiguration

### DIFF
--- a/src/linking/LinkingHandler.test.ts
+++ b/src/linking/LinkingHandler.test.ts
@@ -292,6 +292,41 @@ describe('LinkingHandler', () => {
       uut.configure(baseConfig);
       expect(remove).toHaveBeenCalled();
     });
+
+    it('ignores an initial URL resolved by a previous configuration', async () => {
+      let resolveInitialURL!: (url: string | null) => void;
+      mockLinking.getInitialURL
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveInitialURL = resolve;
+            })
+        )
+        .mockResolvedValueOnce(null);
+      const firstOnLink = jest.fn();
+      const secondOnLink = jest.fn();
+
+      uut.configure({ ...baseConfig, onLink: firstOnLink });
+      uut.setRootReady();
+      uut.configure({ ...baseConfig, onLink: secondOnLink });
+      resolveInitialURL('myapp://home');
+      await Promise.resolve();
+
+      expect(firstOnLink).not.toHaveBeenCalled();
+      expect(secondOnLink).not.toHaveBeenCalled();
+    });
+
+    it('continues handling URL events when the initial URL lookup fails', async () => {
+      mockLinking.getInitialURL.mockRejectedValueOnce(new Error('lookup failed'));
+      uut.configure(baseConfig);
+      uut.setRootReady();
+
+      await Promise.resolve();
+      await Promise.resolve();
+      urlListener?.({ url: 'myapp://home' });
+
+      expect(mockShowModal).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('setRootReady', () => {

--- a/src/linking/LinkingHandler.ts
+++ b/src/linking/LinkingHandler.ts
@@ -46,6 +46,7 @@ export class LinkingHandler {
 
   private config: LinkingConfig | null = null;
   private linkingSubscription: { remove: () => void } | null = null;
+  private subscriptionGeneration = 0;
   private rootReady = false;
   private userReadyOverride: boolean | null = null;
 
@@ -114,6 +115,7 @@ export class LinkingHandler {
   }
 
   public teardown(): void {
+    this.subscriptionGeneration++;
     if (this.linkingSubscription) {
       this.linkingSubscription.remove();
       this.linkingSubscription = null;
@@ -124,13 +126,19 @@ export class LinkingHandler {
   }
 
   private subscribe(): void {
+    const subscriptionGeneration = this.subscriptionGeneration;
     this.linkingSubscription = this.linkingAPI.addEventListener('url', (event) => {
       this.handleURL(event.url);
     });
 
-    this.linkingAPI.getInitialURL().then((url) => {
-      if (url) this.handleURL(url);
-    });
+    this.linkingAPI
+      .getInitialURL()
+      .then((url) => {
+        if (url && subscriptionGeneration === this.subscriptionGeneration) {
+          this.handleURL(url);
+        }
+      })
+      .catch(() => {});
   }
 
   private processURL(url: string): void {


### PR DESCRIPTION
## Problem

Reconfiguring deep linking removes the previous URL-event listener, but it cannot cancel that configuration's pending `getInitialURL()` promise. If the old promise resolves later, its URL is handled through the new configuration and can be duplicated, misrouted, or sent to the wrong callback. A rejected initial-URL lookup can also escape as an unhandled rejection.

## Fix

- generation-tag each linking subscription
- invalidate the generation during teardown
- ignore initial URLs resolved by stale configurations
- absorb initial-URL lookup failures while keeping the live URL listener operational

## Breaking changes

None. Only stale or failed initial-URL lookups change behavior; current subscriptions and live URL events are unchanged.

## Test plan

- Added a deferred-promise regression proving an old configuration's initial URL reaches neither old nor new callbacks.
- Added rejection coverage proving later live URL events still process exactly once.
- Focused suite passes: 30/30 tests.
- Full `yarn test-js` passes: 38 suites/397 tests; 11 suites/59 tests remain intentionally skipped.
- Focused ESLint, Bob module/type builds, and `git diff --check` pass.
