### PR TITLE
fix(Android): ignore reload callbacks after teardown

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/react/JsDevReloadHandler.java
+++ b/android/src/main/java/com/reactnativenavigation/react/JsDevReloadHandler.java
@@ -19,6 +19,8 @@ public class JsDevReloadHandler extends JsDevReloadHandlerFacade {
         void onReload();
     }
 
+    private static final ReloadListener NO_OP_RELOAD_LISTENER = () -> {};
+
 	private final BroadcastReceiver reloadReceiver = new BroadcastReceiver() {
 		@Override
 		public void onReceive(final Context context, final Intent intent) {
@@ -28,7 +30,7 @@ public class JsDevReloadHandler extends JsDevReloadHandlerFacade {
     private final DevSupportManager devSupportManager;
 
     private long firstRTimestamp = 0;
-    private ReloadListener reloadListener = () -> {};
+    private ReloadListener reloadListener = NO_OP_RELOAD_LISTENER;
 
     JsDevReloadHandler(DevSupportManager devSupportManager) {
         this.devSupportManager = devSupportManager;
@@ -45,7 +47,7 @@ public class JsDevReloadHandler extends JsDevReloadHandlerFacade {
 
     public void removeReloadListener(ReloadListener listener) {
         if (reloadListener == listener) {
-            reloadListener = null;
+            reloadListener = NO_OP_RELOAD_LISTENER;
         }
     }
 

--- a/android/src/main/java/com/reactnativenavigation/react/ReloadHandler.java
+++ b/android/src/main/java/com/reactnativenavigation/react/ReloadHandler.java
@@ -2,7 +2,8 @@ package com.reactnativenavigation.react;
 
 public class ReloadHandler extends ReloadHandlerFacade implements JsDevReloadHandler.ReloadListener {
 
-    private Runnable onReloadListener = () -> {};
+    private static final Runnable NO_OP_RELOAD_LISTENER = () -> {};
+    private Runnable onReloadListener = NO_OP_RELOAD_LISTENER;
 
     public void setOnReloadListener(Runnable onReload) {
         this.onReloadListener = onReload;
@@ -19,6 +20,6 @@ public class ReloadHandler extends ReloadHandlerFacade implements JsDevReloadHan
     }
 
     public void destroy() {
-        onReloadListener = null;
+        onReloadListener = NO_OP_RELOAD_LISTENER;
     }
 }

--- a/android/src/test/java/com/reactnativenavigation/react/JsDevReloadHandlerTest.java
+++ b/android/src/test/java/com/reactnativenavigation/react/JsDevReloadHandlerTest.java
@@ -1,0 +1,23 @@
+package com.reactnativenavigation.react;
+
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
+import com.reactnativenavigation.BaseTest;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class JsDevReloadHandlerTest extends BaseTest {
+    @Test
+    public void onSuccess_afterListenerRemovalIsIgnored() {
+        JsDevReloadHandler.ReloadListener listener =
+                Mockito.mock(JsDevReloadHandler.ReloadListener.class);
+        JsDevReloadHandler handler =
+                new JsDevReloadHandler(Mockito.mock(DevSupportManager.class));
+        handler.setReloadListener(listener);
+        handler.removeReloadListener(listener);
+
+        handler.onSuccess();
+
+        Mockito.verifyNoInteractions(listener);
+    }
+}

--- a/android/src/test/java/com/reactnativenavigation/react/ReloadListenerTest.java
+++ b/android/src/test/java/com/reactnativenavigation/react/ReloadListenerTest.java
@@ -21,4 +21,14 @@ public class ReloadListenerTest extends BaseTest {
         uut.onSuccess();
         Mockito.verify(handler).run();
     }
+
+    @Test
+    public void onSuccess_afterDestroyIsIgnored() {
+        uut.setOnReloadListener(handler);
+        uut.destroy();
+
+        uut.onSuccess();
+
+        Mockito.verifyNoInteractions(handler);
+    }
 }


### PR DESCRIPTION
## Problem and fix

Both Android reload handlers replaced their listener with `null` during teardown. A late dev-bundle `onSuccess()` callback then dereferenced that null listener:

- `JsDevReloadHandler` can receive a bundle-download completion after its `NavigationActivity` has been destroyed and removed
- `ReloadHandler` remained callable after `destroy()` through the same callback interface

This change restores the no-op listener each handler already uses before initial registration. Late callbacks are safely ignored without retaining the destroyed listener or adding nullable checks to every call site.

## Regression coverage

- `JsDevReloadHandlerTest` removes an activity listener and invokes a late success callback
- `ReloadListenerTest` destroys the generic handler and invokes a late success callback

Both exact baseline paths throw `NullPointerException`; the fixed focused suite passes 3/3.

## Verification

- focused reload suites: 3/3 passed
- full Android unit suite: 699 passed, 2 skipped, 0 failed
- Android debug Java/Kotlin compilation passed
- `git diff --check` passed

## Breaking changes

None. Callbacks after teardown are now ignored instead of crashing.
