### PR TITLE
fix(Android): restore custom row listener on reattach

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/customrow/BottomTabsCustomRow.kt
+++ b/android/src/main/java/com/reactnativenavigation/customrow/BottomTabsCustomRow.kt
@@ -69,9 +69,14 @@ class BottomTabsCustomRow(
         clipChildren = false
         clipToPadding = false
         addView(backgroundView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
-        BottomTabsCustomRowConfigStore.addListener(configListener)
         applyOptions(currentOptions)
         rebuildCells()
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        BottomTabsCustomRowConfigStore.addListener(configListener)
+        applyOptions(BottomTabsCustomRowConfigStore.get())
     }
 
     override fun onDetachedFromWindow() {

--- a/android/src/test/java/com/reactnativenavigation/customrow/BottomTabsCustomRowTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/customrow/BottomTabsCustomRowTest.kt
@@ -1,0 +1,49 @@
+package com.reactnativenavigation.customrow
+
+import android.content.Context
+import android.widget.FrameLayout
+import com.reactnativenavigation.BaseTest
+import com.reactnativenavigation.views.bottomtabs.BottomTabs
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BottomTabsCustomRowTest : BaseTest() {
+    @Test
+    fun reattachedRowContinuesReceivingConfigurationUpdates() {
+        val activity = newActivity()
+        val container = FrameLayout(activity)
+        val row = BottomTabsCustomRow(activity, BottomTabs(activity))
+        activity.setContentView(container)
+
+        try {
+            container.addView(row)
+            BottomTabsCustomRowConfigStore.update(
+                BottomTabsCustomRowOptions(horizontalMargin = 24f)
+            )
+            idleMainLooper()
+            assertEquals(dp(activity, 24f), row.effectiveHorizontalMarginPx())
+
+            container.removeView(row)
+            BottomTabsCustomRowConfigStore.update(
+                BottomTabsCustomRowOptions(horizontalMargin = 32f)
+            )
+            idleMainLooper()
+            assertEquals(dp(activity, 24f), row.effectiveHorizontalMarginPx())
+
+            container.addView(row)
+            assertEquals(dp(activity, 32f), row.effectiveHorizontalMarginPx())
+
+            BottomTabsCustomRowConfigStore.update(
+                BottomTabsCustomRowOptions(horizontalMargin = 40f)
+            )
+            idleMainLooper()
+            assertEquals(dp(activity, 40f), row.effectiveHorizontalMarginPx())
+        } finally {
+            container.removeView(row)
+            BottomTabsCustomRowConfigStore.update(BottomTabsCustomRowOptions())
+        }
+    }
+
+    private fun dp(context: Context, value: Float): Int =
+        (value * context.resources.displayMetrics.density).toInt()
+}


### PR DESCRIPTION
## Problem and fix

`BottomTabsCustomRow` registered its process-wide configuration listener only during construction and removed it when detached. `BottomTabsCustomRowAttacher.ensureRowHostedOn` can detach and reattach the same row when its host changes, leaving that row permanently unsubscribed from later configuration updates.

This change ties the listener to the actual view lifecycle:

- register in `onAttachedToWindow`
- remove in `onDetachedFromWindow`
- apply the store's latest configuration on every attachment, covering updates that arrived while detached

The listener store is a set, so attachment registration remains idempotent.

## Regression coverage

The new Robolectric test verifies that:

- an attached row receives configuration updates
- a detached row does not
- reattachment immediately catches up to the current configuration
- later updates continue to reach the reattached row

## Verification

- focused regression: 1/1 passed
- full Android unit suite: 698 passed, 2 skipped, 0 failed
- Android debug Kotlin/Java compilation passed
- `git diff --check` passed

## Breaking changes

None. This restores expected updates for an existing row after re-hosting.
