### PR TITLE
fix(Android): close temporary image and theme resources

### DIFF
--- a/android/src/main/java/com/reactnativenavigation/react/modal/ModalViewManager.kt
+++ b/android/src/main/java/com/reactnativenavigation/react/modal/ModalViewManager.kt
@@ -121,7 +121,11 @@ private fun getModalHostSize(activity: Activity): Point {
     val attrs = intArrayOf(android.R.attr.windowFullscreen)
     val theme = activity.theme
     val ta = theme.obtainStyledAttributes(attrs)
-    val windowFullscreen = ta.getBoolean(0, false)
+    val windowFullscreen = try {
+        ta.getBoolean(0, false)
+    } finally {
+        ta.recycle()
+    }
 
     // We need to add the status bar height to the height if we have a fullscreen window,
     // because Display.getCurrentSizeRange doesn't include it.

--- a/android/src/main/java/com/reactnativenavigation/utils/ImageLoader.kt
+++ b/android/src/main/java/com/reactnativenavigation/utils/ImageLoader.kt
@@ -77,10 +77,15 @@ open class ImageLoader {
     @Throws(IOException::class)
     private fun readJsDevImage(context: Context, source: String): Drawable {
         val threadPolicy = adjustThreadPolicyDebug(context)
-        val `is` = openStream(context, source)
-        val bitmap = BitmapFactory.decodeStream(`is`)
-        restoreThreadPolicyDebug(context, threadPolicy)
-        return BitmapDrawable(context.resources, bitmap)
+        try {
+            val stream = openStream(context, source)
+                ?: throw FileNotFoundException("Could not open image $source")
+            val bitmap = stream.use(BitmapFactory::decodeStream)
+                ?: throw IOException("Could not decode image $source")
+            return BitmapDrawable(context.resources, bitmap)
+        } finally {
+            restoreThreadPolicyDebug(context, threadPolicy)
+        }
     }
 
     private fun isLocalFile(uri: Uri): Boolean {

--- a/android/src/test/java/com/reactnativenavigation/utils/ImageLoaderTest.kt
+++ b/android/src/test/java/com/reactnativenavigation/utils/ImageLoaderTest.kt
@@ -1,0 +1,26 @@
+package com.reactnativenavigation.utils
+
+import android.os.StrictMode
+import com.reactnativenavigation.BaseTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class ImageLoaderTest : BaseTest() {
+    @Test
+    fun failedDevImageLoadRestoresThreadPolicy() {
+        val originalPolicy = StrictMode.ThreadPolicy.Builder()
+            .detectNetwork()
+            .penaltyLog()
+            .build()
+        StrictMode.setThreadPolicy(originalPolicy)
+
+        ImageLoader().loadIcon(
+            newActivity(),
+            "content://missing/image",
+            mock<ImageLoader.ImagesLoadingListener>()
+        )
+
+        assertEquals(originalPolicy.toString(), StrictMode.getThreadPolicy().toString())
+    }
+}


### PR DESCRIPTION
## Problems and fixes

The Android resource-lifecycle sweep found two temporary resources that were never closed:

- Dev image loading passed an opened local/network `InputStream` to `BitmapFactory` without closing it. If opening or decoding threw, the temporary permissive `StrictMode` policy also remained installed on the calling thread.
- Modal host measurement obtained a theme `TypedArray` without recycling it.

This change uses `InputStream.use`, rejects missing/undecodable streams through the existing error path, restores the original thread policy in `finally`, and recycles the typed array in `finally`.

## Regression coverage

The new Robolectric regression forces dev-image stream opening to fail and verifies the original network-detecting thread policy is restored. The exact baseline leaves the permissive policy installed.

## Verification

- focused regression: 1/1 passed
- full Android unit suite: 698 passed, 2 skipped, 0 failed
- Android debug Kotlin/Java compilation passed
- `git diff --check` passed

## Breaking changes

None. Failed image decoding continues through the existing error callback; resources and thread policy are now cleaned up reliably.
