### PR TITLE
Fix React surface observer lifecycle

### DIFF
--- a/ios/RNNReactButtonView.mm
+++ b/ios/RNNReactButtonView.mm
@@ -17,7 +17,6 @@ static const CGFloat kMinBarButtonSlotSize = 44.0;
              sizeMeasureMode:(RCTSurfaceSizeMeasureMode)sizeMeasureMode
          reactViewReadyBlock:(RNNReactViewReadyCompletionBlock)reactViewReadyBlock {
     self = [super initWithHost:host moduleName:moduleName initialProperties:initialProperties eventEmitter:eventEmitter sizeMeasureMode:convertToSurfaceSizeMeasureMode(RCTRootViewSizeFlexibilityWidthAndHeight) reactViewReadyBlock:reactViewReadyBlock];
-    [host.surfacePresenter addObserver:self];
     self.backgroundColor = [UIColor clearColor];
 
     if (@available(iOS 26.0, *)) {

--- a/ios/RNNReactView.mm
+++ b/ios/RNNReactView.mm
@@ -15,6 +15,9 @@
     BOOL _pendingDidAppear;
     BOOL _didAppear;
     BOOL _willAppear;
+#ifdef RCT_NEW_ARCH_ENABLED
+    __weak RCTSurfacePresenter *_surfacePresenter;
+#endif
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -38,17 +41,23 @@
     self = [super initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties];
 #endif
 
-    _reactViewReadyBlock = reactViewReadyBlock;
-    _eventEmitter = eventEmitter;
+    if (self) {
+#ifdef RCT_NEW_ARCH_ENABLED
+        _surfacePresenter = (RCTSurfacePresenter *)bridge.surfacePresenter;
+        [_surfacePresenter addObserver:self];
+#endif
+        _reactViewReadyBlock = reactViewReadyBlock;
+        _eventEmitter = eventEmitter;
 
 #ifdef RCT_NEW_ARCH_ENABLED
-    [surface start];
+        [surface start];
 #else
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(contentDidAppear:)
-                                                 name:RCTContentDidAppearNotification
-                                               object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(contentDidAppear:)
+                                                     name:RCTContentDidAppearNotification
+                                                   object:nil];
 #endif
+    }
 
     return self;
 }
@@ -63,15 +72,24 @@
     
     RCTFabricSurface *surface = [host createSurfaceWithModuleName:moduleName
                                                 initialProperties:initialProperties];
-    [host.surfacePresenter addObserver:self];
     self = [super initWithSurface:surface sizeMeasureMode:sizeMeasureMode];
-    
-    _reactViewReadyBlock = reactViewReadyBlock;
-    _eventEmitter = eventEmitter;
-    
+    if (self) {
+        _surfacePresenter = host.surfacePresenter;
+        [_surfacePresenter addObserver:self];
+
+        _reactViewReadyBlock = reactViewReadyBlock;
+        _eventEmitter = eventEmitter;
+    }
+
     return self;
 }
 #endif
+
+- (void)dealloc {
+#ifdef RCT_NEW_ARCH_ENABLED
+    [_surfacePresenter removeObserver:self];
+#endif
+}
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #pragma mark - RCTSurfaceDelegate

--- a/playground/ios/NavigationTests/RNNReactButtonViewTest.mm
+++ b/playground/ios/NavigationTests/RNNReactButtonViewTest.mm
@@ -1,0 +1,54 @@
+#import <OCMock/OCMock.h>
+#import <ReactNativeNavigation/RNNReactButtonView.h>
+#import <XCTest/XCTest.h>
+
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <React-RuntimeApple/ReactCommon/RCTHost.h>
+#import <React/RCTFabricSurface.h>
+#import <React/RCTSurfacePresenter.h>
+
+@interface RNNSurfacePresenterSpy : NSObject
+@property(nonatomic) NSInteger addCount;
+@end
+
+@implementation RNNSurfacePresenterSpy
+
+- (void)addObserver:(__unused id<RCTSurfacePresenterObserver>)observer {
+    self.addCount += 1;
+}
+
+- (void)removeObserver:(__unused id<RCTSurfacePresenterObserver>)observer {
+}
+
+@end
+#endif
+
+@interface RNNReactButtonViewTest : XCTestCase
+@end
+
+@implementation RNNReactButtonViewTest
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (void)testRegistersSurfacePresenterObserverOnce {
+    id host = OCMClassMock([RCTHost class]);
+    id surface = OCMClassMock([RCTFabricSurface class]);
+    RNNSurfacePresenterSpy *surfacePresenter = [RNNSurfacePresenterSpy new];
+    OCMStub([host createSurfaceWithModuleName:@"Button" initialProperties:@{}]).andReturn(surface);
+    OCMStub([host surfacePresenter]).andReturn(surfacePresenter);
+
+    RNNReactButtonView *view = [[RNNReactButtonView alloc]
+        initWithHost:host
+           moduleName:@"Button"
+    initialProperties:@{}
+         eventEmitter:nil
+      sizeMeasureMode:RCTSurfaceSizeMeasureModeWidthUndefined |
+                      RCTSurfaceSizeMeasureModeHeightUndefined
+  reactViewReadyBlock:nil];
+
+    XCTAssertNotNil(view);
+    XCTAssertEqual(surfacePresenter.addCount, 1);
+}
+
+#endif
+
+@end

--- a/playground/ios/playground.xcodeproj/project.pbxproj
+++ b/playground/ios/playground.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		50996C6923AA487800008F89 /* RNNTestRootViewCreator.mm in Sources */ = {isa = PBXBuildFile; fileRef = E58D263D2385888C003F36BA /* RNNTestRootViewCreator.mm */; };
 		50BCB27623F1A2B100D6C8E5 /* TopBarAppearancePresenterTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 50BCB27523F1A26600D6C8E5 /* TopBarAppearancePresenterTest.mm */; };
 		50C085E62591341600B0502C /* RNNUIBarButtonItemTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 50C085E52591341600B0502C /* RNNUIBarButtonItemTest.mm */; };
+		C6FFE0D95634444585A67D66 /* RNNReactButtonViewTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4B9ECE2F1FB6445390982D7F /* RNNReactButtonViewTest.mm */; };
 		50C085E8259141E200B0502C /* RNNButtonsPresenterTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 50C085E7259141E200B0502C /* RNNButtonsPresenterTest.mm */; };
 		50C085F52594973000B0502C /* RNNComponentViewController+Utils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 50C9A8D3240FB9D000BD699F /* RNNComponentViewController+Utils.mm */; };
 		50C9A8D1240EB95F00BD699F /* RNNBottomTabsController+Helpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 50CF233C240695B10098042D /* RNNBottomTabsController+Helpers.mm */; };
@@ -159,6 +160,7 @@
 		50996C6723AA477400008F89 /* RNNRootViewControllerTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RNNRootViewControllerTest.mm; sourceTree = "<group>"; };
 		50BCB27523F1A26600D6C8E5 /* TopBarAppearancePresenterTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TopBarAppearancePresenterTest.mm; sourceTree = "<group>"; };
 		50C085E52591341600B0502C /* RNNUIBarButtonItemTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RNNUIBarButtonItemTest.mm; sourceTree = "<group>"; };
+		4B9ECE2F1FB6445390982D7F /* RNNReactButtonViewTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RNNReactButtonViewTest.mm; sourceTree = "<group>"; };
 		50C085E7259141E200B0502C /* RNNButtonsPresenterTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RNNButtonsPresenterTest.mm; sourceTree = "<group>"; };
 		50C9A8D2240FB9D000BD699F /* RNNComponentViewController+Utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RNNComponentViewController+Utils.h"; sourceTree = "<group>"; };
 		50C9A8D3240FB9D000BD699F /* RNNComponentViewController+Utils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "RNNComponentViewController+Utils.mm"; sourceTree = "<group>"; };
@@ -403,6 +405,7 @@
 				E58D26412385888C003F36BA /* RNNCommandsHandlerTest.mm */,
 				E58D26352385888B003F36BA /* RNNComponentPresenterTest.mm */,
 				50C085E52591341600B0502C /* RNNUIBarButtonItemTest.mm */,
+				4B9ECE2F1FB6445390982D7F /* RNNReactButtonViewTest.mm */,
 				50C085E7259141E200B0502C /* RNNButtonsPresenterTest.mm */,
 				E58D26402385888C003F36BA /* RNNViewControllerFactoryTest.mm */,
 				E58D26272385888B003F36BA /* RNNDotIndicatorPresenterTest.mm */,
@@ -985,6 +988,7 @@
 				E58D265E2385888C003F36BA /* RNNCommandsHandlerTest.mm in Sources */,
 				E58D264B2385888C003F36BA /* RNNLayoutManagerTest.mm in Sources */,
 				50C085E62591341600B0502C /* RNNUIBarButtonItemTest.mm in Sources */,
+				C6FFE0D95634444585A67D66 /* RNNReactButtonViewTest.mm in Sources */,
 				E58D26592385888C003F36BA /* RNNNavigationStackManagerTest.mm in Sources */,
 				E58D26602385888C003F36BA /* RNNModalManagerTest.mm in Sources */,
 				E58D26502385888C003F36BA /* RNNNavigationOptionsTest.mm in Sources */,


### PR DESCRIPTION
## Fix

New-Architecture `RNNReactButtonView` instances created through `RCTHost` register twice with the same `RCTSurfacePresenter`: once in `RNNReactView` and again in the subclass. Every button therefore receives duplicate presenter callbacks. Bridge-created New-Architecture views take the opposite path and never register, so their pending appearance lifecycle cannot be released by mount callbacks. The base view also never unregisters, leaving a stale weak entry in the presenter's observer vector after teardown.

Register exactly once in both base initializers after successful superclass initialization, retain the presenter weakly, remove the observer during deallocation, and delete the subclass registration. This also avoids registering an incompletely initialized `self` before `[super initWithSurface:]` returns.

## Verification

- Added a New-Architecture host-path regression using a non-retaining presenter spy; exact baseline records two registrations and the fix records one.
- Reviewed the bridge path against `_isMounted`'s only assignment sites and added the same base observer lifecycle there; compilation covers both New-Architecture initializers.
- New-Architecture iOS `build-for-testing` succeeds.
- Focused `RNNReactButtonViewTest` passes 1/1 on an iOS 26.5 simulator.
- Full simulator suite before the final test-only refinement: 356/357 pass; the only failure is the unchanged environment-sensitive `RNNRootViewControllerTest.testTopBarNoBorderOff`, also failing on baseline.
- Targeted clang-format and `git diff --check` pass.

## Breaking changes

None. This removes duplicate callbacks and cleans up observer lifecycle without changing the public API.
