### PR TITLE
Fix(JS): Screen Popped Listener

### DIFF
--- a/src/events/ComponentEventsObserver.test.tsx
+++ b/src/events/ComponentEventsObserver.test.tsx
@@ -415,4 +415,16 @@ describe('ComponentEventsObserver', () => {
     expect(mockEventsReceiver.registerSearchBarCancelPressedListener).toHaveBeenCalledTimes(1);
     expect(mockEventsReceiver.registerPreviewCompletedListener).toHaveBeenCalledTimes(1);
   });
+
+  it(`registers notifyScreenPopped for the ScreenPopped native event`, () => {
+    uut.registerOnceForAllComponentEvents();
+
+    expect(mockEventsReceiver.registerScreenPoppedListener).toHaveBeenCalledTimes(1);
+    expect(mockEventsReceiver.registerScreenPoppedListener).toHaveBeenCalledWith(
+      uut.notifyScreenPopped
+    );
+    expect(mockEventsReceiver.registerPreviewCompletedListener).toHaveBeenCalledWith(
+      uut.notifyPreviewCompleted
+    );
+  });
 });

--- a/src/events/ComponentEventsObserver.ts
+++ b/src/events/ComponentEventsObserver.ts
@@ -58,7 +58,7 @@ export class ComponentEventsObserver {
       this.notifySearchBarCancelPressed
     );
     this.nativeEventsReceiver.registerPreviewCompletedListener(this.notifyPreviewCompleted);
-    this.nativeEventsReceiver.registerScreenPoppedListener(this.notifyPreviewCompleted);
+    this.nativeEventsReceiver.registerScreenPoppedListener(this.notifyScreenPopped);
   }
 
   public bindComponent(


### PR DESCRIPTION
**Problem**
--
`ComponentEventsObserver.registerOnceForAllComponentEvents` was passing `notifyPreviewCompleted` to `registerScreenPoppedListener`. This meant `ScreenPopped` events fired the wrong notification (and any `screenPopped` listeners on components never ran).


**Fix**
--
* register `notifyScreenPopped` as the listener for the native `ScreenPopped` event, instead of `notifyPreviewCompleted`
* add a regression test asserting `ScreenPopped` and `PreviewCompleted` are wired to their own distinct handlers


**Verification**
--

* `yarn jest src/events/ComponentEventsObserver.test.tsx` — 14/14 tests passed
* `yarn eslint --ext .js,.jsx,.ts,.tsx src/events/ComponentEventsObserver.ts src/events/ComponentEventsObserver.test.tsx --quiet`

**Breaking changes**
--

None.