### PR TITLE
perf(iOS): avoid blocking a worker during component render

### DIFF
--- a/ios/RNNStackPresenter.mm
+++ b/ios/RNNStackPresenter.mm
@@ -167,24 +167,14 @@
 
 - (void)renderComponents:(RNNNavigationOptions *)options
                  perform:(RNNReactViewReadyCompletionBlock)readyBlock {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-      dispatch_group_t group = dispatch_group_create();
-
-      dispatch_group_enter(group);
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [self setCustomNavigationComponentBackground:options
-                                             perform:^{
-                                               dispatch_group_leave(group);
-                                             }];
-      });
-
-      dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
-
-      dispatch_async(dispatch_get_main_queue(), ^{
-        if (readyBlock) {
-            readyBlock();
-        }
-      });
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self setCustomNavigationComponentBackground:options
+                                           perform:^{
+                                             if (readyBlock) {
+                                                 dispatch_async(dispatch_get_main_queue(),
+                                                                readyBlock);
+                                             }
+                                           }];
     });
 }
 

--- a/playground/ios/NavigationTests/RNNStackPresenterTest.mm
+++ b/playground/ios/NavigationTests/RNNStackPresenterTest.mm
@@ -6,6 +6,13 @@
 #import <ReactNativeNavigation/RNNStackPresenter.h>
 #import <XCTest/XCTest.h>
 
+@interface RNNStackPresenter (Testing)
+
+- (void)setCustomNavigationComponentBackground:(RNNNavigationOptions *)options
+                                       perform:(RNNReactViewReadyCompletionBlock)readyBlock;
+
+@end
+
 @interface RNNStackPresenterTest : XCTestCase
 
 @property(nonatomic, strong) RNNStackPresenter *uut;
@@ -121,6 +128,21 @@
     [self.uut applyOptions:self.options];
     UIColor *expectedColor = [UIColor colorWithRed:1 green:0 blue:0 alpha:1];
     XCTAssertTrue([self.boundViewController.view.backgroundColor isEqual:expectedColor]);
+}
+
+- (void)testRenderComponentsCompletesOnMainThread {
+    id presenter = [OCMockObject partialMockForObject:self.uut];
+    OCMStub([presenter setCustomNavigationComponentBackground:OCMArg.any
+                                                      perform:OCMArg.invokeBlock]);
+    XCTestExpectation *completion = [self expectationWithDescription:@"render completion"];
+
+    [presenter renderComponents:self.options
+                        perform:^{
+                          XCTAssertTrue(NSThread.isMainThread);
+                          [completion fulfill];
+                        }];
+
+    [self waitForExpectations:@[ completion ] timeout:1];
 }
 
 @end


### PR DESCRIPTION
## Performance problem and fix

`RNNStackPresenter.renderComponents` dispatched to a global high-priority queue, dispatched setup back to the main queue, then blocked the global worker with `dispatch_group_wait(..., DISPATCH_TIME_FOREVER)` until the React top-bar background reported ready.

For `waitForRender` components, a slow or failed render could occupy that worker indefinitely. The worker and synchronization primitive are unnecessary because readiness is already callback-based.

This change keeps setup asynchronous on the main queue and forwards readiness back to the main queue without blocking any worker. Completion ordering and main-thread delivery remain unchanged.

## Regression coverage

The presenter test now exercises the render callback path and verifies completion is delivered on the main thread. The focused presenter suite passes 10/10.

## Verification

- New Architecture iOS `build-for-testing` succeeded
- `RNNStackPresenterTest`: 10/10 passed on an iPhone 16 Pro simulator (iOS 26.5)
- clang-format and `git diff --check` passed

## Breaking changes

None. This removes internal blocking while preserving asynchronous callback order and thread affinity.
