### PR TITLE
fix(Android): always release modal lifecycle listener

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/react/modal/ModalViewManager.kt
+++ b/android/src/main/java/com/reactnativenavigation/react/modal/ModalViewManager.kt
@@ -55,8 +55,9 @@ class ModalViewManager(val reactContext: ReactContext) : ViewGroupManager<ModalH
 
     override fun onDropViewInstance(modal: ModalHostLayout) {
         super.onDropViewInstance(modal)
-        navigator?.let {
-            it.dismissModal(modal.viewController.id, CommandListenerAdapter())
+        try {
+            navigator?.dismissModal(modal.viewController.id, CommandListenerAdapter())
+        } finally {
             modal.onDropInstance()
         }
     }

--- a/android/src/test/java/com/reactnativenavigation/react/modal/ModalViewManagerTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/react/modal/ModalViewManagerTest.kt
@@ -1,0 +1,21 @@
+package com.reactnativenavigation.react.modal
+
+import com.facebook.react.bridge.ReactContext
+import com.reactnativenavigation.BaseTest
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class ModalViewManagerTest : BaseTest() {
+    @Test
+    fun dropRemovesLifecycleListenerWithoutActiveNavigator() {
+        val reactContext = mock<ReactContext>()
+        whenever(reactContext.currentActivity).thenReturn(null)
+        val modal = mock<ModalHostLayout>()
+
+        ModalViewManager(reactContext).onDropViewInstance(modal)
+
+        verify(modal).onDropInstance()
+    }
+}


### PR DESCRIPTION
## Problem and fix

`ModalHostLayout` registers itself as a React lifecycle listener during construction. `ModalViewManager.onDropViewInstance` removed that listener only inside `navigator?.let`, so dropping a modal while there was no active `NavigationActivity`/navigator left the discarded host registered with `ReactContext`.

This can occur while an activity is absent, finishing, or destroyed. The stale lifecycle registration retains unnecessary work and references after the React view has been dropped.

The cleanup now runs in `finally`, preserving dismissal when a navigator exists while guaranteeing `onDropInstance()` when it does not—or if synchronous dismissal fails.

## Regression coverage

The new Robolectric test drops a modal with no active activity/navigator and verifies that its lifecycle listener is still removed. The exact baseline fails this assertion.

## Verification

- focused regression: 1/1 passed
- full Android unit suite: 698 passed, 2 skipped, 0 failed
- Android debug Kotlin/Java compilation passed
- `git diff --check` passed

## Breaking changes

None. This guarantees existing teardown behavior on every drop path.
