### PR TITLE
perf(Android): recycle replaced shadow bitmaps

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/views/bottomtabs/ShadowLayout.kt
+++ b/android/src/main/java/com/reactnativenavigation/views/bottomtabs/ShadowLayout.kt
@@ -36,8 +36,8 @@ open class ShadowLayout(context: Context) : FrameLayout(context) {
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        bitmap?.recycle()
-        bitmap = null
+        recycleShadowBitmap()
+        invalidateShadow = true
     }
 
     var isShadowed: Boolean = false
@@ -108,6 +108,7 @@ open class ShadowLayout(context: Context) : FrameLayout(context) {
         if (isShadowed) {
             if (invalidateShadow) {
                 if (bounds.width() != 0 && bounds.height() != 0) {
+                    recycleShadowBitmap()
                     bitmap = Bitmap.createBitmap(bounds.width(), bounds.height(), Bitmap.Config.ARGB_8888).also {
                         mainCanvas.setBitmap(it)
                         invalidateShadow = false
@@ -131,5 +132,11 @@ open class ShadowLayout(context: Context) : FrameLayout(context) {
         }
 
         super.dispatchDraw(canvas)
+    }
+
+    private fun recycleShadowBitmap() {
+        mainCanvas.setBitmap(null)
+        bitmap?.recycle()
+        bitmap = null
     }
 }

--- a/android/src/test/java/com/reactnativenavigation/views/bottomtabs/ShadowLayoutTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/views/bottomtabs/ShadowLayoutTest.kt
@@ -1,0 +1,41 @@
+package com.reactnativenavigation.views.bottomtabs
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.view.View
+import com.reactnativenavigation.BaseTest
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ShadowLayoutTest : BaseTest() {
+    @Test
+    fun regeneratingShadowRecyclesPreviousBitmap() {
+        val view = ShadowLayout(newActivity()).apply { isShadowed = true }
+        val output = Bitmap.createBitmap(40, 40, Bitmap.Config.ARGB_8888)
+
+        measureAndDraw(view, output)
+        val firstShadow = shadowBitmap(view)
+
+        view.requestLayout()
+        measureAndDraw(view, output)
+        val secondShadow = shadowBitmap(view)
+
+        assertNotSame(firstShadow, secondShadow)
+        assertTrue(firstShadow.isRecycled)
+        output.recycle()
+    }
+
+    private fun measureAndDraw(view: ShadowLayout, output: Bitmap) {
+        val size = View.MeasureSpec.makeMeasureSpec(40, View.MeasureSpec.EXACTLY)
+        view.measure(size, size)
+        view.layout(0, 0, 40, 40)
+        view.draw(Canvas(output))
+    }
+
+    private fun shadowBitmap(view: ShadowLayout): Bitmap {
+        val field = ShadowLayout::class.java.getDeclaredField("bitmap")
+        field.isAccessible = true
+        return field.get(view) as Bitmap
+    }
+}


### PR DESCRIPTION
## Performance problem and fix

`ShadowLayout` regenerates its cached bitmap after layout/appearance changes. The previous bitmap was overwritten without being recycled, so each regeneration left its native pixel allocation for GC/finalization instead of releasing it deterministically. A full-screen-width shadow cache can make that churn substantial during repeated layout changes.

This change centralizes cache teardown:

- detach the bitmap from the reusable `Canvas`
- recycle and clear the previous cache before replacement
- use the same cleanup when the view detaches
- mark the shadow dirty after detach so a reattached view rebuilds its cache

The temporary alpha bitmap was already recycled and remains unchanged.

## Regression coverage

The new Robolectric test renders a shadow, invalidates layout, renders again, and verifies the first bitmap was recycled before the replacement became active. The exact baseline leaves it unrecycled.

## Verification

- focused regression: 1/1 passed
- full Android unit suite: 698 passed, 2 skipped, 0 failed
- Android debug Kotlin/Java compilation passed
- `git diff --check` passed

## Breaking changes

None. Rendering output is unchanged; native bitmap memory is released promptly.
