### PR TITLE
Scope appearance listener state per animator

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/views/animations/BaseViewAppearanceAnimator.kt
+++ b/android/src/main/java/com/reactnativenavigation/views/animations/BaseViewAppearanceAnimator.kt
@@ -26,22 +26,19 @@ open class BaseViewAppearanceAnimator<T : View>(
     var showAnimator: Animator = AnimatorSet()
         private set(value) {
             field = value
-            field.addListener(showAnimatorListener)
+            field.addListener(AnimatorListener(AnimationState.AnimatingEnter, View.VISIBLE))
             field.doOnEnd { onShowAnimationEnd() }
         }
     @VisibleForTesting
     var hideAnimator: Animator = AnimatorSet()
         set(value) {
             field = value
-            field.addListener(hideAnimatorListener)
+            field.addListener(AnimatorListener(AnimationState.AnimatingExit, View.GONE))
             field.doOnEnd { onHideAnimationEnd() }
         }
 
-    private val showAnimatorListener = AnimatorListener(AnimationState.AnimatingEnter, View.VISIBLE)
-    private val hideAnimatorListener = AnimatorListener(AnimationState.AnimatingExit, View.GONE)
-
     private inner class AnimatorListener(private val startState: AnimationState, private val endVisibility: Int) : AnimatorListenerAdapter() {
-        var isCancelled = false
+        private var isCancelled = false
 
         override fun onAnimationStart(animation: Animator) {
             view.resetViewProperties()

--- a/android/src/test/java/com/reactnativenavigation/views/animations/BaseViewAppearanceAnimatorTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/views/animations/BaseViewAppearanceAnimatorTest.kt
@@ -103,6 +103,18 @@ class BaseViewAppearanceAnimatorTest : BaseTest() {
         assertThat(uut.hideAnimator).isEqualTo(defaultHideAnimator)
     }
 
+    @Test
+    fun hide_completesAfterPreviousHideWasCancelled() {
+        uut.hide()
+        uut.show()
+        uut.showAnimator.end()
+
+        uut.hide()
+        uut.hideAnimator.end()
+
+        assertThat(view.visibility).isEqualTo(View.GONE)
+    }
+
     private fun assertNotAnimating() = assertThat(uut.isAnimatingHide() && uut.isAnimatingShow()).isFalse()
     private fun assertAnimatingShow() = assertThat(uut.isAnimatingShow() && !uut.isAnimatingHide()).isTrue()
     private fun assertAnimatingHide() = assertThat(uut.isAnimatingHide() && !uut.isAnimatingShow()).isTrue()


### PR DESCRIPTION
## Problem

`BaseViewAppearanceAnimator` reuses one show listener and one hide listener across every replacement animator. Each listener's cancellation flag is sticky: once a hide is interrupted by show, later hide animators inherit the cancelled state and permanently skip their end-state cleanup, leaving the view visible instead of gone.

## Fix

Attach a fresh listener to each replacement animator so cancellation state belongs to exactly that animator. This removes shared mutable listener state and prevents old/new animator callbacks from contaminating one another.

## Breaking changes

None. Completed animations retain their existing states; a later animation now completes normally after an earlier instance was cancelled.

## Test plan

- Added a regression that cancels hide with show, completes show, then runs a second hide and verifies `View.GONE`.
- Exact baseline leaves the view `VISIBLE`; the fixed focused suite passes 9/9.
- Full Android unit suite passes: 698 successes, 0 failures, 2 skipped.
- `git diff --check` passes.
