### PR TITLE
Cancel every running stack animation safely

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackAnimator.kt
+++ b/android/src/main/java/com/reactnativenavigation/viewcontrollers/stack/StackAnimator.kt
@@ -34,7 +34,7 @@ open class StackAnimator @JvmOverloads constructor(
     @VisibleForTesting
     val runningSetRootAnimations: MutableMap<ViewController<*>, AnimatorSet> = HashMap()
 
-    fun cancelPushAnimations() = runningPushAnimations.values.forEach(Animator::cancel)
+    fun cancelPushAnimations() = runningPushAnimations.values.toList().forEach(Animator::cancel)
 
     open fun isChildInTransition(child: ViewController<*>?): Boolean {
         return runningPushAnimations.containsKey(child) ||
@@ -43,9 +43,13 @@ open class StackAnimator @JvmOverloads constructor(
     }
 
     fun cancelAllAnimations() {
+        val animations = runningPushAnimations.values +
+            runningPopAnimations.values +
+            runningSetRootAnimations.values
         runningPushAnimations.clear()
         runningPopAnimations.clear()
         runningSetRootAnimations.clear()
+        animations.forEach(Animator::cancel)
     }
 
     fun setRoot(

--- a/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackAnimatorTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/viewcontrollers/stack/StackAnimatorTest.kt
@@ -213,6 +213,32 @@ class StackAnimatorTest : BaseTest() {
         assertThat(uut.isChildInTransition(child3)).isTrue()
     }
 
+    @Test
+    fun cancelAllAnimations_cancelsRunningAnimatorsWithoutCompletingCommands() {
+        val onAnimationEnd = mock<Runnable>()
+        uut.push(child2, child1, Options.EMPTY, emptyList(), onAnimationEnd)
+
+        uut.cancelAllAnimations()
+
+        verify(commandAnimator).cancel()
+        verify(onAnimationEnd, never()).run()
+        assertThat(uut.isChildInTransition(child2)).isFalse()
+    }
+
+    @Test
+    fun cancelPushAnimations_cancelsEveryRunningAnimator() {
+        uut.push(child2, child1, Options.EMPTY, emptyList(), mock())
+        val firstAnimator = uut.runningPushAnimations[child2]!!
+        val child3 = SimpleViewController(activity, mock(), "child3", Options())
+        uut.push(child3, child2, Options.EMPTY, emptyList(), mock())
+        val secondAnimator = uut.runningPushAnimations[child3]!!
+
+        uut.cancelPushAnimations()
+
+        verify(firstAnimator).cancel()
+        verify(secondAnimator).cancel()
+    }
+
     private fun mockViewController(): ViewController<*> {
         val vc = mock<ViewController<*>>()
         val view = FrameLayout(activity)


### PR DESCRIPTION
## Problem

`StackAnimator.cancelAllAnimations()` only clears its tracking maps; the animators keep running against views the caller may immediately destroy. `cancelPushAnimations()` iterates a live map while synchronous cancel/end listeners remove entries, so cancelling multiple pushes can also trigger concurrent modification or skip work.

## Fix

- snapshot every running animator before mutating its registry
- clear all tracking maps before cancel-all so command-completion callbacks remain suppressed
- cancel the snapshots so every animator actually stops without iterating a listener-mutated map

## Breaking changes

None. Cancellation now performs the action its API promises; normal completed animations and callback semantics are unchanged.

## Test plan

- Added a cancel-all regression proving the animator receives `cancel()`, transition tracking clears, and the command callback stays suppressed.
- Added two-simultaneous-push coverage proving both animators are cancelled safely.
- Exact baseline fails because cancel-all never calls `cancel()`; fixed focused suite passes 14/14.
- Full Android unit suite passes: 699 successes, 0 failures, 2 skipped.
- `git diff --check` passes.
