### PR TITLE
Handle non-navigation Android activities safely

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/react/NavigationModule.java
+++ b/android/src/main/java/com/reactnativenavigation/react/NavigationModule.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import static com.reactnativenavigation.utils.UiUtils.pxToDp;
 
 import android.app.Activity;
+import android.util.Log;
 
 public class NavigationModule extends ReactContextBaseJavaModule {
     private static final String NAME = "RNNBridgeModule";
@@ -58,21 +59,25 @@ public class NavigationModule extends ReactContextBaseJavaModule {
             public void onHostPause() {
                 super.onHostPause();
                 UiUtils.runOnMainThread(() -> {
-                    if (activity() != null) navigator().onHostPause();
+                    final NavigationActivity activity = activity();
+                    if (activity != null) activity.getNavigator().onHostPause();
                 });
             }
 
             @Override
             public void onHostResume() {
+                final NavigationActivity activity = activity();
+                if (activity == null) return;
+                final Navigator navigator = activity.getNavigator();
                 eventEmitter = new EventEmitter(reactContext);
-                navigator().setEventEmitter(eventEmitter);
+                navigator.setEventEmitter(eventEmitter);
                 layoutFactory.init(
-                        activity(),
+                        activity,
                         eventEmitter,
-                        navigator().getChildRegistry(),
-                        ((NavigationApplication) activity().getApplication()).getExternalComponents()
+                        navigator.getChildRegistry(),
+                        ((NavigationApplication) activity.getApplication()).getExternalComponents()
                 );
-                UiUtils.runOnMainThread(() -> navigator().onHostResume());
+                UiUtils.runOnMainThread(navigator::onHostResume);
             }
         });
     }
@@ -221,14 +226,21 @@ public class NavigationModule extends ReactContextBaseJavaModule {
 
     protected void handle(Runnable task) {
         UiThread.post(() -> {
-            if (getCurrentActivity() != null && !activity().isFinishing()) {
+            final NavigationActivity activity = activity();
+            if (activity != null && !activity.isFinishing()) {
                 task.run();
             }
         });
     }
 
+    @Nullable
     protected NavigationActivity activity() {
-        return (NavigationActivity) getCurrentActivity();
+        final Activity activity = getReactApplicationContext().getCurrentActivity();
+        if (!(activity instanceof NavigationActivity)) {
+            Log.e("NavigationModule", "current activity is not a NavigationActivity");
+            return null;
+        }
+        return (NavigationActivity) activity;
     }
 
     @Override

--- a/android/src/main/java/com/reactnativenavigation/react/NavigationTurboModule.kt
+++ b/android/src/main/java/com/reactnativenavigation/react/NavigationTurboModule.kt
@@ -65,7 +65,10 @@ class NavigationTurboModule(
                 UiUtils.getBottomTabsHeight(reactApplicationContext).toFloat()
             ).toDouble()
         constants[Constants.STATUS_BAR_HEIGHT_KEY] =
-            UiUtils.pxToDp(reactApplicationContext, getStatusBarHeight(currentActivity).toFloat())
+            UiUtils.pxToDp(
+                reactApplicationContext,
+                getStatusBarHeight(reactApplicationContext.getCurrentActivity()).toFloat()
+            )
                 .toDouble()
         constants[Constants.TOP_BAR_HEIGHT_KEY] = UiUtils.pxToDp(
             reactApplicationContext,
@@ -84,11 +87,6 @@ class NavigationTurboModule(
         handle {
             Log.d("NavigationTurboModule", "setRoot handle ${Thread.currentThread()}")
             val viewController = layoutFactory.create(layoutTree)
-            val activity = currentActivity
-            if (activity == null) {
-                promise.reject("ACTIVITY_NULL", "Activity is null")
-                return@handle
-            }
             navigator()?.setRoot(
                 viewController,
                 NativeCommandListener("setRoot", commandId, promise, eventEmitter, now)
@@ -295,11 +293,11 @@ class NavigationTurboModule(
     }
 
     private fun activity(): NavigationActivity? {
-        val activity = reactApplicationContext.currentActivity as NavigationActivity?
+        val activity = reactApplicationContext.getCurrentActivity() as? NavigationActivity
         if (activity == null) {
-            Log.e("NavigationTurboModule", "current activity is null!")
+            Log.e("NavigationTurboModule", "current activity is not a NavigationActivity")
         }
-        return currentActivity as NavigationActivity?
+        return activity
     }
 
     companion object {

--- a/android/src/test/java/com/reactnativenavigation/react/NavigationModuleTest.java
+++ b/android/src/test/java/com/reactnativenavigation/react/NavigationModuleTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.reactnativenavigation.BaseTest;
@@ -22,6 +23,7 @@ import com.reactnativenavigation.viewcontrollers.viewcontroller.ViewController;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
@@ -76,6 +78,23 @@ public class NavigationModuleTest extends BaseTest {
         spy.handle(dontRun);
         ShadowLooper.idleMainLooper();
         verify(dontRun, times(0)).run();
+    }
+
+    @Test
+    public void foreignActivity_isIgnoredByCommandsLifecycleAndInvalidate() {
+        when(reactApplicationContext.getCurrentActivity()).thenReturn(newActivity());
+        Runnable command = mock(Runnable.class);
+
+        uut.handle(command);
+        ShadowLooper.idleMainLooper();
+        verify(command, times(0)).run();
+
+        ArgumentCaptor<LifecycleEventListener> listener = ArgumentCaptor.forClass(LifecycleEventListener.class);
+        verify(reactApplicationContext).addLifecycleEventListener(listener.capture());
+        listener.getValue().onHostResume();
+        listener.getValue().onHostPause();
+        ShadowLooper.idleMainLooper();
+        uut.invalidate();
     }
 
     private NavigationActivity mockActivity() {

--- a/android/src/test/java/com/reactnativenavigation/react/NavigationTurboModuleTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/react/NavigationTurboModuleTest.kt
@@ -1,0 +1,20 @@
+package com.reactnativenavigation.react
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.reactnativenavigation.BaseTest
+import com.reactnativenavigation.options.LayoutFactory
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class NavigationTurboModuleTest : BaseTest() {
+    @Test
+    fun command_handlesNonNavigationActivity() {
+        val reactContext = mock<ReactApplicationContext>()
+        whenever(reactContext.getCurrentActivity()).thenReturn(newActivity())
+        val uut = NavigationTurboModule(reactContext, mock<LayoutFactory>())
+
+        uut.setDefaultOptions(null)
+        idleMainLooper()
+    }
+}


### PR DESCRIPTION
## Problem

Both Android bridge implementations force-cast React Native's current `Activity` to `NavigationActivity`. If an OAuth, relay, permission, or other valid foreground Activity is current—or no Activity is current—the TurboModule or legacy lifecycle/command path can throw `ClassCastException` instead of waiting for navigation to become foreground again. This also covers the unsafe cast reported in #8048.

## Fix

- safe-cast the current Activity in both Turbo and legacy modules
- skip commands while the foreground Activity is not a `NavigationActivity`, matching existing null-activity gating
- guard legacy host pause/resume and invalidation through the same validated Activity
- reuse the validated legacy Activity/Navigator within lifecycle callbacks
- remove an unreachable second null check inside Turbo `setRoot`
- replace touched deprecated `currentActivity` property access with `getCurrentActivity()`

## Breaking changes

None. A state that previously crashed is now logged accurately and safely skipped; normal `NavigationActivity` command/lifecycle behavior is unchanged. Commands are not queued by this patch.

## Test plan

- Added a Turbo regression invoking a command with an `AppCompatActivity` foreground; exact baseline throws `ClassCastException`.
- Added legacy coverage for command handling, host resume/pause, and invalidation with the same foreign Activity.
- Focused regressions pass 4/4.
- Full Android RNN unit suite passes: 699 successes, 0 failures, 2 skipped.
- `git diff --check` passes.
