### PR TITLE
fix: remove unused native events catch binding

### DIFF
--- a/src/adapters/NativeEventsReceiver.ts
+++ b/src/adapters/NativeEventsReceiver.ts
@@ -24,7 +24,7 @@ export class NativeEventsReceiver {
   constructor() {
     try {
       this.emitter = new NativeEventEmitter(RNNEventEmitter);
-    } catch (e) {
+    } catch {
       this.emitter = ({
         addListener: () => {
           return {


### PR DESCRIPTION
## What changed

- omit the unused catch binding when `NativeEventEmitter` construction falls back to the no-op emitter
- restore a clean source-only ESLint run without changing fallback behavior

## Why

`NativeEventsReceiver` never reads the caught value, so naming it triggers the repository's `@typescript-eslint/no-unused-vars` rule. JavaScript supports an optional catch binding for this exact case.

## Verification

- `yarn eslint --ext .js,.jsx,.ts,.tsx ./src --quiet`
- `yarn test-js` — 38 suites / 395 tests passed; 11 suites / 59 tests skipped
- `git diff --check`

## Breaking changes

None.